### PR TITLE
Break Handler LockState & Utility changes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/Microbot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/Microbot.java
@@ -161,7 +161,8 @@ public class Microbot {
         GameState idx = client.getGameState();
         return idx == GameState.LOGGED_IN;
     }
-
+    
+    @Deprecated(since = "1.4.0 - use Rs2Player variant", forRemoval = true)
     public static boolean hasLevel(int levelRequired, Skill skill) {
         return Microbot.getClient().getRealSkillLevel(skill) >= levelRequired;
     }
@@ -314,7 +315,6 @@ public class Microbot {
                 Microbot.getClient().addChatMessage(ChatMessageType.ENGINE, "", "[" + formattedTime + "]: " + message, "", false)
         );
     }
-
     private static boolean isPluginEnabled(String name) {
         Plugin dashboard = Microbot.getPluginManager().getPlugins().stream()
                 .filter(x -> x.getClass().getName().equals(name))
@@ -324,6 +324,10 @@ public class Microbot {
         if (dashboard == null) return false;
 
         return Microbot.getPluginManager().isPluginEnabled(dashboard);
+    }
+    
+    public static boolean isPluginEnabled(Class c) {
+        return isPluginEnabled(c.getName());
     }
 }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
@@ -1,5 +1,7 @@
 package net.runelite.client.plugins.microbot.breakhandler;
 
