### PR TITLE
Webwalker Fixes + Plugin Bug Fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerConfig.java
@@ -68,11 +68,21 @@ public interface BreakHandlerConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "useRandomWorld",
+            name = "Use RandomWorld",
+            description = "Change to a random world once break is finished",
+            position = 5
+    )
+    default boolean useRandomWorld() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "UsePlaySchedule",
             name = "Use Play Schedule",
             description = "Enable or disable the use of a play schedule",
-            position = 5,
-            section = "UsePlaySchedule"
+            position = 0,
+            section = usePlaySchedule
     )
     default boolean usePlaySchedule() {
         return false;
@@ -82,8 +92,8 @@ public interface BreakHandlerConfig extends Config {
             keyName = "PlaySchedule",
             name = "Play Schedule",
             description = "Select the play schedule",
-            position = 6,
-            section = "UsePlaySchedule"
+            position = 1,
+            section = usePlaySchedule
     )
     default PlaySchedule playSchedule() {
         return PlaySchedule.MEDIUM_DAY;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
@@ -82,7 +82,11 @@ public class BreakHandlerScript extends Script {
                     if (breakIn <= 0)
                         breakIn = Random.random(config.timeUntilBreakStart() * 60, config.timeUntilBreakEnd() * 60);
 
-                    new Login();
+                    if (config.useRandomWorld()) {
+                        new Login(Login.getRandomWorld(Login.activeProfile.isMember()));
+                    } else {
+                        new Login();
+                    }
                     totalBreaks++;
                     ClientUI.getFrame().setTitle(title);
                     if (Rs2AntibanSettings.takeMicroBreaks) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
@@ -7,6 +7,7 @@ import com.google.inject.Provides;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.GameState;
+import net.runelite.api.WorldType;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
@@ -121,6 +122,8 @@ public class ShootingStarPlugin extends Plugin {
 
         ZonedDateTime now = ZonedDateTime.now(utcZoneId);
 
+        boolean inSeasonalWorld = Microbot.getClient().getWorldType().contains(WorldType.SEASONAL);
+
         // Format starData into Star Model
         for (Star star : starData) {
             // Filter out stars that ended longer than three mintues ago to avoid adding really old stars
@@ -141,6 +144,13 @@ public class ShootingStarPlugin extends Plugin {
             star.setWorldObject(findWorld(star.getWorld()));
 
             if (star.isGameModeWorld()) continue;
+
+            // Seasonal world filtering
+            if (inSeasonalWorld && !star.isInSeasonalWorld()) {
+                continue; // Skip non-seasonal worlds if the player is in a seasonal world
+            } else if (!inSeasonalWorld && star.isInSeasonalWorld()) {
+                continue; // Skip seasonal worlds if the player is not in a seasonal world
+            }
 
             addToList(star);
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/model/Star.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/model/Star.java
@@ -109,6 +109,10 @@ public class Star {
     public boolean isF2PWorld() {
         return !this.isGameModeWorld() && !this.getWorldObject().getTypes().contains(WorldType.MEMBERS);
     }
+
+    public boolean isInSeasonalWorld() {
+        return this.getWorldObject().getTypes().contains(WorldType.SEASONAL);
+    }
     
     @Override
     public boolean equals(Object obj) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
@@ -339,6 +339,15 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
                 Microbot.getClientThread().scheduledFuture.cancel(true);
             }
         }
+
+        if (!startPointSet && !isNearPath(Rs2Player.getWorldLocation())) {
+            if (config.cancelInstead()) {
+                Rs2Walker.setTarget(null);
+                return;
+            }
+            Rs2Walker.restartPathfinding(Rs2Player.getWorldLocation(), pathfinder.getTarget());
+            Rs2Walker.recalculatePath();
+        }
     }
 
     @Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
@@ -339,15 +339,6 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
                 Microbot.getClientThread().scheduledFuture.cancel(true);
             }
         }
-
-        if (!startPointSet && !isNearPath(Rs2Player.getWorldLocation())) {
-            if (config.cancelInstead()) {
-                Rs2Walker.setTarget(null);
-                return;
-            }
-            Rs2Walker.restartPathfinding(Rs2Player.getWorldLocation(), pathfinder.getTarget());
-            Rs2Walker.recalculatePath();
-        }
     }
 
     @Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -471,17 +471,18 @@ public class PathfinderConfig {
         if (Rs2Walker.disableTeleports) return false;
 
         // Handle teleportation items
-        if (TransportType.TELEPORTATION_ITEM.equals(transport.getType())) 
-            return transport.getItemIdRequirements()
-                .stream()
-                .flatMap(Collection::stream)
-                .anyMatch(itemId -> Rs2Equipment.isWearing(itemId) || Rs2Inventory.hasItem(itemId));
+        if (TransportType.TELEPORTATION_ITEM.equals(transport.getType())) {
+            // Special case for Chronicle teleport
+            if (requiresChronicle(transport)) return hasChronicleCharges();
 
+            return transport.getItemIdRequirements()
+                    .stream()
+                    .flatMap(Collection::stream)
+                    .anyMatch(itemId -> Rs2Equipment.isWearing(itemId) || Rs2Inventory.hasItem(itemId));
+        }
+        
         // Handle teleportation spells
         if (TransportType.TELEPORTATION_SPELL.equals(transport.getType())) return Rs2Magic.quickCanCast(transport.getDisplayInfo());
-
-        // Special case for Chronicle teleport
-        if (requiresChronicle(transport)) return hasChronicleCharges();
 
         // Check membership restrictions
         if (!client.getWorldType().contains(WorldType.MEMBERS)) return false;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -356,14 +356,14 @@ public class PathfinderConfig {
         if (!isFeatureEnabled(transport.getType())) return false;
         // If you don't meet level requirements
         if (!hasRequiredLevels(transport)) return false;
-        // If you don't have the required Items & Amount for transport (used for charters & minecarts)
-        if (transport.getAmtItemRequired() > 0 && !Rs2Inventory.hasItemAmount(transport.getItemRequired(), transport.getAmtItemRequired())) return false;
-        // Check Teleport Item Settings
-        if (transport.getType() == TELEPORTATION_ITEM) return isTeleportationItemUsable(transport);
         // If the transport has quest requirements & the quest haven't been completed
         if (transport.isQuestLocked() && !completedQuests(transport)) return false;
         // If the transport has varbit requirements & the varbits do not match
         if (!varbitChecks(transport)) return false;
+        // If you don't have the required Items & Amount for transport (used for charters & minecarts)
+        if (transport.getAmtItemRequired() > 0 && !Rs2Inventory.hasItemAmount(transport.getItemRequired(), transport.getAmtItemRequired())) return false;
+        // Check Teleport Item Settings
+        if (transport.getType() == TELEPORTATION_ITEM) return isTeleportationItemUsable(transport);
 
         return true;
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/security/Login.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/security/Login.java
@@ -1,7 +1,6 @@
 package net.runelite.client.plugins.microbot.util.security;
 
 import net.runelite.client.config.ConfigProfile;
-import net.runelite.client.plugins.defaultworld.DefaultWorldConfig;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.util.WorldUtil;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/security/Login.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/security/Login.java
@@ -1,6 +1,7 @@
 package net.runelite.client.plugins.microbot.util.security;
 
 import net.runelite.client.config.ConfigProfile;
+import net.runelite.client.plugins.defaultworld.DefaultWorldConfig;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.util.WorldUtil;
@@ -22,7 +23,7 @@ public class Login {
     private static final int MAX_PLAYER_COUNT = 1950;
 
     public Login() {
-        this(getRandomWorld(activeProfile.isMember()));
+        this(Microbot.getClient().getWorld() > 300 ? Microbot.getClient().getWorld() : getRandomWorld(activeProfile.isMember()));
     }
 
     public Login(int world) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingPlugin.java
@@ -28,12 +28,6 @@ import java.awt.*;
 public class AutoWoodcuttingPlugin extends Plugin {
     @Inject
     private AutoWoodcuttingConfig config;
-    @Inject
-    private Client client;
-    @Inject
-    private ClientThread clientThread;
-    @Inject
-    Notifier notifier;
 
     @Provides
     AutoWoodcuttingConfig provideConfig(ConfigManager configManager) {
@@ -51,11 +45,6 @@ public class AutoWoodcuttingPlugin extends Plugin {
 
     @Override
     protected void startUp() throws AWTException {
-        Microbot.pauseAllScripts = false;
-        Microbot.setClient(client);
-        Microbot.setClientThread(clientThread);
-        Microbot.setNotifier(notifier);
-        Microbot.setMouse(new VirtualMouse());
         if (overlayManager != null) {
             overlayManager.add(woodcuttingOverlay);
         }
@@ -69,7 +58,7 @@ public class AutoWoodcuttingPlugin extends Plugin {
 
     @Subscribe
     public void onChatMessage(ChatMessage chatMessage) {
-        if (chatMessage.getType() == ChatMessageType.GAMEMESSAGE && chatMessage.getMessage().contains("you can't light a fire here.")) {
+        if (chatMessage.getType() == ChatMessageType.GAMEMESSAGE && chatMessage.getMessage().toLowerCase().contains("you can't light a fire here.")) {
             autoWoodcuttingScript.cannotLightFire = true;
         }
     }

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/quetzals.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/quetzals.tsv
@@ -1,23 +1,23 @@
-# Origin	Destination	Skills	Items	Quests	Duration	Display info
-1389 2901 0				Twilight's Promise	30
-1697 3140 0				Twilight's Promise	30
-1585 3053 0				Twilight's Promise	30
-1510 3221 0				Twilight's Promise	30
-1548 2995 0				Twilight's Promise	30
-1437 3171 0				Twilight's Promise	30
-1779 3111 0				Twilight's Promise	30
-1700 3037 0				Twilight's Promise	30
-1670 2933 0				Twilight's Promise	30
-1446 3108 0				Twilight's Promise	30
-1613 3300 0				Twilight's Promise	30
-	1389 2901 0			Twilight's Promise	30	Aldarin
-	1697 3140 0			Twilight's Promise	30	Civitas illa Fortis
-	1585 3053 0			Twilight's Promise	30	Hunter Guild
-	1510 3221 0			Twilight's Promise	30	Quetzacalli Gorge
-	1548 2995 0			Twilight's Promise	30	Sunset Coast
-	1437 3171 0			Twilight's Promise	30	The Teomat
-	1779 3111 0			Twilight's Promise	30	Fortis Colosseum
-	1700 3037 0			Twilight's Promise	30	Outer Fortis
-	1670 2933 0			Twilight's Promise	30	Colossal Wyrm Remains
-	1446 3108 0			Twilight's Promise	30	Cam Torum Entrance
-	1613 3300 0			Twilight's Promise	30	Salvager Overlook
+# Origin	Destination	Skills	Items	Quests	Varbits	Duration	Display info
+1389 2901 0				Twilight's Promise		30	
+1697 3140 0				Twilight's Promise	9958=1	30	
+1585 3053 0				Twilight's Promise		30	
+1510 3221 0				Twilight's Promise		30	
+1548 2995 0				Twilight's Promise		30	
+1437 3171 0				Twilight's Promise		30	
+1779 3111 0				Twilight's Promise		30	
+1700 3037 0				Twilight's Promise	9957=1	30	
+1670 2933 0				Twilight's Promise	9956=1	30	
+1446 3108 0				Twilight's Promise	9955=1	30	
+1613 3300 0				Twilight's Promise	11379=1	30	
+	1389 2901 0			Twilight's Promise		30	Aldarin
+	1697 3140 0			Twilight's Promise	9958=1	30	Civitas illa Fortis
+	1585 3053 0			Twilight's Promise		30	Hunter Guild
+	1510 3221 0			Twilight's Promise		30	Quetzacalli Gorge
+	1548 2995 0			Twilight's Promise		30	Sunset Coast
+	1437 3171 0			Twilight's Promise		30	The Teomat
+	1779 3111 0			Twilight's Promise		30	Fortis Colosseum
+	1700 3037 0			Twilight's Promise	9957=1	30	Outer Fortis
+	1670 2933 0			Twilight's Promise	9956=1	30	Colossal Wyrm Remains
+	1446 3108 0			Twilight's Promise	9955=1	30	Cam Torum Entrance
+	1613 3300 0			Twilight's Promise	11379=1	30	Salvager Overlook

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/restrictions.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/restrictions.tsv
@@ -26,3 +26,5 @@
 3268 3227 0	Prince Ali Rescue		
 3268 3228 0	Prince Ali Rescue
 2936 9810 0		63 Agility
+# Tree near Draynor Manor			
+3138 3352 0			

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -4492,6 +4492,8 @@
 #corsair cove							
 2578 2840 0	2578 2837 1	Cross;Gangplank;31756				1	
 2578 2837 1	2578 2840 0	Cross;Gangplank;31756				1	
+2523 2860 0	2012 9004 1	Enter;Hole;31791				2	
+2012 9004 1	2523 2860 0	Climb;Vine ladder;31790				2	
 #mining guild							
 3021 9739 0	3021 3339 0	Climb-up;Ladder;17385					
 3021 3339 0	3021 9739 0	Climb-down;Ladder;30367					


### PR DESCRIPTION
## ShortestPathPlugin
- Adjusted useTransport by moving isTeleportationItemUsable as the lowest priority to ensure all other fields are completed before checking if the teleport is usable
- Add Draynor Manor Tree to restricted tiles
- Add ladder for Corsair Cove dungeon
- Add Varbits for Locked Quetzals

## Login
- Adjusted No-Args Constructor in Login.java to fetch current world if its a valid world, if not then use getRandomWorld

## AutoWoodcutting
- Adjust logic for 'You can't light a fire here'

## ShootingStarPlugin
- Filter based on if the player is or is not in a Seasonal World

## BreakHandler
- Added Config Option to use RandomWorld with the additions of Login class, by default it will send you to the same world 