### PR TITLE
Walker Changes + Small Plugin Fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -926,6 +926,7 @@ public class Rs2Walker {
 
     private static boolean handleTeleportItem(Transport transport) {
         boolean succesfullAction = false;
+        System.out.println("Required Transport: " + transport.getDisplayInfo());
         for (Set<Integer> itemIds : transport.getItemIdRequirements()) {
             if (succesfullAction)
                 break;
@@ -948,8 +949,9 @@ public class Rs2Walker {
     public static boolean handleInventoryTeleports(Transport transport, int itemId) {
         Rs2Item rs2Item = Rs2Inventory.get(itemId);
         boolean hasItem = rs2Item != null;
-        List<String> actions = Arrays.asList("break", "teleport", "empty", "lletya", "prifddinas", "commune", "rellekka", "waterbirth island", "neitiznot", "jatiszo",
-                "ver sinhaza", "darkmeyer", "slepe", "troll stronghold", "weiss", "invoke", "rub");
+        // prioritize location names first, then use generic action names such as 'break' or 'teleport' to avoid conflicts with menu actions called 'monastery teleport'
+        List<String> actions = Arrays.asList("farm", "monastery", "lletya", "prifddinas", "rellekka", "waterbirth island", "neitiznot", "jatiszo",
+                "ver sinhaza", "darkmeyer", "slepe", "troll stronghold", "weiss", "invoke", "empty", "consume", "rub", "break", "teleport");
         if (!hasItem) return false;
         boolean hasMultipleDestination = transport.getDisplayInfo().contains(":");
         //hasMultipleDestination is stuff like: games neck, ring of dueling etc...
@@ -958,7 +960,7 @@ public class Rs2Walker {
             String[] values = transport.getDisplayInfo().split(":");
             String destination = values[1].trim().toLowerCase();
             String itemAction = Arrays.stream(rs2Item.getInventoryActions())
-                    .filter(action -> action != null && actions.contains(action.toLowerCase()))
+                    .filter(action -> action != null && actions.stream().anyMatch(keyword -> action.toLowerCase().contains(keyword))) // stream actions to allow for a partial match
                     .findFirst()
                     .orElse(null);
             if (itemAction == null) return false;
@@ -979,7 +981,7 @@ public class Rs2Walker {
 
         //Simple items with one destination like teleport tabs, teleport scrolls etc...
         String itemAction = Arrays.stream(rs2Item.getInventoryActions())
-                .filter(action -> action != null && actions.contains(action.toLowerCase()))
+                .filter(action -> action != null && actions.stream().anyMatch(keyword -> action.toLowerCase().contains(keyword))) // stream actions to allow for a partial match
                 .findFirst()
                 .orElse(null);
         if (itemAction == null) return false;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsPlugin.java
@@ -13,7 +13,8 @@ import javax.inject.Inject;
 @PluginDescriptor(
         name = PluginDescriptor.zerozero + "Blue Dragons",
         description = "Blue dragon farmer for bones",
-        tags = {"blue", "dragons", "prayer"}
+        tags = {"blue", "dragons", "prayer"},
+        enabledByDefault = false
 )
 public class BlueDragonsPlugin extends Plugin {
     static final String CONFIG = "bluedragons";


### PR DESCRIPTION
I have made another change to the walker:

1. I have adjusted the Inventory Actions to allow for a partial match of the action that is found on the item in inventory. 
    - For example, when using the Ardougne Cloak in the inventory, the item actions are not the same as if the item was equipped. this results when the item is in the inventory it would not find the menu action. This would allow for any part of the static list of actions that are in the handleTeleportItem method to suffice the menu action on the item, even if its like troll stronghold teleport for example.

2. I have re-organized the list of static inventory actions, due to the nature of the .findFirst() method when using java streams, if there are multiple results that are returned when finding applicable itemActions, it would favor 'teleport' instead of using the correct menu action, by doing this, items like jewelery & teleport tablets will still find the correct action, just they are at the end of the list so items with multiple locations, or specific location names work correctly.


I also made a change to the Blue Dragon plugin to set it to not be turned on by default..