### PR TITLE
Fixing event handler

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/event/EventHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/event/EventHandler.java
@@ -40,6 +40,13 @@ public class EventHandler extends EventQueue {
         }
     }
 
+    public void regainFocus() {
+        FocusEvent canvasFocusEvent = new FocusEvent(gameCanvas, FocusEvent.FOCUS_GAINED, false, null, FocusEvent.Cause.ACTIVATION);
+        FocusEvent frameFocusEvent = new FocusEvent(gameFrame, FocusEvent.FOCUS_GAINED, false, null, FocusEvent.Cause.ACTIVATION);
+        Microbot.getEventHandler().dispatchUnblockedEvent(canvasFocusEvent);
+        Microbot.getEventHandler().dispatchUnblockedEvent(frameFocusEvent);
+    }
+
     public void dispatchUnblockedEvent(AWTEvent event) {
         if (event != null && event.getSource() != null) {
             postEvent(new UnblockedEvent(event));
@@ -65,27 +72,17 @@ public class EventHandler extends EventQueue {
         if (isUnblockedEvent) {
             ((Component) eventSource).dispatchEvent(event);
 
-        } else if (eventSource == gameCanvas && (event instanceof WindowEvent || event instanceof MouseEvent)) {
+        } else if (eventSource == gameCanvas && (event instanceof WindowEvent || event instanceof MouseEvent || event instanceof KeyEvent)) {
             if (!blocked) {
                 super.dispatchEvent(event);
             }
 
-//        } else if (eventSource == gameCanvas && event instanceof KeyEvent) {
-//            System.out.println("1: " + event);
-//            ((Component) eventSource).dispatchEvent(event);
-//            super.dispatchEvent(event);
-//
-//        } else if (eventSource == gameFrame && event instanceof KeyEvent) {
-////            if (!blocked) {
-////                super.dispatchEvent(event);
-////            }
-//            System.out.println("2: " + event);
-////            ((Component) eventSource).dispatchEvent(event);
-//            super.dispatchEvent(event);
-
+        } else if (eventSource == gameFrame && (event instanceof KeyEvent)) {
+            if (!blocked) {
+                super.dispatchEvent(event);
+            }
 
         } else {
-//            ((Component) eventSource).dispatchEvent(event);
             super.dispatchEvent(event);
         }
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/event/EventSelector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/event/EventSelector.java
@@ -5,6 +5,7 @@ import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
 
+import java.awt.event.FocusEvent;
 import java.awt.image.BufferedImage;
 
 public class EventSelector {
@@ -45,6 +46,7 @@ public class EventSelector {
     public void enableClick() {
         Microbot.getEventHandler().setBlocked(false);
         addAndRemoveButtons();
+        Microbot.getEventHandler().regainFocus();
     }
 
     public void disableClick() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/event/EventSelector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/event/EventSelector.java
@@ -5,7 +5,6 @@ import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
 
-import java.awt.event.FocusEvent;
 import java.awt.image.BufferedImage;
 
 public class EventSelector {


### PR DESCRIPTION
Fixed unblocking key events when the event selector was toggled to enable input. When input is disabled focus, key, mouse, window events are all blocked on the game canvas. Key events are blocked on the jframe. Plugins can still be toggled on and off, but any text inputs currently don't work when the input is being blocked. Unblocking the inputs now invokes focus events on the game canvas and jframe to allow key events to propagate. 