### PR TITLE
chore/gotr-logging-cleanup

### DIFF
--- a/.github/workflows/manual_,nightly.yml
+++ b/.github/workflows/manual_,nightly.yml
@@ -38,4 +38,4 @@ jobs:
           prerelease: false
           title: "Nightly Build"
           files: |
-            /home/runner/work/microbot/microbot/runelite-client/target/*.jar
+            /home/runner/work/Microbot/Microbot/runelite-client/target/*.jar

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
           prerelease: false
           title: "Nightly Build"
           files: |
-            /home/runner/work/microbot/microbot/runelite-client/target/*.jar
+            /home/runner/work/Microbot/Microbot/runelite-client/target/*.jar
 
       - name: Upload Jar
         uses: "bacongobbler/azure-blob-storage-upload@main"

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ If you enjoy my open source work and would like to support me, consider buying m
 
 Thank you for your support! 😊
 
-# I Want To Bot
+# I Want To Play
 
 ## Non jagex account
 
-Here is a youtube video on how to setup the bot from scratch for **NON-JAGEX ACCOUNTS**
+Here is a youtube video on how to setup microbot from scratch for **NON-JAGEX ACCOUNTS**
 
 https://www.youtube.com/watch?v=EbtdZnxq5iw
 
@@ -123,7 +123,7 @@ public static double version = 1.0;
 All our scripts exist of Config. This is the settings for a specific script
 Overlay, this is a visual overlay for a specific script
 Plugin which handles the code for starting and stopping the script
-Script which handles all of the code the bot has to execute.
+Script which handles all of the code that microbot has to execute.
 
 Inside the startup of a plugin we can call the script code like this:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 
 # Microbot
-Microbot is an opensource automated oldschool runescape client based on runelite. It uses a plugin system to enable scripting. Here is a youtube channel showing off some of the scripts
+Microbot is an opensource oldschool runescape client based on runelite. It uses a plugin system to enable scripting. Here is a youtube channel showing off some of the scripts
 
 ## Youtube
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
@@ -354,11 +354,12 @@ public class GotrScript extends Script {
     }
 
     private boolean isOutOfFragments() {
-        if (!Rs2Inventory.hasItem(GUARDIAN_FRAGMENTS) && !Rs2Inventory.isFull()) {
+        if (!Rs2Inventory.hasItem(GUARDIAN_FRAGMENTS) && !Rs2Inventory.isFull() && shouldMineGuardianRemains == false) {
             shouldMineGuardianRemains = true;
             log("Memorize that we no longer have guardian fragments...");
             return true;
         }
+        shouldMineGuardianRemains = false;
         return false;
     }
 


### PR DESCRIPTION
The current iteration of `isOutOfFragments` will log "Memorize that we no longer have guardian fragments..." several times in quick succession when being called. This proposed change adds the `shouldMineGuardianRemains` flag to the IF statement, so that we only call the log, and subsequent flag casting, once as necessary. If we already know we need to mine more guardian fragments, we bomb out of the IF statement early.