### PR TITLE
AutoSmelting Minor Bug Fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingConfig.java
@@ -16,7 +16,7 @@ public interface AutoSmeltingConfig extends Config {
             section = generalSection
     )
     default String GUIDE() {
-        return "Select the type of bar you want to smelt and stand near any furnace.\n" +
+        return "Select the type of bar you want to smelt and stand in line of sight of a nearby furnace.\n" +
                 "You need enough ore in your bank to fill your inventory, e.g. 14 tin and 14 copper or 9 iron and 18 coal.\n";
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingScript.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 public class AutoSmeltingScript extends Script {
 
-    public static String version = "1.0.1";
+    public static String version = "1.0.2";
     private boolean expectingXPDrop = false;
 
     public boolean run(AutoSmeltingConfig config) {
@@ -53,13 +53,11 @@ public class AutoSmeltingScript extends Script {
                     withdrawRightAmountOfMaterials(config);
                     return;
                 }
-
                 if (expectingXPDrop && Rs2Inventory.waitForInventoryChanges(4500)) {
                     Rs2Antiban.actionCooldown();
                     Rs2Antiban.takeMicroBreakByChance();
                     return;
                 }
-
                 // walk to the initial position (near furnace)
                 if (initialPlayerLocation.distanceTo(Rs2Player.getWorldLocation()) > 4) {
                     Rs2Walker.walkTo(initialPlayerLocation, 4);
@@ -68,7 +66,7 @@ public class AutoSmeltingScript extends Script {
 
                 // interact with the furnace until the smelting dialogue opens in chat, click the selected bar icon
                 // then wait for animation to finish
-                GameObject furnace = Rs2GameObject.findObject("furnace", true, 10, true, initialPlayerLocation);
+                GameObject furnace = Rs2GameObject.findObject("furnace", true, 10, false, initialPlayerLocation);
                 if (furnace != null) {
                     Rs2GameObject.interact(furnace, "smelt");
                     sleepUntilOnClientThread(() -> Rs2Widget.getWidget(17694733) != null);
@@ -107,7 +105,6 @@ public class AutoSmeltingScript extends Script {
             }
             Rs2Bank.withdrawX(name, totalAmount);
             sleepUntil(() -> Rs2Inventory.hasItemAmount(name, totalAmount), 3500);
-
             // Exit if we did not end up finding it.
             if (!Rs2Inventory.hasItemAmount(name, totalAmount)) {
                 Microbot.showMessage("Could not find item in bank.");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/enums/Bars.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/enums/Bars.java
@@ -10,6 +10,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public enum Bars {
     BRONZE("Bronze bar", ItemID.BRONZE_BAR, 1, Map.of(Ores.COPPER, 1, Ores.TIN, 1)),
+    BLURITE("Blurite bar", ItemID.IRON_BAR,  8, Map.of(Ores.BLURITE, 1)),
     IRON("Iron bar", ItemID.IRON_BAR,  15, Map.of(Ores.IRON, 1)),
     SILVER("Silver bar", ItemID.SILVER_BAR,  20, Map.of(Ores.SILVER, 1)),
     STEEL("Steel bar", ItemID.STEEL_BAR,  30, Map.of(Ores.IRON, 1, Ores.COAL, 2)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/enums/Ores.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/enums/Ores.java
@@ -9,6 +9,7 @@ public enum Ores {
     TIN("tin ore"),
     COPPER("copper ore"),
     CLAY("clay"),
+    BLURITE("blurite ore"),
     IRON("iron ore"),
     SILVER("silver ore"),
     COAL("coal"),


### PR DESCRIPTION
Removed line of sight requirement when looking for a furnace to prevent player for getting stuck indefinitely when out of line of sight but close to furnace.

Added support for Blurite to fix more advanced bars from trying to smelt the incorrect options. Bars after Bluerite were 1 off when selecting which bar to smelt. Eg Trying to smelt steel bars would try and smelt silver bars.