### PR TITLE
GiantsFoundry: Selecting bars other than steel+mithril now works

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/GiantsFoundryScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/GiantsFoundryScript.java
@@ -7,10 +7,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
-import net.runelite.client.plugins.microbot.giantsfoundry.enums.CommissionType;
-import net.runelite.client.plugins.microbot.giantsfoundry.enums.Heat;
-import net.runelite.client.plugins.microbot.giantsfoundry.enums.Stage;
-import net.runelite.client.plugins.microbot.giantsfoundry.enums.State;
+import net.runelite.client.plugins.microbot.giantsfoundry.enums.*;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
@@ -171,14 +168,15 @@ public class GiantsFoundryScript extends Script {
         if (Rs2Inventory.hasItem(config.FirstBar().getName()) && !canPour()) {
             Rs2GameObject.interact(CRUCIBLE, "Fill");
             sleepUntil(() -> Rs2Widget.findWidget("What metal would you like to add?", null) != null, 5000);
-            Rs2Keyboard.keyPress('3');
+            Rs2Keyboard.keyPress(getKeyFromBar(config.FirstBar()));
             sleepUntil(() -> !Rs2Inventory.hasItem(config.FirstBar().getName()), 5000);
         }
         if (Rs2Inventory.hasItem(config.SecondBar().getName()) && !canPour()) {
             Rs2GameObject.interact(CRUCIBLE, "Fill");
             sleepUntil(() -> Rs2Widget.findWidget("What metal would you like to add?", null) != null, 5000);
             sleep(600, 1200);
-            Rs2Keyboard.keyPress('4');
+
+            Rs2Keyboard.keyPress(getKeyFromBar(config.SecondBar()));
             sleepUntil(() -> !Rs2Inventory.hasItem(config.SecondBar().getName()), 5000);
         }
         if (canPour()) {
@@ -186,6 +184,16 @@ public class GiantsFoundryScript extends Script {
             sleep(5000);
             sleepUntil(() -> !canPour(), 10000);
         }
+    }
+
+    public static char getKeyFromBar(SmithableBars bar) {
+        SmithableBars[] bars = SmithableBars.values();
+        for (int i = 0; i < bars.length; i++) {
+            if (bars[i] == bar) {
+                return (char)('0'+i+1);
+            }
+        }
+        return 'x'; // Not found
     }
 
     public boolean canPickupMould() {


### PR DESCRIPTION
Selecting any bars other than Steel+Mithril in GiantsFoundry did not work because the choice of what to load into the crucible was hardcoded. It always sent "3" (Steel) and "4" (Mithril) even if other bars were selected.
I added a small function getKeyFromBar to fix this.