+import lombok.Getter;
+import lombok.Setter;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.util.math.Random;
@@ -21,6 +23,10 @@ public class BreakHandlerScript extends Script {
     public static int totalBreaks = 0;
 
     public static Duration duration;
+    
+    @Setter
+    @Getter
+    public static boolean lockState = false;
 
     private String title = "";
     public boolean run(BreakHandlerConfig config) {
@@ -52,7 +58,7 @@ public class BreakHandlerScript extends Script {
                     return;
                 }
 
-                if (breakIn <= 0 && !Microbot.pauseAllScripts) {
+                if (breakIn <= 0 && !Microbot.pauseAllScripts && !isLockState()) {
                     Microbot.pauseAllScripts = true;
                     breakDuration = Random.random(config.breakDurationStart() * 60, config.breakDurationEnd() * 60);
                     if (config.logoutAfterBreak())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissScript.java
@@ -24,8 +24,10 @@ public class EventDismissScript extends Script {
 
                 if (npc != null) {
                     if (shouldDismissNpc(npc, config)) {
+                        Microbot.pauseAllScripts = true;
                         dismissNpc(npc);
                     } else if (!Rs2Inventory.isFull()) {
+                        Microbot.pauseAllScripts = true;
                         talkToNPC(npc);
                     }
                 }
@@ -97,6 +99,7 @@ public class EventDismissScript extends Script {
     private void dismissNpc(NPC npc) {
         // Interact with NPC to dismiss it
         Rs2Npc.interact(npc, "Dismiss");
+        Microbot.pauseAllScripts = false;
     }
 
     private void talkToNPC(NPC npc) {
@@ -104,5 +107,6 @@ public class EventDismissScript extends Script {
         Rs2Npc.interact(npc, "Talk-to");
         sleep(1200);
         Rs2Dialogue.clickContinue();
+        Microbot.pauseAllScripts = false;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
@@ -12,6 +12,7 @@ import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
+import net.runelite.client.plugins.microbot.util.misc.Rs2Potion;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.shop.Rs2Shop;
@@ -1806,23 +1807,8 @@ public class Rs2Inventory {
      *
      */
     public static void useRestoreEnergyItem() {
-        String staminaRestoreItemName = "Stamina potion";
-        List<String> restoreEnergyItemNames = Arrays.asList("Super energy", "Super energy mix", "Energy potion", "Energy mix");
-        Pattern pattern = Pattern.compile("^(.*?)(?:\\(\\d+\\))?$");
-
-        List<Rs2Item> filteredRestoreEnergyItems = items().stream()
-                .filter(item -> {
-                    Matcher matcher = pattern.matcher(item.getName());
-                    return matcher.matches() && restoreEnergyItemNames.contains(matcher.group(1).trim());
-                })
-                .collect(Collectors.toList());
-
-        List<Rs2Item> filteredStaminaRestoreItems = items().stream()
-                .filter(item -> {
-                    Matcher matcher = pattern.matcher(item.getName());
-                    return matcher.matches() && staminaRestoreItemName.equals(matcher.group(1).trim());
-                })
-                .collect(Collectors.toList());
+        List<Rs2Item> filteredRestoreEnergyItems = getFilteredPotionItemsInInventory(Rs2Potion.getRestoreEnergyPotionsVariants());
+        List<Rs2Item> filteredStaminaRestoreItems = getFilteredPotionItemsInInventory(Rs2Potion.getStaminaPotion());
         
         if (filteredStaminaRestoreItems.isEmpty() && filteredRestoreEnergyItems.isEmpty()) return;
 
@@ -1835,6 +1821,32 @@ public class Rs2Inventory {
                 Rs2Inventory.interact(filteredStaminaRestoreItems.stream().findFirst().get().name, "drink");
             }
         }
+    }
+
+    /**
+     * Method fetches list of potion items in Inventory, will ignore uses
+     *
+     * @param potionName Potion Name
+     * @return List of Potion Items in Inventory
+     */
+    public static List<Rs2Item> getFilteredPotionItemsInInventory(String potionName) {
+        return getFilteredPotionItemsInInventory(Arrays.asList(potionName));
+    }
+    
+    /**
+     * Method fetches list of potion items in Inventory, will ignore uses
+     *
+     * @param potionNames List of Potion Names
+     * @return List of Potion Items in Inventory
+     */
+    public static List<Rs2Item> getFilteredPotionItemsInInventory(List<String> potionNames) {
+        Pattern usesRegexPattern = Pattern.compile("^(.*?)(?:\\(\\d+\\))?$");
+        return getPotions().stream()
+                .filter(item -> {
+                    Matcher matcher = usesRegexPattern.matcher(item.getName());
+                    return matcher.matches() && potionNames.contains(matcher.group(1).trim());
+                })
+                .collect(Collectors.toList());
     }
     /**
      * Method executes menu actions

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/misc/Rs2Potion.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/misc/Rs2Potion.java
@@ -11,4 +11,12 @@ public class Rs2Potion {
     public static List<String> getRangePotionsVariants() {
         return Arrays.asList("ranging potion", "bastion potion", "divine bastion potion");
     }
+
+    public static String getStaminaPotion() {
+        return "Stamina potion";
+    }
+    
+    public static List<String> getRestoreEnergyPotionsVariants() {
+        return Arrays.asList("Super energy", "Super energy mix", "Energy potion", "Energy mix");
+    }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -318,19 +318,23 @@ public class Rs2Player {
         return Microbot.getClientThread().runOnClientThread(() -> quest.getState(client));
     }
 
-    public static int getRealSkillLevel(Skill skill){
+    public static int getRealSkillLevel(Skill skill) {
         Client client = Microbot.getClient();
         return client.getRealSkillLevel(skill);
     }
 
-    public static int getBoostedSkillLevel(Skill skill){
+    public static int getBoostedSkillLevel(Skill skill) {
         Client client = Microbot.getClient();
         return client.getBoostedSkillLevel(skill);
     }
 
-    public static boolean getSkillRequirement(Skill skill, int levelRequired, boolean isBoosted){
+    public static boolean getSkillRequirement(Skill skill, int levelRequired, boolean isBoosted) {
         if (isBoosted) return getBoostedSkillLevel(skill) >= levelRequired;
         return getRealSkillLevel(skill) >= levelRequired;
+    }
+ 
+    public static boolean getSkillRequirement(Skill skill, int levelRequired) {
+        return getSkillRequirement(skill, levelRequired, false);
     }
 
     public static boolean isIronman() {
@@ -338,7 +342,7 @@ public class Rs2Player {
         return accountType > 0 && accountType <= 3;
     }
 
-    public static boolean isGroupIronman(){
+    public static boolean isGroupIronman() {
         int accountType = Microbot.getVarbitValue(Varbits.ACCOUNT_TYPE);
         return accountType >= 4;
     }


### PR DESCRIPTION
I am going to be opening two PRs to separate my changes here, this will include the break handler change & some small bug fixes.

Features: 
1. Added functionality to the BreakHandler Plugin to allow developers to lock the break handler to prevent breaks in crucial moments of botting. For example, fighting a boss in a instance or fighting wintertodt?
```java
// Lock BreakHandler
if (isPluginEnabled(BreakHandlerPlugin.class)) {
    BreakHandlerScript.setLockState(true);
}
// Unlock BreakHandler
if (isPluginEnabled(BreakHandlerPlugin.class)) {
    BreakHandlerScript.setLockState(true);
}
```

Fixes:
1. Event Dismiss: added Microbot.pauseAllScripts to avoid other scripts from interfering when dismissing random npcs
2. Added Deprecated to Microbot.hasLevel - This seems redundant considering Rs2Player?
3. Cleaned up Stamina Regeneration Logic