### PR TITLE
Improvements for MQuestScript and Rs2Walker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Restriction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Restriction.java
@@ -41,7 +41,7 @@ public class Restriction {
                 Integer.parseInt(parts_point[2]));
 
         // Quest requirements
-        if (!parts[1].isEmpty()) {
+        if (parts.length > 1 && !parts[1].isEmpty()) {
             this.quests = findQuests(parts[1]);
         }
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
@@ -137,6 +137,9 @@ public class ShortestPathPlugin extends Plugin {
     @Setter
     private static boolean startPointSet = false;
 
+    @Setter
+    private static int reachedDistance;
+
     @Provides
     public ShortestPathConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(ShortestPathConfig.class);
@@ -256,12 +259,15 @@ public class ShortestPathPlugin extends Plugin {
             return;
         }
 
-        if (Rs2Player.getWorldLocation().distanceTo(pathfinder.getTarget()) < config.reachedDistance()) {
+        var path = pathfinder.getPath();
+
+        if (Rs2Player.getWorldLocation().distanceTo(pathfinder.getTarget()) < reachedDistance
+                && Rs2Tile.getReachableTilesFromTile(Rs2Player.getWorldLocation(), reachedDistance).containsKey(path.get(path.size() - 1))) {
             setTarget(null);
             if (Microbot.getClientThread().scheduledFuture != null) {
                 Microbot.getClientThread().scheduledFuture.cancel(true);
             }
-            System.out.println("Web Walker finished with reachedDistance " + config.reachedDistance());
+            System.out.println("Web Walker finished with reachedDistance " + reachedDistance);
             return;
         }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
@@ -1035,6 +1035,10 @@ public class Rs2GameObject {
     }
 
     public static boolean hasLineOfSight(TileObject tileObject) {
+        return hasLineOfSight(Rs2Player.getWorldLocation(), tileObject);
+    }
+
+    public static boolean hasLineOfSight(WorldPoint point, TileObject tileObject) {
         if (tileObject == null) return false;
         if (tileObject instanceof GameObject) {
             GameObject gameObject = (GameObject) tileObject;
@@ -1043,14 +1047,14 @@ public class Rs2GameObject {
                     worldPoint,
                     gameObject.sizeX(),
                     gameObject.sizeY())
-                    .hasLineOfSightTo(Microbot.getClient().getTopLevelWorldView(), Microbot.getClient().getLocalPlayer().getWorldLocation().toWorldArea());
+                    .hasLineOfSightTo(Microbot.getClient().getTopLevelWorldView(), point.toWorldArea());
         } else {
             return new WorldArea(
                     tileObject.getWorldLocation(),
                     2,
                     2)
-                    .hasLineOfSightTo(Microbot.getClient().getTopLevelWorldView(), new WorldArea(Rs2Player.getWorldLocation().getX(),
-                            Rs2Player.getWorldLocation().getY(), 2, 2, Rs2Player.getWorldLocation().getPlane()));
+                    .hasLineOfSightTo(Microbot.getClient().getTopLevelWorldView(), new WorldArea(point.getX(),
+                            point.getY(), 2, 2, point.getPlane()));
         }
     }
 
@@ -1089,6 +1093,12 @@ public class Rs2GameObject {
         if (tileObject instanceof GameObject) {
             GameObject gameObject = (GameObject) tileObject;
             WorldPoint worldPoint = WorldPoint.fromScene(Microbot.getClient(), gameObject.getSceneMinLocation().getX(), gameObject.getSceneMinLocation().getY(), gameObject.getPlane());
+
+            if (Microbot.getClient().isInInstancedRegion()){
+                var localPoint = LocalPoint.fromWorld(Microbot.getClient(), worldPoint);
+                worldPoint = WorldPoint.fromLocalInstance(Microbot.getClient(), localPoint);
+            }
+
             objectArea = new WorldArea(
                     worldPoint,
                     gameObject.sizeX(),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/tile/Rs2Tile.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/tile/Rs2Tile.java
@@ -162,7 +162,12 @@ public class Rs2Tile {
             int dist = i;
             for (var kvp : tileDistances.entrySet().stream().filter(x -> x.getValue() == dist).collect(Collectors.toList())) {
                 var point = kvp.getKey();
-                var localPoint = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), point);
+                LocalPoint localPoint;
+                if (Microbot.getClient().isInInstancedRegion()) {
+                    var worldPoint = WorldPoint.toLocalInstance(Microbot.getClient(), point).stream().findFirst().get();
+                    localPoint = LocalPoint.fromWorld(Microbot.getClient(), worldPoint);
+                } else
+                    localPoint = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), point);
 
                 if (Microbot.getClient().getCollisionMaps() != null && localPoint != null) {
                     int[][] flags = Microbot.getClient().getCollisionMaps()[Microbot.getClient().getPlane()].getFlags();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -61,16 +61,18 @@ public class Rs2Walker {
 
 
     public static boolean walkTo(WorldPoint target) {
-        return walkTo(target, 6);
+        return walkTo(target, config.reachedDistance());
     }
 
     public static boolean walkTo(WorldPoint target, int distance) {
-        if (Rs2Player.getWorldLocation().distanceTo(target) <= distance) {
+        if (Rs2Tile.getReachableTilesFromTile(Rs2Player.getWorldLocation(), distance).containsKey(target)
+                || !Rs2Tile.isWalkable(LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), target)) && Rs2Player.getWorldLocation().distanceTo(target) <= distance) {
             return true;
         }
         if (currentTarget != null && currentTarget.equals(target) && ShortestPathPlugin.getMarker() != null && !Microbot.getClientThread().scheduledFuture.isDone())
             return false;
         setTarget(target);
+        ShortestPathPlugin.setReachedDistance(distance);
         stuckCount = 0;
         idle = 0;
         Microbot.getClientThread().runOnSeperateThread(() -> {
@@ -112,7 +114,7 @@ public class Rs2Walker {
                 for (int i = indexOfStartPoint; i < ShortestPathPlugin.getPathfinder().getPath().size() - 1; i++) {
                     WorldPoint currentWorldPoint = ShortestPathPlugin.getPathfinder().getPath().get(i);
 
-                    if (!Rs2Tile.isTileReachable(currentWorldPoint)) {
+                    if (!Rs2Tile.isTileReachable(currentWorldPoint) && !Microbot.getClient().isInInstancedRegion()) {
                         continue;
                     }
 
@@ -163,9 +165,14 @@ public class Rs2Walker {
                     }
                 }
 
-                if (Rs2Tile.getWalkableTilesAroundPlayer(distance).contains(target)) {
+                if (Rs2Tile.getReachableTilesFromTile(Rs2Player.getWorldLocation(), config.reachedDistance()).containsKey(path.get(path.size() - 1))) {
                     System.out.println("walk minimap");
-                    Rs2Walker.walkMiniMap(target);
+
+                    if (Microbot.getClient().isInInstancedRegion())
+                        Rs2Walker.walkFastCanvas(target);
+                    else
+                        Rs2Walker.walkMiniMap(target);
+
                     sleep(600, 1200);
                     System.out.println("sleep walk minimap");
                 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -169,10 +169,10 @@ public class Rs2Walker {
                 if (Rs2Tile.getReachableTilesFromTile(Rs2Player.getWorldLocation(), distance * 2).containsKey(path.get(path.size() - 1))) {
                         System.out.println("walk minimap");
 
-                    if (Microbot.getClient().isInInstancedRegion())
-                        Rs2Walker.walkFastCanvas(target);
-                    else
-                        Rs2Walker.walkMiniMap(target);
+                        if (Microbot.getClient().isInInstancedRegion())
+                            Rs2Walker.walkFastCanvas(target);
+                        else
+                            Rs2Walker.walkMiniMap(target);
 
                         sleep(600, 1200);
                         System.out.println("sleep walk minimap");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/elementalworkshopii/ElementalWorkshopII.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/elementalworkshopii/ElementalWorkshopII.java
@@ -504,10 +504,13 @@ public class ElementalWorkshopII extends BasicQuestHelper
 
 		placeSmallCog = new ObjectStep(this, ObjectID.PIN_18665, new WorldPoint(1959, 5157, 2),
 			"Place the small cog on the top left peg.", smallCog.highlighted());
+		placeSmallCog.addIcon(ItemID.SMALL_COG);
 		placeMediumCog = new ObjectStep(this, ObjectID.PIN, new WorldPoint(1959, 5157, 2),
 			"Place the medium cog on the bottom left peg.", mediumCog.highlighted());
+		placeMediumCog.addIcon(ItemID.MEDIUM_COG);
 		placeLargeCog = new ObjectStep(this, ObjectID.PIN_18666, new WorldPoint(1959, 5157, 2),
 			"Place the large cog on the right peg.", largeCog.highlighted());
+		placeLargeCog.addIcon(ItemID.LARGE_COG);
 
 		placeBar = new NpcStep(this, NpcID.JIG_CART, new WorldPoint(1954, 5147, 2), "Place the elemental bar on the " +
 			"jig cart.", elementalBar.highlighted());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/toweroflife/PuzzleSolver.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/helpers/quests/toweroflife/PuzzleSolver.java
@@ -219,34 +219,33 @@ public class PuzzleSolver
 
 			for (PipeSolverSolution soln : pipeSolverSolutions)
 			{
-				if (soln.isSelected())
+				if ((soln.isRight() || soln.isLeft() || soln.isBelow() || soln.isAbove()) && !soln.isSelected())
 				{
-					if (!soln.isSelected())
-					{
-						highlights.add(soln.pieceInfo);
-					}
-					else if (!soln.isOriented())
-					{ //Rotate
-						highlights.add(PIPE_CTRL_ROTATE);
-					}
-					else if (soln.isRight())
-					{ //Align horizontal
-						highlights.add(PIPE_CTRL_LEFT);
-					}
-					else if (soln.isLeft())
-					{ //Align horizontal
-						highlights.add(PIPE_CTRL_RIGHT);
-					}
-					else if (soln.isBelow())
-					{ //Align vertical
-						highlights.add(PIPE_CTRL_UP);
-					}
-					else if (soln.isAbove())
-					{ //Align vertical
-						highlights.add(PIPE_CTRL_DOWN);
-					}
-					return highlights;
+					highlights.add(soln.pieceInfo);
 				}
+				else if ((soln.isRight() || soln.isLeft() || soln.isBelow() || soln.isAbove()) && !soln.isOriented())
+				{ //Rotate
+					highlights.add(PIPE_CTRL_ROTATE);
+				}
+				else if (soln.isRight())
+				{ //Align horizontal
+					highlights.add(PIPE_CTRL_LEFT);
+				}
+				else if (soln.isLeft())
+				{ //Align horizontal
+					highlights.add(PIPE_CTRL_RIGHT);
+				}
+				else if (soln.isBelow())
+				{ //Align vertical
+					highlights.add(PIPE_CTRL_UP);
+				}
+				else if (soln.isAbove())
+				{ //Align vertical
+					highlights.add(PIPE_CTRL_DOWN);
+				}
+
+				if (!highlights.isEmpty())
+					return highlights;
 			}
 
 			return highlights;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/steps/DetailedQuestStep.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/steps/DetailedQuestStep.java
@@ -119,6 +119,7 @@ public class DetailedQuestStep extends QuestStep
 
 	protected boolean started;
 
+	@Getter
 	@Setter
 	protected boolean hideWorldArrow;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/steps/PuzzleStep.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questhelper/steps/PuzzleStep.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.questhelper.steps;
 
+import lombok.Getter;
 import net.runelite.client.plugins.questhelper.QuestHelperPlugin;
 import net.runelite.client.plugins.questhelper.questhelpers.QuestHelper;
 import net.runelite.client.plugins.questhelper.requirements.Requirement;
@@ -14,6 +15,7 @@ public class PuzzleStep extends DetailedQuestStep
 {
 
 	ButtonHighlighCalculator highlightCalculator;
+	@Getter
 	private HashSet<WidgetDetails> highlightedButtons = new HashSet<>();
 
 	public PuzzleStep(QuestHelper questHelper, ButtonHighlighCalculator highlightCalculator, Requirement... requirements)


### PR DESCRIPTION
Improvements for MQuestScript:

* Added handling of puzzle steps
* Added caching of the current quest step once a dialogue is started to abort the dialogue once the current step changed (improves quest speed and prevents being stuck in dialogues that are repeating)
* Added chooseCorrectNPCOption similar to chooseCorrectObjectOption
* Added handling of multi-object tasks
* Improved walking to objects by choosing a neighbor tile from which the object is visible
* Added sleeps after object interaction

Improvements for Rs2Walker:
* Modified end-condition to check if the target is reachable from the current player position (without doors in its way). Previously the walker could stop in front of doors, which prevents interaction with tiles behind the door and thereby required manual checks.
* Added checks for instanced regions
* Replaced getWalkableTilesAroundPlayer with getReachableTilesFromTile to guarantee that the final click is actually reachable
* Added usage of the passed distance for the end-condition and replaced the hard-coded default walking distance of 6 with the reachedDistance set in the config

Other changes:
* Restriction: Added failsafe for shorter restriction definitions
* Rs2GameObject: Added hasLineOfSight function for custom WorldPoints (used in MQuestScript), added fix for canWalkTo in instanced areas
* Rs2Tile: Added fix for getReachableTilesFromTile in instanced areas
* Added getters and minor fixes in questhelpers