### PR TITLE
Development

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/fletching/FletchingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/fletching/FletchingScript.java
@@ -94,16 +94,16 @@ public class FletchingScript extends Script {
         Rs2Bank.openBank();
 
         // make sure there's no long bows left
-            if (fletchingMode == FletchingMode.STRUNG) {
-                Rs2Bank.depositAll();
-            } else if (fletchingMode == FletchingMode.PROGRESSIVE) {
-                Rs2Bank.depositAll(model.getFletchingItem().getContainsInventoryName());
-                calculateItemToFletch();
-                secondaryItemToFletch = (model.getFletchingMaterial().getName() + " logs").trim();
-            } else {
-                // make sure there's no long bows left
-                Rs2Bank.depositAll(config.fletchingItem().getContainsInventoryName());
-            }
+        if (fletchingMode == FletchingMode.STRUNG) {
+            Rs2Bank.depositAll();
+        } else if (fletchingMode == FletchingMode.PROGRESSIVE) {
+            Rs2Bank.depositAll(model.getFletchingItem().getContainsInventoryName());
+            calculateItemToFletch();
+            secondaryItemToFletch = (model.getFletchingMaterial().getName() + " logs").trim();
+        } else {
+            // make sure there's no long bows left
+            Rs2Bank.depositAll(config.fletchingItem().getContainsInventoryName());
+        }
 
 
         if (Rs2Bank.isOpen() && !Rs2Bank.hasItem(primaryItemToFletch) && !Rs2Inventory.hasItem(primaryItemToFletch)) {
@@ -165,6 +165,7 @@ public class FletchingScript extends Script {
         sleepUntil(() -> Rs2Widget.getWidget(17694736) == null);
         Rs2Antiban.actionCooldown();
         Rs2Antiban.takeMicroBreakByChance();
+        Rs2Bank.preHover();
         if (fletchingMode == FletchingMode.PROGRESSIVE) {
             sleepUntil(() -> !Rs2Inventory.hasItemAmount(secondaryItemToFletch, model.getFletchingItem().getAmountRequired()) || hasLeveledUp, 60000);
         } else {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLConfig.java
@@ -19,12 +19,34 @@ public interface QoLConfig extends Config {
 
     // boolean to use Withdraw-Last from bank
     @ConfigItem(
-            keyName = "useWithdrawLast",
-            name = "Use Withdraw-Last",
-            description = "Use Withdraw-Last",
+            keyName = "useDoLastBank",
+            name = "Use Do-Last Bank",
+            description = "Use Do-Last Bank",
             position = 1
     )
-    default boolean useWithdrawLast() {
+    default boolean useDoLastBank() {
+        return true;
+    }
+
+    // boolean to use DoLast action on furnace
+    @ConfigItem(
+            keyName = "useDoLastFurnace",
+            name = "Use Do-Last Furnace",
+            description = "Use Do-Last Furnace",
+            position = 2
+    )
+    default boolean useDoLastFurnace() {
+        return true;
+    }
+
+    // boolean to use Dialogue auto continue
+    @ConfigItem(
+            keyName = "useDialogueAutoContinue",
+            name = "Dialogue Auto Continue",
+            description = "Use Dialogue Auto Continue",
+            position = 3
+    )
+    default boolean useDialogueAutoContinue() {
         return true;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
@@ -12,6 +12,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
@@ -19,6 +20,7 @@ import java.awt.*;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Consumer;
 
 @PluginDescriptor(
         name = PluginDescriptor.See1Duck + "QoL",
@@ -29,9 +31,11 @@ import java.util.List;
 @Slf4j
 public class QoLPlugin extends Plugin {
     public static String version = "1.0.0";
-    public static List<NewMenuEntry> menuEntries = new LinkedList<>();
+    public static List<NewMenuEntry> bankMenuEntries = new LinkedList<>();
+    public static List<NewMenuEntry> furnaceMenuEntries = new LinkedList<>();
     public static boolean recordActions = false;
-    public static boolean executeActions = false;
+    public static boolean executeBankActions = false;
+    public static boolean executeFurnaceActions = false;
     @Inject
     QoLScript qoLScript;
     @Inject
@@ -61,15 +65,26 @@ public class QoLPlugin extends Plugin {
 
     @Subscribe
     private void onMenuOptionClicked(MenuOptionClicked event) {
-        if (Rs2Bank.isOpen() && recordActions) {
+        if (Rs2Bank.isOpen() && config.useDoLastBank() && recordActions) {
             MenuEntry menuEntry = event.getMenuEntry();
             if (menuEntry.getOption().contains("Withdraw")) {
             }
             NewMenuEntry cachedMenuEntry = new NewMenuEntry(menuEntry.getOption(), menuEntry.getTarget(), menuEntry.getIdentifier(), menuEntry.getType(), menuEntry.getParam0(), menuEntry.getParam1(), menuEntry.isForceLeftClick());
             cachedMenuEntry.setItemId(menuEntry.getItemId());
             cachedMenuEntry.setWidget(menuEntry.getWidget());
-            menuEntries.add(cachedMenuEntry);
+            bankMenuEntries.add(cachedMenuEntry);
             if (menuEntry.getOption().equals("Close")) {
+                recordActions = false;
+                Microbot.log("<col=C3352B>Stopped recording actions</col>");
+            }
+        }
+        if (Rs2Widget.isProductionWidgetOpen() && config.useDoLastFurnace() && recordActions) {
+            MenuEntry menuEntry = event.getMenuEntry();
+            NewMenuEntry cachedMenuEntry = new NewMenuEntry(menuEntry.getOption(), menuEntry.getTarget(), menuEntry.getIdentifier(), menuEntry.getType(), menuEntry.getParam0(), menuEntry.getParam1(), menuEntry.isForceLeftClick());
+            cachedMenuEntry.setItemId(menuEntry.getItemId());
+            cachedMenuEntry.setWidget(menuEntry.getWidget());
+            furnaceMenuEntries.add(cachedMenuEntry);
+            if (menuEntry.getOption().equals("Make sets:") || menuEntry.getOption().equals("Smelt")) {
                 recordActions = false;
                 Microbot.log("<col=C3352B>Stopped recording actions</col>");
             }
@@ -79,42 +94,64 @@ public class QoLPlugin extends Plugin {
 
     @Subscribe
     private void onMenuEntryAdded(MenuEntryAdded event) {
-        if (!config.useWithdrawLast()) return;
-        if (event.getOption().equals("Talk-to")) {
-            List<MenuEntry> entries = new LinkedList<>(Arrays.asList(Microbot.getClient().getMenuEntries()));
-            if (entries.stream().anyMatch(e -> e.getOption().equals("Bank") && e.getTarget().equals(event.getTarget()))) {
-                event.getMenuEntry().setDeprioritized(true);
+        if (config.useDoLastBank()) {
+            if (event.getOption().equals("Talk-to")) {
+                List<MenuEntry> entries = new LinkedList<>(Arrays.asList(Microbot.getClient().getMenuEntries()));
+                if (entries.stream().anyMatch(e -> e.getOption().equals("Bank") && e.getTarget().equals(event.getTarget()))) {
+                    event.getMenuEntry().setDeprioritized(true);
+                }
+            }
+            if (event.getOption().equals("Bank")) {
+                event.getMenuEntry().onClick(this::recordNewActions);
+
+                addMenuEntry(event, "<col=FFA500>Do-Last</col>", event.getTarget(), this::customBankingOnClicked);
             }
         }
-        if (event.getOption().equals("Bank")) {
-            event.getMenuEntry().onClick(this::recordNewActions);
-
-            addMenuEntry(event, "<col=FFA500>Withdraw-Last</col>", event.getTarget());
+        if (config.useDoLastFurnace()) {
+            if (event.getOption().equals("Smelt")) {
+                event.getMenuEntry().onClick(this::recordNewActions);
+                addMenuEntry(event, "<col=FFA500>Do-Last</col>", event.getTarget(), this::customFurnaceOnClicked);
+            }
         }
+    }
 
+    private void customBankingOnClicked(MenuEntry event) {
+        recordActions = false;
+        Microbot.log("<col=337C12>Banking</col>");
+        executeBankActions();
 
     }
 
-    private void customOnClicked(MenuEntry event) {
+    private void customFurnaceOnClicked(MenuEntry event) {
         recordActions = false;
-        Microbot.log("<col=337C12>Banking</col>");
-        executeActions();
+        Microbot.log("<col=337C12>Furnace</col>");
+        executeFurnaceActions();
 
     }
 
     private void recordNewActions(MenuEntry event) {
         recordActions = true;
-        menuEntries.clear();
+        if (event.getOption().equals("Bank")) {
+            bankMenuEntries.clear();
+        }
+        if (event.getOption().equals("Smelt")) {
+            furnaceMenuEntries.clear();
+        }
         Microbot.log("<col=337C12>Recording actions</col>");
 
     }
 
-    private void executeActions() {
-        executeActions = true;
+    private void executeBankActions() {
+        executeBankActions = true;
 
     }
 
-    private void addMenuEntry(MenuEntryAdded event, String option, String target) {
+    private void executeFurnaceActions() {
+        executeFurnaceActions = true;
+
+    }
+
+    private void addMenuEntry(MenuEntryAdded event, String option, String target, Consumer<MenuEntry> callback) {
         List<MenuEntry> entries = new LinkedList<>(Arrays.asList(Microbot.getClient().getMenuEntries()));
 
         if (entries.stream().anyMatch(e -> e.getOption().equals(option) && e.getTarget().equals(target))) {
@@ -128,7 +165,7 @@ public class QoLPlugin extends Plugin {
                 .setParam1(event.getActionParam1())
                 .setIdentifier(event.getIdentifier())
                 .setType(event.getMenuEntry().getType())
-                .onClick(this::customOnClicked);
+                .onClick(callback);
 
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLScript.java
@@ -4,73 +4,142 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcManager;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-
 @Slf4j
 public class QoLScript extends Script {
 
-    public boolean bankOpen = false;
+    private final boolean bankOpen = false;
 
     public boolean run(QoLConfig config) {
         Microbot.enableAutoRunOn = false;
-        try {
-            Rs2NpcManager.loadJson();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        loadNpcData();
+
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                if (!Microbot.isLoggedIn()) return;
-                if (!super.run()) {
-                    return;
+                if (!Microbot.isLoggedIn() || !super.run()) return;
+
+                if (QoLPlugin.executeBankActions) {
+                    handleBankActions();
                 }
 
-                if (QoLPlugin.executeActions) {
-                    sleepUntil(Rs2Bank::isOpen, 10000);
-                    if (!Rs2Bank.isOpen()) {
-                        Microbot.log("Bank did not open");
-                        QoLPlugin.executeActions = false;
-                        return;
-                    }
-                    for (NewMenuEntry menuEntry : QoLPlugin.menuEntries) {
-                        Microbot.log("Executing action: " + menuEntry.getOption() + " " + menuEntry.getTarget());
-                        if (menuEntry.getOption().contains("Withdraw")) {
-                            int itemTab = Rs2Bank.getItemTabForBankItem(menuEntry.getParam0());
-                            if (!Rs2Bank.isTabOpen(itemTab)) {
-                                Microbot.log("Switching to tab: " + itemTab);
-                                Rs2Bank.openTab(itemTab);
-                                sleepUntil(() -> Rs2Bank.isTabOpen(itemTab), 5000);
-                                Rs2Bank.scrollBankToSlot(menuEntry.getParam0());
-                                Rs2Random.wait(200, 500);
-                                menuEntry.setWidget(Rs2Bank.getItemWidget(menuEntry.getParam0()));
-                            }
-                            Rs2Bank.scrollBankToSlot(menuEntry.getParam0());
-                            Rs2Random.wait(200, 500);
-                        }
-                        Microbot.doInvoke(menuEntry, Objects.requireNonNull(menuEntry.getWidget()).getBounds());
-                        Rs2Random.wait(200, 500);
-                    }
-                    QoLPlugin.executeActions = false;
+                if (QoLPlugin.executeFurnaceActions) {
+                    handleFurnaceActions();
                 }
 
+                if (config.useDialogueAutoContinue() && Rs2Dialogue.isInDialogue()) {
+                    handleDialogueContinue();
+                }
 
             } catch (Exception ex) {
-                System.out.println(ex.getMessage());
+                log.error("Error in QoLScript execution: {}", ex.getMessage(), ex);
             }
-        }, 0, 2000, TimeUnit.MILLISECONDS);
+        }, 0, 600, TimeUnit.MILLISECONDS);
         return true;
     }
 
+    private void loadNpcData() {
+        try {
+            Rs2NpcManager.loadJson();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load NPC data", e);
+        }
+    }
+
+    // handle dialogue continue
+    private void handleDialogueContinue() {
+        Rs2Dialogue.clickContinue();
+    }
+
+    private void handleBankActions() {
+        if (!openBank()) {
+            log.warn("Bank did not open");
+            QoLPlugin.executeBankActions = false;
+            return;
+        }
+
+        for (NewMenuEntry menuEntry : QoLPlugin.bankMenuEntries) {
+            processBankMenuEntry(menuEntry);
+        }
+        QoLPlugin.executeBankActions = false;
+    }
+
+    private boolean openBank() {
+        sleepUntil(Rs2Bank::isOpen, 10000);
+        return Rs2Bank.isOpen();
+    }
+
+    private void processBankMenuEntry(NewMenuEntry menuEntry) {
+        log.info("Executing action: {} {}", menuEntry.getOption(), menuEntry.getTarget());
+
+        if (menuEntry.getOption().contains("Withdraw")) {
+            int itemTab = Rs2Bank.getItemTabForBankItem(menuEntry.getParam0());
+            openAndScrollToTab(itemTab, menuEntry);
+        } else if (menuEntry.getOption().contains("Deposit") &&
+                !menuEntry.getOption().equals("Deposit inventory") &&
+                !menuEntry.getOption().equals("Deposit worn items")) {
+
+            if (Rs2Inventory.isSlotEmpty(menuEntry.getParam0())) {
+                int nonEmptySlot = Rs2Inventory.slot(menuEntry.getItemId());
+                if (nonEmptySlot != -1) {
+                    menuEntry.setParam0(nonEmptySlot);
+                } else {
+                    log.info("No item found in inventory to deposit, skipping action");
+                    return;
+                }
+            }
+        }
+        Microbot.doInvoke(menuEntry, Objects.requireNonNull(menuEntry.getWidget()).getBounds());
+        Rs2Random.wait(200, 500);
+    }
+
+    private void openAndScrollToTab(int itemTab, NewMenuEntry menuEntry) {
+        if (!Rs2Bank.isTabOpen(itemTab)) {
+            log.info("Switching to tab: {}", itemTab);
+            Rs2Bank.openTab(itemTab);
+            sleepUntil(() -> Rs2Bank.isTabOpen(itemTab), 5000);
+        }
+
+        Rs2Bank.scrollBankToSlot(menuEntry.getParam0());
+        Rs2Random.wait(200, 500);
+        menuEntry.setWidget(Rs2Bank.getItemWidget(menuEntry.getParam0()));
+    }
+
+    private void handleFurnaceActions() {
+        if (!openFurnace()) {
+            log.warn("Production widget did not open");
+            QoLPlugin.executeFurnaceActions = false;
+            return;
+        }
+
+        for (NewMenuEntry menuEntry : QoLPlugin.furnaceMenuEntries) {
+            processFurnaceMenuEntry(menuEntry);
+        }
+        QoLPlugin.executeFurnaceActions = false;
+    }
+
+    private boolean openFurnace() {
+        sleepUntil(Rs2Widget::isProductionWidgetOpen, 10000);
+        return Rs2Widget.isProductionWidgetOpen();
+    }
+
+    private void processFurnaceMenuEntry(NewMenuEntry menuEntry) {
+        log.info("Executing action: {} {}", menuEntry.getOption(), menuEntry.getTarget());
+        Microbot.doInvoke(menuEntry, Objects.requireNonNull(menuEntry.getWidget()).getBounds());
+        Rs2Random.wait(200, 500);
+    }
 
     @Override
     public void shutdown() {
-
         super.shutdown();
+        log.info("QoLScript shutdown complete.");
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/AntibanPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/AntibanPlugin.java
@@ -136,7 +136,8 @@ public class AntibanPlugin extends Plugin {
                 }
             } else {
                 Rs2AntibanSettings.actionCooldownActive = false;
-                Microbot.pauseAllScripts = false;
+                if (Rs2AntibanSettings.universalAntiban && !Rs2AntibanSettings.microBreakActive)
+                    Microbot.pauseAllScripts = false;
             }
         }
     }
@@ -244,6 +245,8 @@ public class AntibanPlugin extends Plugin {
         }
 
         if (Rs2AntibanSettings.usePlayStyle) {
+            if (Rs2Antiban.getPlayStyle() == null)
+                return;
             if (Rs2AntibanSettings.simulateAttentionSpan && Rs2AntibanSettings.profileSwitching &&
                     Rs2Antiban.getPlayStyle().shouldSwitchProfileBasedOnAttention()) {
                 Rs2Antiban.setPlayStyle(Rs2Antiban.getPlayStyle().switchProfile());
@@ -267,6 +270,9 @@ public class AntibanPlugin extends Plugin {
                 Rs2Antiban.actionCooldown();
                 Rs2Antiban.takeMicroBreakByChance();
             }
+            if (Rs2Antiban.getActivity() == null)
+                updateAntibanSettings(skill);
+
             return;
         }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/Rs2Antiban.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/Rs2Antiban.java
@@ -267,15 +267,19 @@ public class Rs2Antiban {
             logDebug("PlayStyle not enabled, cannot perform action cooldown");
             return;
         }
+        if (Rs2AntibanSettings.actionCooldownChance == 1.0) {
+            performActionCooldown();
+            return;
+        }
         if (Rs2AntibanSettings.actionCooldownChance <= 0.0) {
             logDebug("Action cooldown chance is 0%, cannot perform action cooldown");
             return;
         }
         if (Rs2AntibanSettings.actionCooldownChance <= 0.99 && Rs2Random.diceFractional(Rs2AntibanSettings.actionCooldownChance)) {
             performActionCooldown();
-            return;
+
         }
-        performActionCooldown();
+
     }
 
     private static void logDebug(String message) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
@@ -6,6 +6,7 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
@@ -740,6 +741,7 @@ public class Rs2GameObject {
      * TODO remove this method, maybe use find or get(int id)
      *
      * @param id
+     *
      * @return
      */
     public static List<GameObject> getGameObjects(int id) {
@@ -775,7 +777,7 @@ public class Rs2GameObject {
                 .collect(Collectors.toList());
     }
 
-    public static List<TileObject> getTileObjects(int id){
+    public static List<TileObject> getTileObjects(int id) {
         return getTileObjects(id, Rs2Player.getWorldLocation());
     }
 
@@ -988,9 +990,9 @@ public class Rs2GameObject {
                 if (tile == null) {
                     continue;
                 }
-                    if (tile.getWallObject() != null
-                            && tile.getWallObject().getId() == id)
-                        tileObjects.add(tile.getWallObject());
+                if (tile.getWallObject() != null
+                        && tile.getWallObject().getId() == id)
+                    tileObjects.add(tile.getWallObject());
             }
         }
 
@@ -1160,7 +1162,7 @@ public class Rs2GameObject {
             GameObject gameObject = (GameObject) tileObject;
             WorldPoint worldPoint = WorldPoint.fromScene(Microbot.getClient(), gameObject.getSceneMinLocation().getX(), gameObject.getSceneMinLocation().getY(), gameObject.getPlane());
 
-            if (Microbot.getClient().isInInstancedRegion()){
+            if (Microbot.getClient().isInInstancedRegion()) {
                 var localPoint = LocalPoint.fromWorld(Microbot.getClient(), worldPoint);
                 worldPoint = WorldPoint.fromLocalInstance(Microbot.getClient(), localPoint);
             }
@@ -1177,11 +1179,32 @@ public class Rs2GameObject {
         }
 
         var tiles = Rs2Tile.getReachableTilesFromTile(Rs2Player.getWorldLocation(), distance);
-        for (var tile : tiles.keySet()){
+        for (var tile : tiles.keySet()) {
             if (tile.distanceTo(objectArea) < 2)
                 return true;
         }
 
         return false;
+    }
+
+    /**
+     * Hovers over the given game object using the natural mouse.
+     *
+     * @param object The game object to hover over.
+     *
+     * @return True if successfully hovered, otherwise false.
+     */
+    public static boolean hoverOverObject(TileObject object) {
+        if (!Rs2AntibanSettings.naturalMouse) {
+            Microbot.log("Natural mouse is not enabled, can't hover");
+            return false;
+        }
+        Point point = Rs2UiHelper.getClickingPoint(Rs2UiHelper.getObjectClickbox(object), true);
+        // if the point is 1,1 then the object is not on screen and we should return false
+        if (point.getX() == 1 && point.getY() == 1) {
+            return false;
+        }
+        Microbot.getNaturalMouse().moveTo(point.getX(), point.getY());
+        return true;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
@@ -9,7 +9,6 @@ import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
-import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
@@ -83,6 +82,7 @@ public class Rs2Inventory {
      * A list of all the items that meet a specified filter criteria.
      *
      * @param filter The filter to apply when selecting items.
+     *
      * @return A list of items that match the filter.
      */
     public static List<Rs2Item> all(Predicate<Rs2Item> filter) {
@@ -103,6 +103,7 @@ public class Rs2Inventory {
      *
      * @param primaryItemId   The ID of the primary item.
      * @param secondaryItemId The ID of the secondary item.
+     *
      * @return True if the combine operation was successful, false otherwise.
      */
     public static boolean combine(int primaryItemId, int secondaryItemId) {
@@ -117,6 +118,7 @@ public class Rs2Inventory {
      *
      * @param primaryItemName   The name of the primary item.
      * @param secondaryItemName The name of the secondary item.
+     *
      * @return True if the combine operation was successful, false otherwise.
      */
     public static boolean combine(String primaryItemName, String secondaryItemName) {
@@ -131,6 +133,7 @@ public class Rs2Inventory {
      *
      * @param primary   The primary item.
      * @param secondary The secondary item.
+     *
      * @return True if the combine operation was successful, false otherwise.
      */
     public static boolean combine(Rs2Item primary, Rs2Item secondary) {
@@ -150,6 +153,7 @@ public class Rs2Inventory {
      *
      * @param primaryItemName   the name of the primary item to combine
      * @param secondaryItemName the name of the secondary item to combine
+     *
      * @return true if the items were successfully combined, false otherwise
      */
     public static boolean combineClosest(String primaryItemName, String secondaryItemName) {
@@ -187,6 +191,7 @@ public class Rs2Inventory {
      *
      * @param primaryItemId   the ID of the primary item to combine
      * @param secondaryItemId the ID of the secondary item to combine
+     *
      * @return true if the items were successfully combined, false otherwise
      */
     public static boolean combineClosest(int primaryItemId, int secondaryItemId) {
@@ -231,6 +236,7 @@ public class Rs2Inventory {
      * Checks if the inventory contains an item with the specified ID.
      *
      * @param id The ID to check for.
+     *
      * @return True if the inventory contains an item with the given ID, false otherwise.
      */
     public static boolean contains(int id) {
@@ -241,6 +247,7 @@ public class Rs2Inventory {
      * Checks if the inventory contains items with the specified IDs.
      *
      * @param ids The IDs to check for.
+     *
      * @return True if the inventory contains all the specified IDs, false otherwise.
      */
     public static boolean contains(int[] ids) {
@@ -251,6 +258,7 @@ public class Rs2Inventory {
      * Checks if the inventory contains items with the specified IDs.
      *
      * @param ids The IDs to check for.
+     *
      * @return True if the inventory contains all the specified IDs, false otherwise.
      */
     public static boolean contains(Integer... ids) {
@@ -261,6 +269,7 @@ public class Rs2Inventory {
      * Checks if the inventory contains an item with the specified name.
      *
      * @param name The name to check for.
+     *
      * @return True if the inventory contains an item with the specified name, false otherwise.
      */
     public static boolean contains(String name) {
@@ -271,6 +280,7 @@ public class Rs2Inventory {
      * Checks if the inventory contains items with the specified names.
      *
      * @param names The names to check for.
+     *
      * @return True if the inventory contains all the specified names, false otherwise.
      */
     public static boolean contains(String... names) {
@@ -281,6 +291,7 @@ public class Rs2Inventory {
      * Checks if the inventory contains an item that matches the specified filter.
      *
      * @param predicate The filter to apply.
+     *
      * @return True if the inventory contains an item that matches the filter, false otherwise.
      */
     public static boolean contains(Predicate<Rs2Item> predicate) {
@@ -291,6 +302,7 @@ public class Rs2Inventory {
      * Checks if the inventory contains all the specified IDs.
      *
      * @param ids The IDs to check for.
+     *
      * @return True if the inventory contains all the specified IDs, false otherwise.
      */
     public static boolean containsAll(int... ids) {
@@ -301,6 +313,7 @@ public class Rs2Inventory {
      * Checks if the inventory contains all the specified names.
      *
      * @param names The names to check for.
+     *
      * @return True if the inventory contains all the specified names, false otherwise.
      */
     public static boolean containsAll(String... names) {
@@ -311,6 +324,7 @@ public class Rs2Inventory {
      * Counts the number of items in the inventory that match the specified ID.
      *
      * @param id The ID to match.
+     *
      * @return The count of items that match the ID.
      */
     public static int count(int id) {
@@ -330,6 +344,7 @@ public class Rs2Inventory {
      * Counts the number of items in the inventory that match the specified name.
      *
      * @param name The name to match.
+     *
      * @return The count of items that match the name.
      */
     public static int count(String name) {
@@ -340,6 +355,7 @@ public class Rs2Inventory {
      * Counts the number of items in the inventory that match the specified filter.
      *
      * @param predicate The filter to apply.
+     *
      * @return The count of items that match the filter.
      */
     public static int count(Predicate<Rs2Item> predicate) {
@@ -362,6 +378,7 @@ public class Rs2Inventory {
      * Drops the item with the specified ID from the inventory.
      *
      * @param id The ID of the item to drop.
+     *
      * @return True if the item was successfully dropped, false otherwise.
      */
     public static boolean drop(int id) {
@@ -377,6 +394,7 @@ public class Rs2Inventory {
      * Drops the item with the specified name from the inventory.
      *
      * @param name The name of the item to drop.
+     *
      * @return True if the item was successfully dropped, false otherwise.
      */
     public static boolean drop(String name) {
@@ -392,6 +410,7 @@ public class Rs2Inventory {
      * Drops the item from the inventory that matches the specified filter.
      *
      * @param predicate The filter to identify the item to drop.
+     *
      * @return True if the item was successfully dropped, false otherwise.
      */
     public static boolean drop(Predicate<Rs2Item> predicate) {
@@ -423,6 +442,7 @@ public class Rs2Inventory {
      * Drops all items in the inventory matching the specified ID.
      *
      * @param id The ID to match.
+     *
      * @return True if all matching items were successfully dropped, false otherwise.
      */
     public static boolean dropAll(int id) {
@@ -440,6 +460,7 @@ public class Rs2Inventory {
      * Drops all items in the inventory matching the specified IDs.
      *
      * @param ids The IDs to match.
+     *
      * @return True if all matching items were successfully dropped, false otherwise.
      */
     public static boolean dropAll(Integer... ids) {
@@ -457,6 +478,7 @@ public class Rs2Inventory {
      * Drops all items in the inventory matching the specified name.
      *
      * @param name The name to match.
+     *
      * @return True if all matching items were successfully dropped, false otherwise.
      */
     public static boolean dropAll(String name) {
@@ -474,6 +496,7 @@ public class Rs2Inventory {
      * Drops all items in the inventory matching the specified names.
      *
      * @param names The names to match.
+     *
      * @return True if all matching items were successfully dropped, false otherwise.
      */
     public static boolean dropAll(String... names) {
@@ -491,6 +514,7 @@ public class Rs2Inventory {
      * Drops all items in the inventory matching the specified filter.
      *
      * @param predicate The filter to apply.
+     *
      * @return True if all matching items were successfully dropped, false otherwise.
      */
     public static boolean dropAll(Predicate<Rs2Item> predicate) {
@@ -513,6 +537,7 @@ public class Rs2Inventory {
      *                  - EFFICIENT_ROW: Items are dropped row by row. For even rows, items are dropped from left to right. For odd rows, items are dropped from right to left.
      *                  - COLUMN: Items are dropped column by column, from top to bottom.
      *                  - EFFICIENT_COLUMN: Items are dropped column by column. For even columns, items are dropped from top to bottom. For odd columns, items are dropped from bottom to top.
+     *
      * @return True if all matching items were successfully dropped, false otherwise.
      */
     public static boolean dropAll(Predicate<Rs2Item> predicate, DropOrder dropOrder) {
@@ -596,6 +621,7 @@ public class Rs2Inventory {
      * Drops all items in the inventory that don't match the given IDs.
      *
      * @param ids The IDs to exclude.
+     *
      * @return True if all non-matching items were successfully dropped, false otherwise.
      */
     public static boolean dropAllExcept(Integer... ids) {
@@ -606,6 +632,7 @@ public class Rs2Inventory {
      * Drops all items in the inventory that don't match the given names.
      *
      * @param names The names to exclude.
+     *
      * @return True if all non-matching items were successfully dropped, false otherwise.
      */
     public static boolean dropAllExcept(String... names) {
@@ -624,6 +651,7 @@ public class Rs2Inventory {
      *                  - COLUMN: Items are dropped column by column, from top to bottom.
      *                  - EFFICIENT_COLUMN: Items are dropped column by column. For even columns, items are dropped from top to bottom. For odd columns, items are dropped from bottom to top.
      * @param names     The names of the items to keep in the inventory.
+     *
      * @return True if all non-matching items were successfully dropped, false otherwise.
      */
     public static boolean dropAllExcept(boolean exact, DropOrder dropOrder, String... names) {
@@ -637,6 +665,7 @@ public class Rs2Inventory {
      * Drops all items in the inventory that are not filtered.
      *
      * @param predicate The filter to apply.
+     *
      * @return True if all non-matching items were successfully dropped, false otherwise.
      */
     public static boolean dropAllExcept(Predicate<Rs2Item> predicate) {
@@ -654,6 +683,7 @@ public class Rs2Inventory {
      * Drop all items that fall under the gpValue
      *
      * @param gpValue minimum amount of gp required to not drop the item
+     *
      * @return
      */
     public static boolean dropAllExcept(int gpValue) {
@@ -665,6 +695,7 @@ public class Rs2Inventory {
      *
      * @param gpValue     minimum amount of gp required to not drop the item
      * @param ignoreItems List of items to not drop
+     *
      * @return
      */
     public static boolean dropAllExcept(int gpValue, List<String> ignoreItems) {
@@ -699,6 +730,7 @@ public class Rs2Inventory {
      * Returns a list of items that do not fit the given criteria based on the provided filter.
      *
      * @param predicate The filter to apply.
+     *
      * @return A list of items that do not match the filter criteria.
      */
     public static List<Rs2Item> except(Predicate<Rs2Item> predicate) {
@@ -719,6 +751,7 @@ public class Rs2Inventory {
      * Gets the last item in the inventory that matches the specified item ID.
      *
      * @param id The ID to match.
+     *
      * @return The last item that matches the ID, or null if not found.
      */
     public static Rs2Item getLast(int id) {
@@ -733,6 +766,7 @@ public class Rs2Inventory {
      * Gets the first item in the inventory that matches the specified item ID.
      *
      * @param id The ID to match.
+     *
      * @return The first item that matches the ID, or null if not found.
      */
     public static Rs2Item get(int id) {
@@ -743,6 +777,7 @@ public class Rs2Inventory {
      * Gets the first item in the inventory that matches one of the given IDs.
      *
      * @param ids The IDs to match.
+     *
      * @return The first item that matches one of the IDs, or null if not found.
      */
     public static Rs2Item get(Integer... ids) {
@@ -754,6 +789,7 @@ public class Rs2Inventory {
      * this method ignores casing
      *
      * @param name The name to match.
+     *
      * @return The item with the specified name, or null if not found.
      */
     public static Rs2Item get(String name) {
@@ -765,6 +801,7 @@ public class Rs2Inventory {
      * this method ignores casing
      *
      * @param name The name to match.
+     *
      * @return The item with the specified name, or null if not found.
      */
     public static Rs2Item get(String name, boolean exact) {
@@ -778,6 +815,7 @@ public class Rs2Inventory {
      * Gets the item in the inventory with one of the specified names.
      *
      * @param names The names to match.
+     *
      * @return The item with one of the specified names, or null if not found.
      */
     public static Rs2Item get(String... names) {
@@ -789,6 +827,7 @@ public class Rs2Inventory {
      *
      * @param names The names to match.
      * @param exact true to match the exact name
+     *
      * @return The item with one of the specified names, or null if not found.
      */
     public static Rs2Item get(List<String> names, boolean exact) {
@@ -803,6 +842,7 @@ public class Rs2Inventory {
      * Gets the item in the inventory with one of the specified names.
      *
      * @param names The names to match.
+     *
      * @return The item with one of the specified names, or null if not found.
      */
     public static Rs2Item get(List<String> names) {
@@ -813,6 +853,7 @@ public class Rs2Inventory {
      * Gets the item in the inventory that matches the specified filter criteria.
      *
      * @param predicate The filter to apply.
+     *
      * @return The item that matches the filter criteria, or null if not found.
      */
     public static Rs2Item get(Predicate<Rs2Item> predicate) {
@@ -824,6 +865,7 @@ public class Rs2Inventory {
      *
      * @param id     The id of the item to check.
      * @param amount The desired quantity of the item.
+     *
      * @return True if the player has the specified quantity of the item, false otherwise.
      */
     public static boolean hasItemAmount(int id, int amount) {
@@ -842,6 +884,7 @@ public class Rs2Inventory {
      * @param id        The id of the item to check.
      * @param amount    The desired quantity of the item.
      * @param stackable A boolean indicating if the item is stackable.
+     *
      * @return True if the player has the specified quantity of the item, false otherwise.
      */
     public static boolean hasItemAmount(int id, int amount, boolean stackable) {
@@ -854,6 +897,7 @@ public class Rs2Inventory {
      *
      * @param name   The name of the item to check.
      * @param amount The desired quantity of the item.
+     *
      * @return True if the player has the specified quantity of the item, false otherwise.
      */
     public static boolean hasItemAmount(String name, int amount) {
@@ -866,6 +910,7 @@ public class Rs2Inventory {
      * Retrieves the quantity of an item based on its ID.
      *
      * @param id The ID of the item.
+     *
      * @return The quantity of the item if found, otherwise 0.
      */
     public static long ItemQuantity(int id) {
@@ -885,6 +930,7 @@ public class Rs2Inventory {
      * Retrieves the quantity of an item based on its name.
      *
      * @param itemName The name of the item.
+     *
      * @return The quantity of the item if found, otherwise 0.
      */
     public static long ItemQuantity(String itemName) {
@@ -906,6 +952,7 @@ public class Rs2Inventory {
      * @param name      The name of the item to check.
      * @param amount    The desired quantity of the item.
      * @param stackable A boolean indicating if the item is stackable.
+     *
      * @return True if the player has the specified quantity of the item, false otherwise.
      */
     public static boolean hasItemAmount(String name, int amount, boolean stackable) {
@@ -919,6 +966,7 @@ public class Rs2Inventory {
      * @param amount    The desired quantity of the item.
      * @param stackable A boolean indicating if the item is stackable.
      * @param exact     A boolean indicating whether the check should be exact or partial for non-stackable items.
+     *
      * @return True if the player has the specified quantity of the item, false otherwise.
      */
     public static boolean hasItemAmount(String name, int amount, boolean stackable, boolean exact) {
@@ -937,6 +985,7 @@ public class Rs2Inventory {
 
     /**
      * @param id
+     *
      * @return boolean
      */
     public static boolean hasItem(int id) {
@@ -945,6 +994,7 @@ public class Rs2Inventory {
 
     /**
      * @param name
+     *
      * @return boolean
      */
     public static boolean hasItem(String name) {
@@ -953,6 +1003,7 @@ public class Rs2Inventory {
 
     /**
      * @param name
+     *
      * @return boolean
      */
     public static boolean hasItem(String name, boolean exact) {
@@ -961,6 +1012,7 @@ public class Rs2Inventory {
 
     /**
      * @param names
+     *
      * @return boolean
      */
     public static boolean hasItem(String... names) {
@@ -970,6 +1022,7 @@ public class Rs2Inventory {
 
     /**
      * @param names
+     *
      * @return boolean
      */
     public static boolean hasItem(List<String> names) {
@@ -980,6 +1033,7 @@ public class Rs2Inventory {
      * Gets the actions available for the item in the specified slot.
      *
      * @param slot The slot to check.
+     *
      * @return An array of available actions for the item in the slot.
      */
     public static String[] getActionsForSlot(int slot) {
@@ -1060,6 +1114,7 @@ public class Rs2Inventory {
      * Returns -1 if the slot has not been found or no item has been found
      *
      * @param slot The slot to check.
+     *
      * @return The ID of the item in the slot, or -1 if the slot is empty.
      */
     public static int getIdForSlot(int slot) {
@@ -1081,6 +1136,7 @@ public class Rs2Inventory {
      * Gets the item in the specified slot of the inventory.
      *
      * @param slot The index of the slot to retrieve.
+     *
      * @return The item in the specified slot, or null if the slot is empty.
      */
     public static Rs2Item getItemInSlot(int slot) {
@@ -1094,6 +1150,7 @@ public class Rs2Inventory {
      * Gets the name of the item in the specified slot of the inventory.
      *
      * @param slot The slot to retrieve the name for.
+     *
      * @return The name of the item in the slot, or an empty string if the slot is empty.
      */
     public static String getNameForSlot(int slot) {
@@ -1108,6 +1165,7 @@ public class Rs2Inventory {
      * Gets a random item from the inventory that matches the specified item IDs.
      *
      * @param itemIDs The item IDs to match.
+     *
      * @return A random item that matches the item IDs, or null if no matching items are found.
      */
     public static Rs2Item getRandom(int... itemIDs) {
@@ -1122,6 +1180,7 @@ public class Rs2Inventory {
      * Gets a random item from the inventory that matches the specified item names.
      *
      * @param itemNames The item names to match.
+     *
      * @return A random item that matches the item names, or null if no matching items are found.
      */
     public static Rs2Item getRandom(String... itemNames) {
@@ -1136,6 +1195,7 @@ public class Rs2Inventory {
      * Gets a random item from the inventory that matches the specified item filter.
      *
      * @param itemFilter The filter to apply.
+     *
      * @return A random item that matches the filter criteria, or null if no matching items are found.
      */
     public static Rs2Item getRandom(Predicate<Rs2Item> itemFilter) {
@@ -1181,6 +1241,7 @@ public class Rs2Inventory {
      * Interacts with an item with the specified ID in the inventory using the first available action.
      *
      * @param id The ID of the item to interact with.
+     *
      * @return True if the interaction was successful, false otherwise.
      */
     public static boolean interact(int id) {
@@ -1192,6 +1253,7 @@ public class Rs2Inventory {
      *
      * @param id     The ID of the item to interact with.
      * @param action The action to perform on the item.
+     *
      * @return True if the interaction was successful, false otherwise.
      */
     public static boolean interact(int id, String action) {
@@ -1205,6 +1267,7 @@ public class Rs2Inventory {
      * Interacts with an item with the specified name in the inventory using the first available action.
      *
      * @param name The name of the item to interact with.
+     *
      * @return True if the interaction was successful, false otherwise.
      */
     public static boolean interact(String name) {
@@ -1217,6 +1280,7 @@ public class Rs2Inventory {
      *
      * @param name   The name of the item to interact with.
      * @param action The action to perform on the item.
+     *
      * @return True if the interaction was successful, false otherwise.
      */
     public static boolean interact(String name, String action) {
@@ -1229,6 +1293,7 @@ public class Rs2Inventory {
      *
      * @param names  The name of the item to interact with.
      * @param action The action to perform on the item.
+     *
      * @return True if the interaction was successful, false otherwise.
      */
     public static boolean interact(List<String> names, String action) {
@@ -1244,6 +1309,7 @@ public class Rs2Inventory {
      *
      * @param name   The name of the item to interact with.
      * @param action The action to perform on the item.
+     *
      * @return True if the interaction was successful, false otherwise.
      */
     public static boolean interact(String name, String action, boolean exact) {
@@ -1262,6 +1328,7 @@ public class Rs2Inventory {
      * Interacts with an item in the inventory using the first available action based on the specified filter.
      *
      * @param filter The filter to apply.
+     *
      * @return True if the interaction was successful, false otherwise.
      */
     public static boolean interact(Predicate<Rs2Item> filter) {
@@ -1273,6 +1340,7 @@ public class Rs2Inventory {
      *
      * @param filter The filter to apply.
      * @param action The action to perform on the item.
+     *
      * @return True if the interaction was successful, false otherwise.
      */
     public static boolean interact(Predicate<Rs2Item> filter, String action) {
@@ -1287,6 +1355,7 @@ public class Rs2Inventory {
      * If the item has an invalid slot value, it will find the slot based on the item ID.
      *
      * @param item The item to interact with.
+     *
      * @return True if the interaction was successful, false otherwise.
      */
     public static boolean interact(Rs2Item item) {
@@ -1299,6 +1368,7 @@ public class Rs2Inventory {
      *
      * @param item   The item to interact with.
      * @param action The action to perform on the item.
+     *
      * @return True if the interaction was successful, false otherwise.
      */
     public static boolean interact(Rs2Item item, String action) {
@@ -1338,6 +1408,7 @@ public class Rs2Inventory {
      * Checks if the inventory is full based on the item name.
      *
      * @param name The name of the item to check.
+     *
      * @return true if the inventory is full, false otherwise.
      */
     public static boolean isFull(String name) {
@@ -1350,6 +1421,7 @@ public class Rs2Inventory {
      * Checks if the inventory is full based on the item ID.
      *
      * @param id The ID of the item to check.
+     *
      * @return true if the inventory is full, false otherwise.
      */
     public static boolean isFull(int id) {
@@ -1380,20 +1452,23 @@ public class Rs2Inventory {
      * Checks if the given slot in the inventory is empty.
      *
      * @param slot The slot to check.
+     *
      * @return True if the slot is empty, false otherwise.
      */
     public static boolean isSlotEmpty(int slot) {
         Widget inventory = getInventory();
 
         if (inventory == null) return false;
-
-        return slot <= inventory.getDynamicChildren().length;
+        Widget inventoryItem = inventory.getChild(slot);
+        assert inventoryItem != null;
+        return inventoryItem.getName().isEmpty();
     }
 
     /**
      * Checks if the given slot in the inventory is empty.
      *
      * @param slots The slots to check.
+     *
      * @return True if the slot is empty, false otherwise.
      */
     public static boolean isSlotsEmpty(int... slots) {
@@ -1401,9 +1476,11 @@ public class Rs2Inventory {
 
         if (inventory == null) return false;
 
-        for (int slot :
-                slots) {
-            if (slot > inventory.getDynamicChildren().length) return false;
+        for (int slot : slots) {
+            if (slot < 0 || slot >= inventory.getDynamicChildren().length)
+                return false; // Check if slot is within bounds
+            Widget inventoryItem = inventory.getChild(slot);
+            if (inventoryItem == null || !inventoryItem.getName().isEmpty()) return false; // Check if slot is empty
         }
 
         return true;
@@ -1413,6 +1490,7 @@ public class Rs2Inventory {
      * Checks if the given slot in the inventory is full (contains an item).
      *
      * @param slot The slot to check.
+     *
      * @return True if the slot is full, false otherwise.
      */
     public static boolean isSlotFull(int slot) {
@@ -1423,6 +1501,7 @@ public class Rs2Inventory {
      * Gets the bounding rectangle for the slot of the specified item in the inventory.
      *
      * @param rs2Item The item to get the bounds for.
+     *
      * @return The bounding rectangle for the item's slot, or null if the item is not found.
      */
     public static Rectangle itemBounds(Rs2Item rs2Item) {
@@ -1444,6 +1523,7 @@ public class Rs2Inventory {
      * Checks if your inventory only contains items with the specified ID.
      *
      * @param ids The IDs to check.
+     *
      * @return True if the inventory only contains items with the specified IDs, false otherwise.
      */
     public static boolean onlyContains(Integer... ids) {
@@ -1454,6 +1534,7 @@ public class Rs2Inventory {
      * Checks if your inventory only contains items with the specified names.
      *
      * @param names The names to check.
+     *
      * @return True if the inventory only contains items with the specified names, false otherwise.
      */
     public static boolean onlyContains(String... names) {
@@ -1464,6 +1545,7 @@ public class Rs2Inventory {
      * Checks if your inventory only contains items that match the specified filter.
      *
      * @param predicate The filter to apply.
+     *
      * @return True if the inventory only contains items that match the filter, false otherwise.
      */
     public static boolean onlyContains(Predicate<Rs2Item> predicate) {
@@ -1494,39 +1576,42 @@ public class Rs2Inventory {
      * Gets the slot for the item with the specified ID.
      *
      * @param id The ID of the item.
+     *
      * @return The slot index for the item, or -1 if not found.
      */
     public static int slot(int id) {
         Rs2Item item = items().stream().filter(x -> x.id == id).findFirst().orElse(null);
         if (item == null) return -1;
 
-        return items().indexOf(item);
+        return item.slot;
     }
 
     /**
      * Gets the slot for the item with the specified name.
      *
      * @param name The name of the item.
+     *
      * @return The slot index for the item, or -1 if not found.
      */
     public static int slot(String name) {
         Rs2Item item = items().stream().filter(x -> x.name.equalsIgnoreCase(name)).findFirst().orElse(null);
         if (item == null) return -1;
 
-        return items().indexOf(item);
+        return item.slot;
     }
 
     /**
      * Gets the slot for the item that matches the specified filter.
      *
      * @param predicate The filter to apply.
+     *
      * @return The slot index for the item, or -1 if not found.
      */
     public static int slot(Predicate<Rs2Item> predicate) {
         Rs2Item item = items().stream().filter(predicate).findFirst().orElse(null);
         if (item == null) return -1;
 
-        return items().indexOf(item);
+        return item.slot;
     }
 
     /**
@@ -1534,6 +1619,7 @@ public class Rs2Inventory {
      *
      * @param slot The slot to check.
      * @param ids  The IDs to match.
+     *
      * @return True if the slot contains items that match the IDs, false otherwise.
      */
     public static boolean slotContains(int slot, int[] ids) {
@@ -1547,6 +1633,7 @@ public class Rs2Inventory {
      *
      * @param slot The slot to check.
      * @param ids  The IDs to match.
+     *
      * @return True if the slot contains items that match the IDs, false otherwise.
      */
     public static boolean slotContains(int slot, Integer... ids) {
@@ -1560,6 +1647,7 @@ public class Rs2Inventory {
      *
      * @param slot  The slot to check.
      * @param names The names to match.
+     *
      * @return True if the slot contains items that match the names, false otherwise.
      */
     public static boolean slotContains(int slot, String... names) {
@@ -1573,6 +1661,7 @@ public class Rs2Inventory {
      * Interacts with the specified slot in the inventory using the first available action.
      *
      * @param slot The slot to interact with.
+     *
      * @return True if the interaction is successful, false otherwise.
      */
     public static boolean slotInteract(int slot) {
@@ -1584,6 +1673,7 @@ public class Rs2Inventory {
      *
      * @param slot   The slot to interact with.
      * @param action The action to perform.
+     *
      * @return True if the interaction is successful, false otherwise.
      */
     public static boolean slotInteract(int slot, String action) {
@@ -1601,6 +1691,7 @@ public class Rs2Inventory {
      *
      * @param slot The slot to check.
      * @param sub  The substring to search for in item names.
+     *
      * @return True if the slot contains items with names containing the substring, false otherwise.
      */
     public static boolean slotNameContains(int slot, String sub) {
@@ -1614,6 +1705,7 @@ public class Rs2Inventory {
      * Uses the last item with the specified ID in the inventory.
      *
      * @param id The ID to match.
+     *
      * @return The last item that matches the ID, or null if not found.
      */
     public static boolean useLast(int id) {
@@ -1627,6 +1719,7 @@ public class Rs2Inventory {
      * Uses the item with the specified name in the inventory.
      *
      * @param name The name of the item to use.
+     *
      * @return True if the item is successfully used, false otherwise.
      */
     public static boolean useUnNoted(String name) {
@@ -1639,6 +1732,7 @@ public class Rs2Inventory {
      * Uses the item with the specified ID in the inventory.
      *
      * @param id The ID of the item to use.
+     *
      * @return True if the item is successfully used, false otherwise.
      */
     public static boolean use(int id) {
@@ -1651,6 +1745,7 @@ public class Rs2Inventory {
      * Uses the item with the specified name in the inventory.
      *
      * @param name The name of the item to use.
+     *
      * @return True if the item is successfully used, false otherwise.
      */
     public static boolean use(String name) {
@@ -1663,6 +1758,7 @@ public class Rs2Inventory {
      * Uses the given item in the inventory.
      *
      * @param rs2Item The item to use.
+     *
      * @return True if the item is successfully used, false otherwise.
      */
     public static boolean use(Rs2Item rs2Item) {
@@ -1679,6 +1775,7 @@ public class Rs2Inventory {
 
     /**
      * @param names possible item names to wield
+     *
      * @return
      */
     public static boolean wield(String... names) {
@@ -1693,6 +1790,7 @@ public class Rs2Inventory {
 
     /**
      * @param name
+     *
      * @return
      */
     public static boolean wield(String name) {
@@ -1738,6 +1836,7 @@ public class Rs2Inventory {
      *
      * @param item     name of the item to use
      * @param objectID to use item on
+     *
      * @return
      */
     public static boolean useUnNotedItemOnObject(String item, int objectID) {
@@ -1752,6 +1851,7 @@ public class Rs2Inventory {
      *
      * @param item   name of the item to use
      * @param object to use item on
+     *
      * @return
      */
     public static boolean useUnNotedItemOnObject(String item, TileObject object) {
@@ -1768,6 +1868,7 @@ public class Rs2Inventory {
      *
      * @param item
      * @param objectID
+     *
      * @return
      */
     public static boolean useItemOnObject(int item, int objectID) {
@@ -1782,6 +1883,7 @@ public class Rs2Inventory {
     /**
      * @param itemId
      * @param npcID
+     *
      * @return
      */
     public static boolean useItemOnNpc(int itemId, int npcID) {
@@ -1796,6 +1898,7 @@ public class Rs2Inventory {
     /**
      * @param itemId
      * @param Npc
+     *
      * @return
      */
     public static boolean useItemOnNpc(int itemId, NPC Npc) {
@@ -1810,6 +1913,7 @@ public class Rs2Inventory {
     /**
      * @param name
      * @param exact
+     *
      * @return
      */
     public static Rs2Item getNotedItem(String name, boolean exact) {
@@ -1821,6 +1925,7 @@ public class Rs2Inventory {
 
     /**
      * @param name
+     *
      * @return
      */
     public static boolean hasNotedItem(String name) {
@@ -1830,6 +1935,7 @@ public class Rs2Inventory {
     /**
      * @param name
      * @param exact
+     *
      * @return
      */
     public static boolean hasNotedItem(String name, boolean exact) {
@@ -1853,12 +1959,11 @@ public class Rs2Inventory {
 
     /**
      * Method will search for restore energy items in inventory & use them
-     *
      */
     public static void useRestoreEnergyItem() {
         List<Rs2Item> filteredRestoreEnergyItems = getFilteredPotionItemsInInventory(Rs2Potion.getRestoreEnergyPotionsVariants());
         List<Rs2Item> filteredStaminaRestoreItems = getFilteredPotionItemsInInventory(Rs2Potion.getStaminaPotion());
-        
+
         if (filteredStaminaRestoreItems.isEmpty() && filteredRestoreEnergyItems.isEmpty()) return;
 
         if (filteredStaminaRestoreItems.isEmpty()) {
@@ -1876,16 +1981,18 @@ public class Rs2Inventory {
      * Method fetches list of potion items in Inventory, will ignore uses
      *
      * @param potionName Potion Name
+     *
      * @return List of Potion Items in Inventory
      */
     public static List<Rs2Item> getFilteredPotionItemsInInventory(String potionName) {
         return getFilteredPotionItemsInInventory(Collections.singletonList(potionName));
     }
-    
+
     /**
      * Method fetches list of potion items in Inventory, will ignore uses
      *
      * @param potionNames List of Potion Names
+     *
      * @return List of Potion Items in Inventory
      */
     public static List<Rs2Item> getFilteredPotionItemsInInventory(List<String> potionNames) {
@@ -1897,6 +2004,7 @@ public class Rs2Inventory {
                 })
                 .collect(Collectors.toList());
     }
+
     /**
      * Method executes menu actions
      *
@@ -1958,7 +2066,7 @@ public class Rs2Inventory {
 
         Microbot.doInvoke(new NewMenuEntry(param0, param1, menuAction.getId(), identifier, rs2Item.id, rs2Item.name), (itemBounds(rs2Item) == null) ? new Rectangle(1, 1) : itemBounds(rs2Item));
 
-        if (action.equalsIgnoreCase("destroy")){
+        if (action.equalsIgnoreCase("destroy")) {
             sleepUntil(() -> Rs2Widget.isWidgetVisible(584, 0));
             Rs2Widget.clickWidget(Rs2Widget.getWidget(584, 1).getId());
         }
@@ -1988,6 +2096,7 @@ public class Rs2Inventory {
      *
      * @param itemName item to sell
      * @param quantity STRING quantity of items to sell
+     *
      * @return true if the item was successfully sold, false otherwise
      */
     public static boolean sellItem(String itemName, String quantity) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/mouse/Mouse.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/mouse/Mouse.java
@@ -22,9 +22,14 @@ public abstract class Mouse {
     float hue = 0.0f; // Initial hue value
     Timer timer = new Timer(POINT_LIFETIME, e -> {
         if (!points.isEmpty()) {
-            points.removeFirst();
+            try {
+                points.removeFirst();
+            } catch (Exception ignore) {
+            }
+
         }
     });
+
     public Mouse() {
     }
 
@@ -50,7 +55,6 @@ public abstract class Mouse {
     public abstract void setLastMove(Point point);
 
 
-
     public abstract Mouse click(int x, int y);
 
     public abstract Mouse click(double x, double y);
@@ -60,22 +64,29 @@ public abstract class Mouse {
     public abstract Mouse click(int x, int y, boolean rightClick);
 
     public abstract Mouse click(Point point);
+
     public abstract Mouse click(Point point, boolean rightClick);
 
     public abstract Mouse click(Point point, NewMenuEntry entry);
+
     public abstract Mouse click();
 
     public abstract Mouse move(Point point);
+
     public abstract Mouse move(Rectangle rect);
 
     public abstract Mouse move(int x, int y);
 
     public abstract Mouse move(double x, double y);
+
     public abstract Mouse move(Polygon polygon);
+
     public abstract Mouse scrollDown(Point point);
+
     public abstract Mouse scrollUp(Point point);
 
     public abstract Mouse drag(Point startPoint, Point endPoint);
+
     public abstract java.awt.Point getMousePosition();
 
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/npc/Rs2Npc.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/npc/Rs2Npc.java
@@ -6,6 +6,7 @@ import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.game.npcoverlay.HighlightedNpc;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
@@ -64,7 +65,7 @@ public class Rs2Npc {
         int ratio = npc.getHealthRatio();
         int scale = npc.getHealthScale();
 
-        double targetHpPercent = (double) ratio  / (double) scale * 100;
+        double targetHpPercent = (double) ratio / (double) scale * 100;
 
         return targetHpPercent;
     }
@@ -83,6 +84,7 @@ public class Rs2Npc {
 
     /**
      * @param name
+     *
      * @return
      */
     public static Stream<NPC> getNpcs(String name) {
@@ -92,6 +94,7 @@ public class Rs2Npc {
     /**
      * @param name
      * @param exact
+     *
      * @return
      */
     public static Stream<NPC> getNpcs(String name, boolean exact) {
@@ -108,6 +111,7 @@ public class Rs2Npc {
 
     /**
      * @param id
+     *
      * @return
      */
     public static Stream<NPC> getNpcs(int id) {
@@ -164,7 +168,7 @@ public class Rs2Npc {
 
     public static NPC getRandomEventNPC() {
         return getNpcs()
-                .filter(value -> (value.getComposition() != null && value.getComposition().getActions() != null && 
+                .filter(value -> (value.getComposition() != null && value.getComposition().getActions() != null &&
                         Arrays.asList(value.getComposition().getActions()).contains("Dismiss")) && value.getInteracting() == Microbot.getClient().getLocalPlayer())
                 .findFirst()
                 .orElse(null);
@@ -291,7 +295,7 @@ public class Rs2Npc {
     }
 
     public static boolean pickpocket(Map<NPC, HighlightedNpc> highlightedNpcs) {
-        for (NPC npc: highlightedNpcs.keySet()) {
+        for (NPC npc : highlightedNpcs.keySet()) {
             if (!hasLineOfSight(npc)) {
                 Rs2Walker.walkTo(npc.getWorldLocation(), 1);
                 return false;
@@ -329,7 +333,7 @@ public class Rs2Npc {
         var location = getWorldLocation(npc);
 
         var tiles = Rs2Tile.getReachableTilesFromTile(Rs2Player.getWorldLocation(), distance);
-        for (var tile : tiles.keySet()){
+        for (var tile : tiles.keySet()) {
             if (tile.equals(location))
                 return true;
         }
@@ -343,6 +347,7 @@ public class Rs2Npc {
 
     /**
      * @param player
+     *
      * @return
      */
     public static List<NPC> getNpcsAttackingPlayer(Player player) {
@@ -351,7 +356,9 @@ public class Rs2Npc {
 
     /**
      * gets list of npcs within line of sight for a player by name
+     *
      * @param name of the npc
+     *
      * @return list of npcs
      */
     public static List<NPC> getNpcsInLineOfSight(String name) {
@@ -360,7 +367,9 @@ public class Rs2Npc {
 
     /**
      * gets the npc within line of sight for a player by name
+     *
      * @param name of the npc
+     *
      * @return npc
      */
     public static NPC getNpcInLineOfSight(String name) {
@@ -368,5 +377,25 @@ public class Rs2Npc {
         if (npcsInLineOfSight.isEmpty()) return null;
 
         return npcsInLineOfSight.get(0);
+    }
+
+    /**
+     * Hovers over the given actor (e.g., NPC).
+     *
+     * @param actor The actor to hover over.
+     *
+     * @return True if successfully hovered, otherwise false.
+     */
+    public static boolean hoverOverActor(Actor actor) {
+        if (!Rs2AntibanSettings.naturalMouse) {
+            Microbot.log("Natural mouse is not enabled, can't hover");
+            return false;
+        }
+        Point point = Rs2UiHelper.getClickingPoint(Rs2UiHelper.getActorClickbox(actor), true);
+        if (point.getX() == 1 && point.getY() == 1) {
+            return false;
+        }
+        Microbot.getNaturalMouse().moveTo(point.getX(), point.getY());
+        return true;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/widget/Rs2Widget.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/widget/Rs2Widget.java
@@ -5,12 +5,9 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
-import net.runelite.client.plugins.microbot.util.reflection.Rs2Reflection;
 
-import java.awt.*;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
@@ -25,6 +22,7 @@ public class Rs2Widget {
         }
         return false;
     }
+
     public static boolean clickWidget(String text, boolean exact) {
         Widget widget = findWidget(text, null, exact);
         if (widget != null) {
@@ -33,6 +31,7 @@ public class Rs2Widget {
         }
         return false;
     }
+
     public static boolean clickWidget(int parentId, int childId) {
         Widget widget = getWidget(parentId, childId);
         if (widget != null) {
@@ -41,6 +40,7 @@ public class Rs2Widget {
         }
         return false;
     }
+
     public static boolean clickWidget(WidgetInfo widgetInfo) {
         Widget widget = getWidget(widgetInfo);
         if (widget != null) {
@@ -49,21 +49,25 @@ public class Rs2Widget {
         }
         return false;
     }
+
     public static boolean isWidgetVisible(WidgetInfo wiget) {
         return !Microbot.getClientThread().runOnClientThread(() -> getWidget(wiget) == null || getWidget(wiget).isHidden());
     }
+
     public static boolean isWidgetVisible(int widgetId, int childId) {
-        return !Microbot.getClientThread().runOnClientThread(() ->  getWidget(widgetId, childId) == null || getWidget(widgetId, childId).isHidden());
+        return !Microbot.getClientThread().runOnClientThread(() -> getWidget(widgetId, childId) == null || getWidget(widgetId, childId).isHidden());
     }
+
     public static Widget getWidget(WidgetInfo wiget) {
         return Microbot.getClientThread().runOnClientThread(() -> Microbot.getClient().getWidget(wiget));
     }
+
     public static Widget getWidget(int id) {
         return Microbot.getClientThread().runOnClientThread(() -> Microbot.getClient().getWidget(id));
     }
 
     public static boolean isHidden(int id) {
-        return Microbot.getClientThread().runOnClientThread(() ->  {
+        return Microbot.getClientThread().runOnClientThread(() -> {
             Widget widget = Microbot.getClient().getWidget(id);
             if (widget == null) return true;
             return widget.isHidden();
@@ -112,10 +116,11 @@ public class Rs2Widget {
     }
 
     public static int getChildWidgetSpriteID(int id, int childId) {
-        return  Microbot.getClientThread().runOnClientThread(() -> Microbot.getClient().getWidget(id).getChild(childId).getSpriteId());
+        return Microbot.getClientThread().runOnClientThread(() -> Microbot.getClient().getWidget(id).getChild(childId).getSpriteId());
     }
+
     public static String getChildWidgetText(int id, int childId) {
-        return  Microbot.getClientThread().runOnClientThread(() -> Microbot.getClient().getWidget(id).getChild(childId).getText());
+        return Microbot.getClientThread().runOnClientThread(() -> Microbot.getClient().getWidget(id).getChild(childId).getText());
     }
 
     public static boolean clickWidget(int id) {
@@ -131,6 +136,7 @@ public class Rs2Widget {
         Microbot.getMouse().click(widget.getChild(childId).getBounds());
         return true;
     }
+
     public static boolean childWidgetExits(int id, int childId) {
         return Microbot.getClientThread().runOnClientThread(() -> Microbot.getClient().getWidget(id).getChild(childId) != null);
     }
@@ -141,7 +147,7 @@ public class Rs2Widget {
                 Widget widget = findWidget(textToSearch, null);
                 if (widget == null) break;
                 Microbot.getClientThread().runOnClientThread(() -> widget.setText(newText));
-            } catch(Exception ex) {
+            } catch (Exception ex) {
                 System.out.println(ex.getMessage());
             }
 
@@ -181,6 +187,7 @@ public class Rs2Widget {
             return foundWidget;
         });
     }
+
     public static Widget findWidget(String text) {
         return findWidget(text, null, false);
     }
@@ -194,7 +201,7 @@ public class Rs2Widget {
     }
 
     public static boolean sleepUntilHasWidget(String text) {
-        sleepUntil(() ->  findWidget(text, null, false) != null);
+        sleepUntil(() -> findWidget(text, null, false) != null);
         return findWidget(text, null, false) != null;
     }
 
@@ -244,7 +251,7 @@ public class Rs2Widget {
     }
 
     public static Widget searchChildren(String text, Widget child) {
-       return searchChildren(text, child, false);
+        return searchChildren(text, child, false);
     }
 
     public static Widget findWidget(int spriteId, List<Widget> children) {
@@ -310,7 +317,7 @@ public class Rs2Widget {
 
     public static void clickWidgetFast(int packetId, int identifier) {
         Widget widget = getWidget(packetId);
-        clickWidgetFast(widget,-1, identifier);
+        clickWidgetFast(widget, -1, identifier);
     }
 
     public static void clickWidgetFast(int packetId, MenuAction menuAction) {
@@ -328,7 +335,7 @@ public class Rs2Widget {
         String option = "Select";
         String target = "";
         Microbot.doInvoke(new NewMenuEntry(-1, param1, menuAction.getId(), 0, widget.getItemId(), target), widget.getBounds());
-       // Rs2Reflection.invokeMenu(-1, param1, menuAction.getId(), 0, widget.getItemId(), option, target, -1, -1);
+        // Rs2Reflection.invokeMenu(-1, param1, menuAction.getId(), 0, widget.getItemId(), option, target, -1, -1);
     }
 
     public static void clickWidgetFast(Widget widget, int param0, int identifier) {
@@ -337,7 +344,7 @@ public class Rs2Widget {
         String target = "";
         MenuAction menuAction = MenuAction.CC_OP;
         Microbot.doInvoke(new NewMenuEntry(param0 != -1 ? param0 : widget.getType(), param1, menuAction.getId(), identifier, widget.getItemId(), target), widget.getBounds());
-       // Rs2Reflection.invokeMenu(param0 != -1 ? param0 : widget.getType(), param1, menuAction.getId(), identifier, widget.getItemId(), option, target, -1, -1);
+        // Rs2Reflection.invokeMenu(param0 != -1 ? param0 : widget.getType(), param1, menuAction.getId(), identifier, widget.getItemId(), option, target, -1, -1);
     }
 
     public static void clickWidgetFast(Widget widget, int param0, int identifier, MenuAction menuAction) {
@@ -345,7 +352,7 @@ public class Rs2Widget {
         String option = "Select";
         String target = "";
         Microbot.doInvoke(new NewMenuEntry(param0 != -1 ? param0 : widget.getType(), param1, menuAction.getId(), identifier, widget.getItemId(), target), widget.getBounds());
-       // Rs2Reflection.invokeMenu(param0 != -1 ? param0 : widget.getType(), param1, menuAction.getId(), identifier, widget.getItemId(), option, target, -1, -1);
+        // Rs2Reflection.invokeMenu(param0 != -1 ? param0 : widget.getType(), param1, menuAction.getId(), identifier, widget.getItemId(), option, target, -1, -1);
     }
 
     public static void clickWidgetFast(Widget widget, int param0) {
@@ -354,5 +361,10 @@ public class Rs2Widget {
 
     public static void clickWidgetFast(Widget widget) {
         clickWidgetFast(widget, -1, 1);
+    }
+
+    // check if production widget is open
+    public static boolean isProductionWidgetOpen() {
+        return isWidgetVisible(270, 0);
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/wintertodt/MWintertodtConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/wintertodt/MWintertodtConfig.java
@@ -62,16 +62,16 @@ public interface MWintertodtConfig extends Config {
         return true;
     }
 
-//    @ConfigItem(
-//            keyName = "FixBrazier",
-//            name = "Fix Brazier",
-//            description = "The Wintertodt will occasionally break the braziers; they must be repaired again before use. This rewards 4x the player's Construction level in experience, provided they own a player-owned house.",
-//            position = 3,
-//            section = generalSection
-//    )
-//    default boolean fixBrazier() {
-//        return true;
-//    }
+    @ConfigItem(
+            keyName = "FixBrazier",
+            name = "Fix Brazier",
+            description = "The Wintertodt will occasionally break the braziers; they must be repaired again before use. This rewards 4x the player's Construction level in experience, provided they own a player-owned house.",
+            position = 3,
+            section = generalSection
+    )
+    default boolean fixBrazier() {
+        return true;
+    }
 
     @ConfigItem(
             keyName = "OpenCrates",


### PR DESCRIPTION
# Changelog #

## Antiban ##
- Fixed a bug that caused the break handler to be ignored when the antiban action cooldown finished.
- Fixed an issue where the antiban action cooldown would not trigger if the chance was 100%, as it was represented as 1% after fractional conversion.

## Rs2Bank ##
- All interactions with the bank are now properly implemented with both the natural mouse and the old clicking method.
- The main `invokeMenu` method will handle bank tab switching and scrolling to ensure the item we are interacting with is in view. This avoids having to handle it at the Script/Plugin level.
- NEW METHOD: `Rs2Bank.preHover()` will attempt to move the mouse and pre-hover over the bank. This only works with the natural mouse, as it is not necessary without it.

## Rs2GameObject ##
- NEW METHOD: `Rs2GameObject.hoverOverObject(TileObject object)` will attempt to move the mouse and pre-hover over the given object. This only works with the natural mouse, as it is not necessary without it.

## Rs2Inventory ##
- Fixed the `isSlotEmpty` method; the old method was not reliable and provided false positives.
- Updated all `slot()` methods to just return `item.slot` instead of getting the index, as in rare cases these did not match.

## Bot Mouse Overlay ##
- A rare null pointer error causing the overlay to go into "disco mode" should now be avoided and fixed.

## Rs2Npc ##
- NEW METHOD: `Rs2Npc.hoverOverActor(Actor actor)` will attempt to move the mouse and pre-hover over the given NPC. This only works with the natural mouse, as it is not necessary without it.

## Rs2Widget ##
- NEW METHOD: `Rs2Widget.isProductionWidgetOpen()` checks if the production widget is open.

## Wintertodt ##
- Fixed and reintroduced the option to fix the broken Brazier.
- Made some minor performance improvements and tweaks.
- When using the natural mouse, it will hover over the Brazier while waiting for the game to begin.
- Added check for Bruma torch (off-hand)

## Fletcher ##
- Implemented `Rs2Bank.preHover()` to serve as an example.

## QoL ##
- Renamed the banking replay from `Withdraw-Last` to `Do-Last` to avoid confusion that it would only withdraw.
- NEW: Furnaces with the Smelt action have been given the same function as the bank replay; set up by performing whatever action you wish and use `Do-Last` to replay the same actions.
- NEW: `Dialogue Auto Continue` to handle all annoying continue dialogs.

