### PR TITLE
Another Walker Fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
@@ -115,24 +115,22 @@ public class ThievingScript extends Script {
     }
 
     private void pickpocket() {
-        if (config.THIEVING_NPC() != ThievingNpc.NONE) {
-            if (config.THIEVING_NPC() == ThievingNpc.WEALTHY_CITIZEN) {
-                handleWealthyCitizen();
-            } else if (config.THIEVING_NPC() == ThievingNpc.ELVES) {
-                handleElves();
+        if (config.THIEVING_NPC() == ThievingNpc.WEALTHY_CITIZEN) {
+            handleWealthyCitizen();
+        } else if (config.THIEVING_NPC() == ThievingNpc.ELVES) {
+            handleElves();
+        } else {
+            Map<NPC, HighlightedNpc> highlightedNpcs =  net.runelite.client.plugins.npchighlight.NpcIndicatorsPlugin.getHighlightedNpcs();
+            if (highlightedNpcs.isEmpty()) {
+                if (Rs2Npc.pickpocket(config.THIEVING_NPC().getName())) {
+                    Rs2Walker.setTarget(null);
+                    sleep(50, 250);
+                } else if (Rs2Npc.getNpc(config.THIEVING_NPC().getName()) == null){
+                    Rs2Walker.walkTo(initialPlayerLocation);
+                }
             } else {
-                Map<NPC, HighlightedNpc> highlightedNpcs =  net.runelite.client.plugins.npchighlight.NpcIndicatorsPlugin.getHighlightedNpcs();
-                if (highlightedNpcs.isEmpty()) {
-                    if (Rs2Npc.pickpocket(config.THIEVING_NPC().getName())) {
-                        Rs2Walker.setTarget(null);
-                        sleep(50, 250);
-                    } else if (Rs2Npc.getNpc(config.THIEVING_NPC().getName()) == null){
-                        Rs2Walker.walkTo(initialPlayerLocation);
-                    }
-                } else {
-                    if (Rs2Npc.pickpocket(highlightedNpcs)) {
-                        sleep(50, 250);
-                    }
+                if (Rs2Npc.pickpocket(highlightedNpcs)) {
+                    sleep(50, 250);
                 }
             }
         }


### PR DESCRIPTION
In this latest iteration, I have adjusted how the actions are found inside of the inventory teleports

1. I split up the teleport actions to be location or generic 'keywords', by doing this, this allowed me to do a partial match of if the location keyword is found inside of the destination AND the action name from the item.
2. I then used the 'generic' keyWords such as teleport & invoke to be searched for if we can not find the destination in the item actions (e.g requires to you to rub & bring up a dialog) 