### PR TITLE
[Agility] Remove delay before starting new course lap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static net.runelite.api.NullObjectID.*;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
@@ -209,7 +209,7 @@ public class AgilityScript extends Script {
                             Rs2Magic.alch(config.item(), 50, 100);
                         }
                         if (Rs2Player.getWorldLocation().distanceTo(startCourse) < 100) {//extra check for prif course
-                            Rs2Walker.walkTo(startCourse, 15);
+                            Rs2Walker.walkTo(startCourse, 8);
                             Microbot.log("Going back to course's starting point");
                             isWalkingToStart = true;
                             return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
@@ -26,11 +26,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static net.runelite.api.NullObjectID.*;
 import static net.runelite.api.ObjectID.LADDER_36231;
-import static net.runelite.client.plugins.microbot.util.math.Random.random;
 import static net.runelite.client.plugins.microbot.agility.enums.AgilityCourseName.GNOME_STRONGHOLD_AGILITY_COURSE;
 import static net.runelite.client.plugins.microbot.agility.enums.AgilityCourseName.PRIFDDINAS_AGILITY_COURSE;
 
@@ -59,6 +59,7 @@ public class AgilityScript extends Script {
     WorldPoint startCourse = null;
 
     public static int currentObstacle = 0;
+    private static boolean isWalkingToStart = false;
 
     public static final Set<Integer> PORTAL_OBSTACLE_IDS = ImmutableSet.of(
             // Prifddinas portals
@@ -163,7 +164,6 @@ public class AgilityScript extends Script {
 
         Rs2Antiban.resetAntibanSettings();
         Rs2Antiban.antibanSetupTemplates.applyAgilitySetup();
-
         init(config);
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
@@ -182,7 +182,8 @@ public class AgilityScript extends Script {
                 // Eat food.
                 Rs2Player.eatAt(config.hitpoints());
 
-                if (Rs2Player.isMoving()) return;
+                if(isWalkingToStart) Microbot.log("isWalkingToStart: true");
+                else if (Rs2Player.isMoving()) return;
                 if (Rs2Player.isAnimating()) return;
 
                 if (currentObstacle >= getCurrentCourse(config).size()) {
@@ -208,7 +209,9 @@ public class AgilityScript extends Script {
                             Rs2Magic.alch(config.item(), 50, 100);
                         }
                         if (Rs2Player.getWorldLocation().distanceTo(startCourse) < 100) {//extra check for prif course
-                            Rs2Walker.walkTo(startCourse, 8);
+                            Rs2Walker.walkTo(startCourse, 15);
+                            Microbot.log("Going back to course's starting point");
+                            isWalkingToStart = true;
                             return;
                         }
                     }
@@ -267,6 +270,7 @@ public class AgilityScript extends Script {
                         }
 
                         if (Rs2GameObject.interact(gameObject)) {
+                            isWalkingToStart = false;
                             //LADDER_36231 in prifddinas does not give experience
                             if (gameObject.getId() != LADDER_36231 && waitForAgilityObstabcleToFinish(agilityExp))
                                 break;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -293,13 +293,14 @@ public class Rs2Walker {
                 }
             }
 
-
             if (!doorOrTransportResult) {
                 if (!path.isEmpty()) {
                     var moveableTiles = Rs2Tile.getReachableTilesFromTile(path.get(path.size() - 1), Math.min(3, distance)).keySet().toArray(new WorldPoint[0]);
                     var finalTile = moveableTiles.length > 0 ? moveableTiles[Random.random(0, moveableTiles.length)] : path.get(path.size() - 1);
 
-                    if (Rs2Tile.isTileReachable(finalTile)) {
+
+                    Microbot.log("Distance check: " + (Rs2Player.getWorldLocation().distanceTo(target) > distance));
+                    if (Rs2Tile.isTileReachable(finalTile) && Rs2Player.getWorldLocation().distanceTo(target) > distance) {
                         if (Rs2Walker.walkFastCanvas(finalTile)) {
                             sleepUntil(() -> Rs2Player.getWorldLocation().distanceTo(finalTile) < 2, 3000);
                         }
@@ -309,6 +310,7 @@ public class Rs2Walker {
             }
             if (Rs2Player.getWorldLocation().distanceTo(target) < distance) {
                 setTarget(null);
+                sleep(300);
                 return WalkerState.ARRIVED;
             } else {
                 return processWalk(target, distance);
@@ -324,6 +326,7 @@ public class Rs2Walker {
         }
         return WalkerState.EXIT;
     }
+
 
     public static boolean walkNextTo(GameObject target) {
         Rs2WorldArea gameObjectArea = new Rs2WorldArea(Objects.requireNonNull(Rs2GameObject.getWorldArea(target)));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -561,19 +561,19 @@ public class Rs2Walker {
     }
 
     /**
-     * Retrieves the walk path from the player's current location to the specified target location.
-     *
-     * @param target The target `WorldPoint` to which the path should be calculated.
-     * @return A list of `WorldPoint` objects representing the path from the player's current location to the target.
-     */
-    public static List<WorldPoint> getWalkPath(WorldPoint target) {
-        if (ShortestPathPlugin.getPathfinderConfig().getTransports().isEmpty()) {
-            ShortestPathPlugin.getPathfinderConfig().refresh();
-        }
-        Pathfinder pathfinder = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), Rs2Player.getWorldLocation(), target);
-        pathfinder.run();
-        return pathfinder.getPath();
+ * Retrieves the walk path from the player's current location to the specified target location.
+ *
+ * @param target The target `WorldPoint` to which the path should be calculated.
+ * @return A list of `WorldPoint` objects representing the path from the player's current location to the target.
+ */
+public static List<WorldPoint> getWalkPath(WorldPoint target) {
+    if (ShortestPathPlugin.getPathfinderConfig().getTransports().isEmpty()) {
+        ShortestPathPlugin.getPathfinderConfig().refresh();
     }
+    Pathfinder pathfinder = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), Rs2Player.getWorldLocation(), target);
+    pathfinder.run();
+    return pathfinder.getPath();
+}
 
     public static boolean isCloseToRegion(int distance, int regionX, int regionY) {
         WorldPoint worldPoint = WorldPoint.fromRegion(Microbot.getClient().getLocalPlayer().getWorldLocation().getRegionID(),
@@ -870,7 +870,7 @@ public class Rs2Walker {
                     if (path.stream().noneMatch(x -> x.equals(transport.getDestination()))) continue;
                     if ((transport.getType() == TransportType.TELEPORTATION_ITEM ||
                             transport.getType() == TransportType.TELEPORTATION_SPELL) &&
-                            Rs2Player.getWorldLocation().distanceTo(transport.getDestination()) < 3) continue;
+                                    Rs2Player.getWorldLocation().distanceTo(transport.getDestination()) < 3) continue;
 
                     // we don't need to check for teleportation_item & teleportation_spell as they will be set on the first tile
                     if (transport.getType() != TransportType.TELEPORTATION_ITEM && transport.getType() != TransportType.TELEPORTATION_SPELL) {
@@ -934,7 +934,7 @@ public class Rs2Walker {
                             break;
                         }
                     }
-
+                    
                     if (transport.getType() == TransportType.QUETZAL) {
                         if (handleQuetzal(transport)) {
                             sleep(600 * 2); // wait 2 extra ticks before walking
@@ -1269,12 +1269,12 @@ public class Rs2Walker {
         return false;
 
     }
-
+    
     private static boolean handleQuetzal(Transport transport) {
         int varlamoreMapParentID = 874;
         String displayInfo = transport.getDisplayInfo();
         if (displayInfo == null || displayInfo.isEmpty()) return false;
-
+        
         NPC renu = Rs2Npc.getNpc(NpcID.RENU_13350);
 
         if (Rs2Npc.canWalkTo(renu, 20) && Rs2Npc.interact(renu, "travel")) {
@@ -1294,7 +1294,7 @@ public class Rs2Walker {
             }
         }
         return false;
-    }
+    } 
 
     /**
      * interact with interfaces like spirit tree & xeric talisman etc...
@@ -1404,9 +1404,9 @@ public class Rs2Walker {
             rotateSlotToDesiredRotation(SLOT_TWO, Rs2Widget.getWidget(SLOT_TWO).getRotationY(), getDesiredRotation(fairyRingCode.charAt(1)), SLOT_TWO_ACW_ROTATION, SLOT_TWO_CW_ROTATION);
             rotateSlotToDesiredRotation(SLOT_THREE, Rs2Widget.getWidget(SLOT_THREE).getRotationY(), getDesiredRotation(fairyRingCode.charAt(2)), SLOT_THREE_ACW_ROTATION, SLOT_THREE_CW_ROTATION);
             Rs2Widget.clickWidget(TELEPORT_BUTTON);
-
+            
             Rs2Player.waitForAnimation(Random.random(4200, 4800)); // Required due to long animation time
-
+            
             // Re-equip the starting weapon if it was unequipped
             if (startingWeapon != null & !Rs2Equipment.isWearing(startingWeaponId)) {
                 Microbot.log("Equipping Starting Weapon: " + startingWeaponId);
@@ -1422,7 +1422,7 @@ public class Rs2Walker {
             var fairyRing = Rs2GameObject.findObjectByLocation(origin);
             Rs2GameObject.interact(fairyRing, "Configure");
             Rs2Player.waitForWalking();
-        }
+        } 
         else {
             // Manage weapon and staff as needed if elite Lumbridge Diary is not complete
             if (startingWeapon == null) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -292,14 +292,13 @@ public class Rs2Walker {
                 }
             }
 
+
             if (!doorOrTransportResult) {
                 if (!path.isEmpty()) {
                     var moveableTiles = Rs2Tile.getReachableTilesFromTile(path.get(path.size() - 1), Math.min(3, distance)).keySet().toArray(new WorldPoint[0]);
                     var finalTile = moveableTiles.length > 0 ? moveableTiles[Random.random(0, moveableTiles.length)] : path.get(path.size() - 1);
 
-
-                    Microbot.log("Distance check: " + (Rs2Player.getWorldLocation().distanceTo(target) > distance));
-                    if (Rs2Tile.isTileReachable(finalTile) && Rs2Player.getWorldLocation().distanceTo(target) > distance) {
+                    if (Rs2Tile.isTileReachable(finalTile)) {
                         if (Rs2Walker.walkFastCanvas(finalTile)) {
                             sleepUntil(() -> Rs2Player.getWorldLocation().distanceTo(finalTile) < 2, 3000);
                         }
@@ -309,7 +308,6 @@ public class Rs2Walker {
             }
             if (Rs2Player.getWorldLocation().distanceTo(target) < distance) {
                 setTarget(null);
-                sleep(300);
                 return WalkerState.ARRIVED;
             } else {
                 return processWalk(target, distance);
@@ -325,7 +323,6 @@ public class Rs2Walker {
         }
         return WalkerState.EXIT;
     }
-
 
     public static boolean walkNextTo(GameObject target) {
         Rs2WorldArea gameObjectArea = new Rs2WorldArea(Objects.requireNonNull(Rs2GameObject.getWorldArea(target)));
@@ -564,19 +561,19 @@ public class Rs2Walker {
     }
 
     /**
- * Retrieves the walk path from the player's current location to the specified target location.
- *
- * @param target The target `WorldPoint` to which the path should be calculated.
- * @return A list of `WorldPoint` objects representing the path from the player's current location to the target.
- */
-public static List<WorldPoint> getWalkPath(WorldPoint target) {
-    if (ShortestPathPlugin.getPathfinderConfig().getTransports().isEmpty()) {
-        ShortestPathPlugin.getPathfinderConfig().refresh();
+     * Retrieves the walk path from the player's current location to the specified target location.
+     *
+     * @param target The target `WorldPoint` to which the path should be calculated.
+     * @return A list of `WorldPoint` objects representing the path from the player's current location to the target.
+     */
+    public static List<WorldPoint> getWalkPath(WorldPoint target) {
+        if (ShortestPathPlugin.getPathfinderConfig().getTransports().isEmpty()) {
+            ShortestPathPlugin.getPathfinderConfig().refresh();
+        }
+        Pathfinder pathfinder = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), Rs2Player.getWorldLocation(), target);
+        pathfinder.run();
+        return pathfinder.getPath();
     }
-    Pathfinder pathfinder = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), Rs2Player.getWorldLocation(), target);
-    pathfinder.run();
-    return pathfinder.getPath();
-}
 
     public static boolean isCloseToRegion(int distance, int regionX, int regionY) {
         WorldPoint worldPoint = WorldPoint.fromRegion(Microbot.getClient().getLocalPlayer().getWorldLocation().getRegionID(),
@@ -873,7 +870,7 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
                     if (path.stream().noneMatch(x -> x.equals(transport.getDestination()))) continue;
                     if ((transport.getType() == TransportType.TELEPORTATION_ITEM ||
                             transport.getType() == TransportType.TELEPORTATION_SPELL) &&
-                                    Rs2Player.getWorldLocation().distanceTo(transport.getDestination()) < 3) continue;
+                            Rs2Player.getWorldLocation().distanceTo(transport.getDestination()) < 3) continue;
 
                     // we don't need to check for teleportation_item & teleportation_spell as they will be set on the first tile
                     if (transport.getType() != TransportType.TELEPORTATION_ITEM && transport.getType() != TransportType.TELEPORTATION_SPELL) {
@@ -937,7 +934,7 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
                             break;
                         }
                     }
-                    
+
                     if (transport.getType() == TransportType.QUETZAL) {
                         if (handleQuetzal(transport)) {
                             sleep(600 * 2); // wait 2 extra ticks before walking
@@ -1272,12 +1269,12 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
         return false;
 
     }
-    
+
     private static boolean handleQuetzal(Transport transport) {
         int varlamoreMapParentID = 874;
         String displayInfo = transport.getDisplayInfo();
         if (displayInfo == null || displayInfo.isEmpty()) return false;
-        
+
         NPC renu = Rs2Npc.getNpc(NpcID.RENU_13350);
 
         if (Rs2Npc.canWalkTo(renu, 20) && Rs2Npc.interact(renu, "travel")) {
@@ -1297,7 +1294,7 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
             }
         }
         return false;
-    } 
+    }
 
     /**
      * interact with interfaces like spirit tree & xeric talisman etc...
@@ -1407,9 +1404,9 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
             rotateSlotToDesiredRotation(SLOT_TWO, Rs2Widget.getWidget(SLOT_TWO).getRotationY(), getDesiredRotation(fairyRingCode.charAt(1)), SLOT_TWO_ACW_ROTATION, SLOT_TWO_CW_ROTATION);
             rotateSlotToDesiredRotation(SLOT_THREE, Rs2Widget.getWidget(SLOT_THREE).getRotationY(), getDesiredRotation(fairyRingCode.charAt(2)), SLOT_THREE_ACW_ROTATION, SLOT_THREE_CW_ROTATION);
             Rs2Widget.clickWidget(TELEPORT_BUTTON);
-            
+
             Rs2Player.waitForAnimation(Random.random(4200, 4800)); // Required due to long animation time
-            
+
             // Re-equip the starting weapon if it was unequipped
             if (startingWeapon != null & !Rs2Equipment.isWearing(startingWeaponId)) {
                 Microbot.log("Equipping Starting Weapon: " + startingWeaponId);
@@ -1425,7 +1422,7 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
             var fairyRing = Rs2GameObject.findObjectByLocation(origin);
             Rs2GameObject.interact(fairyRing, "Configure");
             Rs2Player.waitForWalking();
-        } 
+        }
         else {
             // Manage weapon and staff as needed if elite Lumbridge Diary is not complete
             if (startingWeapon == null) {


### PR DESCRIPTION
This PR reverts changes to RS2Walker that were present in a previous PR, so it only makes changes to the agility plugin's code.

Is moving lags behind when the player actually stops. (ex Player stops first, Rs2Player.isMoving() will return true for another tick or so until it returns false)

Also RS2Walker always ends with a canvas walk (yellow click) which I don't like but will not attempt to fix in this PR. However it was always a part of the agility script (and everything else)