### PR TITLE
[Agility] remove delay before starting a new lap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
@@ -209,7 +209,7 @@ public class AgilityScript extends Script {
                             Rs2Magic.alch(config.item(), 50, 100);
                         }
                         if (Rs2Player.getWorldLocation().distanceTo(startCourse) < 100) {//extra check for prif course
-                            Rs2Walker.walkTo(startCourse, 15);
+                            Rs2Walker.walkTo(startCourse, 8);
                             Microbot.log("Going back to course's starting point");
                             isWalkingToStart = true;
                             return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
@@ -26,11 +26,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static net.runelite.api.NullObjectID.*;
 import static net.runelite.api.ObjectID.LADDER_36231;
-import static net.runelite.client.plugins.microbot.util.math.Random.random;
 import static net.runelite.client.plugins.microbot.agility.enums.AgilityCourseName.GNOME_STRONGHOLD_AGILITY_COURSE;
 import static net.runelite.client.plugins.microbot.agility.enums.AgilityCourseName.PRIFDDINAS_AGILITY_COURSE;
 
@@ -59,6 +59,7 @@ public class AgilityScript extends Script {
     WorldPoint startCourse = null;
 
     public static int currentObstacle = 0;
+    private static boolean isWalkingToStart = false;
 
     public static final Set<Integer> PORTAL_OBSTACLE_IDS = ImmutableSet.of(
             // Prifddinas portals
@@ -163,7 +164,6 @@ public class AgilityScript extends Script {
 
         Rs2Antiban.resetAntibanSettings();
         Rs2Antiban.antibanSetupTemplates.applyAgilitySetup();
-
         init(config);
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
@@ -182,7 +182,8 @@ public class AgilityScript extends Script {
                 // Eat food.
                 Rs2Player.eatAt(config.hitpoints());
 
-                if (Rs2Player.isMoving()) return;
+                if(isWalkingToStart) Microbot.log("isWalkingToStart: true");
+                else if (Rs2Player.isMoving()) return;
                 if (Rs2Player.isAnimating()) return;
 
                 if (currentObstacle >= getCurrentCourse(config).size()) {
@@ -208,7 +209,9 @@ public class AgilityScript extends Script {
                             Rs2Magic.alch(config.item(), 50, 100);
                         }
                         if (Rs2Player.getWorldLocation().distanceTo(startCourse) < 100) {//extra check for prif course
-                            Rs2Walker.walkTo(startCourse, 8);
+                            Rs2Walker.walkTo(startCourse, 15);
+                            Microbot.log("Going back to course's starting point");
+                            isWalkingToStart = true;
                             return;
                         }
                     }
@@ -267,6 +270,7 @@ public class AgilityScript extends Script {
                         }
 
                         if (Rs2GameObject.interact(gameObject)) {
+                            isWalkingToStart = false;
                             //LADDER_36231 in prifddinas does not give experience
                             if (gameObject.getId() != LADDER_36231 && waitForAgilityObstabcleToFinish(agilityExp))
                                 break;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -293,13 +293,14 @@ public class Rs2Walker {
                 }
             }
 
-
             if (!doorOrTransportResult) {
                 if (!path.isEmpty()) {
                     var moveableTiles = Rs2Tile.getReachableTilesFromTile(path.get(path.size() - 1), Math.min(3, distance)).keySet().toArray(new WorldPoint[0]);
                     var finalTile = moveableTiles.length > 0 ? moveableTiles[Random.random(0, moveableTiles.length)] : path.get(path.size() - 1);
 
-                    if (Rs2Tile.isTileReachable(finalTile)) {
+
+                    Microbot.log("Distance check: " + (Rs2Player.getWorldLocation().distanceTo(target) > distance));
+                    if (Rs2Tile.isTileReachable(finalTile) && Rs2Player.getWorldLocation().distanceTo(target) > distance) {
                         if (Rs2Walker.walkFastCanvas(finalTile)) {
                             sleepUntil(() -> Rs2Player.getWorldLocation().distanceTo(finalTile) < 2, 3000);
                         }
@@ -309,6 +310,7 @@ public class Rs2Walker {
             }
             if (Rs2Player.getWorldLocation().distanceTo(target) < distance) {
                 setTarget(null);
+                sleep(300);
                 return WalkerState.ARRIVED;
             } else {
                 return processWalk(target, distance);
@@ -324,6 +326,7 @@ public class Rs2Walker {
         }
         return WalkerState.EXIT;
     }
+
 
     public static boolean walkNextTo(GameObject target) {
         Rs2WorldArea gameObjectArea = new Rs2WorldArea(Objects.requireNonNull(Rs2GameObject.getWorldArea(target)));


### PR DESCRIPTION
When the RS2Walker function returns the player necessarily hasn't stopped moving and this line 
```
if (Rs2Player.isMoving()) return;
```
will stall any subsequent actions until the player has come to a complete stop, which causes a delay before the course's start is interacted with. 