### PR TITLE
Gilded altar refactor

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/prayer/GildedAltarConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/prayer/GildedAltarConfig.java
@@ -6,25 +6,14 @@ import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup("GildedAltar")
 public interface GildedAltarConfig extends Config {
+
     @ConfigItem(
             keyName = "Guide",
             name = "How to use",
             description = "How to use the script",
             position = 0
     )
-    default String GUIDE()
-    {
+    default String GUIDE() {
         return "This only supports house advertisements. Use this script in w330";
-    }
-
-    @ConfigItem(
-            keyName = "Player Name",
-            name = "Player Name Houses",
-            description = "Choose the player name's house comma seperated",
-            position = 1
-    )
-    default String housePlayerName()
-    {
-        return "xgrace,workless";
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/prayer/GildedAltarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/prayer/GildedAltarPlugin.java
@@ -1,20 +1,16 @@
 package net.runelite.client.plugins.microbot.prayer;
 
-import java.awt.AWTException;
+import java.awt.*;
 import java.util.Arrays;
-import java.util.stream.Collectors;
-
+import java.util.Objects;
 import javax.inject.Inject;
-
 import com.google.inject.Provides;
-
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.GameState;
-import net.runelite.api.ObjectID;
-import net.runelite.api.TileObject;
+import net.runelite.api.*;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.config.ConfigManager;
@@ -27,9 +23,11 @@ import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.math.Random;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.tabs.Rs2Tab;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.api.ChatMessageType;
 
 @PluginDescriptor(
         name = PluginDescriptor.Mocrosoft + "Gilded Altar",
@@ -41,6 +39,7 @@ import net.runelite.client.ui.overlay.OverlayManager;
 public class GildedAltarPlugin extends Plugin {
     @Inject
     private GildedAltarConfig config;
+
     @Provides
     GildedAltarConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(GildedAltarConfig.class);
@@ -57,6 +56,16 @@ public class GildedAltarPlugin extends Plugin {
     @Setter
     int skipTicks;
     private final int HOUSE_PORTAL_OBJECT = 4525;
+    private Widget toggleArrow;
+    boolean listen = false;
+    Widget targetWidget;
+    String houseOwner;
+    private TileObject cachedAltar = null; // Cache for the altar object
+    private WorldPoint portalCoords;
+    private WorldPoint altarCoords;
+    private Boolean usePortal;
+    private boolean visitedOnce;
+
 
     GildedAltarPlayerState state = GildedAltarPlayerState.IDLE;
 
@@ -78,30 +87,27 @@ public class GildedAltarPlugin extends Plugin {
             overlayManager.add(gildedAltarOverlay);
         }
     }
+
     /**
-     *
      * @param name plugin name
      * @return the plguin
      */
     public static Plugin findPlugin(String name) {
         return Microbot.getPluginManager().getPlugins().stream().filter(x -> x.getName().equals(name)).findFirst().orElse(null);
     }
+
     @Override
     protected void shutDown() {
         overlayManager.remove(gildedAltarOverlay);
     }
 
     @Subscribe
-    public void onGameTick(GameTick gameTick)
-    {
+    public void onGameTick(GameTick gameTick) {
         if (client.getGameState() != GameState.LOGGED_IN)
             return;
 
-        if (skipTicks > 0)
-        {
-            if (Random.random(1, 7) != 2) {
-                skipTicks--;
-            }
+        if (skipTicks > 0) {
+            skipTicks--;
             return;
         }
 
@@ -141,22 +147,32 @@ public class GildedAltarPlugin extends Plugin {
     }
 
     private void calculateState() {
-        if (hasUnNotedBones() && !inHouse()) {
-            state = GildedAltarPlayerState.ENTER_HOUSE;
-        } else if (hasUnNotedBones() && inHouse()) {
-            state = GildedAltarPlayerState.BONES_ON_ALTAR;
-        } else if (!hasUnNotedBones() && !inHouse()) {
-            state = GildedAltarPlayerState.UNNOTE_BONES;
-        } else if (!hasUnNotedBones() && inHouse()) {
-            state = GildedAltarPlayerState.LEAVE_HOUSE;
+        boolean inHouse = inHouse();
+        boolean hasUnNotedBones = hasUnNotedBones();
+
+        // If we have unNoted bones:
+            // If we're in the house, use bones on altar. Else, enter the portal
+        // If we don't have unNoted bones:
+            // If we're in the house, leave house. Else, talk to Phials
+        if (hasUnNotedBones) {
+            state = inHouse ? GildedAltarPlayerState.BONES_ON_ALTAR : GildedAltarPlayerState.ENTER_HOUSE;
+        } else {
+            state = inHouse ? GildedAltarPlayerState.LEAVE_HOUSE : GildedAltarPlayerState.UNNOTE_BONES;
         }
     }
 
     public void leaveHouse() {
         System.out.println("Attempting to leave house...");
-        
-        if (Rs2GameObject.findObjectById(HOUSE_PORTAL_OBJECT) == null) {
-            System.out.println("Not in house, HOUSE_PORTAL_OBJECT not found.");
+
+        // We should only rely on using the settings menu if the portal is several rooms away from the portal. Bringing up 3 different interfaces when we can see the portal on screen is unnecessary.
+        if(usePortal) {
+            TileObject portalObject = Rs2GameObject.findObjectById(HOUSE_PORTAL_OBJECT);
+            if (portalObject == null) {
+                System.out.println("Not in house, HOUSE_PORTAL_OBJECT not found.");
+                return;
+            }
+            Rs2GameObject.interact(portalObject);
+            setSkipTicks(5);
             return;
         }
 
@@ -164,9 +180,14 @@ public class GildedAltarPlugin extends Plugin {
         Rs2Tab.switchToSettingsTab();
         setSkipTicks(2);
 
+        //If the house options button is not visible, player is on Display or Sound settings, need to click Controls.
+        if(!(Rs2Widget.isWidgetVisible(7602207))){
+            Rs2Widget.clickWidget(7602243);
+            setSkipTicks(1);
+        }
+
         // Click House Options
         if (Rs2Widget.clickWidget(7602207)) {
-            System.out.println("Clicked House Options button");
             setSkipTicks(2);
         } else {
             System.out.println("House Options button not found.");
@@ -175,8 +196,8 @@ public class GildedAltarPlugin extends Plugin {
 
         // Click Leave House
         if (Rs2Widget.clickWidget(24248341)) {
-            System.out.println("Clicked Leave House button");
-            setSkipTicks(4);
+            listen = true;
+            setSkipTicks(5);
         } else {
             System.out.println("Leave House button not found.");
         }
@@ -197,35 +218,116 @@ public class GildedAltarPlugin extends Plugin {
     }
 
     private void enterHouse() {
-        boolean isAdvertisementWidgetOpen = Rs2Widget.hasWidget("House advertisement");
+        // If we've already visited a house this session, use 'Visit-Last' on advertisement board
+        if (visitedOnce) {
+            Rs2GameObject.interact(ObjectID.HOUSE_ADVERTISEMENT, "Visit-Last");
+            setSkipTicks(4);
+            listen = false;
+            return;
+        }
+
+        boolean isAdvertisementWidgetOpen = Rs2Widget.isWidgetVisible(3407875);
 
         if (!isAdvertisementWidgetOpen) {
             Rs2GameObject.interact(ObjectID.HOUSE_ADVERTISEMENT, "View");
             setSkipTicks(2);
-            return;
         }
 
-        Widget container = Rs2Widget.getWidget(52, 9);
-        if (container == null || container.getChildren() == null) return;
+        Widget containerNames = Rs2Widget.getWidget(52, 9);
+        Widget containerEnter = Rs2Widget.getWidget(52, 19);
+        if (containerNames == null || containerNames.getChildren() == null) return;
 
-        for (String player : config.housePlayerName().split(",")) {
-            Widget playerHouse = Rs2Widget.findWidget(player, Arrays.stream(container.getChildren()).collect(Collectors.toList()));
-            if (playerHouse != null) {
-                Rs2Widget.clickChildWidget(3407891, playerHouse.getIndex());
-                setSkipTicks(2);
-                return;
+        //Sort house advertisements by Gilded Altar availability
+        toggleArrow = Rs2Widget.getWidget(3407877);
+        if (toggleArrow.getSpriteId() == 1050) {
+            Rs2Widget.clickWidget(3407877);
+            setSkipTicks(1);
+        }
+
+        // Get all names on house board and find the one with the smallest Y value
+        if (containerNames.getChildren() != null) {
+            int smallestOriginalY = Integer.MAX_VALUE; // Track the smallest OriginalY
+
+            Widget[] children = containerNames.getChildren();
+
+            for (int i = 0; i < children.length; i++) {
+                Widget child = children[i];
+                if (child.getText() == null || child.getText().isEmpty()|| child.getText() == ""){
+                    continue;
+                }
+                if (child.getText() != null) {
+                    if (child.getOriginalY() < smallestOriginalY) {
+                        houseOwner = child.getText();
+                        smallestOriginalY = child.getOriginalY();
+                    }
+                }
             }
-        }
+
+            // Use playername at top of advertisement board as search criteria and find their Enter button
+            Widget[] children2 = containerEnter.getChildren();
+            for (int i = 0; i < children2.length; i++) {
+                Widget child = children2[i];
+                if (child == null || child.getOnOpListener() == null) {
+                    continue;
+                }
+                Object[] listenerArray = child.getOnOpListener();
+                boolean containsHouseOwner = Arrays.stream(listenerArray)
+                        .filter(Objects::nonNull) // Ensure no null elements
+                        .anyMatch(obj -> obj.toString().contains(houseOwner)); // Check if houseOwner is part of any listener object
+                if (containsHouseOwner) {
+                    targetWidget = child;
+                    break;
+                }
+            }
+            setSkipTicks(1);
+            Rs2Widget.clickChildWidget(3407891, targetWidget.getIndex());
+            visitedOnce = true;
+            listen = false;
+            setSkipTicks(5);
+            }
     }
 
     public void bonesOnAltar() {
-        TileObject altar = Rs2GameObject.findObjectById(ObjectID.ALTAR_40878);
-        if (altar == null) {
-            altar = Rs2GameObject.findObjectById(ObjectID.ALTAR_13197);
+        // If we haven't cached the altar yet or it's no longer valid, find it
+        if (cachedAltar == null) {
+            cachedAltar = Rs2GameObject.findObjectById(ObjectID.ALTAR_40878);
+            if (cachedAltar == null) {
+                cachedAltar = Rs2GameObject.findObjectById(ObjectID.ALTAR_13197);
+            }
         }
-        if (altar != null) {
-            Rs2Inventory.useUnNotedItemOnObject("bones", altar);
-            setSkipTicks(1);
+        if(portalCoords == null){
+            portalCoords = Rs2Player.getWorldLocation();
         }
-    }
+
+        // Use bones on the altar if it's valid
+        if (cachedAltar != null) {
+            Rs2Inventory.useUnNotedItemOnObject("bones", cachedAltar);
+                }
+        if(altarCoords == null){
+            altarCoords = Rs2Player.getWorldLocation();
+        }
+        // If portal is more than 10 tiles from altar, use settings menu to leave. Else, just walk back to portal.
+        if(usePortal == null){
+            usePortal = altarCoords.distanceTo(portalCoords) <= 10;
+        }
+        }
+
+    @Subscribe
+    public void onChatMessage(ChatMessage chatMessage) {
+        if(!listen){
+            return;
+        }
+        if(chatMessage.getType() == ChatMessageType.PUBLICCHAT){
+            return;
+        }
+        String chatMsg = chatMessage.getMessage().toLowerCase();
+        if(chatMsg.contains("that player is offline")||chatMsg.contains("haven't visited anyone this session")){
+            // If we try to use Visit-Last unsuccessfully, these chat messages will appear, and we need to reset vars.
+            visitedOnce= false;
+            cachedAltar= null;
+            usePortal = null;
+            altarCoords = null;
+            portalCoords = null;
+        }
+}
 }


### PR DESCRIPTION
Refactored the logic and flow of the Gilded Altar plugin.

- No longer requires House Owner names in config file. Clicks the widget to sort available houses by Gilded Altar availability and chooses top entry
- Uses 'Visit-Last' on the House Advertisement board after 1 successful visit instead of bringing up the Board each time.
- Caches altar location so we don't need to find the Tile Object in between each use of bones
- Will use the House Portal to leave if the altar is 10 or less tiles from the portal
- Handles cases where we tried to use the Settings menu to leave, but the player was on Display or Sound settings instead of Control.
- Speeds up CalculateState() that is called every game tick by simplifying the expression.
- Removed redundant imports (May need review)