### PR TITLE
Walker improvements (follow-up)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -117,6 +117,7 @@ public class Rs2Walker {
                     /**
                      * MAIN WALK LOOP
                      */
+                    boolean doorOrTransportResult = false;
                     for (int i = indexOfStartPoint; i < path.size(); i++) {
                         WorldPoint currentWorldPoint = path.get(i);
 
@@ -130,7 +131,7 @@ public class Rs2Walker {
                         Microbot.status = "Checking for doors...";
                         long startTime = System.currentTimeMillis();
 
-                        boolean doorOrTransportResult = handleDoors(path, i);
+                        doorOrTransportResult = handleDoors(path, i);
                         if (doorOrTransportResult) {
                             break;
                         }
@@ -172,19 +173,21 @@ public class Rs2Walker {
                             }
                         }
                     }
-                    
-                    var moveableTiles = Rs2Tile.getReachableTilesFromTile(path.get(path.size() - 1), Math.min(3, distance)).keySet().toArray(new WorldPoint[0]);
-                    var finalTile = moveableTiles.length > 0 ? moveableTiles[Random.random(0, moveableTiles.length)] : path.get(path.size() - 1);
-                    if (Rs2Tile.isTileReachable(finalTile)) {
-                        System.out.println("walk minimap");
 
-                        if (Microbot.getClient().isInInstancedRegion())
-                            Rs2Walker.walkFastCanvas(finalTile);
-                        else
-                            Rs2Walker.walkMiniMap(finalTile);
+                    if (!doorOrTransportResult){
+                        var moveableTiles = Rs2Tile.getReachableTilesFromTile(path.get(path.size() - 1), Math.min(3, distance)).keySet().toArray(new WorldPoint[0]);
+                        var finalTile = moveableTiles.length > 0 ? moveableTiles[Random.random(0, moveableTiles.length)] : path.get(path.size() - 1);
+                        if (Rs2Tile.isTileReachable(finalTile)) {
+                            System.out.println("walk minimap");
 
-                        sleep(600, 1200);
-                        System.out.println("sleep walk minimap");
+                            if (Microbot.getClient().isInInstancedRegion())
+                                Rs2Walker.walkFastCanvas(finalTile);
+                            else
+                                Rs2Walker.walkMiniMap(finalTile);
+
+                            sleep(600, 1200);
+                            System.out.println("sleep walk minimap");
+                        }
                     }
                 }
                 return Rs2Player.getWorldLocation().distanceTo(target) < distance;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -172,14 +172,16 @@ public class Rs2Walker {
                             }
                         }
                     }
