### PR TITLE
Banks Shopper Fix + Extend Wait time for Fairy Rings

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankjs/BanksShopper/BanksShopperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankjs/BanksShopper/BanksShopperScript.java
@@ -61,10 +61,8 @@ public class BanksShopperScript extends Script {
                 boolean successfullAction = false;
 
                 if (Rs2Shop.isOpen()) {
-
                     for (String itemName : plugin.getItemNames()) {
-                        if (!isRunning()) break;
-                        if (Microbot.pauseAllScripts) break;
+                        if (!isRunning() || Microbot.pauseAllScripts) break;
 
                         switch (plugin.getSelectedAction()) {
                             case BUY:
@@ -72,6 +70,7 @@ public class BanksShopperScript extends Script {
                                 successfullAction = processBuyAction(itemName, plugin.getSelectedQuantity().toString());
                                 break;
                             case SELL:
+                                if (Rs2Shop.isFull()) continue;
                                 if (Rs2Shop.hasMinimumStock(itemName, plugin.getMinStock())) continue;
                                 successfullAction = processSellAction(itemName, plugin.getSelectedQuantity().toString());
                                 break;
@@ -79,12 +78,13 @@ public class BanksShopperScript extends Script {
                                 System.out.println("Invalid action specified in config.");
                         }
 
-                        if (!successfullAction) continue;
-
-                        allOutOfStock = false;
-                        Rs2Random.waitEx(900, 300);
+                        if (successfullAction) {
+                            allOutOfStock = false;
+                            Rs2Random.waitEx(900, 300);
+                        }
                     }
 
+                    // If no successful actions occurred, trigger a world hop
                     if (allOutOfStock) {
                         hopWorld();
                     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankjs/BanksShopper/BanksShopperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankjs/BanksShopper/BanksShopperScript.java
@@ -56,6 +56,7 @@ public class BanksShopperScript extends Script {
                 }
 
                 Rs2Shop.openShop(plugin.getNpcName());
+                Rs2Random.waitEx(1800, 300); // this wait is required ensure that Rs2Shop.shopItems has been updated before we proceed.
 
                 boolean allOutOfStock = true;
                 boolean successfullAction = false;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/shop/Rs2Shop.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/shop/Rs2Shop.java
@@ -99,7 +99,7 @@ public class Rs2Shop {
      * @return
      */
     public static boolean isFull() {
-        return shopItems.size() >= 40 && shopItems.stream().noneMatch(item -> item.getName() == null);
+        return shopItems.size() >= 40 && shopItems.stream().noneMatch(item -> item.getId() == -1);
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/shop/Rs2Shop.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/shop/Rs2Shop.java
@@ -93,6 +93,14 @@ public class Rs2Shop {
         return true;
     }
 
+    /**
+     * Checks if the shop is completely full
+     * 
+     * @return
+     */
+    public static boolean isFull() {
+        return shopItems.size() >= 40;
+    }
 
     /**
      * Checks if the specified item is in stock in the shop. **Note** if the item has stock 0 this will still return true.
@@ -123,6 +131,7 @@ public class Rs2Shop {
      * @return true if the item is in stock with quantity >= minimumQuantity, false otherwise.
      */
     public static boolean hasMinimumStock(String itemName, int minimumQuantity) {
+        
         // Iterate through the shop items to find the specified item
         for (Rs2Item item : shopItems) {
             // Check if the item name matches the specified item name and quantity is >= minimumQuantity

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/shop/Rs2Shop.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/shop/Rs2Shop.java
@@ -99,7 +99,7 @@ public class Rs2Shop {
      * @return
      */
     public static boolean isFull() {
-        return shopItems.size() >= 40;
+        return shopItems.size() >= 40 && shopItems.stream().noneMatch(item -> item.getName() == null);
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1385,7 +1385,7 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
             rotateSlotToDesiredRotation(SLOT_THREE, Rs2Widget.getWidget(SLOT_THREE).getRotationY(), getDesiredRotation(fairyRingCode.charAt(2)), SLOT_THREE_ACW_ROTATION, SLOT_THREE_CW_ROTATION);
             Rs2Widget.clickWidget(TELEPORT_BUTTON);
             
-            Rs2Player.waitForAnimation(Random.random(3800, 4200)); // Required due to long animation time
+            Rs2Player.waitForAnimation(Random.random(4200, 4800)); // Required due to long animation time
             
             // Re-equip the starting weapon if it was unequipped
             if (startingWeapon != null & !Rs2Equipment.isWearing(startingWeaponId)) {


### PR DESCRIPTION
I have included the following fixes here:

## Banks Shopper Plugin
- Added a method to check if the shop is completely full to not attempt to sell items if its full.

## Rs2Walker
- Extended Wait time for Fairy Rings