### PR TITLE
Shooting Star Bug Fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarConfig.java
@@ -10,8 +10,9 @@ public interface ShootingStarConfig extends Config {
     
     String configGroup = "shooting-star";
     String displayAsMinutes = "displayAsMinutes";
-    String displayMembersWorlds = "displayMembersWorlds";
-    String displayWildernessLocations = "displayWildernessLocations";
+    String hideF2PWorlds = "hideF2PWorlds";
+    String hideMembersWorlds = "hideMembersWorlds";
+    String hideWildernessLocations = "hideWildernessLocations";
     String useNearestHighTierStar = "useNearestHighTierStar";
 
     @ConfigSection(
@@ -70,24 +71,35 @@ public interface ShootingStarConfig extends Config {
     String panelSection = "panel";
 
     @ConfigItem(
-            keyName = displayMembersWorlds,
+            keyName = hideMembersWorlds,
             name = "Hide Members Worlds",
             description = "Hide Members worlds inside of the panel",
             position = 0,
             section = panelSection
     )
-    default boolean isDisplayMembersWorlds() {
+    default boolean isHideMembersWorlds() {
         return false;
     }
 
     @ConfigItem(
-            keyName = displayWildernessLocations,
-            name = "Hide Wilderness Locations",
-            description = "Hide Wilderness locations inside of the panel",
+            keyName = hideF2PWorlds,
+            name = "Hide F2P Worlds",
+            description = "Hide F2P worlds inside of the panel",
             position = 1,
             section = panelSection
     )
-    default boolean isDisplayWildernessLocations() {
+    default boolean isHideF2PWorlds() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = hideWildernessLocations,
+            name = "Hide Wilderness Locations",
+            description = "Hide Wilderness locations inside of the panel",
+            position = 2,
+            section = panelSection
+    )
+    default boolean isHideWildernessLocations() {
         return true;
     }
 
@@ -95,7 +107,7 @@ public interface ShootingStarConfig extends Config {
             keyName = displayAsMinutes,
             name = "Display as Minutes",
             description = "Shows time left as minutes",
-            position = 2,
+            position = 3,
             section = panelSection
     )
     default boolean isDisplayAsMinutes() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPanel.java
@@ -274,10 +274,13 @@ public class ShootingStarPanel extends PluginPanel {
 
     public void hideStars(List<Star> starList) {
         for (Star star : starList) {
-            if (plugin.isDisplayMembersWorlds() && star.isMemberWorld()) {
+            if (plugin.isHideMembersWorlds() && star.isMemberWorld()) {
                 hiddenStars.add(star);
             }
-            if (plugin.isDisplayWildernessLocations() && star.isInWilderness()) {
+            if (plugin.isHideF2PWorlds() && star.isF2PWorld()) {
+                hiddenStars.add(star);
+            }
+            if (plugin.isHideWildernessLocations() && star.isInWilderness()) {
                 hiddenStars.add(star);
             }
         }
@@ -286,12 +289,19 @@ public class ShootingStarPanel extends PluginPanel {
     public void showStars() {
         List<Star> starsToRemove = new ArrayList<>();
         for (Star star : hiddenStars) {
-            if (!plugin.isDisplayMembersWorlds() && star.isMemberWorld()) {
-                if (plugin.isDisplayWildernessLocations() && star.isInWilderness()) continue;
+            if (!plugin.isHideMembersWorlds() && star.isMemberWorld()) {
+                if (plugin.isHideF2PWorlds() && star.isF2PWorld()) continue;
+                if (plugin.isHideWildernessLocations() && star.isInWilderness()) continue;
                 starsToRemove.add(star);
             }
-            if (!plugin.isDisplayWildernessLocations() && star.isInWilderness()) {
-                if (plugin.isDisplayMembersWorlds() && star.isMemberWorld()) continue;
+            if (!plugin.isHideF2PWorlds() && star.isF2PWorld()) {
+                if (plugin.isHideMembersWorlds() && star.isMemberWorld()) continue;
+                if (plugin.isHideWildernessLocations() && star.isInWilderness()) continue;
+                starsToRemove.add(star);
+            }
+            if (!plugin.isHideWildernessLocations() && star.isInWilderness()) {
+                if (plugin.isHideMembersWorlds() && star.isMemberWorld()) continue;
+                if (plugin.isHideF2PWorlds() && star.isF2PWorld()) continue;
                 starsToRemove.add(star);
             }
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
@@ -70,9 +70,11 @@ public class ShootingStarPlugin extends Plugin {
     @Getter
     private boolean displayAsMinutes;
     @Getter
-    private boolean displayMembersWorlds;
+    private boolean hideMembersWorlds;
     @Getter
-    private boolean displayWildernessLocations;
+    private boolean hideF2PWorlds;
+    @Getter
+    private boolean hideWildernessLocations;
     private boolean useNearestHighTierStar;
     @Inject
     private WorldService worldService;
@@ -125,7 +127,7 @@ public class ShootingStarPlugin extends Plugin {
 
             addToList(star);
         }
-        filterPanelList(displayWildernessLocations || displayMembersWorlds);
+        filterPanelList(hideWildernessLocations || hideMembersWorlds || hideF2PWorlds);
         updatePanelList(true);
     }
 
@@ -223,9 +225,10 @@ public class ShootingStarPlugin extends Plugin {
     @Override
     protected void startUp() throws AWTException {
         displayAsMinutes = config.isDisplayAsMinutes();
-        displayMembersWorlds = config.isDisplayMembersWorlds();
+        hideMembersWorlds = config.isHideMembersWorlds();
+        hideF2PWorlds = config.isHideF2PWorlds();
         useNearestHighTierStar = config.useNearestHighTierStar();
-        displayWildernessLocations = config.isDisplayWildernessLocations();
+        hideWildernessLocations = config.isHideWildernessLocations();
         try {
             loadUrlFromProperties();
         } catch (IOException e) {
@@ -259,15 +262,21 @@ public class ShootingStarPlugin extends Plugin {
             updatePanelList(true);
         }
 
-        if (event.getKey().equals(ShootingStarConfig.displayMembersWorlds)) {
-            displayMembersWorlds = config.isDisplayMembersWorlds();
-            filterPanelList(displayMembersWorlds);
+        if (event.getKey().equals(ShootingStarConfig.hideMembersWorlds)) {
+            hideMembersWorlds = config.isHideMembersWorlds();
+            filterPanelList(hideMembersWorlds);
             updatePanelList(true);
         }
 
-        if (event.getKey().equals(ShootingStarConfig.displayWildernessLocations)) {
-            displayWildernessLocations = config.isDisplayWildernessLocations();
-            filterPanelList(displayWildernessLocations);
+        if (event.getKey().equals(ShootingStarConfig.hideF2PWorlds)) {
+            hideF2PWorlds = config.isHideF2PWorlds();
+            filterPanelList(hideF2PWorlds);
+            updatePanelList(true);
+        }
+
+        if (event.getKey().equals(ShootingStarConfig.hideWildernessLocations)) {
+            hideWildernessLocations = config.isHideWildernessLocations();
+            filterPanelList(hideWildernessLocations);
             updatePanelList(true);
         }
 
@@ -327,7 +336,7 @@ public class ShootingStarPlugin extends Plugin {
         // Get the highest tier available
         int highestTier = starList.stream()
                 .filter(Star::hasRequirements)
-                .filter(x -> !panel.getHiddenStars().contains(x))
+                .filter(s -> panel.getHiddenStars().stream().noneMatch(h -> h.equals(s)))
                 .mapToInt(Star::getTier)
                 .max()
                 .orElse(-1);  // Return -1 if no star meets the requirements
@@ -344,7 +353,7 @@ public class ShootingStarPlugin extends Plugin {
 
         // Iterate through all stars and categorize them by distance
         for (Star star : starList) {
-            if (panel.getHiddenStars().contains(star)) continue;
+            if (panel.getHiddenStars().stream().anyMatch(h -> h.equals(star))) continue;
             if (!star.hasRequirements()) continue;
 
             int starTier = star.getTier();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarScript.java
@@ -78,6 +78,13 @@ public class ShootingStarScript extends Script {
 
                         if (plugin.useNearestHighTierStar()) {
                             star = plugin.getClosestHighestTierStar();
+                            
+                            if (star == null) {
+                                Microbot.showMessage("Unable to find a star within your tier range. Consider disabling useNearestHighTierStar until higher mining level.");
+                                shutdown();
+                                return;
+                            }
+                            
                             plugin.updateSelectedStar(star);
                         } else {
                             star = plugin.getSelectedStar();
@@ -291,6 +298,7 @@ public class ShootingStarScript extends Script {
 
             star.setObjectID(starObject.getId());
             star.setTier(star.getTierBasedOnObjectID());
+            star.setMiningLevel(star.getRequiredMiningLevel());
         }
         return ShootingStarState.MINING;
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/enums/ShootingStarLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/enums/ShootingStarLocation.java
@@ -27,7 +27,7 @@ public enum ShootingStarLocation {
     DWARVEN_MINE_NORTHERN_ENTRANCE(new WorldPoint(3017, 3445, 0), "North Dwarven Mine entrance", "Dwarven Mine", false),
     NARDAH(new WorldPoint(3434, 2891, 0), "Nardah bank", "Nardah", false),
     AGILITY_PYRAMID_MINE(new WorldPoint(3314, 2867, 0), "Agility Pyramid mine", "Agility Pyramid", false),
-    UZER_MINE(new WorldPoint(3424, 3160, 0), "Nw of Uzer (Eagle's Eyrie)", "Uzer Mine", false),
+    UZER_MINE(new WorldPoint(3422, 3159, 0), "Nw of Uzer (Eagle's Eyrie)", "Uzer Mine", false),
     PORT_KHAZARD_MINE(new WorldPoint(2625, 3143, 0), "Port Khazard mine", "Port Khazard", false),
     GRAND_TREE(new WorldPoint(2446, 3491, 0), "West of Grand Tree", "Grand Tree", false),
     BANDIT_CAMP_MINE__HOBGOBLINS(new WorldPoint(3093, 3751, 0), "Hobgoblin mine (lvl 30 Wildy)", "Hobgoblin mine", true),
@@ -171,6 +171,15 @@ public enum ShootingStarLocation {
             case MINE_NORTH_WEST_OF_HUNTER_GUILD:
                 // Requires Children of the Sun
                 return Rs2Player.getQuestState(Quest.CHILDREN_OF_THE_SUN) == QuestState.FINISHED;
+            case CORSAIR_COVE:
+                // Requires The Corsair Curse if not Member
+                if (!Rs2Player.isMember()) {
+                    return (Rs2Player.getQuestState(Quest.THE_CORSAIR_CURSE) == QuestState.IN_PROGRESS || Rs2Player.getQuestState(Quest.THE_CORSAIR_CURSE) == QuestState.FINISHED);
+                }
+                return true;
+            case CORSAIR_COVE_RESOURCE_AREA:
+                // Requires Dragon Slayer I
+                return Rs2Player.getQuestState(Quest.DRAGON_SLAYER_I) == QuestState.FINISHED;
             default:
                 return true;
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/model/Star.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/model/Star.java
@@ -108,6 +108,9 @@ public class Star {
     public boolean isMemberWorld() {
         return !this.isGameModeWorld() && this.getWorldObject().getTypes().contains(WorldType.MEMBERS);
     }
+    public boolean isF2PWorld() {
+        return !this.isGameModeWorld() && !this.getWorldObject().getTypes().contains(WorldType.MEMBERS);
+    }
     
     @Override
     public boolean equals(Object obj) {


### PR DESCRIPTION
I am creating this PR to fix a few bugs that are inside of the Current Version of the ShootingStar Plugin.

Features: 
- Added config option to hide F2P worlds to prevent hopping to free to play.

Fixes:
- Added a method to update the selected star's mining level to shorten the wait time when standing at stars.
- Added a check if the getClosestHighestTierStar method can not find a star within the acceptable tier range.
- When using getClosestHighestTierStar, adjusted the check if a star is apart of the hidden list to be more generic.
- Added Location requirements for Corsair Resource Area & Corsair Bank
- Adjusted config options to align more with the name shown in the plugin panel.