### PR TITLE
GE Cooker & GE Firemaker: minor fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/sticktothescript/gecooker/GECookerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/sticktothescript/gecooker/GECookerScript.java
@@ -160,7 +160,7 @@ public class GECookerScript extends Script {
                    }
 
                    Rs2Inventory.combine("Tinderbox", logType.getLogName());
-                   Rs2Player.waitForXpDrop(Skill.FIREMAKING, 5000);
+                   Rs2Player.waitForXpDrop(Skill.FIREMAKING, 20000);
                 break;
 
             default:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/sticktothescript/gefiremaker/GEFiremakerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/sticktothescript/gefiremaker/GEFiremakerScript.java
@@ -158,7 +158,7 @@ public class GEFiremakerScript extends Script {
                    }
 
                    Rs2Inventory.combine("Tinderbox", logType.getLogName());
-                   Rs2Player.waitForXpDrop(Skill.FIREMAKING, 5000);
+                   Rs2Player.waitForXpDrop(Skill.FIREMAKING, 20000);
                 break;
 
             default:


### PR DESCRIPTION
This PR adds some minor fixes to the GE Cooker and GE Firemaker script. 

For situations where fires may take a long time to build, the script would malfunction. The timeout has simply been increased to 20 seconds from 5 seconds.

I will add some additional logic (animation checks) soon, but this is a good temporary solution.