### PR TITLE
Wintertodt Rejuvenation Potions + Tempoross Plugin bugfixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/State.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/State.java
@@ -8,12 +8,12 @@ import java.util.function.BooleanSupplier;
 public enum State {
     ATTACK_TEMPOROSS(() -> TemporossScript.ENERGY >= 94, null),
     SECOND_FILL(() -> getCookedFish() == 0, ATTACK_TEMPOROSS),
-    THIRD_COOK(() -> getCookedFish() == 19 || TemporossScript.INTENSITY >= 92 || (TemporossScript.ENERGY < 50 && getAllFish() > 16 && !TemporossScript.temporossConfig.solo()), SECOND_FILL),
-    THIRD_CATCH(() -> getAllFish() >= 19, THIRD_COOK),
+    THIRD_COOK(() -> getCookedFish() == (TemporossScript.temporossConfig.solo() ? 19 : getAllFish()) || TemporossScript.INTENSITY >= 92 || (TemporossScript.ENERGY < 50 && getAllFish() > 16 && !TemporossScript.temporossConfig.solo()), SECOND_FILL),
+    THIRD_CATCH(() -> getAllFish() >= (TemporossScript.temporossConfig.solo() ? 19 : getTotalAvailableFishSlots()), THIRD_COOK),
     EMERGENCY_FILL(() -> getAllFish() == 0, THIRD_CATCH),
     INITIAL_FILL(() -> getCookedFish() == 0, THIRD_CATCH),
-    SECOND_COOK(() -> getCookedFish() == 17, INITIAL_FILL),
-    SECOND_CATCH(() -> getAllFish() >= 17, SECOND_COOK),
+    SECOND_COOK(() -> getCookedFish() == (TemporossScript.temporossConfig.solo() ? 17 : getAllFish()), INITIAL_FILL),
+    SECOND_CATCH(() -> getAllFish() >= (TemporossScript.temporossConfig.solo() ? 17 : getTotalAvailableFishSlots()), SECOND_COOK),
     INITIAL_COOK(() -> getRawFish() == 0, SECOND_CATCH),
     INITIAL_CATCH(() -> getRawFish() >= 7 || getAllFish() >= 10, INITIAL_COOK);
 
@@ -39,6 +39,10 @@ public enum State {
 
     public static int getCookedFish() {
         return Rs2Inventory.count(ItemID.HARPOONFISH);
+    }
+
+    public static int getTotalAvailableFishSlots() {
+        return Rs2Inventory.getEmptySlots() + getAllFish();
     }
 
     public String toString() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossConfig.java
@@ -8,9 +8,7 @@ import net.runelite.client.plugins.microbot.tempoross.enums.HarpoonType;
         "<h3>Version: " + TemporossScript.VERSION + "</h3>\n" +
         "<p>1. <strong>Start the bot outside of the minigame area</strong> to ensure proper functionality.</p>\n" +
         "<p></p>\n" +
-        "<p>2. <strong>Solo Mode:</strong> If selecting solo mode, an <em>Infernal Harpoon</em> is REQUIRED. This allows the bot to manage effectively within the game.</p>\n" +
-        "<p></p>\n" +
-        "<p>3. <strong>Requirements:</strong> You need a minimum of 19 free inventory slots.</p>\n" )
+        "<p>2. <strong>Solo Mode:</strong> If selecting solo mode, an <em>Infernal Harpoon</em> is REQUIRED. You also need a <strong>MINIMUM</strong> of <em>19</em> free inv slots</p>\n")
 public interface TemporossConfig extends Config {
     //sections
     // General

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossProgressionOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossProgressionOverlay.java
@@ -10,6 +10,9 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 import javax.inject.Inject;
 import java.awt.*;
 
+import static net.runelite.client.plugins.microbot.tempoross.State.getAllFish;
+import static net.runelite.client.plugins.microbot.tempoross.State.getTotalAvailableFishSlots;
+
 public class TemporossProgressionOverlay extends OverlayPanel {
 
     private final TemporossPlugin plugin;
@@ -68,48 +71,48 @@ public class TemporossProgressionOverlay extends OverlayPanel {
             case SECOND_FILL:
                 // Progression goes up as cooked fish decreases (0 fish = 100% progress).
                 int cookedFishSecondFill = State.getCookedFish();
-                return 1.0 - Math.min((double) cookedFishSecondFill / 19.0, 1.0);
+                return 1.0 - Math.min((double) cookedFishSecondFill / (TemporossScript.temporossConfig.solo() ? 19 : getTotalAvailableFishSlots()), 1.0);
 
             case INITIAL_FILL:
                 // Progression goes up as cooked fish decreases (0 fish = 100% progress).
                 int cookedFishInitialFill = State.getCookedFish();
-                return 1.0 - Math.min((double) cookedFishInitialFill / 17.0, 1.0);
+                return 1.0 - Math.min((double) cookedFishInitialFill / (TemporossScript.temporossConfig.solo() ? 17 : getTotalAvailableFishSlots()), 1.0);
 
             case THIRD_COOK:
                 // Progression based on cooked fish count or intensity threshold.
                 int cookedFishThirdCook = State.getCookedFish();
-                return Math.min((double) cookedFishThirdCook / 19.0, 1.0);
+                return Math.min((double) cookedFishThirdCook / (TemporossScript.temporossConfig.solo() ? 19 : getAllFish()), 1.0);
 
             case THIRD_CATCH:
                 // Progression based on total fish count, target is 19.
-                int allFishThirdCatch = State.getAllFish();
-                return Math.min((double) allFishThirdCatch / 19.0, 1.0);
+                int allFishThirdCatch = getAllFish();
+                return Math.min((double) allFishThirdCatch / (TemporossScript.temporossConfig.solo() ? 19 : getTotalAvailableFishSlots()), 1.0);
 
             case EMERGENCY_FILL:
                 // Progression reaches 100% when all fish count is zero.
-                int allFishEmergencyFill = State.getAllFish();
+                int allFishEmergencyFill = getAllFish();
                 return allFishEmergencyFill == 0 ? 1.0 : 0.0;
 
             case SECOND_COOK:
                 // Progression based on cooked fish count reaching 17.
                 int cookedFishSecondCook = State.getCookedFish();
-                return Math.min((double) cookedFishSecondCook / 17.0, 1.0);
+                return Math.min((double) cookedFishSecondCook / (TemporossScript.temporossConfig.solo() ? 17 : getAllFish()), 1.0);
 
             case SECOND_CATCH:
                 // Progression based on total fish count, target is 17.
-                int allFishSecondCatch = State.getAllFish();
-                return Math.min((double) allFishSecondCatch / 17.0, 1.0);
+                int allFishSecondCatch = getAllFish();
+                return Math.min((double) allFishSecondCatch / (TemporossScript.temporossConfig.solo() ? 17 : getTotalAvailableFishSlots()), 1.0);
 
             case INITIAL_COOK:
                 // Progression reaches 100% when raw fish count is zero.
                 int cookedFishInitialCook = State.getCookedFish();
-                int allFishInitialCook = State.getAllFish();
+                int allFishInitialCook = getAllFish();
                 return Math.min((double) cookedFishInitialCook / allFishInitialCook, 1.0);
 
             case INITIAL_CATCH:
                 // Progression based on raw fish count or total fish count; targets are 7 or 10.
                 int rawFishInitialCatch = State.getRawFish();
-                int allFishInitialCatch = State.getAllFish();
+                int allFishInitialCatch = getAllFish();
                 return Math.max(
                         Math.min((double) rawFishInitialCatch / 7.0, 1.0),
                         Math.min((double) allFishInitialCatch / 10.0, 1.0)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossScript.java
@@ -484,9 +484,14 @@ public class TemporossScript extends Script {
                         return;
                     LocalPoint localPoint = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(),workArea.totemPoint);
                     Rs2Camera.turnTo(localPoint);
-                    Rs2Walker.walkFastLocal(localPoint);
+                    if (Rs2Camera.isTileOnScreen(localPoint)) {
+                        Rs2Walker.walkFastLocal(localPoint);
+                        log("Can't find the fish spot, walking to the totem pole");
+                        Rs2Player.waitForWalking(2000);
+                        return;
+                    }
                     log("Can't find the fish spot, walking to the totem pole");
-                    Rs2Player.waitForWalking(2000);
+                    Rs2Walker.walkTo(WorldPoint.fromLocalInstance(Microbot.getClient(),localPoint));
                     return;
 
                 }
@@ -597,12 +602,14 @@ public class TemporossScript extends Script {
 
     private void walkToSafePoint() {
         LocalPoint localPoint = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(),workArea.safePoint);
+        WorldPoint worldPoint = WorldPoint.fromLocalInstance(Microbot.getClient(),localPoint);
         Rs2Camera.turnTo(localPoint);
-        if(Rs2Camera.isTileOnScreen(localPoint))
+        if (Rs2Camera.isTileOnScreen(localPoint)) {
             Rs2Walker.walkFastLocal(localPoint);
-        else
-            Rs2Walker.walkTo(getTrueWorldPoint(workArea.safePoint));
-        Rs2Player.waitForWalking(2000);
+            Rs2Player.waitForWalking(2000);
+        } else {
+            Rs2Walker.walkTo(worldPoint);
+        }
     }
 
     private void walkToSpiritPool() {
@@ -611,11 +618,12 @@ public class TemporossScript extends Script {
         assert localPoint != null;
         if(Objects.equals(Microbot.getClient().getLocalDestinationLocation(), localPoint) || Objects.equals(Microbot.getClient().getLocalPlayer().getWorldLocation(), workArea.spiritPoolPoint))
             return;
-        if(Rs2Camera.isTileOnScreen(localPoint))
+        if(Rs2Camera.isTileOnScreen(localPoint)) {
             Rs2Walker.walkFastLocal(localPoint);
+            Rs2Player.waitForWalking(2000);
+        }
         else
             Rs2Walker.walkTo(getTrueWorldPoint(workArea.spiritPoolPoint));
-        Rs2Player.waitForWalking(2000);
     }
 
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/camera/Rs2Camera.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/camera/Rs2Camera.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.util.camera;
 
+import net.runelite.api.Point;
 import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.RuneLite;
@@ -227,15 +228,20 @@ public class Rs2Camera {
     }
 
     public static boolean isTileOnScreen(LocalPoint localPoint) {
-        int viewportHeight = Microbot.getClient().getViewportHeight();
-        int viewportWidth = Microbot.getClient().getViewportWidth();
+        Client client = Microbot.getClient();
+        int viewportHeight = client.getViewportHeight();
+        int viewportWidth = client.getViewportWidth();
 
-
-        Polygon poly = Perspective.getCanvasTilePoly(Microbot.getClient(), localPoint);
-
+        Polygon poly = Perspective.getCanvasTilePoly(client, localPoint);
         if (poly == null) return false;
 
-        return poly.getBounds2D().getX() <= viewportWidth && poly.getBounds2D().getY() <= viewportHeight;
+        // Check if any part of the polygon intersects with the screen bounds
+        Rectangle viewportBounds = new Rectangle(0, 0, viewportWidth, viewportHeight);
+        if (!poly.intersects(viewportBounds)) return false;
+
+        // Optionally, check if the tile is in front of the camera
+        Point canvasPoint = Perspective.localToCanvas(client, localPoint, client.getPlane());
+        return canvasPoint != null;
     }
 
     // get the camera zoom

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/wintertodt/MWintertodtConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/wintertodt/MWintertodtConfig.java
@@ -139,6 +139,18 @@ public interface MWintertodtConfig extends Config {
         return 20;
     }
 
+    // use rejuvenation potions instead of food
+    @ConfigItem(
+            keyName = "RejuvenationPotions",
+            name = "Rejuvenation Potions",
+            description = "Use rejuvenation potions instead of food",
+            position = 6,
+            section = foodSection
+    )
+    default boolean rejuvenationPotions() {
+        return false;
+    }
+
     @ConfigItem(
             keyName = "Brazier",
             name = "Brazier",


### PR DESCRIPTION
## **[Wintertodt Plugin]**

- **Added**: Support to use **Rejuvenation Potions** instead of food. This update allows the plugin to prioritize Rejuvenation Potions for healing, providing users with an alternative to traditional food-based health restoration during Wintertodt activities.

## **Class: [Rs2Camera]**

- **Fixed**: Corrected the `isTileOnScreen` method to ensure it accurately checks whether a tile is visible on the screen. This fix improves the reliability of camera checks and enhances interaction accuracy in plugins relying on this functionality.

## **[Tempoross Plugin]**

### **Fixes**
- **Fixed**: Addressed pathing issues that caused navigation disruptions during Tempoross activities. This update ensures smoother and more efficient movement between locations.
- **Fixed**: Improved inventory management when participating in mass worlds. The fix optimizes how inventory spaces are utilized, getting the most out of available slots.