### PR TITLE
Fix getLastMousePosition

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/mouse/Mouse.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/mouse/Mouse.java
@@ -14,7 +14,7 @@ public abstract class Mouse {
     public List<Point> mousePositions = new ArrayList<>();
 
     public Point getLastMousePosition() {
-        return mousePositions.stream().reduce((first, second) -> second).get();
+        return mousePositions.stream().reduce((first, second) -> second).orElse(null);
     }
 
     public Mouse() {


### PR DESCRIPTION
`.get()` throws an exception. Prefer returning `null` instead with `.orElse(null)`