### PR TITLE
Small Tutorial Island Fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tutorialisland/TutorialIslandScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tutorialisland/TutorialIslandScript.java
@@ -444,16 +444,17 @@ public class TutorialIslandScript extends Script {
 
             Rs2Walker.walkTo(new WorldPoint(3127, 3123, 0), 2);
             Rs2Player.waitForWalking();
-            Rs2Npc.interact(npc, "Talk-to");
-            Rs2Random.waitEx(1200, 300);
-            if (!(Microbot.getClient().getLocalPlayer().getInteracting() == npc)){
-                Rs2Npc.interact(npc, "Talk-to");
+            if (Rs2Npc.interact(npc, "Talk-to")) {
+                sleepUntil(Rs2Dialogue::isInDialogue);
             }
-            sleepUntil(Rs2Dialogue::isInDialogue);
         } else if (Microbot.getVarbitPlayerValue(281) == 531) {
             Rs2Widget.clickWidget(10747943); //switchToAccountManagementTab
             Rs2Random.waitEx(1200, 300);
         } else if (Microbot.getVarbitPlayerValue(281) == 532) {
+            if (Rs2Dialogue.isInDialogue()) {
+                clickContinue();
+                return;
+            }
             if (Rs2Npc.interact(npc, "Talk-to")) {
                 sleepUntil(Rs2Dialogue::isInDialogue);
             }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tutorialisland/TutorialIslandScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tutorialisland/TutorialIslandScript.java
@@ -41,7 +41,7 @@ public class TutorialIslandScript extends Script {
     final int CharacterCreation = 679;
     final int[] CharacterCreation_Arrows = new int[]{13, 17, 21, 25, 29, 33, 37, 44, 48, 52, 56, 60};
     private final TutorialislandPlugin plugin;
-    int LOOKUPNAME = 558;
+    private final int NameCreation = 558;
     private boolean toggledSettings = false;
     private boolean toggledMusic = false;
 
@@ -72,15 +72,34 @@ public class TutorialIslandScript extends Script {
 
                 switch (status) {
                     case NAME:
+                        Widget nameSearchBar = Rs2Widget.getWidget(NameCreation, 12); // enterName Field text
+                        
+                        String nameSearchBarText = nameSearchBar.getText();
+
+                        if (nameSearchBarText.endsWith("*")) {
+                            nameSearchBarText = nameSearchBarText.substring(0, nameSearchBarText.length() - 1);
+                        }
+                        
+                        if (!nameSearchBarText.isEmpty()) {
+                            Rs2Widget.clickWidget(NameCreation, 7); // enterName Field
+                            
+                            for (int i = 0; i < nameSearchBarText.length(); i++) {
+                                Rs2Keyboard.keyPress(KeyEvent.VK_BACK_SPACE);
+                                Rs2Random.waitEx(600, 100);
+                            }
+                            
+                            return;
+                        }
+                        
                         String name = new NameGenerator(random(7, 10)).getName();
-                        Rs2Widget.clickWidget(36569095);
+                        Rs2Widget.clickWidget(NameCreation, 7); // enterName Field
                         Rs2Random.waitEx(1200, 300);
                         Rs2Keyboard.typeString(name);
                         Rs2Random.waitEx(2400, 600);
-                        Rs2Widget.clickWidget("Look up name");
+                        Rs2Widget.clickWidget(NameCreation, 18); // lookupName Button
                         Rs2Random.waitEx(4800, 600);
 
-                        Widget responseWidget = Rs2Widget.getWidget(36569101);
+                        Widget responseWidget = Rs2Widget.getWidget(NameCreation, 13); // responseText Widget
 
                         if (responseWidget != null) {
                             String widgetText = responseWidget.getText();
@@ -89,21 +108,10 @@ public class TutorialIslandScript extends Script {
                             boolean nameAvailable = cleanedWidgetText.startsWith(expectedText);
 
                             if (nameAvailable) {
-                                Rs2Widget.clickWidget("Set name");
+                                Rs2Widget.clickWidget(NameCreation, 19); // setName Button
                                 Rs2Random.waitEx(4800, 600);
 
-                                if (isLookupNameButtonVisible()) {
-                                    Rs2Widget.clickWidget("Set name");
-                                    Rs2Random.waitEx(1200, 300);
-                                }
-
-                                sleepUntil(() -> !isLookupNameButtonVisible());
-                            } else {
-                                Rs2Widget.clickWidget(36569095);
-                                for (int i = 0; i < name.length(); i++) {
-                                    Rs2Keyboard.keyPress(KeyEvent.VK_BACK_SPACE);
-                                    Rs2Random.waitEx(600, 100);
-                                }
+                                sleepUntil(() -> !isNameCreationVisible());
                             }
                         }
                         break;
@@ -154,16 +162,16 @@ public class TutorialIslandScript extends Script {
         Rs2Antiban.resetAntibanSettings();
     }
 
-    private boolean isLookupNameButtonVisible() {
-        return Rs2Widget.getWidget(LOOKUPNAME, 1) != null;
+    private boolean isNameCreationVisible() {
+        return Rs2Widget.isWidgetVisible(NameCreation, 2);
     }
 
     private boolean isCharacterCreationVisible() {
-        return Rs2Widget.getWidget(CharacterCreation, 1) != null;
+        return Rs2Widget.isWidgetVisible(CharacterCreation, 2);
     }
 
     public void CalculateStatus() {
-        if (isLookupNameButtonVisible()) {
+        if (isNameCreationVisible()) {
             status = Status.NAME;
         } else if (isCharacterCreationVisible()) {
             status = Status.CHARACTER;
@@ -436,9 +444,12 @@ public class TutorialIslandScript extends Script {
 
             Rs2Walker.walkTo(new WorldPoint(3127, 3123, 0), 2);
             Rs2Player.waitForWalking();
-            if (Rs2Npc.interact(npc, "Talk-to")) {
-                sleepUntil(Rs2Dialogue::isInDialogue);
+            Rs2Npc.interact(npc, "Talk-to");
+            Rs2Random.waitEx(1200, 300);
+            if (!(Microbot.getClient().getLocalPlayer().getInteracting() == npc)){
+                Rs2Npc.interact(npc, "Talk-to");
             }
+            sleepUntil(Rs2Dialogue::isInDialogue);
         } else if (Microbot.getVarbitPlayerValue(281) == 531) {
             Rs2Widget.clickWidget(10747943); //switchToAccountManagementTab
             Rs2Random.waitEx(1200, 300);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tutorialisland/TutorialIslandScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tutorialisland/TutorialIslandScript.java
@@ -21,13 +21,17 @@ import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.player.NameGenerator;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.tabs.Rs2Tab;
+import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import net.runelite.client.plugins.skillcalculator.skills.MagicAction;
 
 import javax.inject.Inject;
 import java.awt.event.KeyEvent;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue.*;
@@ -82,6 +86,7 @@ public class TutorialIslandScript extends Script {
                         
                         if (!nameSearchBarText.isEmpty()) {
                             Rs2Widget.clickWidget(NameCreation, 7); // enterName Field
+                            Rs2Random.waitEx(1200, 300);
                             
                             for (int i = 0; i < nameSearchBarText.length(); i++) {
                                 Rs2Keyboard.keyPress(KeyEvent.VK_BACK_SPACE);
@@ -305,11 +310,17 @@ public class TutorialIslandScript extends Script {
                 sleepUntil(Rs2Dialogue::isInDialogue);
             }
         } else if (Microbot.getVarbitPlayerValue(281) <= 90) {
+            if (!Rs2Inventory.hasItem("Bronze Axe") || !Rs2Inventory.hasItem("Tinderbox")) {
+                if (Rs2Npc.interact(npc, "talk-to")) {
+                    sleepUntil(Rs2Dialogue::isInDialogue);
+                }
+                return;
+            }
             if (!Rs2Inventory.contains("Raw shrimps")) {
                 fishShrimp();
                 return;
             }
-            if (!Rs2Inventory.contains("Logs") && !Rs2GameObject.exists(ObjectID.FIRE_26185)) {
+            if (!Rs2Inventory.contains("Logs") && (!Rs2GameObject.exists(ObjectID.FIRE_26185) || Rs2Player.getRealSkillLevel(Skill.WOODCUTTING) == 0)) {
                 CutTree();
                 return;
             }
@@ -570,18 +581,29 @@ public class TutorialIslandScript extends Script {
                 return;
             }
             if (Rs2Inventory.contains("Bronze pickaxe") && (!Rs2Inventory.contains("Copper ore") || !Rs2Inventory.contains("Tin ore"))) {
+                List<Integer> rockIds = new ArrayList<>();
                 if (!Rs2Inventory.contains("Copper ore")) {
-                    Rs2GameObject.interact(ObjectID.COPPER_ROCKS, "Mine");
-                    sleepUntil(() -> Rs2Inventory.contains("Copper ore") && !Rs2Player.isAnimating(1800));
+                    rockIds.add(ObjectID.COPPER_ROCKS);
                 }
                 if (!Rs2Inventory.contains("Tin ore")) {
-                    Rs2GameObject.interact(ObjectID.TIN_ROCKS, "Mine");
-                    sleepUntil(() -> Rs2Inventory.contains("Tin ore")&& !Rs2Player.isAnimating(1800));
+                    rockIds.add(ObjectID.TIN_ROCKS);
                 }
+
+                Collections.shuffle(rockIds);
+                int rockId = rockIds.get(0);
+
+                Rs2GameObject.interact(rockId, "Mine");
+                sleepUntil(() -> {
+                    if (rockId == ObjectID.COPPER_ROCKS) {
+                        return Rs2Inventory.contains("Copper ore") && !Rs2Player.isAnimating(1800);
+                    } else {
+                        return Rs2Inventory.contains("Tin ore") && !Rs2Player.isAnimating(1800);
+                    }
+                });
             } else if (Rs2Inventory.contains("Copper ore") && Rs2Inventory.contains("Tin ore")) {
                 int[] ores = {ItemID.TIN_ORE, ItemID.COPPER_ORE};
-                int selectedOreId = ores[(int) (System.currentTimeMillis() / 1000) % ores.length];
-                Rs2Inventory.useItemOnObject(selectedOreId, ObjectID.FURNACE_10082);
+                Collections.shuffle(Arrays.asList(ores));
+                Rs2Inventory.useItemOnObject(ores[0], ObjectID.FURNACE_10082);
                 sleepUntil(() -> Rs2Inventory.contains("Bronze bar") && !Rs2Player.isAnimating(1800));
             }
         }
@@ -601,6 +623,8 @@ public class TutorialIslandScript extends Script {
             Rs2Widget.clickWidget(164, 54); // switchToQuestTab
             Rs2Random.waitEx(1200, 300);
         } else {
+            Rs2Tab.switchToInventoryTab();
+            Rs2Random.waitEx(600, 100);
             Rs2GameObject.interact(9726, "Climb-down");
             Rs2Random.waitEx(2400, 100);
         }
@@ -638,13 +662,13 @@ public class TutorialIslandScript extends Script {
     }
 
     public void LightFire() {
-        if (Rs2GameObject.findObjectById(ObjectID.FIRE_26185) == null && Rs2GameObject.findGameObjectByLocation(Microbot.getClient().getLocalPlayer().getWorldLocation()) == null) {
-            Rs2Inventory.combine("Logs", "Tinderbox");
-            sleepUntil(() -> !Rs2Inventory.hasItem("Logs") && !Rs2Player.isAnimating(2400));
-        } else {
-            if (!Rs2Inventory.hasItem("Bronze Axe") || !Rs2Inventory.hasItem("Tinderbox"))
-                Rs2Npc.interact(NpcID.SURVIVAL_EXPERT);
+        if (Rs2GameObject.getGameObject(Rs2Player.getWorldLocation()) != null) {
+            WorldPoint nearestWalkable = Rs2Tile.getNearestWalkableTileWithLineOfSight(Rs2Player.getWorldLocation());
+            Rs2Walker.walkFastCanvas(nearestWalkable);
+            Rs2Player.waitForWalking();
         }
+        Rs2Inventory.combine("Logs", "Tinderbox");
+        sleepUntil(() -> !Rs2Inventory.hasItem("Logs") && !Rs2Player.isAnimating(2400));
     }
 
     public void CutTree() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tutorialisland/TutorialIslandScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tutorialisland/TutorialIslandScript.java
@@ -662,7 +662,7 @@ public class TutorialIslandScript extends Script {
     }
 
     public void LightFire() {
-        if (Rs2GameObject.getGameObject(Rs2Player.getWorldLocation()) != null) {
+        if (Rs2Player.isStandingOnGameObject()) {
             WorldPoint nearestWalkable = Rs2Tile.getNearestWalkableTileWithLineOfSight(Rs2Player.getWorldLocation());
             Rs2Walker.walkFastCanvas(nearestWalkable);
             Rs2Player.waitForWalking();


### PR DESCRIPTION
I have created two small fixes for the tutorial island script I had found when creating my test accounts..

- I have fixed the issue with it clicking the top left corner / not properly finding the set name button by using the Widget IDs..
- I have also re-order the logic to be more robust by finding existing names & removing them OR invalid names (which were handed before..)
- I have also fixed a part with the account manager where you can be stuck in a loop when talking about worlds..