### PR TITLE
Add microbot-debug as a parser argument

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -43,6 +43,7 @@ import net.runelite.client.discord.DiscordService;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.externalplugins.ExternalPluginManager;
 import net.runelite.client.plugins.PluginManager;
+import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.rs.ClientLoader;
 import net.runelite.client.rs.ClientUpdateCheckMode;
 import net.runelite.client.ui.ClientUI;
@@ -163,6 +164,7 @@ public class RuneLite {
         final OptionParser parser = new OptionParser(false);
         parser.accepts("developer-mode", "Enable developer tools");
         parser.accepts("debug", "Show extra debugging output");
+        parser.accepts("microbot-debug", "Enables debug features for microbot");
         parser.accepts("safe-mode", "Disables external plugins and the GPU plugin");
         parser.accepts("insecure-skip-tls-verification", "Disables TLS verification");
         parser.accepts("jav_config", "jav_config url")
@@ -206,6 +208,10 @@ public class RuneLite {
         if (options.has("debug")) {
             final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
             logger.setLevel(Level.DEBUG);
+        }
+
+        if (options.has("microbot-debug")) {
+            Microbot.debug = true;
         }
 
         //More information about java proxies can be found here

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/Microbot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/Microbot.java
@@ -67,6 +67,8 @@ public class Microbot {
     @Setter
     private static boolean disableWalkerUpdate;
 
+    public static boolean debug = false;
+
     public static boolean isGainingExp = false;
     public static boolean pauseAllScripts = false;
     public static String status = "IDLE";
@@ -94,7 +96,6 @@ public class Microbot {
     public static boolean isAnimating() {
         return Microbot.getClientThread().runOnClientThread(() -> getClient().getLocalPlayer().getAnimation() != -1);
     }
-
 
     public static int getVarbitValue(int varbit) {
         return getClientThread().runOnClientThread(() -> getClient().getVarbitValue(varbit));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/pathfinder/Pathfinder.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/pathfinder/Pathfinder.java
@@ -57,9 +57,8 @@ public class Pathfinder implements Runnable {
     boolean useCanvas;
     public boolean customPath = false;
 
-
     public boolean getDebugger() {
-        return true;
+        return Microbot.debug;
     }
 
     public Pathfinder(PathfinderConfig config) {


### PR DESCRIPTION
Every other action that is in any way connected to debugging should probably require `Microbot.debug` to actually print the info etc.

Currently just pathfinding.

Example on how to use the debug:
![image](https://github.com/chsami/microbot/assets/73128678/1efe64ae-07a3-425b-86fa-23c89d3b55f9)

