### PR TITLE
Improvents to Rs2Walker and tile restrictions for pathfinder

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Restriction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Restriction.java
@@ -1,0 +1,85 @@
+package net.runelite.client.plugins.microbot.shortestpath;
+
+import lombok.Getter;
+import net.runelite.api.Quest;
+import net.runelite.api.QuestState;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+/**
+ * This class represents (conditional) restrictions for a WorldPoint to use in the pathfinder.
+ */
+@Getter
+public class Restriction {
+    /**
+     * The restricted point (packed)
+     */
+    private final int packedWorldPoint;
+
+    /**
+     * The quests required to lift the restriction
+     */
+    private List<Quest> quests = new ArrayList<>();
+
+    public Restriction(int x, int y, int z){
+        packedWorldPoint = WorldPointUtil.packWorldPoint(x, y, z);
+    }
+
+    Restriction(final String line) {
+        final String DELIM = " ";
+
+        String[] parts = line.split("\t");
+
+        String[] parts_point = parts[0].split(DELIM);
+
+        packedWorldPoint = WorldPointUtil.packWorldPoint(
+                Integer.parseInt(parts_point[0]),
+                Integer.parseInt(parts_point[1]),
+                Integer.parseInt(parts_point[2]));
+
+        // Quest requirements
+        if (!parts[1].isEmpty()) {
+            this.quests = findQuests(parts[1]);
+        }
+    }
+
+    private static List<Quest> findQuests(String questNamesCombined) {
+        String[] questNames = questNamesCombined.split(";");
+        List<Quest> quests = new ArrayList<>();
+        for (String questName : questNames) {
+            for (Quest quest : Quest.values()) {
+                if (quest.getName().equals(questName)) {
+                    quests.add(quest);
+                    break;
+                }
+            }
+        }
+        return quests;
+    }
+
+    public static List<Restriction> loadAllFromResources() {
+        List<Restriction> restrictions = new ArrayList<>();
+
+        try {
+            String s = new String(Util.readAllBytes(ShortestPathPlugin.class.getResourceAsStream("restrictions.tsv")), StandardCharsets.UTF_8);
+            Scanner scanner = new Scanner(s);
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine();
+
+                if (line.startsWith("#") || line.isBlank()) {
+                    continue;
+                }
+
+                restrictions.add(new Restriction(line));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return restrictions;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Restriction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Restriction.java
@@ -2,7 +2,6 @@ package net.runelite.client.plugins.microbot.shortestpath;
 
 import lombok.Getter;
 import net.runelite.api.Quest;
-import net.runelite.api.QuestState;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
@@ -146,8 +146,10 @@ public class ShortestPathPlugin extends Plugin {
     protected void startUp() {
         SplitFlagMap map = SplitFlagMap.fromResources();
         Map<WorldPoint, List<Transport>> transports = Transport.loadAllFromResources();
+        List<Restriction> restrictions = Restriction.loadAllFromResources();
 
-        pathfinderConfig = new PathfinderConfig(map, transports, client, config);
+
+        pathfinderConfig = new PathfinderConfig(map, transports, restrictions, client, config);
 
         Rs2Walker.setConfig(config);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Transport.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Transport.java
@@ -4,7 +4,6 @@ import com.google.common.base.Strings;
 import lombok.Getter;
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
@@ -41,6 +40,9 @@ public class Transport {
      * The skill levels required to use this transport
      */
     private final int[] skillLevels = new int[Skill.values().length];
+
+    @Getter
+    private final HashMap<String, Integer> items = new HashMap<>();
 
     /**
      * The quests required to use this transport
@@ -186,6 +188,30 @@ public class Transport {
                         break;
                     }
                 }
+            }
+        }
+
+        // Item requirements
+        if (parts.length >= 5 && !parts[4].isEmpty()) {
+            String[] itemRequirements = parts[4].split(";");
+
+            for (String requirement : itemRequirements) {
+                if (requirement.isBlank())
+                    continue;
+
+                int splitIndex = requirement.indexOf(DELIM);
+                int amount;
+                String item;
+
+                try {
+                    amount = Integer.parseInt(requirement.substring(0, splitIndex));
+                    item = requirement.substring(splitIndex + 1);
+                } catch (NumberFormatException e){
+                    amount = 1;
+                    item = requirement;
+                }
+
+                items.put(item, amount);
             }
         }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/CollisionMap.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/CollisionMap.java
@@ -127,6 +127,7 @@ public class CollisionMap {
             OrdinalDirection d = ORDINAL_VALUES[i];
             int neighborPacked = packedPointFromOrdinal(node.packedPosition, d);
             if (visited.get(neighborPacked)) continue;
+            if (config.getRestrictedPointsPacked().contains(neighborPacked)) continue;
 
             if (traversable[i]) {
                 neighbors.add(new Node(neighborPacked, node));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -5,6 +5,7 @@ import net.runelite.api.*;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.shortestpath.*;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -254,6 +255,9 @@ public class PathfinderConfig {
         if (isQuestLocked && !completedQuests(transport)) {
             return false;
         }
+
+        if (transport.getItems().entrySet().stream().anyMatch(x -> !Rs2Inventory.hasItemAmount(x.getKey(), x.getValue())))
+            return false;
 
         return true;
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/enums/BankLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/enums/BankLocation.java
@@ -23,6 +23,7 @@ public enum BankLocation {
     BLAST_MINE(new WorldPoint(1502, 3856, 0)),
     BURGH_DE_ROTT(new WorldPoint(3495, 3212, 0)),
     CAMELOT(new WorldPoint(2725, 3493, 0)),
+    CAMODZAAL(new WorldPoint(2979, 5798, 0)),
     CAM_TORUM(new WorldPoint(1450, 9557, 1)),
     CANIFIS(new WorldPoint(3512, 3480, 0)),
     CASTLE_WARS(new WorldPoint(2443, 3083, 0)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
@@ -654,7 +654,13 @@ public class Rs2Inventory {
      * @return True if the player has the specified quantity of the item, false otherwise.
      */
     public static boolean hasItemAmount(String name, int amount) {
-        return hasItemAmount(name, amount, false);
+        Rs2Item rs2Item = get(name);
+        if (rs2Item == null) return false;
+        if (rs2Item.isStackable) {
+            return rs2Item.quantity >= amount;
+        } else {
+            return items().stream().filter(x -> x.name.equalsIgnoreCase(name)).count() >= amount;
+        }
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -287,6 +287,16 @@ public class Rs2Walker {
         }
 
         if (wallObject != null) {
+            ObjectComposition objectComposition = Rs2GameObject.getObjectComposition(wallObject.getId());
+
+            for (var action : objectComposition.getActions()){
+                if (action != null && action.contains("Pay-toll")){
+                    Rs2GameObject.interact(wallObject, action);
+                    Rs2Player.waitForWalking();
+                    return true;
+                }
+            }
+
             Rs2GameObject.interact(wallObject);
             Rs2Player.waitForWalking();
             return true;
@@ -422,7 +432,7 @@ public class Rs2Walker {
             }
             boolean found = false;
             for (String action : objectComposition.getActions()) {
-                if (action != null && (action.equals("Open") || action.contains("pay-toll"))) {
+                if (action != null && (action.equals("Open") || action.contains("Pay-toll"))) {
                     found = true;
                     break;
                 }
@@ -433,25 +443,26 @@ public class Rs2Walker {
             int orientation = wallObject.getOrientationA();
             if (orientation == 1) {
                 //blocks west
-                if (a.dx(-1).equals(b)) {
+                if (a.dx(-1).getX() == b.getX()) {
                     return true;
                 }
             }
             if (orientation == 4) {
                 //blocks east
-                if (a.dx(+1).equals(b)) {
+                if (a.dx(+1).getX() == b.getX()) {
                     return true;
                 }
             }
             if (orientation == 2) {
                 //blocks north
-                if (a.dy(1).equals(b)) {
+                if (a.dy(1).getY() == b.getY()) {
                     return true;
                 }
             }
             if (orientation == 8) {
                 //blocks south
-                return a.dy(-1).equals(b);
+                if (a.dy(-1).getY() == b.getY())
+                    return true;
             }
         }
 
@@ -471,7 +482,7 @@ public class Rs2Walker {
         }
         boolean foundb = false;
         for (String action : objectCompositionb.getActions()) {
-            if (action != null && (action.equals("Open") || action.contains("pay-toll"))) {
+            if (action != null && (action.equals("Open") || action.contains("Pay-toll"))) {
                 foundb = true;
                 break;
             }
@@ -482,25 +493,25 @@ public class Rs2Walker {
         int orientationb = wallObjectb.getOrientationA();
         if (orientationb == 1) {
             //blocks east
-            if (b.dx(-1).equals(a)) {
+            if (b.dx(-1).getX() == a.getX()) {
                 return true;
             }
         }
         if (orientationb == 4) {
-            //blocks south
-            if (b.dx(+1).equals(a)) {
+            //blocks west
+            if (b.dx(+1).getX() == a.getX()) {
                 return true;
             }
         }
         if (orientationb == 2) {
             //blocks south
-            if (b.dy(+1).equals(a)) {
+            if (b.dy(+1).getY() == a.getY()) {
                 return true;
             }
         }
         if (orientationb == 8) {
             //blocks north
-            return b.dy(-1).equals(a);
+            return b.dy(-1).getY() == a.getY();
         }
         return false;
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -16,6 +16,7 @@ import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.math.Random;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
@@ -571,6 +572,15 @@ public class Rs2Walker {
                         if (indexOfDestination < indexOfOrigin) continue;
 
                         if (path.get(i).equals(origin)) {
+                            if (b.isShip()){
+                                if (Rs2Npc.getNpcInLineOfSight(b.getNpcName()) != null){
+                                    Rs2Npc.interact(b.getNpcName(), b.getAction());
+                                    sleep(1200, 1600);
+                                } else {
+                                    Rs2Walker.walkFastCanvas(path.get(i));
+                                    sleep(1200, 1600);
+                                }
+                            }
 
                             if (b.getDestination().distanceTo2D(Rs2Player.getWorldLocation()) > 20) {
                                 handleTrapdoor(b);

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/restrictions.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/restrictions.tsv
@@ -1,0 +1,5 @@
+# X Y Z	Quest
+# Varrock museum
+3265 3442 0	The Dig Site
+3264 3442 0	The Dig Site
+3261 3446 0	The Dig Site


### PR DESCRIPTION
Added restrictions to tiles used in the pathfinder (static from resources and dynamic by setting them in the PathfinderConfig), improvements to the Rs2Walker (actually use the pay-toll option if it is found on a door, handle doors that the path moves through diagonally), added camodzaal bank (missed this part in the last PR)

Second commit adds support for ships by using the item requiements already defined in resources.