### PR TITLE
Automatically farms blue dragons in Taverley Dungeon

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonState.java
@@ -1,0 +1,8 @@
+package net.runelite.client.plugins.microbot.zerozero.bluedragons;
+
+public enum BlueDragonState {
+    BANKING,
+    TRAVEL_TO_DRAGONS,
+    FIGHTING,
+    STARTING
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsConfig.java
@@ -1,0 +1,95 @@
+package net.runelite.client.plugins.microbot.zerozero.bluedragons;
+
+import net.runelite.client.config.*;
+import net.runelite.client.plugins.microbot.util.misc.Rs2Food;
+
+@ConfigGroup("bluedragons")
+public interface BlueDragonsConfig extends Config {
+
+    @ConfigItem(
+            keyName = "How To",
+            name = "How to use",
+            description = "How to use the blue dragon plugin",
+            position = 0
+    )
+    default String howTo()
+    {
+        return "Start with falador runes/teletab and correct number of food from config";
+    }
+
+    @ConfigItem(
+            keyName = "startPlugin",
+            name = "Start/Stop the Plugin",
+            description = "This is start or stop the plugin on a toggle"
+    )
+    default boolean startPlugin() {
+        return true;
+    }
+
+    @ConfigSection(
+            name = "Loot Options",
+            description = "Settings related to item looting",
+            position = 1,
+            closedByDefault = false
+    )
+    String lootSection = "lootSection";
+
+    @ConfigItem(
+            keyName = "lootDragonhide",
+            name = "Loot Blue Dragonhide",
+            description = "Loot blue dragonhide dropped by the dragon",
+            section = lootSection
+    )
+    default boolean lootDragonhide() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "lootEnsouledHead",
+            name = "Loot Ensouled heads",
+            description = "LootEnsouled heads dropped by the dragon",
+            section = lootSection
+    )
+    default boolean lootEnsouledHead() {
+        return true;
+    }
+
+
+    @ConfigSection(
+            name = "Food Options",
+            description = "Settings for selecting food and health threshold",
+            position = 2,
+            closedByDefault = false
+    )
+    String foodSection = "foodSection";
+
+    @ConfigItem(
+            keyName = "foodType",
+            name = " ",
+            description = "Select the type of food to withdraw",
+            section = foodSection
+    )
+    default Rs2Food foodType() {
+        return Rs2Food.LOBSTER;
+    }
+
+    @ConfigItem(
+            keyName = "foodAmount",
+            name = "Amount of Food",
+            description = "Specify the number of food items to withdraw",
+            section = foodSection
+    )
+    default int foodAmount() {
+        return 3;
+    }
+
+    @ConfigItem(
+            keyName = "eatAtHealthPercent",
+            name = "Eat at Health Percentage",
+            description = "Eat food when health drops below this percentage",
+            section = foodSection
+    )
+    default int eatAtHealthPercent() {
+        return 50;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsConfig.java
@@ -3,19 +3,17 @@ package net.runelite.client.plugins.microbot.zerozero.bluedragons;
 import net.runelite.client.config.*;
 import net.runelite.client.plugins.microbot.util.misc.Rs2Food;
 
-@ConfigGroup("bluedragons")
-public interface BlueDragonsConfig extends Config {
+@ConfigGroup(BlueDragonsPlugin.CONFIG)
+@ConfigInformation("<center><p style='font-weight: bold;'>[00] BLUE DRAGON FARMER</p> <br />" +
+        "<hr style='width: 75%; border-top: 1px solid #000;'/>" +
+        "<p style='color: black;'>The plugin will travel/kill and bank as needed. Early prayer farmer!</p>" +
+        "<hr style='width: 75%; border-top: 1px solid #000;'/> </center> <br />" +
+        "1. Equip your gear <br />" +
+        "2. <b style='color: red;'>MUST</b> have Falador teleport (runes/teletab) <br />" +
+        "3. Correct food amount from config <br /> <br />" +
+        "<center>Press <b style='color: green;'>START</b> and enjoy :)</center>")
 
-    @ConfigItem(
-            keyName = "How To",
-            name = "How to use",
-            description = "How to use the blue dragon plugin",
-            position = 0
-    )
-    default String howTo()
-    {
-        return "Start with falador runes/teletab and correct number of food from config";
-    }
+public interface BlueDragonsConfig extends Config {
 
     @ConfigItem(
             keyName = "startPlugin",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsOverlay.java
@@ -1,0 +1,35 @@
+package net.runelite.client.plugins.microbot.zerozero.bluedragons;
+
+
+import lombok.Setter;
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class BlueDragonsOverlay extends Overlay {
+
+    private final Client client;
+    @Setter
+    private BlueDragonsScript script;
+
+    @Inject
+    public BlueDragonsOverlay(Client client) {
+        this.client = client;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setLayer(OverlayLayer.ABOVE_SCENE);
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        if (script.isRunning()) {
+            graphics.setColor(Color.CYAN);
+            graphics.drawString("Farming Blue Dragons", 10, 10);
+        }
+        return null;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsPlugin.java
@@ -1,0 +1,76 @@
+package net.runelite.client.plugins.microbot.zerozero.bluedragons;
+
+import com.google.inject.Provides;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.eventbus.Subscribe;
+
+import javax.inject.Inject;
+
+@PluginDescriptor(
+        name = PluginDescriptor.zerozero + "Blue Dragons",
+        description = "Blue dragon farmer for bones",
+        tags = {"blue", "dragons", "prayer"}
+)
+public class BlueDragonsPlugin extends Plugin {
+
+    @Inject
+    private BlueDragonsScript script;
+
+    @Inject
+    private BlueDragonsConfig config;
+
+    @Override
+    protected void startUp() {
+        if (config.startPlugin()) {
+            script.run(config);
+        }
+    }
+
+    @Override
+    protected void shutDown() {
+        Microbot.log("Stopping Blue Dragons plugin...");
+        script.stop();
+    }
+
+    @Subscribe
+    public void onConfigChanged(ConfigChanged event) {
+        if (event.getGroup().equals("bluedragons")) {
+
+            switch (event.getKey()) {
+                case "startPlugin":
+                    if (config.startPlugin()) {
+                        Microbot.log("Starting Blue Dragon plugin...");
+                        script.run(config);
+                    } else {
+                        Microbot.log("Stopping Blue Dragon plugin!");
+                        script.stop();
+                    }
+                    break;
+
+                case "lootDragonhide":
+                case "foodType":
+                case "foodAmount":
+                case "eatAtHealthPercent":
+                case "lootEnsouledHead":
+                    Microbot.log("Configuration changed. Updating script settings.");
+                    if (config.startPlugin()) {
+                        script.updateConfig(config);
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
+
+
+    @Provides
+    BlueDragonsConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(BlueDragonsConfig.class);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsPlugin.java
@@ -16,6 +16,7 @@ import javax.inject.Inject;
         tags = {"blue", "dragons", "prayer"}
 )
 public class BlueDragonsPlugin extends Plugin {
+    static final String CONFIG = "bluedragons";
 
     @Inject
     private BlueDragonsScript script;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsScript.java
@@ -239,7 +239,6 @@ public class BlueDragonsScript extends Script {
     private boolean attackDragon(NPC dragon) {
         final int dragonId = dragon.getId();
         if (Rs2Npc.attack(dragon)) {
-            Microbot.log("Attacking Blue Dragon with ID: " + dragonId);
             sleepUntil(() -> Rs2Npc.getNpc(dragonId) == null, 5000);
             return true;
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsScript.java
@@ -1,0 +1,272 @@
+package net.runelite.client.plugins.microbot.zerozero.bluedragons;
+
+import net.runelite.api.NPC;
+import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.bank.enums.BankLocation;
+import net.runelite.client.plugins.microbot.util.grounditem.LootingParameters;
+import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.RunePouch;
+import net.runelite.client.plugins.microbot.util.magic.Runes;
+import net.runelite.client.plugins.microbot.util.misc.Rs2Food;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+import java.util.concurrent.TimeUnit;
+
+public class BlueDragonsScript extends Script {
+
+    public static BlueDragonState currentState;
+
+    private static final WorldPoint SAFE_SPOT = new WorldPoint(2918, 9781, 0);
+    private final int[] dragonIds = {265, 266};
+    private Integer currentTargetId = null;
+
+    public boolean run(BlueDragonsConfig config) {
+        currentState = BlueDragonState.STARTING;
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!super.run() || !Microbot.isLoggedIn()) return;
+
+                switch (currentState) {
+                    case STARTING:
+                        determineStartingState(config);
+                        break;
+
+                    case BANKING:
+                        handleBanking(config);
+                        break;
+
+                    case TRAVEL_TO_DRAGONS:
+                        handleTravelToDragons();
+                        break;
+
+                    case FIGHTING:
+                        handleFighting(config);
+                        break;
+                }
+            } catch (Exception ex) {
+                Microbot.log(ex.getMessage());
+            }
+        }, 0, 100, TimeUnit.MILLISECONDS);
+
+        return true;
+    }
+
+    private void handleBanking(BlueDragonsConfig config) {
+        Microbot.log("Traveling to Falador West bank for depositing looted items.");
+
+        if (Rs2Bank.walkToBankAndUseBank(BankLocation.FALADOR_WEST)) {
+            Rs2Bank.depositAll("Dragon bones");
+            Rs2Bank.depositAll("Dragon spear");
+            Rs2Bank.depositAll("Shield left half");
+
+            if (config.lootEnsouledHead()) {
+                Rs2Bank.depositAll("Ensouled dragon head");
+            }
+
+            if (config.lootDragonhide()) {
+                Rs2Bank.depositAll("Blue dragonhide");
+            }
+
+            withdrawFood(config);
+            Rs2Bank.closeBank();
+            currentState = BlueDragonState.TRAVEL_TO_DRAGONS;
+        }
+    }
+
+    private void determineStartingState(BlueDragonsConfig config) {
+        boolean hasFood = hasRequiredFood(config);
+        boolean hasTeleport = hasTeleportToFalador();
+        boolean hasAgilityOrKey = Microbot.getClient().getRealSkillLevel(Skill.AGILITY) >= 70 || hasDustyKey();
+
+        if (!hasFood) {
+            Microbot.log("Missing required food for the trip.");
+        }
+
+        if (!hasTeleport) {
+            Microbot.log("Missing teleport to Falador or required runes.");
+        }
+
+        if (!hasAgilityOrKey) {
+            Microbot.log("Requires Agility level 70 or a Dusty Key.");
+        }
+
+        // Check if all requirements are met
+        if (hasFood && hasTeleport && hasAgilityOrKey) {
+            currentState = BlueDragonState.TRAVEL_TO_DRAGONS;
+        } else {
+            Microbot.log("Starting conditions not met. Stopping the plugin.");
+            stop();
+        }
+    }
+
+
+    private boolean hasRequiredFood(BlueDragonsConfig config) {
+        Rs2Food food = config.foodType();
+        int amount = config.foodAmount();
+        return food != null && Rs2Inventory.count(food.getName()) >= amount;
+    }
+
+    private boolean hasTeleportToFalador() {
+        if (Rs2Inventory.contains("Falador teleport")) {
+            Microbot.log("Found Falador teleport in inventory.");
+            return true;
+        }
+
+        int lawRuneId = Runes.LAW.getItemId();
+        int waterRuneId = Runes.WATER.getItemId();
+        int dustRuneId = Runes.DUST.getItemId();
+        int airRuneId = Runes.AIR.getItemId();
+
+        int requiredLawRunes = 1;
+        int requiredAirRunes = 3;
+        int requiredWaterRunes = 1;
+
+        boolean runePouchInInventory = Rs2Inventory.contains("Rune pouch") || Rs2Inventory.contains("Divine rune pouch");
+        boolean hasLawRunes = checkRuneAvailability(lawRuneId, requiredLawRunes, runePouchInInventory);
+        boolean hasWaterRunes = checkRuneAvailability(waterRuneId, requiredWaterRunes, runePouchInInventory);
+        boolean hasAirOrDustRunes = checkRuneAvailability(dustRuneId, requiredAirRunes, runePouchInInventory) ||
+                checkRuneAvailability(airRuneId, requiredAirRunes, runePouchInInventory);
+
+        return hasLawRunes && hasWaterRunes && hasAirOrDustRunes;
+    }
+
+    private boolean checkRuneAvailability(int runeId, int requiredAmount, boolean checkRunePouch) {
+        boolean inInventory = Rs2Inventory.contains(runeId) && Rs2Inventory.count(runeId) >= requiredAmount;
+        boolean inRunePouch = checkRunePouch && RunePouch.contains(runeId, requiredAmount);
+        return inInventory || inRunePouch;
+    }
+
+
+
+    private boolean hasDustyKey() {
+        return Rs2Inventory.contains("Dusty key");
+    }
+
+    private void handleTravelToDragons() {
+        Microbot.log("Traveling to dragons...");
+        Rs2Walker.walkTo(SAFE_SPOT);
+        sleepUntil(this::isPlayerAtSafeSpot);
+        currentState = BlueDragonState.FIGHTING;
+    }
+
+    private void handleFighting(BlueDragonsConfig config) {
+        if (!isPlayerAtSafeSpot()) {
+            Microbot.log("Not at safe spot. Moving back before continuing to fight.");
+            moveToSafeSpot();
+            return;
+        }
+
+        if (attemptLooting(config)) {
+            return;
+        }
+
+        Rs2Player.eatAt(config.eatAtHealthPercent());
+
+        NPC dragon = getAvailableDragon();
+        if (dragon != null && attackDragon(dragon)) {
+            currentTargetId = dragon.getId();
+
+            if (!isPlayerAtSafeSpot()) {
+                Microbot.log("Attacked dragon, moving back to safe spot.");
+                moveToSafeSpot();
+            }
+        }
+    }
+
+
+    private boolean attemptLooting(BlueDragonsConfig config) {
+        if (Rs2Inventory.isFull()) {
+            Microbot.log("Inventory is full after looting, switching to BANKING state.");
+            currentState = BlueDragonState.BANKING;
+            return true;
+        }
+
+        lootItem("Dragon bones");
+        lootItem("Dragon spear");
+        lootItem("Shield left half");
+
+        if (config.lootDragonhide()) {
+            lootItem("Blue dragonhide");
+        }
+
+        if (config.lootEnsouledHead()) {
+            lootItem("Ensouled dragon head");
+        }
+
+        if (!isPlayerAtSafeSpot()) {
+            Microbot.log("Returning to safe spot after looting.");
+            moveToSafeSpot();
+        }
+
+        return false;
+    }
+
+    private void lootItem(String itemName) {
+        if (!Rs2Inventory.isFull()) {
+            LootingParameters params = new LootingParameters(10, 1, 1, 0, false, true, itemName);
+            Rs2GroundItem.lootItemsBasedOnNames(params);
+        }
+    }
+
+    private void withdrawFood(BlueDragonsConfig config) {
+        Rs2Food food = config.foodType();
+        int amount = config.foodAmount();
+        if (food != null && amount > 0 && Rs2Bank.isOpen() && !hasRequiredFood(config)) {
+            Microbot.log("Withdrawing " + amount + "x " + food.getName() + " for dragon fight.");
+            Rs2Bank.withdrawX(food.getName(), amount);
+        } else if (hasRequiredFood(config)) {
+            Microbot.log("Already have the required amount of food in inventory. No need to withdraw.");
+        }
+    }
+
+
+    private NPC getAvailableDragon() {
+        NPC dragon = Rs2Npc.getNpc("Blue dragon");
+        if (dragon != null && (dragon.getId() == 265 || dragon.getId() == 266)) {
+            return dragon;
+        }
+        return null;
+    }
+
+
+    private boolean attackDragon(NPC dragon) {
+        final int dragonId = dragon.getId();
+        if (Rs2Npc.attack(dragon)) {
+            Microbot.log("Attacking Blue Dragon with ID: " + dragonId);
+            sleepUntil(() -> Rs2Npc.getNpc(dragonId) == null, 5000);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isPlayerAtSafeSpot() {
+        return SAFE_SPOT.equals(Microbot.getClient().getLocalPlayer().getWorldLocation());
+    }
+
+    private void moveToSafeSpot() {
+        Microbot.pauseAllScripts = true;
+        Rs2Walker.walkFastCanvas(SAFE_SPOT);
+        sleepUntil(this::isPlayerAtSafeSpot);
+        Microbot.pauseAllScripts = false;
+    }
+
+    public void updateConfig(BlueDragonsConfig config) {
+        Microbot.log("Applying new configuration to Blue Dragons script.");
+        withdrawFood(config);
+    }
+
+    public void stop() {
+        Microbot.log("Blue Dragons plugin stopped.");
+        if (mainScheduledFuture != null) {
+            mainScheduledFuture.cancel(true);
+            super.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
Automatically farms blue dragons in Taverley Dungeon, collects bones and banks/restocks.

Option to enable scales to be looted too.

You must have a falador teleport in your inventor, runes or teletab and also the same amount of food that you have in your config.

This uses a safe spot, so you should need anymore more than 1-3 food, used when running there normally.

If you are less than 70 agility, you need a dusty key

The plugin will bank and restock the food