### PR TITLE
Fix PluginListPanel UnsupportedException when adding pinned plugins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -192,10 +192,6 @@ class PluginListPanel extends PluginPanel
 						.map(Plugin::getName)
 						.collect(Collectors.toList());
 
-					if (descriptor.name().toLowerCase().contains("micro")) {
-						pinnedPlugins.add(descriptor.name());
-					}
-
 					return new PluginConfigurationDescriptor(
 						descriptor.name(),
 						descriptor.description(),


### PR DESCRIPTION
Code is never used. If we really want to pin we should instead do
```java
listItem.setPinned(pinnedPlugins.contains(desc.getName()) /* || OUR CONDITION*/);
```