### PR TITLE
Improvements for MQuestScript and different helper changes

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/NpcID.java
+++ b/runelite-api/src/main/java/net/runelite/api/NpcID.java
@@ -750,8 +750,8 @@ public final class NpcID
 	public static final int SKRAELING_774 = 774;
 	public static final int FISHMONGER = 775;
 	public static final int GREENGROCER = 776;
-	public static final int ETHEREAL_MAN = 777;
-	public static final int ETHEREAL_LADY = 778;
+	public static final int ETHEREAL_BEING = 777;
+	public static final int ETHEREAL_BEING_778 = 778;
 	public static final int ETHEREAL_NUMERATOR = 779;
 	public static final int ETHEREAL_EXPERT = 780;
 	public static final int ETHEREAL_PERCEPTIVE = 781;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/WorldPointUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/WorldPointUtil.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.shortestpath;
 
+import net.runelite.api.World;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 
@@ -40,15 +41,18 @@ public class WorldPointUtil {
     public static int distanceBetween(int previousPacked, int currentPacked, int diagonal) {
         final int previousX = WorldPointUtil.unpackWorldX(previousPacked);
         final int previousY = WorldPointUtil.unpackWorldY(previousPacked);
+        final int previousZ = WorldPointUtil.unpackWorldPlane(previousPacked);
         final int currentX = WorldPointUtil.unpackWorldX(currentPacked);
         final int currentY = WorldPointUtil.unpackWorldY(currentPacked);
+        final int currentZ = WorldPointUtil.unpackWorldPlane(currentPacked);
         final int dx = Math.abs(previousX - currentX);
         final int dy = Math.abs(previousY - currentY);
+        final int dz = previousZ != currentZ ? 1000 : 0;
 
         if (diagonal == 1) {
-            return Math.max(dx, dy);
+            return Math.max(dx, dy) + dz;
         } else if (diagonal == 2) {
-            return dx + dy;
+            return dx + dy + dz;
         }
 
         return Integer.MAX_VALUE;
@@ -86,5 +90,23 @@ public class WorldPointUtil {
         final int dy = Math.max(Math.max(area.getY() - y, 0), y - areaMaxY);
 
         return Math.max(dx, dy);
+    }
+
+    public static boolean isPointInPolygon(WorldPoint point, WorldPoint[] polygon) {
+        int n = polygon.length;
+        int j = n - 1;
+        boolean inside = false;
+
+        for (int i = 0; i < n; i++) {
+            if (polygon[i].getY() < point.getY() && polygon[j].getY() >= point.getY() ||
+                    polygon[j].getY() < point.getY() && polygon[i].getY() >= point.getY()) {
+                if (polygon[i].getX() + (point.getY() - polygon[i].getY()) / (double)(polygon[j].getY() - polygon[i].getY()) * (polygon[j].getX() - polygon[i].getX()) < point.getX()) {
+                    inside = !inside;
+                }
+            }
+            j = i;
+        }
+
+        return inside;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
@@ -1038,7 +1038,7 @@ public class Rs2Bank {
         Rs2Player.toggleRunEnergy(true);
         BankLocation bankLocation = getNearestBank();
         Microbot.status = "Walking to nearest bank " + bankLocation.toString();
-        boolean result = bankLocation.getWorldPoint().distanceTo2D(Microbot.getClient().getLocalPlayer().getWorldLocation()) <= 8;
+        boolean result = bankLocation.getWorldPoint().distanceTo(Microbot.getClient().getLocalPlayer().getWorldLocation()) <= 8;
         if (result) {
             return Rs2Bank.useBank();
         } else {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/camera/Rs2Camera.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/camera/Rs2Camera.java
@@ -127,8 +127,8 @@ public class Rs2Camera {
             Global.awaitExecutionUntil(() -> Rs2Keyboard.keyRelease((char) KeyEvent.VK_UP),
                     () -> cameraPitchPercentage() >= percentage, 600);
         } else {
-            Rs2Keyboard.keyHold(KeyEvent.VK_RIGHT);
-            Global.awaitExecutionUntil(() -> Rs2Keyboard.keyRelease((char) KeyEvent.VK_RIGHT),
+            Rs2Keyboard.keyHold(KeyEvent.VK_DOWN);
+            Global.awaitExecutionUntil(() -> Rs2Keyboard.keyRelease((char) KeyEvent.VK_DOWN),
                     () -> cameraPitchPercentage() <= percentage, 600);
         }
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/dialogues/Rs2Dialogue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/dialogues/Rs2Dialogue.java
@@ -8,15 +8,23 @@ import java.awt.event.KeyEvent;
 public class Rs2Dialogue {
 
     public static boolean isInDialogue() {
-        return Rs2Widget.isWidgetVisible(231, 0) || Rs2Widget.isWidgetVisible(217, 0);
+        return Rs2Widget.isWidgetVisible(231, 0)
+                || Rs2Widget.isWidgetVisible(229, 0)
+                || Rs2Widget.isWidgetVisible(219, 0)
+                || Rs2Widget.isWidgetVisible(217, 0)
+                || Rs2Widget.isWidgetVisible(193, 0)
+                || hasContinue();
     }
     public static void clickContinue() {
         if (Rs2Widget.hasWidget("Click here to continue"))
             Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
     }
 
+    public static boolean hasContinue(){
+        return Rs2Widget.hasWidget("Click here to continue");
+    }
+
     public static boolean hasSelectAnOption() {
         return Rs2Widget.hasWidget("Select an Option");
     }
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
@@ -706,6 +706,49 @@ public class Rs2GameObject {
                 .collect(Collectors.toList());
     }
 
+    public static List<TileObject> getTileObjects(int id){
+        return getTileObjects(id, Rs2Player.getWorldLocation());
+    }
+
+    public static List<TileObject> getTileObjects(int id, WorldPoint anchorPoint) {
+        Scene scene = Microbot.getClient().getScene();
+        Tile[][][] tiles = scene.getTiles();
+
+        if (tiles == null) return new ArrayList<>();
+
+        int z = Microbot.getClient().getPlane();
+        List<TileObject> tileObjects = new ArrayList<>();
+        for (int x = 0; x < Constants.SCENE_SIZE; ++x) {
+            for (int y = 0; y < Constants.SCENE_SIZE; ++y) {
+                Tile tile = tiles[z][x][y];
+
+                if (tile == null) {
+                    continue;
+                }
+
+                if (tile.getDecorativeObject() != null
+                        && tile.getDecorativeObject().getId() == id
+                        && tile.getDecorativeObject().getWorldLocation().equals(tile.getWorldLocation()))
+                    tileObjects.add(tile.getDecorativeObject());
+
+                if (tile.getGroundObject() != null
+                        && tile.getGroundObject().getId() == id
+                        && tile.getGroundObject().getWorldLocation().equals(tile.getWorldLocation()))
+                    tileObjects.add(tile.getGroundObject());
+
+                if (tile.getWallObject() != null
+                        && tile.getWallObject().getId() == id
+                        && tile.getWallObject().getWorldLocation().equals(tile.getWorldLocation()))
+                    tileObjects.add(tile.getWallObject());
+            }
+        }
+
+        return tileObjects.stream()
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparingInt(tile -> tile.getWorldLocation().distanceTo(anchorPoint)))
+                .collect(Collectors.toList());
+    }
+
     public static List<GameObject> getGameObjects() {
         Scene scene = Microbot.getClient().getScene();
         Tile[][][] tiles = scene.getTiles();
@@ -928,7 +971,7 @@ public class Rs2GameObject {
             }
 
             int index = 0;
-            if (action != null && !action.isEmpty()) {
+            if (action != null) {
                 String[] actions;
                 if (objComp.getImpostorIds() != null) {
                     actions = objComp.getImpostor().getActions();
@@ -942,6 +985,12 @@ public class Rs2GameObject {
                         break;
                     }
                 }
+
+                while (index < actions.length && actions[index] == null)
+                    index++;
+
+                if (index == actions.length)
+                    index = 0;
             }
 
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
@@ -15,6 +15,7 @@ import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.shop.Rs2Shop;
 import net.runelite.client.plugins.microbot.util.tabs.Rs2Tab;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import org.apache.commons.lang3.NotImplementedException;
 
@@ -200,7 +201,7 @@ public class Rs2Inventory {
      * @return True if the inventory contains all the specified IDs, false otherwise.
      */
     public static boolean containsAll(int... ids) {
-        return contains(ids);
+        return Arrays.stream(ids).allMatch(x -> items().stream().anyMatch(y -> y.id == x));
     }
 
     /**
@@ -1679,6 +1680,11 @@ public class Rs2Inventory {
         }
 
         Microbot.doInvoke(new NewMenuEntry(param0, param1, menuAction.getId(), identifier, rs2Item.id, rs2Item.name), new Rectangle(0, 0, 1, 1));
+
+        if (action.equalsIgnoreCase("destroy")){
+            sleepUntil(() -> Rs2Widget.isWidgetVisible(584, 0));
+            Rs2Widget.clickWidget(Rs2Widget.getWidget(584, 1).getId());
+        }
     }
 
     private static Widget getInventory() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/npc/Rs2Npc.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/npc/Rs2Npc.java
@@ -106,6 +106,14 @@ public class Rs2Npc {
         return npcs;
     }
 
+    /**
+     * @param id
+     * @return
+     */
+    public static Stream<NPC> getNpcs(int id) {
+        return getNpcs().filter(x -> x.getId() == id);
+    }
+
     public static Stream<NPC> getAttackableNpcs() {
         Stream<NPC> npcs = Microbot.getClient().getNpcs().stream()
                 .filter((npc) -> npc.getCombatLevel() > 0 && !npc.isDead())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/tile/Rs2Tile.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/tile/Rs2Tile.java
@@ -109,6 +109,9 @@ public class Rs2Tile {
     }
 
     public static boolean isWalkable(LocalPoint localPoint) {
+        if (localPoint == null)
+            return true;
+
         Client client = Microbot.getClient();
         if (client.getCollisionMaps() != null) {
             int[][] flags = client.getCollisionMaps()[client.getPlane()].getFlags();
@@ -116,17 +119,20 @@ public class Rs2Tile {
 
             Set<MovementFlag> movementFlags = MovementFlag.getSetFlags(data);
 
-            if (movementFlags.isEmpty()) {
-                return true;
-            }
-            return false;
+            if (movementFlags.contains(MovementFlag.BLOCK_MOVEMENT_FULL)
+                    || movementFlags.contains(MovementFlag.BLOCK_MOVEMENT_FLOOR))
+                return false;
         }
         return true;
     }
 
     public static List<WorldPoint> getWalkableTilesAroundPlayer(int radius) {
+        return getWalkableTilesAroundTile(Rs2Player.getWorldLocation(), radius);
+    }
+
+    public static List<WorldPoint> getWalkableTilesAroundTile(WorldPoint point, int radius) {
         List<WorldPoint> worldPoints = new ArrayList<>();
-        LocalPoint playerLocalPosition = Rs2Player.getLocalLocation();
+        LocalPoint playerLocalPosition = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), point);
 
         for (int dx = -radius; dx <= radius; dx++) {
             for (int dy = -radius; dy <= radius; dy++) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/widget/Rs2Widget.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/widget/Rs2Widget.java
@@ -50,7 +50,7 @@ public class Rs2Widget {
         return false;
     }
     public static boolean isWidgetVisible(WidgetInfo wiget) {
-        return !Microbot.getClientThread().runOnClientThread(() -> Objects.requireNonNull(Microbot.getClient().getWidget(wiget)).isHidden());
+        return !Microbot.getClientThread().runOnClientThread(() -> getWidget(wiget) == null || getWidget(wiget).isHidden());
     }
     public static boolean isWidgetVisible(int widgetId, int childId) {
         return !Microbot.getClientThread().runOnClientThread(() ->  getWidget(widgetId, childId) == null || getWidget(widgetId, childId).isHidden());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/VarrockMuseumAnswer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/VarrockMuseumAnswer.java
@@ -35,7 +35,7 @@ import net.runelite.api.widgets.Widget;
 
 @Getter
 @RequiredArgsConstructor
-enum VarrockMuseumAnswer
+public enum VarrockMuseumAnswer
 {
 	LIZARD_1("How does a lizard regulate body heat?", "Sunlight."),
 	LIZARD_2("Who discovered how to kill lizards?", "The Slayer Masters."),
@@ -135,7 +135,7 @@ enum VarrockMuseumAnswer
 	LEECH_5("What is special about Morytanian leeches?", "They attack by jumping."),
 	LEECH_6("How does a leech change when it feeds?", "It doubles in size.");
 
-	private static final Map<String, String> MATCHES;
+	public static final Map<String, String> MATCHES;
 
 	static
 	{
@@ -152,7 +152,7 @@ enum VarrockMuseumAnswer
 	private final String question;
 	private final String answer;
 
-	static Widget findCorrect(final Client client, final String question, @Component final int... widgets)
+	public static Widget findCorrect(final Client client, final String question, @Component final int... widgets)
 	{
 		final String s = MATCHES.get(question);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/lunardiplomacy/LunarDiplomacy.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/lunardiplomacy/LunarDiplomacy.java
@@ -764,13 +764,13 @@ public class LunarDiplomacy extends BasicQuestHelper
 
 		if (client.getLocalPlayer() != null && client.getLocalPlayer().getPlayerComposition() != null && client.getLocalPlayer().getPlayerComposition().getGender() == 1)
 		{
-			talkToEthereal = new NpcStep(this, NpcID.ETHEREAL_LADY, new WorldPoint(1762, 5088, 2), "Talk to the Ethereal Lady.");
-			talkWithEtherealToFight = new NpcStep(this, NpcID.ETHEREAL_LADY, new WorldPoint(1762, 5088, 2), "Talk to the Ethereal Lady. Be prepared to fight.");
+			talkToEthereal = new NpcStep(this, NpcID.ETHEREAL_BEING_778, new WorldPoint(1762, 5088, 2), "Talk to the Ethereal Lady.");
+			talkWithEtherealToFight = new NpcStep(this, NpcID.ETHEREAL_BEING_778, new WorldPoint(1762, 5088, 2), "Talk to the Ethereal Lady. Be prepared to fight.");
 		}
 		else
 		{
-			talkToEthereal = new NpcStep(this, NpcID.ETHEREAL_MAN, new WorldPoint(1762, 5088, 2), "Talk to the Ethereal Man.");
-			talkWithEtherealToFight = new NpcStep(this, NpcID.ETHEREAL_MAN, new WorldPoint(1762, 5088, 2), "Talk to the Ethereal Man. Be prepared to fight.");
+			talkToEthereal = new NpcStep(this, NpcID.ETHEREAL_BEING, new WorldPoint(1762, 5088, 2), "Talk to the Ethereal Man.");
+			talkWithEtherealToFight = new NpcStep(this, NpcID.ETHEREAL_BEING, new WorldPoint(1762, 5088, 2), "Talk to the Ethereal Man. Be prepared to fight.");
 		}
 		talkWithEtherealToFight.addDialogStep("Of course. I'm ready.");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/recruitmentdrive/DoorPuzzle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/recruitmentdrive/DoorPuzzle.java
@@ -25,6 +25,7 @@
  */
 package net.runelite.client.plugins.questhelper.helpers.quests.recruitmentdrive;
 
+import lombok.Getter;
 import net.runelite.client.plugins.questhelper.QuestHelperPlugin;
 import net.runelite.client.plugins.questhelper.questhelpers.QuestHelper;
 import net.runelite.client.plugins.questhelper.steps.QuestStep;
@@ -62,6 +63,7 @@ public class DoorPuzzle extends QuestStep
 
 	private final int COMPLETE = 56;
 
+	@Getter
 	private final HashMap<Integer, Integer> highlightButtons = new HashMap<>();
 	private final HashMap<Integer, Integer> distance = new HashMap<>();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/recruitmentdrive/RecruitmentDrive.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/recruitmentdrive/RecruitmentDrive.java
@@ -156,7 +156,7 @@ public class RecruitmentDrive extends BasicQuestHelper
 		ObjectStep climbDownfirstFloorStaircase = new ObjectStep(this, ObjectID.STAIRCASE_24074,
 			firstFloorStairsPosition, "Climb down the stairs from the first floor.");
 
-		talkToSirTiffy = new NpcStep(this, NpcID.SIR_TIFFY_CASHIEN,
+		talkToSirTiffy = new NpcStep(this, NpcID.SIR_TIFFY_CASHIEN, new WorldPoint(2996, 3374, 0),
 			"Talk to Sir Tiffy Cashien in Falador Park.", noItemRequirement);
 
 		ConditionalStep conditionalTalkToSirTiffy = new ConditionalStep(this, talkToSirTiffy);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/sleepinggiants/SleepingGiants.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/sleepinggiants/SleepingGiants.java
@@ -351,9 +351,9 @@ public class SleepingGiants extends BasicQuestHelper
 
 		coolDownSword = new ObjectStep(this, NullObjectID.NULL_44777, "Pick up the sword from the mould with a bucket of water or ice gloves equipped.",
 			iceGloves.equipped().showConditioned(iceGloves), bucketOfWater.showConditioned(bucketOfWater).highlighted());
-		coolDownSword.addIcon(ItemID.BUCKET_OF_WATER);
 		fillBucketWaterfall = new ObjectStep(this, ObjectID.WATERFALL_44632,
 			"Fill the bucket with water by using it on the Waterfall.", bucketOfWater);
+		fillBucketWaterfall.addIcon(ItemID.BUCKET);
 
 		takeBucket = new ObjectStep(this, ObjectID.PILE_OF_BUCKETS /* Pile of Buckets */, "Take a Bucket from the Pile of Buckets");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/steps/NpcStep.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/steps/NpcStep.java
@@ -25,6 +25,7 @@
  */
 package net.runelite.client.plugins.questhelper.steps;
 
+import lombok.Getter;
 import net.runelite.client.plugins.questhelper.QuestHelperConfig;
 import net.runelite.client.plugins.questhelper.QuestHelperPlugin;
 import static net.runelite.client.plugins.questhelper.overlays.QuestHelperWorldOverlay.IMAGE_Z_OFFSET;
@@ -66,6 +67,7 @@ public class NpcStep extends DetailedQuestStep
 	public final int npcID;
 	protected final List<Integer> alternateNpcIDs = new ArrayList<>();
 
+	@Getter
 	@Setter
 	protected boolean allowMultipleHighlights;
 

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/agility_shortcuts.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/agility_shortcuts.tsv
@@ -151,4 +151,6 @@
 2768 10002 0	2770 10002 0	Jump-over Strange floor 16544	81 Agility				
 2770 10002 0	2768 10002 0	Jump-over Strange floor 16544	81 Agility				
 3500 9510 2	3506 9505 2	Squeeze-through Crevice 16465	86 Agility				
-3506 9505 2	3500 9510 2	Squeeze-through Crevice 16465	86 Agility				
+3506 9505 2	3500 9510 2	Squeeze-through Crevice 16465	86 Agility
+3308 3491 0	3308 3493 0	Climb-over Broken fence 2618
+3308 3493 0	3308 3491 0	Climb-over Broken fence 2618

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -1338,10 +1338,10 @@
 2557 9844 0	2557 3444 0	Climb-up Ladder 17387				2	
 							
 # Tree Gnome Village Dungeon (during Waterfall quest)							
-2533 3156 0	2533 9556 0	Climb-down Ladder 5250			Waterfall Quest		
-2534 3155 0	2534 9555 0	Climb-down Ladder 5250			Waterfall Quest		
-2532 3155 0	2532 9555 0	Climb-down Ladder 5250			Waterfall Quest		
-2533 9556 0	2533 3156 0	Climb-up Ladder 17387			Waterfall Quest		
+2533 3156 0	2533 9556 0	Climb-down Ladder 5250
+2534 3155 0	2534 9555 0	Climb-down Ladder 5250
+2532 3155 0	2532 9555 0	Climb-down Ladder 5250
+2533 9556 0	2533 3156 0	Climb-up Ladder 17387
 							
 # Tree Gnome Village Dungeon (after Waterfall quest)							
 2533 3156 0	2597 4436 0	Climb-down Ladder 5250			Waterfall Quest		
@@ -4418,3 +4418,19 @@
 2591 3088 0	2591 3092 1	Climb-up Staircase 15645
 2591 3092 1	2590 3088 0	Climb-down Staircase 15648
 2590 3092 1	2590 3088 0	Climb-down Staircase 15648
+
+# Asgarnian ice dungeon
+3008 9550 0	3007 3150 0	Climb-up Ladder 17385
+3008 3150 0	3009 9550 0	Climb-down Trapdoor 1738
+
+# Sawmill
+3310 3508 1	3310 3508 0	Climb-down Ladder 11795
+3310 3508 0	3310 3508 1	Climb-up Ladder 11794
+
+# Desert mining camp
+3290 3035 0	3290 3035 1	Climb-up Ladder 18903
+3290 3037 1	3290 3037 0	Climb-down Ladder 18904
+
+# Kovac
+3366 11483 0	3361 3148 0	Exit Exit 44636
+3361 3148 0	3366 11483 0	Enter Cave 44635


### PR DESCRIPTION
Changes for MQuestScript:
* Re-added the click selection 1 part, if the choices from questhelper are not complete or the "Yes" to start the quest is not included
* Added sleeps to prevent spamming
* Added support for multi-NPC steps
* Added support for using items on NPCs if the widget is displayed by the questhelper
* Rs2Walker target will now be cleared if an Object/NPC is clicked to prevent the walker from aborting the action
* Added support for ground objects
* Added object action validation when interacting with objects that have multiple actions available, as the questhelper step description will most likely contain the correct action to be used 

Different helper changes:
* WorldPointUtil: Fix or the distanceBetween function to respect planes (hard distance of 1000 to make the pathfinder not ignore the tile if it would just return max value), added isPointInPolygon function
* Rs2Walker: Added walkTo and walkMiniMap functions for areas (choosing a random point within), added walk-through action for some tents in the desert, removed hasLineOfSight check for wall- and ground-objects as some transport never pass the line-of-sight check
* Rs2Tile: Fixed the isWalkable function (to not block tiles that are walkable and just have the n/s/w/e flag), added a getWalkableTiles function independent of the player position
* Rs2Npc: Added function to get all npcs by an id
* Rs2Inventory: Fixed the containsAll function to actually check all passed ids, added confirmation for destroy dialogs to the invokeMenu function
* Rs2Widget: Bugfix for the isWidgetVisible function if the widget is not present at all
* Rs2Dialogue: Added multiple widgets to isInDialogue check, and added a function to check if the continue widget is displayed
* Rs2Camera: Bugfix to not use the right key when lowering the pitch
* Rs2Bank: Bugfix for walkToBankAndUseBank as 2d distance calculation leads to the walker stopping on a lower/higher plane
* Rs2GameObject: Extension for clickObject function to use the first not-null action if passing no specific action or the specified action is not found (for some objects the default index would be 1 or 2), added getTileObjects to get all non-gameobject objects by id similar to getGameObjects
* QuestHelper: Added some getters, small fixes in quests to be better automated by quest plugin
* Puzzlesolver: Made VarrockMuseumAnswer accessable from outside the puzzlesolver plugin
* Added quest related transports, and made the waterfall quest transports usable during waterfall quest