### PR TITLE
Another Walker Fix & Removed World Options from Shooting Star

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarConfig.java
@@ -12,8 +12,6 @@ public interface ShootingStarConfig extends Config {
     
     String configGroup = "shooting-star";
     String displayAsMinutes = "displayAsMinutes";
-    String hideF2PWorlds = "hideF2PWorlds";
-    String hideMembersWorlds = "hideMembersWorlds";
     String hideWildernessLocations = "hideWildernessLocations";
     String useNearestHighTierStar = "useNearestHighTierStar";
     String useBreakAtBank = "useBreakAtBank";
@@ -68,32 +66,10 @@ public interface ShootingStarConfig extends Config {
     String panelSection = "panel";
 
     @ConfigItem(
-            keyName = hideMembersWorlds,
-            name = "Hide Members Worlds",
-            description = "Hide Members worlds inside of the panel",
-            position = 0,
-            section = panelSection
-    )
-    default boolean isHideMembersWorlds() {
-        return false;
-    }
-
-    @ConfigItem(
-            keyName = hideF2PWorlds,
-            name = "Hide F2P Worlds",
-            description = "Hide F2P worlds inside of the panel",
-            position = 1,
-            section = panelSection
-    )
-    default boolean isHideF2PWorlds() {
-        return false;
-    }
-
-    @ConfigItem(
             keyName = hideWildernessLocations,
             name = "Hide Wilderness Locations",
             description = "Hide Wilderness locations inside of the panel",
-            position = 2,
+            position = 0,
             section = panelSection
     )
     default boolean isHideWildernessLocations() {
@@ -104,7 +80,7 @@ public interface ShootingStarConfig extends Config {
             keyName = displayAsMinutes,
             name = "Display as Minutes",
             description = "Shows time left as minutes",
-            position = 3,
+            position = 1,
             section = panelSection
     )
     default boolean isDisplayAsMinutes() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPanel.java
@@ -276,9 +276,11 @@ public class ShootingStarPanel extends PluginPanel {
         for (Star star : starList) {
             if (plugin.isHideMembersWorlds() && star.isMemberWorld()) {
                 hiddenStars.add(star);
+                continue;
             }
             if (plugin.isHideF2PWorlds() && star.isF2PWorld()) {
                 hiddenStars.add(star);
+                continue;
             }
             if (plugin.isHideWildernessLocations() && star.isInWilderness()) {
                 hiddenStars.add(star);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
@@ -21,6 +21,7 @@ import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerPlugin;
 import net.runelite.client.plugins.microbot.mining.shootingstar.enums.ShootingStarLocation;
 import net.runelite.client.plugins.microbot.mining.shootingstar.model.Star;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.security.Login;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -58,9 +59,7 @@ import java.util.regex.Pattern;
 public class ShootingStarPlugin extends Plugin {
     @Getter
     public List<Star> starList = new ArrayList<>();
-    @Getter
-    public List<Star> ignoreStars = new ArrayList<>();
-
+    
     @Inject
     ShootingStarScript shootingStarScript;
 
@@ -243,8 +242,8 @@ public class ShootingStarPlugin extends Plugin {
     @Override
     protected void startUp() throws AWTException {
         displayAsMinutes = config.isDisplayAsMinutes();
-        hideMembersWorlds = config.isHideMembersWorlds();
-        hideF2PWorlds = config.isHideF2PWorlds();
+        hideMembersWorlds = !Login.activeProfile.isMember();
+        hideF2PWorlds = Login.activeProfile.isMember();
         useNearestHighTierStar = config.useNearestHighTierStar();
         useBreakAtBank = config.useBreakAtBank();
         hideWildernessLocations = config.isHideWildernessLocations();
@@ -284,18 +283,6 @@ public class ShootingStarPlugin extends Plugin {
         if (event.getKey().equals(ShootingStarConfig.displayAsMinutes)) {
             displayAsMinutes = config.isDisplayAsMinutes();
             updatePanelList(false);
-        }
-
-        if (event.getKey().equals(ShootingStarConfig.hideMembersWorlds)) {
-            hideMembersWorlds = config.isHideMembersWorlds();
-            filterPanelList(hideMembersWorlds);
-            updatePanelList(true);
-        }
-
-        if (event.getKey().equals(ShootingStarConfig.hideF2PWorlds)) {
-            hideF2PWorlds = config.isHideF2PWorlds();
-            filterPanelList(hideF2PWorlds);
-            updatePanelList(true);
         }
 
         if (event.getKey().equals(ShootingStarConfig.hideWildernessLocations)) {
@@ -408,7 +395,6 @@ public class ShootingStarPlugin extends Plugin {
 
         // Iterate through all stars and categorize them by distance
         for (Star star : starList) {
-            if (ignoreStars.contains(star)) continue;
             if (panel.getHiddenStars().stream().anyMatch(h -> h.equals(star))) continue;
             if (!star.hasRequirements()) continue;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarScript.java
@@ -72,8 +72,8 @@ public class ShootingStarScript extends Script {
                     return;
                 }
 
-                if (Rs2AntibanSettings.actionCooldownActive) return;
                 if (Rs2Player.isMoving() || Rs2Antiban.getCategory().isBusy() || Microbot.pauseAllScripts) return;
+                if (Rs2AntibanSettings.actionCooldownActive) return;
 
                 switch (state) {
                     case WAITING_FOR_STAR:
@@ -107,22 +107,21 @@ public class ShootingStarScript extends Script {
                     case WALKING:
                         toggleLockState(true);
 
+                        if (Rs2Player.getWorld() != star.getWorldObject().getId()) {
+                            Microbot.hopToWorld(star.getWorldObject().getId());
+                            sleepUntil(() -> Microbot.getClient().getGameState() == GameState.LOGGED_IN);
+                            return;
+                        }
+
                         boolean isNearShootingStar = Rs2Player.getWorldLocation().distanceTo(star.getShootingStarLocation().getWorldPoint()) < 6;
 
                         if (!isNearShootingStar) {
                             WalkerState walkerState = Rs2Walker.walkWithState(star.getShootingStarLocation().getWorldPoint(), 6);
                             if (walkerState == WalkerState.UNREACHABLE) {
-                                plugin.ignoreStars.add(plugin.getSelectedStar());
                                 plugin.removeStar(plugin.getSelectedStar());
                                 plugin.updatePanelList(true);
                                 state = ShootingStarState.WAITING_FOR_STAR;
                             }
-                            return;
-                        }
-
-                        if (Rs2Player.getWorld() != star.getWorldObject().getId()) {
-                            Microbot.hopToWorld(star.getWorldObject().getId());
-                            sleepUntil(() -> Microbot.getClient().getGameState() == GameState.LOGGED_IN);
                             return;
                         }
 


### PR DESCRIPTION
## Rs2Walker
- With the latest change, I split up the locationKeyWords & the genericKeyWords into two separate lists so that they can searched for seperately, but I only included this logic inside of 'hasMultipleDestinations'. With this latest commit, I have refactored `handleInventoryTeleport` once again to simplify whether if destination is the entire DisplayInfo or if it has a semicolon, then it would just use the portion after it.

## ShootingStar plugin
- As requested, I removed the configuration settings to filter out the F2P stars & Members Stars by leveraging the runelite profile. I just found this was more straight forward then creating the logic for determining the world type & using that.