### PR TITLE
Add Alternative WalkTo Interaction

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/callback/ClientThread.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/ClientThread.java
@@ -69,6 +69,19 @@ public class ClientThread
 		scheduledFuture = scheduledExecutorService.submit(() -> method.call());
 	}
 
+	/***
+	 * Runs a Callable<Boolean> on a seperate thread. Similar to runOnSeperateThread except this
+	 * method blocks until the callable returns.
+	 * @param method Callable to submit
+	 * @return the result of the callable
+	 */
+	@SneakyThrows
+	public boolean runBlockingCallable(Callable<Boolean> method) {
+		if (scheduledFuture != null && !scheduledFuture.isDone()) return false;
+		scheduledFuture = scheduledExecutorService.submit(method);
+		return (boolean) scheduledFuture.get();
+	}
+
 
 	/**
 	 * Will run r on the game thread, at an unspecified point in the future.


### PR DESCRIPTION
When using the original walkTo(WorldPoint target, int distance) method, there’s a noticeable delay between when the walking finishes and when the script resumes. This often results in the player stopping a few tiles short of a GameObject, pausing briefly before interacting with it.

This pull request introduces a new walkTo-based function that:

- Blocks execution until the walking task completes.
- Automatically attempts to resolve and interact with a GameObject based on a given condition when the player gets near the target.
- 
The goal is preform a more seamless transition from walking to interacting, all within a single thread so there doesn't need to be any synchronization.


Since the original walkTo is non-blocking, the code that invokes it doesn't know when the main walking loop finishes. This uncertainty likely causes delays, as the invoking code has to wait until the player stops moving.