### PR TITLE
Added Restrictions for the Al Kharid Gate + Adjusted Display Info for Falador Park on the ring of wealth

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/restrictions.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/restrictions.tsv
@@ -20,3 +20,8 @@
 3207 3217 0	Recipe for Disaster		
 3213 3222 0	Recipe for Disaster		
 3213 3221 0	Recipe for Disaster		
+# Al Kharid Gate			
+3267 3228 0	Prince Ali Rescue		
+3267 3227 0	Prince Ali Rescue		
+3268 3227 0	Prince Ali Rescue		
+3268 3228 0	Prince Ali Rescue		

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
@@ -60,7 +60,7 @@
 # Ring of Wealth (1-5, 1i-5i) (uncharged is 2572, trimmed 12785)									
 2534 3862 0			11988;11986;11984;11982;11980;20790;20789;20788;20787;20786	Throne of Miscellania	4	Ring of wealth: Miscellania	T	30	
 3163 3478 0			11988;11986;11984;11982;11980;20790;20789;20788;20787;20786		4	Ring of wealth: Grand Exchange	T	30	
-2995 3375 0			11988;11986;11984;11982;11980;20790;20789;20788;20787;20786		4	Ring of wealth: Falador Park	T	30	
+2995 3375 0			11988;11986;11984;11982;11980;20790;20789;20788;20787;20786		4	Ring of wealth: Falador	T	30	
 2824 10168 0			11988;11986;11984;11982;11980;20790;20789;20788;20787;20786	Between a Rock...	4	Ring of wealth: Dondakan	T	30	
 									
 # Slayer Ring (1-8, eternal)									


### PR DESCRIPTION
## ShortestPathPlugin
- Added Restrictions for the Al Kharid Gate, this will now require prince ali rescue in-order to add this into the path
- Adjusted Display Info for Falador Park on the ring of wealth, with the logic that is used when rubbing, just Falador will suffice here.