-
-                    if (Rs2Tile.isTileReachable(path.get(path.size() - 1))) {
+                    
+                    var moveableTiles = Rs2Tile.getReachableTilesFromTile(path.get(path.size() - 1), Math.min(3, distance)).keySet().toArray(new WorldPoint[0]);
+                    var finalTile = moveableTiles.length > 0 ? moveableTiles[Random.random(0, moveableTiles.length)] : path.get(path.size() - 1);
+                    if (Rs2Tile.isTileReachable(finalTile)) {
                         System.out.println("walk minimap");
 
                         if (Microbot.getClient().isInInstancedRegion())
-                            Rs2Walker.walkFastCanvas(target);
+                            Rs2Walker.walkFastCanvas(finalTile);
                         else
-                            Rs2Walker.walkMiniMap(target);
+                            Rs2Walker.walkMiniMap(finalTile);
 
                         sleep(600, 1200);
                         System.out.println("sleep walk minimap");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -660,7 +660,9 @@ public class Rs2Walker {
                         List<TileObject> tileObjects = Rs2GameObject.getTileObjects(b.getObjectId(), b.getOrigin());
                         TileObject tileObject = tileObjects.stream().findFirst().orElse(null);
                         if (tileObject instanceof GroundObject)
-                            tileObject = tileObjects.stream().min(Comparator.comparing(x -> x.getWorldLocation().distanceTo(b.getDestination()))).orElse(null);
+                            tileObject = tileObjects.stream()
+                                    .filter(x -> !x.getWorldLocation().equals(Rs2Player.getWorldLocation()))
+                                    .min(Comparator.comparing(x -> x.getWorldLocation().distanceTo(b.getOrigin()))).orElse(null);
 
                         if (tileObject != null && tileObject.getId() == b.getObjectId()) {
                             boolean interact = Rs2GameObject.interact(tileObject, b.getAction(), true);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -662,7 +662,8 @@ public class Rs2Walker {
                         if (tileObject instanceof GroundObject)
                             tileObject = tileObjects.stream()
                                     .filter(x -> !x.getWorldLocation().equals(Rs2Player.getWorldLocation()))
-                                    .min(Comparator.comparing(x -> x.getWorldLocation().distanceTo(b.getOrigin()))).orElse(null);
+                                    .min(Comparator.comparing(x -> ((TileObject)x).getWorldLocation().distanceTo(b.getOrigin()))
+                                            .thenComparing(x -> ((TileObject)x).getWorldLocation().distanceTo(b.getDestination()))).orElse(null);
 
                         if (tileObject != null && tileObject.getId() == b.getObjectId()) {
                             boolean interact = Rs2GameObject.interact(tileObject, b.getAction(), true);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -99,8 +99,12 @@ public class Rs2Walker {
                         break;
                     }
 
+                    //avoid tree attacking you in draynor
+                    checkIfStuck();
                     if (stuckCount > 10) {
-                        setTarget(null);
+                        var moveableTiles = Rs2Tile.getReachableTilesFromTile(Rs2Player.getWorldLocation(), 5).keySet().toArray(new WorldPoint[0]);
+                        walkMiniMap(moveableTiles[Random.random(0, moveableTiles.length)]);
+                        sleep(600, 1000);
                     }
 
                     List<WorldPoint> path = ShortestPathPlugin.getPathfinder().getPath();
@@ -166,8 +170,6 @@ public class Rs2Walker {
                                 }
                                 break;
                             }
-                            //avoid tree attacking you in draynor
-                            checkIfStuck();
                         }
                     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -77,7 +77,7 @@ public class Rs2Walker {
         idle = 0;
         Microbot.getClientThread().runOnSeperateThread(() -> {
             try {
-                while (!Thread.currentThread().isInterrupted() && true) {
+                while (!Thread.currentThread().isInterrupted()) {
                     if (!Microbot.isLoggedIn()) {
                         setTarget(null);
                         break;
@@ -149,8 +149,7 @@ public class Rs2Walker {
                             continue;
                         }
 
-                        if (currentWorldPoint.distanceTo2D(Rs2Player.getWorldLocation()) > 10
-                                || Rs2Player.getWorldLocation().distanceTo(target) < 12 && currentWorldPoint.distanceTo2D(Rs2Player.getWorldLocation()) > distance) {
+                        if (currentWorldPoint.distanceTo2D(Rs2Player.getWorldLocation()) > 10) {
                             // InstancedRegions require localPoint instead of worldpoint to navigate
                             if (Microbot.getClient().isInInstancedRegion()) {
                                 Rs2Walker.walkFastCanvas(currentWorldPoint);
@@ -170,10 +169,7 @@ public class Rs2Walker {
                         }
                     }
 
-                    if (Rs2Player.getWorldLocation().distanceTo(target) < distance) return true;
-
-
-                    if (Rs2Tile.getReachableTilesFromTile(Rs2Player.getWorldLocation(), 12).containsKey(path.get(path.size() - 1))) {
+                    if (Rs2Tile.isTileReachable(path.get(path.size() - 1))) {
                         System.out.println("walk minimap");
 
                         if (Microbot.getClient().isInInstancedRegion())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -41,6 +41,7 @@ public class Rs2Walker {
     static WorldPoint lastPosition;
     static int idle = 0;
     static WorldPoint currentTarget;
+    static int nextWalkingDistance = 10;
 
     public static boolean walkTo(WorldArea area, int distanceThreshold) {
         if (area.distanceTo(Rs2Player.getWorldLocation()) > distanceThreshold) {
@@ -149,7 +150,8 @@ public class Rs2Walker {
                             continue;
                         }
 
-                        if (currentWorldPoint.distanceTo2D(Rs2Player.getWorldLocation()) > 10) {
+                        if (currentWorldPoint.distanceTo2D(Rs2Player.getWorldLocation()) > nextWalkingDistance) {
+                            nextWalkingDistance = Random.random(7, 11);
                             // InstancedRegions require localPoint instead of worldpoint to navigate
                             if (Microbot.getClient().isInInstancedRegion()) {
                                 Rs2Walker.walkFastCanvas(currentWorldPoint);


### PR DESCRIPTION
Follow-up adjustments regarding my last PR:
* Fixed ground object transports (especially for agility shortcuts) that have multiple objects with the same id, where the distance to destination sorting would select a wrong object. Changed to sorting by origin and filtering out the players location.

Further changes:
* Changed condition for the final click from getReachableTilesFromTile to isTileReachable. This makes it also catch targets that are behind a wall with a walking distance > 12 tiles. This way, the temp-fix for wintertodt could also be removed (and should be, since it prevents the final click).
* Moved the stuck prevention out of the walker loop since the player could also get stuck in front of transports. Additionally, changed the stuck handling from abortion to a random movement of up to 5 tiles. Aborting would not have any effect if a script calls the walker as it would most likely just re-set the same target.
* Added randomisation to the walking distance and the final destination (within the set destination parameters) to make the walker more human-like
* Moved the doorOrTransportResult out of the loop and only do the target click if no transport/door was handled before. This prevents clicks behind transports/doors.