### PR TITLE
Add Developer Overlay to ShootingStarPlugin + Fletch Arrow Shaft

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarConfig.java
@@ -16,13 +16,14 @@ public interface ShootingStarConfig extends Config {
     String hideMembersWorlds = "hideMembersWorlds";
     String hideWildernessLocations = "hideWildernessLocations";
     String useNearestHighTierStar = "useNearestHighTierStar";
+    String useBreakAtBank = "useBreakAtBank";
     String hideOverlay = "hideOverlay";
     String hideDevOverlay = "hideDevOverlay";
 
     @ConfigSection(
             name = "General Settings",
             description = "Configure general plugin configuration & preferences",
-            position = 1
+            position = 0
     )
     String generalSection = "general";
 
@@ -41,10 +42,21 @@ public interface ShootingStarConfig extends Config {
             keyName = useNearestHighTierStar,
             name = "Use Nearest High Tier Star",
             description = "Toggles automatic mode - when enabled script will automatically check all stars within an acceptable tier range & find the closest star that has the highest tier",
-            position = 2,
+            position = 1,
             section = generalSection
     )
     default boolean useNearestHighTierStar() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = useBreakAtBank,
+            name = "Use Break at Bank",
+            description = "Toggles breaks at the bank - when enabled script will force the player to a bank before triggering the Break Handler",
+            position = 2,
+            section = generalSection
+    )
+    default boolean useBreakAtBank() {
         return false;
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarConfig.java
@@ -16,6 +16,7 @@ public interface ShootingStarConfig extends Config {
     String hideMembersWorlds = "hideMembersWorlds";
     String hideWildernessLocations = "hideWildernessLocations";
     String useNearestHighTierStar = "useNearestHighTierStar";
+    String hideOverlay = "hideOverlay";
     String hideDevOverlay = "hideDevOverlay";
 
     @ConfigSection(
@@ -104,13 +105,23 @@ public interface ShootingStarConfig extends Config {
             position = 2
     )
     String overlaySection = "overlay";
-    
+
+    @ConfigItem(
+            keyName = hideOverlay,
+            name = "Hide Overlay",
+            description = "Hide overlay",
+            position = 0,
+            section = overlaySection
+    )
+    default boolean isHideOverlay() {
+        return false;
+    }
 
     @ConfigItem(
             keyName = hideDevOverlay,
             name = "Hide Dev Overlay",
             description = "Hide developer overlay",
-            position = 0,
+            position = 1,
             section = overlaySection
     )
     default boolean isHideDevOverlay() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarConfig.java
@@ -1,11 +1,13 @@
 package net.runelite.client.plugins.microbot.mining.shootingstar;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.*;
 
 @ConfigGroup(ShootingStarConfig.configGroup)
+@ConfigInformation(
+        "• This plugin will assist in finding & traveling to shooting stars. <br />" +
+        "• Configure inventory setup name or the plugin will look for best owned pickaxe <br />" +
+        "• Start the plugin it will configure the inventory, if needed, then travel based on configuration settings <br />"
+)
 public interface ShootingStarConfig extends Config {
     
     String configGroup = "shooting-star";
@@ -14,25 +16,7 @@ public interface ShootingStarConfig extends Config {
     String hideMembersWorlds = "hideMembersWorlds";
     String hideWildernessLocations = "hideWildernessLocations";
     String useNearestHighTierStar = "useNearestHighTierStar";
-
-    @ConfigSection(
-            name = "",
-            description = "",
-            position = 0
-    )
-    String guideSection = "guide";
-
-    @ConfigItem(
-            keyName = "guide",
-            name = "Guide",
-            description = "",
-            position = 0,
-            section = guideSection
-    )
-    default String guide() {
-        return "This plugin will assist in finding & traveling to shooting stars.\n" +
-                "Start this plugin in any state & it will setup inventory, then travel based on configuration settings";
-    }
+    String hideDevOverlay = "hideDevOverlay";
 
     @ConfigSection(
             name = "General Settings",
@@ -112,5 +96,24 @@ public interface ShootingStarConfig extends Config {
     )
     default boolean isDisplayAsMinutes() {
         return false;
+    }
+
+    @ConfigSection(
+            name = "Overlay Settings",
+            description = "Configure overlay settings",
+            position = 2
+    )
+    String overlaySection = "overlay";
+    
+
+    @ConfigItem(
+            keyName = hideDevOverlay,
+            name = "Hide Dev Overlay",
+            description = "Hide developer overlay",
+            position = 0,
+            section = overlaySection
+    )
+    default boolean isHideDevOverlay() {
+        return true;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarOverlay.java
@@ -1,6 +1,7 @@
 package net.runelite.client.plugins.microbot.mining.shootingstar;
 
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.misc.TimeUtils;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.LineComponent;
@@ -9,15 +10,25 @@ import net.runelite.client.util.ColorUtil;
 
 import javax.inject.Inject;
 import java.awt.*;
+import java.sql.Time;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 public class ShootingStarOverlay extends OverlayPanel {
+
+    ShootingStarPlugin plugin;
+    private final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm");
+
     @Inject
-    ShootingStarOverlay(ShootingStarPlugin plugin)
-    {
+    ShootingStarOverlay(ShootingStarPlugin plugin) {
         super(plugin);
+        this.plugin = plugin;
         setPosition(OverlayPosition.TOP_LEFT);
         setNaughty();
     }
+
     @Override
     public Dimension render(Graphics2D graphics) {
         try {
@@ -26,14 +37,102 @@ public class ShootingStarOverlay extends OverlayPanel {
                     .text("ShootingStar Miner V" + ShootingStarPlugin.version)
                     .color(ColorUtil.fromHex("0077B6"))
                     .build());
-            
+
             panelComponent.getChildren().add(LineComponent.builder().build());
 
             panelComponent.getChildren().add(LineComponent.builder()
-                    .left(Microbot.status)
+                    .left("Status:")
+                    .right(Microbot.status)
                     .build());
-            
-        } catch(Exception ex) {
+
+            if (!plugin.isHideDevOverlay()) {
+                if (ShootingStarScript.state != null) {
+                    panelComponent.getChildren().add(LineComponent.builder()
+                            .left("Current State:")
+                            .right(ShootingStarScript.state.name())
+                            .build());
+                }
+
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("Run time:")
+                        .right(TimeUtils.getFormattedDurationBetween(plugin.getStartTime(), Instant.now()))
+                        .build());
+
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("Total Stars Mined:")
+                        .right(Integer.toString(plugin.getTotalStarsMined()))
+                        .build());
+
+                if (plugin.getSelectedStar() != null) {
+                    panelComponent.getChildren().add(LineComponent.builder().build());
+
+                    panelComponent.getChildren().add(TitleComponent.builder()
+                            .text("Current Star Information")
+                            .color(ColorUtil.fromHex("0077B6"))
+                            .build());
+
+                    panelComponent.getChildren().add(LineComponent.builder().build());
+
+                    panelComponent.getChildren().add(LineComponent.builder()
+                            .left("Location:")
+                            .right(plugin.getSelectedStar().getShootingStarLocation().getLocationName())
+                            .build());
+
+                    panelComponent.getChildren().add(LineComponent.builder()
+                            .left("Is in Wilderness:")
+                            .right(String.valueOf(plugin.getSelectedStar().isInWilderness()))
+                            .build());
+
+                    panelComponent.getChildren().add(LineComponent.builder()
+                            .left("World:")
+                            .right(Integer.toString(plugin.getSelectedStar().getWorld()))
+                            .build());
+
+                    String worldType = plugin.getSelectedStar().isMemberWorld() ? "Member" :
+                            plugin.getSelectedStar().isF2PWorld() ? "F2P" : "Unknown";
+
+                    panelComponent.getChildren().add(LineComponent.builder()
+                            .left("World Type:")
+                            .right(worldType)
+                            .build());
+
+                    panelComponent.getChildren().add(LineComponent.builder()
+                            .left("Tier:")
+                            .right(Integer.toString(plugin.getSelectedStar().getTier()))
+                            .build());
+
+                    Instant endInstant = Instant.ofEpochMilli(plugin.getSelectedStar().getEndsAt());
+                    String estEndTime = plugin.isDisplayAsMinutes() ? TimeUtils.getFormattedDurationBetween(Instant.now(), endInstant) :
+                            LocalDateTime.ofInstant(endInstant, ZoneId.systemDefault()).format(dtf);
+
+                    panelComponent.getChildren().add(LineComponent.builder()
+                            .left("Est. End Time:")
+                            .right(estEndTime)
+                            .build());
+                    
+
+                    panelComponent.getChildren().add(LineComponent.builder()
+                            .left("Has Requirements:")
+                            .right(String.valueOf(plugin.getSelectedStar().hasRequirements()))
+                            .build());
+
+                    if (!plugin.getSelectedStar().hasRequirements()) {
+                        panelComponent.getChildren().add(LineComponent.builder().build());
+                        
+                        panelComponent.getChildren().add(LineComponent.builder()
+                                .left("Has Location Requirements:")
+                                .right(String.valueOf(plugin.getSelectedStar().hasLocationRequirements()))
+                                .build());
+
+                        panelComponent.getChildren().add(LineComponent.builder()
+                                .left("Has Mining Level:")
+                                .right(String.valueOf(plugin.getSelectedStar().hasMiningLevel()))
+                                .build());
+                    }
+                }
+            }
+
+        } catch (Exception ex) {
             System.out.println(ex.getMessage());
         }
         return super.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarOverlay.java
@@ -10,7 +10,6 @@ import net.runelite.client.util.ColorUtil;
 
 import javax.inject.Inject;
 import java.awt.*;
-import java.sql.Time;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -19,7 +18,7 @@ import java.time.format.DateTimeFormatter;
 public class ShootingStarOverlay extends OverlayPanel {
 
     ShootingStarPlugin plugin;
-    private final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm");
+    private final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm:ss");
 
     @Inject
     ShootingStarOverlay(ShootingStarPlugin plugin) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
@@ -362,7 +362,7 @@ public class ShootingStarPlugin extends Plugin {
 
     private void toggleOverlay(boolean hideOverlay) {
         if (overlayManager != null) {
-            boolean hasOverlay = overlayManager.anyMatch(ov -> ov.getName().equalsIgnoreCase(ShootingStarOverlay.class.getName()));
+            boolean hasOverlay = overlayManager.anyMatch(ov -> ov.getName().equalsIgnoreCase(ShootingStarOverlay.class.getSimpleName()));
 
             if (hideOverlay) {
                 if(!hasOverlay) return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
@@ -84,6 +84,7 @@ public class ShootingStarPlugin extends Plugin {
     private boolean hideF2PWorlds;
     @Getter
     private boolean hideWildernessLocations;
+    private boolean hideOverlay;
     @Getter
     private boolean hideDevOverlay;
     private boolean useNearestHighTierStar;
@@ -242,6 +243,7 @@ public class ShootingStarPlugin extends Plugin {
         hideF2PWorlds = config.isHideF2PWorlds();
         useNearestHighTierStar = config.useNearestHighTierStar();
         hideWildernessLocations = config.isHideWildernessLocations();
+        hideOverlay = config.isHideOverlay();
         hideDevOverlay = config.isHideDevOverlay();
         
         try {
@@ -253,10 +255,8 @@ public class ShootingStarPlugin extends Plugin {
         fetchStars();
         createPanel();
         SwingUtilities.invokeLater(() -> panel.hideStars(starList));
-
-        if (overlayManager != null) {
-            overlayManager.add(shootingStarOverlay);
-        }
+        
+        toggleOverlay(hideOverlay);
         
         startTime = Instant.now();
         
@@ -301,6 +301,11 @@ public class ShootingStarPlugin extends Plugin {
 
         if (event.getKey().equals(ShootingStarConfig.useNearestHighTierStar)) {
             useNearestHighTierStar = config.useNearestHighTierStar();
+        }
+
+        if (event.getKey().equals(ShootingStarConfig.hideOverlay)) {
+            hideOverlay = config.isHideOverlay();
+            toggleOverlay(hideOverlay);
         }
 
         if (event.getKey().equals(ShootingStarConfig.hideDevOverlay)) {
@@ -353,6 +358,22 @@ public class ShootingStarPlugin extends Plugin {
         clientToolbar.removeNavigation(navButton);
         navButton = null;
         panel = null;
+    }
+
+    private void toggleOverlay(boolean hideOverlay) {
+        if (overlayManager != null) {
+            boolean hasOverlay = overlayManager.anyMatch(ov -> ov.getName().equalsIgnoreCase(ShootingStarOverlay.class.getName()));
+
+            if (hideOverlay) {
+                if(!hasOverlay) return;
+
+                overlayManager.remove(shootingStarOverlay);
+            } else {
+                if (hasOverlay) return;
+
+                overlayManager.add(shootingStarOverlay);
+            }
+        }
     }
 
     public Star getClosestHighestTierStar() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarScript.java
@@ -5,6 +5,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.inventorysetups.MInventorySetupsPlugin;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
 import net.runelite.client.plugins.microbot.mining.shootingstar.enums.Pickaxe;
 import net.runelite.client.plugins.microbot.mining.shootingstar.enums.ShootingStarState;
 import net.runelite.client.plugins.microbot.mining.shootingstar.model.Star;
@@ -29,10 +30,10 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 public class ShootingStarScript extends Script {
+    public static ShootingStarState state;
     private final ShootingStarPlugin plugin;
     Rs2InventorySetup rs2InventorySetup;
     Pickaxe pickaxe;
-    public static ShootingStarState state;
     Star star;
     private boolean hasEquipment = false;
     private boolean hasInventory = false;
@@ -43,7 +44,7 @@ public class ShootingStarScript extends Script {
     }
 
     public boolean run(ShootingStarConfig config) {
-        Microbot.enableAutoRunOn = false;
+        Microbot.enableAutoRunOn = true;
         initialPlayerLocation = null;
         hasEquipment = false;
         hasInventory = false;
@@ -75,30 +76,35 @@ public class ShootingStarScript extends Script {
 
                 switch (state) {
                     case WAITING_FOR_STAR:
-
                         if (plugin.useNearestHighTierStar()) {
-                            star = plugin.getClosestHighestTierStar();
+                            if (!hasSelectedStar()) {
+                                star = plugin.getClosestHighestTierStar();
 
-                            if (star == null) {
-                                Microbot.showMessage("Unable to find a star within your tier range. Consider disabling useNearestHighTierStar until higher mining level.");
-                                shutdown();
-                                return;
+                                if (star == null) {
+                                    Microbot.showMessage("Unable to find a star within your tier range. Consider disabling useNearestHighTierStar until higher mining level.");
+                                    shutdown();
+                                    return;
+                                }
+                            } else {
+                                star = plugin.getSelectedStar();
                             }
-
-                            plugin.updateSelectedStar(star);
                         } else {
                             star = plugin.getSelectedStar();
 
-                            if (!checkSelectedStar()) {
+                            if (star == null) {
                                 Microbot.log("Please select a star inside of the panel to start the script.");
-                                sleepUntil(this::checkSelectedStar);
+                                sleepUntil(this::hasSelectedStar);
                                 return;
                             }
                         }
 
+                        plugin.updateSelectedStar(star);
+
                         state = ShootingStarState.WALKING;
                         break;
                     case WALKING:
+                        toggleLockState(true);
+
                         if (Rs2Player.getWorld() != star.getWorldObject().getId()) {
                             Microbot.hopToWorld(star.getWorldObject().getId());
                             sleepUntil(() -> Microbot.getClient().getGameState() == GameState.LOGGED_IN);
@@ -140,7 +146,12 @@ public class ShootingStarScript extends Script {
 
                         break;
                     case BANKING:
-                        boolean isBankOpen = Rs2Bank.walkToBankAndUseBank();
+                        boolean isNearBank = Rs2Bank.walkToBank();
+                        if (!isNearBank || !Rs2Bank.isNearBank(6)) return;
+
+                        toggleLockState(false);
+
+                        boolean isBankOpen = Rs2Bank.useBank();
                         if (!isBankOpen || !Rs2Bank.isOpen()) return;
 
                         if (Rs2Inventory.hasItem("uncut")) {
@@ -150,11 +161,11 @@ public class ShootingStarScript extends Script {
                         if (isUsingInventorySetup(config)) {
                             if (!hasEquipment) {
                                 hasEquipment = rs2InventorySetup.loadEquipment();
-                                Rs2Random.wait(800, 1200);
+                                Rs2Random.waitEx(1200, 300);
                             }
                             if (!hasInventory && rs2InventorySetup.doesEquipmentMatch()) {
                                 hasInventory = rs2InventorySetup.loadInventory();
-                                Rs2Random.wait(800, 1200);
+                                Rs2Random.waitEx(1200, 300);
                             }
 
                             if (!hasEquipment || !hasInventory) return;
@@ -163,7 +174,7 @@ public class ShootingStarScript extends Script {
                                 pickaxe = getBestPickaxe(Rs2Bank.bankItems());
                                 if (pickaxe != null) {
                                     Rs2Bank.withdrawItem(pickaxe.getItemName());
-                                    Rs2Random.wait(800, 1200);
+                                    Rs2Random.waitEx(1200, 300);
                                 } else {
                                     Microbot.showMessage("Unable to find pickaxe, please purchase a pickaxe");
                                     shutdown();
@@ -175,7 +186,7 @@ public class ShootingStarScript extends Script {
                         boolean bankClosed = Rs2Bank.closeBank();
                         if (!bankClosed || Rs2Bank.isOpen()) return;
 
-                        if (checkSelectedStar()) {
+                        if (hasSelectedStar()) {
                             if (!star.equals(plugin.getSelectedStar()))
                                 return;
 
@@ -214,19 +225,21 @@ public class ShootingStarScript extends Script {
         return isInventorySetupPluginEnabled && hasInventorySetupConfigured;
     }
 
-    private boolean checkSelectedStar() {
+    private boolean hasSelectedStar() {
         return plugin.getSelectedStar() != null;
     }
 
     public boolean shouldBank(ShootingStarConfig config) {
+        boolean isInventoryFull = Rs2Inventory.isFull();
+        boolean shouldBreak = (shouldBreak() && plugin.useBreakAtBank());
         if (isUsingInventorySetup(config)) {
             hasEquipment = rs2InventorySetup.doesEquipmentMatch();
             hasInventory = rs2InventorySetup.doesInventoryMatch();
-            System.out.printf("hasEquipment %s%nhasInventory %s%n", hasEquipment, hasInventory);
+            System.out.printf("hasEquipment: %s%nhasInventory: %s%nIs Inventory Full: %s%nshouldBreak: %s%n", hasEquipment, hasInventory, isInventoryFull, shouldBreak);
 
-            return (!hasEquipment || !hasInventory) || Rs2Inventory.isFull();
+            return (!hasEquipment || !hasInventory) || isInventoryFull || shouldBreak;
         }
-        return pickaxe == null || Rs2Inventory.isFull();
+        return pickaxe == null || isInventoryFull || shouldBreak;
     }
 
     public ShootingStarState getState(ShootingStarConfig config) {
@@ -234,7 +247,7 @@ public class ShootingStarScript extends Script {
             return ShootingStarState.BANKING;
         }
 
-        if (checkSelectedStar()) {
+        if (hasSelectedStar()) {
             return ShootingStarState.WALKING;
         }
 
@@ -363,7 +376,7 @@ public class ShootingStarScript extends Script {
         return getNearestWalkableTile(distance + 1);
     }
 
-    public Pickaxe getBestPickaxe(List<Rs2Item> items) {
+    private Pickaxe getBestPickaxe(List<Rs2Item> items) {
         Pickaxe bestPickaxe = null;
 
         for (Pickaxe pickaxe : Pickaxe.values()) {
@@ -375,6 +388,22 @@ public class ShootingStarScript extends Script {
             }
         }
         return bestPickaxe;
+    }
+
+    private boolean shouldBreak() {
+        boolean isReadyToBreak = BreakHandlerScript.breakIn <= 1;
+
+        return plugin.isBreakHandlerEnabled() && isReadyToBreak;
+    }
+
+    public void toggleLockState(boolean lock) {
+        if (plugin.isBreakHandlerEnabled() && plugin.useBreakAtBank()) {
+            if (lock && !BreakHandlerScript.isLockState()) {
+                BreakHandlerScript.setLockState(true);
+            } else if (!lock && BreakHandlerScript.isLockState()) {
+                BreakHandlerScript.setLockState(false);
+            }
+        }
     }
 
     private void applyAntiBanSettings() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarScript.java
@@ -32,7 +32,7 @@ public class ShootingStarScript extends Script {
     private final ShootingStarPlugin plugin;
     Rs2InventorySetup rs2InventorySetup;
     Pickaxe pickaxe;
-    ShootingStarState state;
+    public static ShootingStarState state;
     Star star;
     private boolean hasEquipment = false;
     private boolean hasInventory = false;
@@ -292,15 +292,18 @@ public class ShootingStarScript extends Script {
                 plugin.updatePanelList(true);
 
                 if (shouldBank(config)) {
+                    plugin.setTotalStarsMined(plugin.getTotalStarsMined() + 1);
                     return ShootingStarState.BANKING;
                 }
 
+                plugin.setTotalStarsMined(plugin.getTotalStarsMined() + 1);
                 return ShootingStarState.WAITING_FOR_STAR;
             }
 
             star.setObjectID(starObject.getId());
-            star.setTier(star.getTierBasedOnObjectID());
-            star.setMiningLevel(star.getRequiredMiningLevel());
+            plugin.updateSelectedStar(star);
+            plugin.updatePanelList(true);
+            star = selectedStar;
         }
         return ShootingStarState.MINING;
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/enums/ShootingStarLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/enums/ShootingStarLocation.java
@@ -46,7 +46,7 @@ public enum ShootingStarLocation {
     CATHERBY_BANK(new WorldPoint(2804, 3438, 0), "Catherby bank", "Catherby", false),
     CORSAIR_COVE(new WorldPoint(2566, 2858, 0), "Corsair Cove bank", "Corsair Cove bank", false),
     CORSAIR_COVE_RESOURCE_AREA(new WorldPoint(2482, 2881, 0), "Corsair Resource Area", "Corsair Resource Area", false),
-    COAL_TRUCKS(new WorldPoint(2590, 3479, 0), "Coal Trucks west of Seers'", "Seers Village", false),
+    COAL_TRUCKS(new WorldPoint(2594, 3479, 0), "Coal Trucks west of Seers'", "Seers Village", false),
     KELDAGRIM_ENTRANCE_MINE(new WorldPoint(2725, 3683, 0), "Keldagrim entrance mine", "Keldagrim entrance", false),
     PISCATORIS_MINE(new WorldPoint(2342, 3632, 0), "Piscatoris mine", "Piscatoris mine", false),
     SOUTH_BRIMHAVEN_MINE(new WorldPoint(2743, 3145, 0), "Southwest of Brimhaven Poh", "SW Brimhaven", false),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/model/ShootingStarTableRow.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/model/ShootingStarTableRow.java
@@ -25,7 +25,7 @@ import static net.runelite.client.ui.ColorScheme.*;
 
 public class ShootingStarTableRow extends JPanel {
 
-    private static final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm");
+    private static final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm:ss");
     private static final ZoneId utcZoneId = ZoneId.of("UTC");
     private static final Color COLOR_NEGATIVE = new Color(255, 80, 80);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/model/ShootingStarTableRow.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/model/ShootingStarTableRow.java
@@ -7,6 +7,7 @@ import javax.swing.border.LineBorder;
 import lombok.Getter;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.mining.shootingstar.ShootingStarPanel;
+import net.runelite.client.plugins.microbot.util.misc.TimeUtils;
 import net.runelite.client.ui.ColorScheme;
 
 import net.runelite.client.ui.FontManager;
@@ -19,7 +20,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.concurrent.TimeUnit;
 
 import static net.runelite.client.ui.ColorScheme.*;
 
@@ -75,21 +75,6 @@ public class ShootingStarTableRow extends JPanel {
         timeLeftField.setPreferredSize(new Dimension(ShootingStarPanel.TIME_WIDTH, 20));
         timeLeftField.setOpaque(false);
         add(timeLeftField);
-    }
-
-    public static String convertTime(long epoch) {
-        long seconds = TimeUnit.MILLISECONDS.toSeconds(epoch - Instant.now().toEpochMilli());
-        boolean negative = seconds < 0;
-        seconds = Math.abs(seconds);
-        String time = negative ? "-" : "";
-        long minutes = seconds / 60;
-        seconds %= 60;
-        if (minutes >= 100) {
-            time += minutes + "m";
-        } else {
-            time += String.format("%d:%02d", minutes, seconds);
-        }
-        return time;
     }
 
     private MouseAdapter createMouseOptions(Star starData, Color backgroundColor) {
@@ -192,7 +177,7 @@ public class ShootingStarTableRow extends JPanel {
     public void updateTime() {
         String endTime;
         if (displayAsMinutes) {
-            endTime = convertTime(starData.getEndsAt());
+            endTime = TimeUtils.getFormattedDurationBetween(Instant.now(), Instant.ofEpochMilli(starData.getEndsAt()));
         } else {
             Instant endInstant = Instant.ofEpochMilli(starData.getEndsAt());
             endTime = LocalDateTime.ofInstant(endInstant, ZoneId.systemDefault()).format(dtf);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/model/Star.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/model/Star.java
@@ -5,10 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import net.runelite.api.ObjectID;
 import net.runelite.api.Skill;
-import net.runelite.api.Varbits;
-import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.mining.shootingstar.enums.ShootingStarLocation;
-import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.http.api.worlds.World;
 import net.runelite.http.api.worlds.WorldType;
@@ -108,6 +105,7 @@ public class Star {
     public boolean isMemberWorld() {
         return !this.isGameModeWorld() && this.getWorldObject().getTypes().contains(WorldType.MEMBERS);
     }
+    
     public boolean isF2PWorld() {
         return !this.isGameModeWorld() && !this.getWorldObject().getTypes().contains(WorldType.MEMBERS);
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/misc/TimeUtils.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/misc/TimeUtils.java
@@ -13,9 +13,20 @@ public class TimeUtils {
      */
     public static String getFormattedDurationBetween(Instant start, Instant finish) {
         Duration duration = Duration.between(start, finish);
-        return String.format("%d:%02d:%02d",
+
+        // Check if the duration is negative
+        boolean isNegative = duration.isNegative();
+
+        // Use the absolute value of the duration for formatting
+        duration = duration.abs();
+
+        // Format the time components
+        String formattedDuration = String.format("%d:%02d:%02d",
                 duration.toHours(),
                 duration.toMinutesPart(),
                 duration.toSecondsPart());
+
+        // Prefix with "-" if the original duration was negative
+        return (isNegative ? "-" : "") + formattedDuration;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingScript.java
@@ -14,6 +14,7 @@ import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.math.Random;
+import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
@@ -206,6 +207,7 @@ public class AutoWoodcuttingScript extends Script {
     
     private void fletchArrowShaft(AutoWoodcuttingConfig config) {
         Rs2Inventory.combineClosest("knife", config.TREE().getLog());
+        Rs2Random.waitEx(1200, 300);
         Rs2Widget.clickWidget("arrow shafts");
         sleepUntil(() -> !isFlectching(), 5000);
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingScript.java
@@ -17,6 +17,7 @@ import net.runelite.client.plugins.microbot.util.math.Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import net.runelite.client.plugins.microbot.woodcutting.enums.WoodcuttingWalkBack;
 
 import java.util.*;
@@ -74,7 +75,7 @@ public class AutoWoodcuttingScript extends Script {
                     return;
                 }
 
-                if (Rs2Player.isMoving() || Rs2Player.isAnimating() || Microbot.pauseAllScripts || Rs2AntibanSettings.actionCooldownActive)
+                if (Rs2Player.isMoving() || Rs2Player.isAnimating() || Microbot.pauseAllScripts)
                     return;
 
                 if (Rs2AntibanSettings.actionCooldownActive)
@@ -142,6 +143,12 @@ public class AutoWoodcuttingScript extends Script {
                 walkBack(config);
                 state = State.WOODCUTTING;
                 break;
+            case FLETCH_ARROWSHAFT:
+                fletchArrowShaft(config);
+                
+                walkBack(config);
+                state = State.WOODCUTTING;
+                break;
         }
     }
 
@@ -195,6 +202,16 @@ public class AutoWoodcuttingScript extends Script {
 
     private boolean isFiremake() {
         return Rs2Player.isAnimating(1800) && Rs2Player.getLastAnimationID() == AnimationID.FIREMAKING;
+    }
+    
+    private void fletchArrowShaft(AutoWoodcuttingConfig config) {
+        Rs2Inventory.combineClosest("knife", config.TREE().getLog());
+        Rs2Widget.clickWidget("arrow shafts");
+        sleepUntil(() -> !isFlectching(), 5000);
+    }
+    
+    private boolean isFlectching() {
+        return Rs2Player.isAnimating(3000) && Rs2Player.getLastAnimationID() == AnimationID.FLETCHING_BOW_CUTTING;
     }
 
     private WorldPoint calculateReturnPoint(AutoWoodcuttingConfig config) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/enums/WoodcuttingResetOptions.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/enums/WoodcuttingResetOptions.java
@@ -6,5 +6,6 @@ import lombok.Getter;
 public enum WoodcuttingResetOptions {
     BANK,
     DROP,
-    FIREMAKE
+    FIREMAKE,
+    FLETCH_ARROWSHAFT
 }


### PR DESCRIPTION
While I am working on my revenant plugin, there has been a couple commits I would like to just get merged upstream..

# ShootingStar
- Add config option for show/hide overlay
- Added developer overlay to show more information about current star & runtime
- Add config option to force breaks at bank

# AutoWoodcutting
- Added Reset Option to fletch logs into arrow shafts

# Utility classes
- TimeUtils: change getFormattedDurationBetween to properly format negative duration