### PR TITLE
Add null checks to fix Kotlin compilation errors

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/griffinplugins/griffintrainer/trainers/combat/CombatTrainer.kt
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/griffinplugins/griffintrainer/trainers/combat/CombatTrainer.kt
@@ -60,7 +60,7 @@ class CombatTrainer(private val config: GriffinTrainerConfig) : BaseTrainer(conf
         val attackLevel = Microbot.getClientForKotlin().getRealSkillLevel(Skill.ATTACK)
         val strengthLevel = Microbot.getClientForKotlin().getRealSkillLevel(Skill.STRENGTH)
         val defenceLevel = Microbot.getClientForKotlin().getRealSkillLevel(Skill.DEFENCE)
-        return listOf(attackLevel, strengthLevel, defenceLevel).min()
+        return minOf(attackLevel, strengthLevel, defenceLevel)
     }
 
     override fun shouldTrain(): Boolean {


### PR DESCRIPTION
Attempting to compile microbot on a fresh install of IntelliJ IDEA and fresh clone of microbot results in compilation errors due to Type mismatches. 

![image](https://github.com/chsami/microbot/assets/46322193/306b1bd5-29a7-4bd6-8cc9-876dc3349781)

The changes in this pull request allow microbot to compile by adding null checks.

Steps to reproduce the compilation error on your machine:
1. Spin up a fresh windows VM
2. Install IntelliJ IDEA and clone the microbot repo
3. Configure IntelliJ to allow compiliation of microbot and attempt to compile
4. Kotlin should fail to compile due to type mismatch. 