### PR TITLE
Webwalker Changes + Fix World Hopping

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPanel.java
@@ -321,7 +321,7 @@ public class ShortestPathPanel extends PluginPanel {
         JPanel hunterGuildPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
         JButton hunterGuildButton = new JButton("      Hunter Guild      ");
 
-        hunterGuildButton.addActionListener(e -> startWalking(new WorldPoint(1555, 3420, 0)));
+        hunterGuildButton.addActionListener(e -> startWalking(new WorldPoint(1558, 3046, 0)));
 
         hunterGuildPanel.add(hunterGuildButton);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPanel.java
@@ -2,6 +2,7 @@ package net.runelite.client.plugins.microbot.shortestpath;
 
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.nateplugins.skilling.natefishing.enums.Fish;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.bank.enums.BankLocation;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
@@ -33,7 +34,13 @@ public class ShortestPathPanel extends PluginPanel {
     private JComboBox<Hops> hopsComboBox;
     private JComboBox<Trees> treesComboBox;
     private JComboBox<CompostBins> compostBinsComboBox;
-    private JComboBox<HuntingAreas> hunterCreatureComboBox;
+    private JComboBox<HuntingAreas> huntingAreasComboBox;
+    private JComboBox<Birds> birdsComboBox;
+    private JComboBox<Chinchompas> chinchompasComboBox;
+    private JComboBox<Insects> insectsComboBox;
+    private JComboBox<Kebbits> kebbitsJComboBox;
+    private JComboBox<Salamanders> salamandersComboBox;
+    private JComboBox<SpecialHuntingAreas> specialHuntingAreasJComboBox;
 
     @Inject
     private ShortestPathPanel(ShortestPathPlugin plugin) {
@@ -268,25 +275,64 @@ public class ShortestPathPanel extends PluginPanel {
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
         panel.setBorder(createCenteredTitledBorder("Travel to Hunter Creature", "/net/runelite/client/plugins/microbot/shortestpath/Hunter_icon.png"));
 
-        hunterCreatureComboBox = new JComboBox<>(HuntingAreas.values());
-        hunterCreatureComboBox.setRenderer(new ComboBoxListRenderer());
-        hunterCreatureComboBox.setAlignmentX(Component.CENTER_ALIGNMENT);
-        hunterCreatureComboBox.setMaximumSize(new Dimension(Integer.MAX_VALUE, hunterCreatureComboBox.getPreferredSize().height));
-        ((JLabel) hunterCreatureComboBox.getRenderer()).setHorizontalAlignment(SwingConstants.CENTER);
+        huntingAreasComboBox = new JComboBox<>(HuntingAreas.values());
+        huntingAreasComboBox.setRenderer(new ComboBoxListRenderer());
+        huntingAreasComboBox.setAlignmentX(Component.CENTER_ALIGNMENT);
+        huntingAreasComboBox.setMaximumSize(new Dimension(Integer.MAX_VALUE, huntingAreasComboBox.getPreferredSize().height));
+        ((JLabel) huntingAreasComboBox.getRenderer()).setHorizontalAlignment(SwingConstants.CENTER);
+        
+        birdsComboBox = new JComboBox<>(Birds.values());
+        chinchompasComboBox = new JComboBox<>(Chinchompas.values());
+        insectsComboBox = new JComboBox<>(Insects.values());
+        kebbitsJComboBox = new JComboBox<>(Kebbits.values());
+        salamandersComboBox = new JComboBox<>(Salamanders.values());
+        specialHuntingAreasJComboBox = new JComboBox<>(SpecialHuntingAreas.values());
+        
+        JComboBox<?>[] subComboBoxes = {birdsComboBox, chinchompasComboBox, insectsComboBox, kebbitsJComboBox, salamandersComboBox, specialHuntingAreasJComboBox};
+
+        for (JComboBox<?> comboBox : subComboBoxes) {
+            comboBox.setRenderer(new ComboBoxListRenderer());
+            comboBox.setAlignmentX(Component.CENTER_ALIGNMENT);
+            comboBox.setMaximumSize(new Dimension(Integer.MAX_VALUE, comboBox.getPreferredSize().height));
+            ((JLabel)comboBox.getRenderer()).setHorizontalAlignment(SwingConstants.CENTER);
+            comboBox.setVisible(false);
+        }
+        
+        huntingAreasComboBox.addActionListener(e -> {
+            HuntingAreas selectedHuntingArea = (HuntingAreas) huntingAreasComboBox.getSelectedItem();
+            birdsComboBox.setVisible(selectedHuntingArea == HuntingAreas.BIRDS);
+            chinchompasComboBox.setVisible(selectedHuntingArea == HuntingAreas.CHINCHOMPAS);
+            insectsComboBox.setVisible(selectedHuntingArea == HuntingAreas.INSECTS);
+            kebbitsJComboBox.setVisible(selectedHuntingArea == HuntingAreas.KEBBITS);
+            salamandersComboBox.setVisible(selectedHuntingArea == HuntingAreas.SALAMANDERS);
+            specialHuntingAreasJComboBox.setVisible(selectedHuntingArea == HuntingAreas.SPECIAL);
+        });
 
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
         JButton startButton = new JButton("Start");
         JButton stopButton = new JButton("Stop");
 
-        startButton.addActionListener(e -> startWalking(getSelectedHunterCreature().getWorldPoint()));
+        startButton.addActionListener(e -> startWalking(getSelectedHuntingArea()));
         stopButton.addActionListener(e -> stopWalking());
 
         buttonPanel.add(startButton);
         buttonPanel.add(stopButton);
 
-        panel.add(hunterCreatureComboBox);
+        JPanel hunterGuildPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        JButton hunterGuildButton = new JButton("      Hunter Guild      ");
+
+        hunterGuildButton.addActionListener(e -> startWalking(new WorldPoint(1555, 3420, 0)));
+
+        hunterGuildPanel.add(hunterGuildButton);
+
+        panel.add(huntingAreasComboBox);
+        for (JComboBox<?> comboBox : subComboBoxes) {
+            panel.add(comboBox);
+        }
         panel.add(Box.createRigidArea(new Dimension(0, 5)));
         panel.add(buttonPanel);
+        panel.add(Box.createRigidArea(new Dimension(0, 2)));
+        panel.add(hunterGuildPanel);
 
         return panel;
     }
@@ -336,30 +382,28 @@ public class ShortestPathPanel extends PluginPanel {
         }
     }
 
-    public String getSelectedFarmingLocationName() {
-        Farming selectedFarming = getSelectedFarmingCategory();
-        switch (selectedFarming) {
-            case ALLOTMENTS:
-                return ((Allotments) allotmentsComboBox.getSelectedItem()).name();
-            case BUSHES:
-                return ((Bushes) bushesComboBox.getSelectedItem()).name();
-            case FRUIT_TREES:
-                return ((FruitTrees) fruitTreesComboBox.getSelectedItem()).name();
-            case HERBS:
-                return ((Herbs) herbsComboBox.getSelectedItem()).name();
-            case HOPS:
-                return ((Hops) hopsComboBox.getSelectedItem()).name();
-            case TREES:
-                return ((Trees) treesComboBox.getSelectedItem()).name();
-            case COMPOST_BINS:
-                return ((CompostBins) compostBinsComboBox.getSelectedItem()).name();
-            default:
-                return "Unknown";
-        }
+    public HuntingAreas getSelectedHunterArea() {
+        return (HuntingAreas) huntingAreasComboBox.getSelectedItem();
     }
 
-    public HuntingAreas getSelectedHunterCreature() {
-        return (HuntingAreas) hunterCreatureComboBox.getSelectedItem();
+    public WorldPoint getSelectedHuntingArea() {
+        HuntingAreas selectedHunting = getSelectedHunterArea();
+        switch (selectedHunting) {
+            case BIRDS:
+                return ((Birds) birdsComboBox.getSelectedItem()).getWorldPoint();
+            case INSECTS:
+                return ((Insects) insectsComboBox.getSelectedItem()).getWorldPoint();
+            case KEBBITS:
+                return ((Kebbits) kebbitsJComboBox.getSelectedItem()).getWorldPoint();
+            case CHINCHOMPAS:
+                return ((Chinchompas) chinchompasComboBox.getSelectedItem()).getWorldPoint();
+            case SALAMANDERS:
+                return ((Salamanders) salamandersComboBox.getSelectedItem()).getWorldPoint();
+            case SPECIAL:
+                return ((SpecialHuntingAreas) specialHuntingAreasJComboBox.getSelectedItem()).getWorldPoint();
+            default:
+                return null;
+        }
     }
     
     private void startWalking(WorldPoint point) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/enums/BankLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/enums/BankLocation.java
@@ -165,6 +165,8 @@ public enum BankLocation {
             case CORSAIR_COVE:
                 // Requires The Corsair Curse
                 return Rs2Player.getQuestState(Quest.THE_CORSAIR_CURSE) == QuestState.FINISHED;
+            case SOPHANEM:
+                return Rs2Player.getQuestState(Quest.CONTACT) == QuestState.FINISHED;
             default:
                 return true;
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/security/Login.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/security/Login.java
@@ -73,73 +73,13 @@ public class Login {
     public static int getRandomWorld(boolean isMembers, WorldRegion region) {
         WorldResult worldResult = Microbot.getWorldService().getWorlds();
 
-        List<World> worlds;
-        if (worldResult != null) {
-            worlds = worldResult.getWorlds();
-            Random r = new Random();
-            List<World> filteredWorlds = worlds
-                    .stream()
-                    .filter(x ->
-                            (!x.getTypes().contains(WorldType.PVP) &&
-                                    !x.getTypes().contains(WorldType.HIGH_RISK) &&
-                                    !x.getTypes().contains(WorldType.BOUNTY) &&
-                                    !x.getTypes().contains(WorldType.SKILL_TOTAL) &&
-                                    !x.getTypes().contains(WorldType.LAST_MAN_STANDING) &&
-                                    !x.getTypes().contains(WorldType.QUEST_SPEEDRUNNING) &&
-                                    !x.getTypes().contains(WorldType.BETA_WORLD) &&
-                                    !x.getTypes().contains(WorldType.DEADMAN) &&
-                                    !x.getTypes().contains(WorldType.PVP_ARENA) &&
-                                    !x.getTypes().contains(WorldType.TOURNAMENT) &&
-                                    !x.getTypes().contains(WorldType.FRESH_START_WORLD)) &&
-                                    x.getPlayers() < MAX_PLAYER_COUNT &&
-                                    x.getPlayers() >= 0)
-                    .collect(Collectors.toList());
-
-            if (!isMembers) {
-                filteredWorlds = filteredWorlds
-                        .stream()
-                        .filter(x -> !x.getTypes().contains(WorldType.MEMBERS)).collect(Collectors.toList());
-            } else {
-                filteredWorlds = filteredWorlds
-                        .stream()
-                        .filter(x -> x.getTypes().contains(WorldType.MEMBERS)).collect(Collectors.toList());
-            }
-
-            if (region != null)
-                filteredWorlds = filteredWorlds
-                        .stream()
-                        .filter(x -> x.getRegion() == region).collect(Collectors.toList());
-
-            World world =
-                    filteredWorlds.stream()
-                            .skip(r.nextInt(filteredWorlds.size()))
-                            .findFirst()
-                            .orElse(null);
-
-            if (world != null) {
-                return world.getId();
-            }
-        }
-
-        return isMembers ? 360 : 383;
-    }
-
-    public static int getRandomWorld(boolean isMembers) {
-        return getRandomWorld(isMembers, null);
-    }
-
-    public static int getNextWorld(boolean isMembers) {
-        return getNextWorld(isMembers, null);
-    }
-    
-    public static int getNextWorld(boolean isMembers, WorldRegion region) {
-        WorldResult worldResult = Microbot.getWorldService().getWorlds();
-
         if (worldResult == null) {
             return isMembers ? 360 : 383;
         }
 
         List<World> worlds = worldResult.getWorlds();
+        boolean isInSeasonalWorld = Microbot.getClient().getWorldType().contains(WorldType.SEASONAL);
+
         List<World> filteredWorlds = worlds.stream()
                 .filter(x -> !x.getTypes().contains(WorldType.PVP) &&
                         !x.getTypes().contains(WorldType.HIGH_RISK) &&
@@ -154,6 +94,61 @@ public class Login {
                         !x.getTypes().contains(WorldType.FRESH_START_WORLD) &&
                         x.getPlayers() < MAX_PLAYER_COUNT &&
                         x.getPlayers() >= 0)
+                .filter(x -> isInSeasonalWorld == x.getTypes().contains(WorldType.SEASONAL)) // seasonal filter
+                .collect(Collectors.toList());
+
+        filteredWorlds = isMembers
+                ? filteredWorlds.stream().filter(x -> x.getTypes().contains(WorldType.MEMBERS)).collect(Collectors.toList())
+                : filteredWorlds.stream().filter(x -> !x.getTypes().contains(WorldType.MEMBERS)).collect(Collectors.toList());
+
+        if (region != null) {
+            filteredWorlds = filteredWorlds.stream()
+                    .filter(x -> x.getRegion() == region)
+                    .collect(Collectors.toList());
+        }
+
+        Random random = new Random();
+        World world = filteredWorlds.stream()
+                .skip(random.nextInt(filteredWorlds.size()))
+                .findFirst()
+                .orElse(null);
+
+        return (world != null) ? world.getId() : (isMembers ? 360 : 383);
+    }
+
+    public static int getRandomWorld(boolean isMembers) {
+        return getRandomWorld(isMembers, null);
+    }
+
+    public static int getNextWorld(boolean isMembers) {
+        return getNextWorld(isMembers, null);
+    }
+
+    public static int getNextWorld(boolean isMembers, WorldRegion region) {
+        WorldResult worldResult = Microbot.getWorldService().getWorlds();
+
+        if (worldResult == null) {
+            return isMembers ? 360 : 383;
+        }
+
+        List<World> worlds = worldResult.getWorlds();
+        boolean isInSeasonalWorld = Microbot.getClient().getWorldType().contains(WorldType.SEASONAL);
+
+        List<World> filteredWorlds = worlds.stream()
+                .filter(x -> !x.getTypes().contains(WorldType.PVP) &&
+                        !x.getTypes().contains(WorldType.HIGH_RISK) &&
+                        !x.getTypes().contains(WorldType.BOUNTY) &&
+                        !x.getTypes().contains(WorldType.SKILL_TOTAL) &&
+                        !x.getTypes().contains(WorldType.LAST_MAN_STANDING) &&
+                        !x.getTypes().contains(WorldType.QUEST_SPEEDRUNNING) &&
+                        !x.getTypes().contains(WorldType.BETA_WORLD) &&
+                        !x.getTypes().contains(WorldType.DEADMAN) &&
+                        !x.getTypes().contains(WorldType.PVP_ARENA) &&
+                        !x.getTypes().contains(WorldType.TOURNAMENT) &&
+                        !x.getTypes().contains(WorldType.FRESH_START_WORLD) &&
+                        x.getPlayers() < MAX_PLAYER_COUNT &&
+                        x.getPlayers() >= 0)
+                .filter(x -> isInSeasonalWorld == x.getTypes().contains(WorldType.SEASONAL)) // Strict seasonal filter
                 .collect(Collectors.toList());
 
         filteredWorlds = isMembers

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Allotments.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Allotments.java
@@ -8,6 +8,7 @@ public enum Allotments {
     NONE("None"),
     ARDOUGNE("Ardougne", new WorldPoint(2668, 3375, 0)),
     CATHERBY("Catherby", new WorldPoint(2811, 3465, 0)),
+    CIVITAS_ILLA_FORTIS("Civitas illa Fortis", new WorldPoint(1587, 3099, 0)),
     FALADOR("Falador", new WorldPoint(3056, 3310, 0)),
     FARMING_GUILD("Farming Guild", new WorldPoint(1265, 3730, 0)),
     KOUREND("Kourend", new WorldPoint(1736, 3553, 0)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Birds.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Birds.java
@@ -1,0 +1,31 @@
+package net.runelite.client.plugins.microbot.util.walker.enums;
+
+import lombok.Getter;
+import net.runelite.api.coords.WorldPoint;
+
+@Getter
+public enum Birds {
+
+    COPPER_LONGTAIL("Copper Longtail (Aldarin North)", new WorldPoint(1357, 2977, 0)),
+    COPPER_LONGTAIL_2("Copper Longtail (Isle of Souls North)", new WorldPoint(2207, 2964, 0)),
+    CRIMSON_SWIFT("Crimson Swift (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
+    CRIMSON_SWIFT_2("Crimson Swift (Isle of Souls South West)", new WorldPoint(2158, 2822, 0)),
+    TROPICAL_WAGTAIL("Tropical Wagtail (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0));
+    
+    private final String name;
+    private WorldPoint worldPoint;
+
+    Birds(String name, WorldPoint worldPoint) {
+        this.name = name;
+        this.worldPoint = worldPoint;
+    }
+
+    Birds(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Chinchompas.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Chinchompas.java
@@ -1,0 +1,32 @@
+package net.runelite.client.plugins.microbot.util.walker.enums;
+
+import lombok.Getter;
+import net.runelite.api.coords.WorldPoint;
+
+@Getter
+public enum Chinchompas {
+
+    BLACK_CHINCHOMPA("Black Chinchompa (Wilderness)", new WorldPoint(3142, 3771, 0)),
+    CARNIVOROUS_CHINCHOMPA("Carnivorous Chinchompa (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
+    CARNIVOROUS_CHINCHOMPA_2("Carnivorous Chinchompa (Gwenith Hunter Area Outside)", new WorldPoint(2269, 3408, 0)),
+    CARNIVOROUS_CHINCHOMPA_3("Carnivorous Chinchompa (Gwenith Hunter Area Inside)", new WorldPoint(3293, 6160, 0)),
+    CHINCHOMPA("Chinchompa (Isle of Souls North West)", new WorldPoint(2127, 2950, 0)),
+    CHINCHOMPA_2("Chinchompa (Piscatoris Hunter Area)", new WorldPoint(2335, 3584, 0));
+    
+    private final String name;
+    private WorldPoint worldPoint;
+
+    Chinchompas(String name, WorldPoint worldPoint) {
+        this.name = name;
+        this.worldPoint = worldPoint;
+    }
+
+    Chinchompas(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/FruitTrees.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/FruitTrees.java
@@ -11,7 +11,7 @@ public enum FruitTrees {
     FARMING_GUILD("Farming Guild", new WorldPoint(1243, 3756, 0)),
     GNOME_STRONGHOLD("Gnome Stronghold", new WorldPoint(2473, 3446, 0)),
     TREE_GNOME_VILLAGE("Tree Gnome Village", new WorldPoint(2489, 3182, 0)),
-    TAI_BWO_WANNAI("Tai Bwo Wannai", new WorldPoint(2767, 3215, 0)),
+    TAI_BWO_WANNAI("Tai Bwo Wannai", new WorldPoint(2798, 3101, 0)),
     PRIFDDINAS("Prifddinas", new WorldPoint(3292, 6117, 0));
 
     private final String name;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Herbs.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Herbs.java
@@ -8,10 +8,12 @@ public enum Herbs {
     NONE("None"),
     ARDOUGNE("Ardougne", new WorldPoint(2668, 3375, 0)),
     CATHERBY("Catherby", new WorldPoint(2811, 3465, 0)),
+    CIVITAS_ILLA_FORTIS("Civitas illa Fortis", new WorldPoint(1583, 3094, 0)),
     FALADOR("Falador", new WorldPoint(3056, 3310, 0)),
     FARMING_GUILD("Farming Guild", new WorldPoint(1238, 3729, 0)),
     KOUREND("Kourend", new WorldPoint(1736, 3553, 0)),
-    MORYTANIA("Morytania", new WorldPoint(3600, 3523, 0));
+    MORYTANIA("Morytania", new WorldPoint(3600, 3523, 0)),
+    TROLLIEHM("Trolliehm", new WorldPoint(2828, 3695, 0));
 
     private final String name;
     private WorldPoint worldPoint;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/HuntingAreas.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/HuntingAreas.java
@@ -5,53 +5,17 @@ import net.runelite.api.coords.WorldPoint;
 
 @Getter
 public enum HuntingAreas {
-    HUNTER_GUILD("Hunter Guild", new WorldPoint(1555, 3420, 0)),
-    BARB_TAILED_KEBBIT("Barb-tailed Kebbit (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
-    BLACK_CHINCHOMPA("Black Chinchompa (Wilderness)", new WorldPoint(3142, 3771, 0)),
-    BLACK_SALAMANDER("Black Salamander (Boneyard Hunter Area)", new WorldPoint(3294, 3673, 0)),
-    BLACK_WARLOCK("Black Warlock (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
-    CARNIVOROUS_CHINCHOMPA("Carnivorous Chinchompa (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
-    CARNIVOROUS_CHINCHOMPA_2("Carnivorous Chinchompa (Gwenith Hunter Area Outside)", new WorldPoint(2269, 3408, 0)),
-    CARNIVOROUS_CHINCHOMPA_3("Carnivorous Chinchompa (Gwenith Hunter Area Inside)", new WorldPoint(3293, 6160, 0)),
-    CHINCHOMPA("Chinchompa (Isle of Souls North West)", new WorldPoint(2127, 2950, 0)),
-    CHINCHOMPA_2("Chinchompa (Piscatoris Hunter Area)", new WorldPoint(2335, 3584, 0)),
-    COPPER_LONGTAIL("Copper Longtail (Aldarin North)", new WorldPoint(1357, 2977, 0)),
-    COPPER_LONGTAIL_2("Copper Longtail (Isle of Souls North)", new WorldPoint(2207, 2964, 0)),
-    CRIMSON_SWIFT("Crimson Swift (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
-    CRIMSON_SWIFT_2("Crimson Swift (Isle of Souls South West)", new WorldPoint(2158, 2822, 0)),
-    DARK_KEBBIT("Dark Kebbit (Falconry)", new WorldPoint(2379, 3599, 0)),
-    DASHING_KEBBIT("Dashing Kebbit (Falconry)", new WorldPoint(2379, 3599, 0)),
-    EMBERTAILED_JERBOA("Embertailed Jerboa (Hunter Guild West)", new WorldPoint(1515, 3047, 0)),
-    FELDIP_WEASEL("Feldip Weasel (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
-    FISH_SHOAL("Fish Shoal (Fossil Island Underwater)", new WorldPoint(3743, 10295, 0)),
-    HERBIBOAR("Herbiboar (Fossil Island 1)", new WorldPoint(3693, 3800, 0)),
-    HORNED_GRAAHK("Horned Graahk (Karamja)", new WorldPoint(2786, 3001, 0)),
-    MOONLIGHT_ANTELOPE("Moonlight Antelope (Hunter Guild Caverns)", new WorldPoint(1559, 9420, 0)),
-    ORANGE_SALAMANDER("Orange Salamander (Necropolis)", new WorldPoint(3285, 2739, 0)),
-    ORANGE_SALAMANDER_2("Orange Salamander (Uzer Hunter Area)", new WorldPoint(3401, 3104, 0)),
-    PYRE_FOX("Pyre Fox (Avium Savannah)", new WorldPoint(1616, 2999, 0)),
-    RED_SALAMANDER("Red Salamander (Ourania Hunter Area East)", new WorldPoint(2447, 3219, 0)),
-    RED_SALAMANDER_2("Red Salamander (Ourania Hunter Area South)", new WorldPoint(2475, 3240, 0)),
-    RUBY_HARVEST("Ruby Harvest (Aldarin West)", new WorldPoint(1342, 2934, 0)),
-    SANDWORMS("Sandworms (Port Piscarilius Beach)", new WorldPoint(1840, 3802, 0)),
-    SPINED_LARUPIA("Spined Larupia (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
-    SPOTTED_KEBBIT("Spotted Kebbit (Falconry)", new WorldPoint(2379, 3599, 0)),
-    SUNLIGHT_ANTELOPE("Sunlight Antelope (Avium Savannah East)", new WorldPoint(1745, 3008, 0)),
-    SUNLIGHT_MOTH("Sunlight Moth (Hunter Guild North)", new WorldPoint(1556, 3091, 0)),
-    SUNLIGHT_MOTH_2("Sunlight Moth (Hunter Guild Southeast)", new WorldPoint(1575, 3020, 0)),
-    TECU_SALAMANDER("Tecu Salamander (Ralos Rise)", new WorldPoint(1475, 3096, 0)),
-    TROPICAL_WAGTAIL("Tropical Wagtail (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0));
+    NONE("None"),
+    BIRDS("Birds"),
+    CHINCHOMPAS("Chinchompas"),
+    INSECTS("Insects"),
+    KEBBITS("Kebbits"),
+    SALAMANDERS("Salamanders"),
+    SPECIAL("Special");
 
     private final String name;
-    private final WorldPoint worldPoint;
 
-    HuntingAreas(String name, WorldPoint worldPoint) {
+    HuntingAreas(String name) {
         this.name = name;
-        this.worldPoint = worldPoint;
-    }
-
-    @Override
-    public String toString() {
-        return name;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Insects.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Insects.java
@@ -1,0 +1,31 @@
+package net.runelite.client.plugins.microbot.util.walker.enums;
+
+import lombok.Getter;
+import net.runelite.api.coords.WorldPoint;
+
+@Getter
+public enum Insects {
+
+    BLACK_WARLOCK("Black Warlock (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
+    RUBY_HARVEST("Ruby Harvest (Aldarin West)", new WorldPoint(1342, 2934, 0)),
+    SANDWORMS("Sandworms (Port Piscarilius Beach)", new WorldPoint(1840, 3802, 0)),
+    SUNLIGHT_MOTH("Sunlight Moth (Hunter Guild North)", new WorldPoint(1556, 3091, 0)),
+    SUNLIGHT_MOTH_2("Sunlight Moth (Hunter Guild Southeast)", new WorldPoint(1575, 3020, 0));
+
+    private final String name;
+    private WorldPoint worldPoint;
+
+    Insects(String name, WorldPoint worldPoint) {
+        this.name = name;
+        this.worldPoint = worldPoint;
+    }
+
+    Insects(String name) {
+        this.name = name;
+    }
+    
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Kebbits.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Kebbits.java
@@ -1,0 +1,30 @@
+package net.runelite.client.plugins.microbot.util.walker.enums;
+
+import lombok.Getter;
+import net.runelite.api.coords.WorldPoint;
+
+@Getter
+public enum Kebbits {
+
+    BARB_TAILED_KEBBIT("Barb-tailed Kebbit (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
+    DARK_KEBBIT("Dark Kebbit (Falconry)", new WorldPoint(2379, 3599, 0)),
+    DASHING_KEBBIT("Dashing Kebbit (Falconry)", new WorldPoint(2379, 3599, 0)),
+    SPOTTED_KEBBIT("Spotted Kebbit (Falconry)", new WorldPoint(2379, 3599, 0));
+
+    private final String name;
+    private WorldPoint worldPoint;
+
+    Kebbits(String name, WorldPoint worldPoint) {
+        this.name = name;
+        this.worldPoint = worldPoint;
+    }
+
+    Kebbits(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Salamanders.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/Salamanders.java
@@ -1,0 +1,33 @@
+package net.runelite.client.plugins.microbot.util.walker.enums;
+
+import lombok.Getter;
+import net.runelite.api.coords.WorldPoint;
+
+@Getter
+public enum Salamanders {
+    
+    BLACK_SALAMANDER("Black Salamander (Boneyard Hunter Area)", new WorldPoint(3294, 3673, 0)),
+    ORANGE_SALAMANDER("Orange Salamander (Necropolis)", new WorldPoint(3285, 2739, 0)),
+    ORANGE_SALAMANDER_2("Orange Salamander (Uzer Hunter Area)", new WorldPoint(3401, 3104, 0)),
+    RED_SALAMANDER("Red Salamander (Ourania Hunter Area East)", new WorldPoint(2447, 3219, 0)),
+    RED_SALAMANDER_2("Red Salamander (Ourania Hunter Area South)", new WorldPoint(2475, 3240, 0)),
+    TECU_SALAMANDER("Tecu Salamander (Ralos Rise)", new WorldPoint(1475, 3096, 0));
+
+
+    private final String name;
+    private WorldPoint worldPoint;
+
+    Salamanders(String name, WorldPoint worldPoint) {
+        this.name = name;
+        this.worldPoint = worldPoint;
+    }
+
+    Salamanders(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/SpecialHuntingAreas.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/enums/SpecialHuntingAreas.java
@@ -1,0 +1,35 @@
+package net.runelite.client.plugins.microbot.util.walker.enums;
+
+import lombok.Getter;
+import net.runelite.api.coords.WorldPoint;
+
+@Getter
+public enum SpecialHuntingAreas {
+
+    EMBERTAILED_JERBOA("Embertailed Jerboa (Hunter Guild West)", new WorldPoint(1515, 3047, 0)),
+    FELDIP_WEASEL("Feldip Weasel (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
+    FISH_SHOAL("Fish Shoal (Fossil Island Underwater)", new WorldPoint(3743, 10295, 0)),
+    HERBIBOAR("Herbiboar (Fossil Island 1)", new WorldPoint(3693, 3800, 0)),
+    HORNED_GRAAHK("Horned Graahk (Karamja)", new WorldPoint(2786, 3001, 0)),
+    MOONLIGHT_ANTELOPE("Moonlight Antelope (Hunter Guild Caverns)", new WorldPoint(1559, 9420, 0)),
+    PYRE_FOX("Pyre Fox (Avium Savannah)", new WorldPoint(1616, 2999, 0)),
+    SPINED_LARUPIA("Spined Larupia (Feldip Hunter Area)", new WorldPoint(2557, 2912, 0)),
+    SUNLIGHT_ANTELOPE("Sunlight Antelope (Avium Savannah East)", new WorldPoint(1745, 3008, 0));
+
+    private final String name;
+    private WorldPoint worldPoint;
+
+    SpecialHuntingAreas(String name, WorldPoint worldPoint) {
+        this.name = name;
+        this.worldPoint = worldPoint;
+    }
+
+    SpecialHuntingAreas(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -4511,3 +4511,15 @@
 2371 3620 0	2371 3622 0	Climb-over;Stile;19222				8
 # Taverly dungeon
 2924 9803 0	2923 9803 0	Open;Gate;2623		1590			Taverly gate
+# Fight Caves
+2493 5174 0	2495 5174 0	Pass;Hot vent door;30266				2
+2495 5174 0	2493 5174 0	Pass;Hot vent door;30266				2
+2494 5157 0	2496 5157 0	Pass;Hot vent door;30266				2
+2496 5157 0	2494 5157 0	Pass;Hot vent door;30266				2
+2474 5138 0	2474 5136 0	Pass;Hot vent door;30266				2
+2474 5136 0	2474 5138 0	Pass;Hot vent door;30266				2
+2457 5120 0	2457 5118 0	Pass;Hot vent door;30266				2
+2457 5118 0	2457 5120 0	Pass;Hot vent door;30266				2
+2436 5121 0	2436 5119 0	Pass;Hot vent door;30266				2
+2436 5119 0	2436 5121 0	Pass;Hot vent door;30266				2
+2399 5177 0	2399 5175 0	Pass;Hot vent door;30266				2

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -792,6 +792,10 @@
 3131 9918 0	3131 9917 0	Open;Gate;1727					
 3122 3488 0	3122 3487 0	Open;Door;102					
 3122 3487 0	3122 3488 0	Open;Door;102					
+3115 3449 0	3115 3450 0	Open;Door;1804		1 Brass key		2	
+3115 3450 0	3115 3449 0	Open;Door;1804				2	
+3115 3452 0	3115 9852 0	Climb-down;Ladder;17384				2	
+3115 9852 0	3115 3452 0	Climb-up;Ladder;17385				2	
 							
 # Varrock							
 3212 3472 0	3212 3476 1	Climb-up;Staircase;11807					


### PR DESCRIPTION
## ShortestPathPlugin
- Added various doors around the fight caves
- Added door & ladder transports for using the building near varrock west to enter edgeville dungeon
- Fixed Worldpoint for Tai bwo wanni village patch
- Added Civitas illa Fortis & Trolliehm farm patches to ShortestPathPanel
- Converted Hunter Creature Section of the ShortestPathPanel to be broken into sub-sections, similar to farming patches

## BankLocations
- Added requirements for SOPHANEM bank (requires contact! quest completion)

## Login
- Updated getRandomWorld & getNextWorld to filter based on if current WorldType is seasonal to only use seasonal worlds if currently in seasonal world & to filter out seasonal worlds if not in a seasonal world