### PR TITLE
BUG FIX: Auto Chin Null object

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/jrPlugins/autoChin/AutoChin.kt
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/jrPlugins/autoChin/AutoChin.kt
@@ -131,7 +131,7 @@ class AutoChin: Plugin() {
             }
         } catch (e: Exception) {
             //e.printStackTrace()
-            currentState = State.IDLE
+            currentState = State.CATCHING
         }
     }
 


### PR DESCRIPTION
Fixed null object causing plugin to stop prematurely. 