### PR TITLE
Shooting Star Bug Fix + Add Transport in Varrock Sewers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarScript.java
@@ -399,12 +399,14 @@ public class ShootingStarScript extends Script {
     }
 
     private boolean shouldBreak() {
-        boolean isReadyToBreak = BreakHandlerScript.breakIn <= 1;
+        if (!plugin.isBreakHandlerEnabled()) return false;
 
-        return plugin.isBreakHandlerEnabled() && isReadyToBreak;
+        return BreakHandlerScript.breakIn <= 1;
     }
 
     public void toggleLockState(boolean lock) {
+        if (!plugin.isBreakHandlerEnabled()) return;
+        
         if (plugin.isBreakHandlerEnabled() && plugin.useBreakAtBank()) {
             if (lock && !BreakHandlerScript.isLockState()) {
                 BreakHandlerScript.setLockState(true);

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -927,8 +927,8 @@
 3237 9858 0	3236 3458 0	Climb-up;Ladder;11806					
 3236 3458 0	3237 9858 0	Open;Manhole;881					
 3236 3458 0	3237 9858 0	Climb-down;Manhole;882					
-3210 9899 0	3210 9898 0	Slash;Web;733		946		8	
-3210 9898 0	3210 9899 0	Slash;Web;733		946		8	
+3210 9899 0	3210 9898 0	Slash;Web;733				8	
+3210 9898 0	3210 9899 0	Slash;Web;733				8	
 							
 # Stronghold of Security							
 3081 3421 0	1859 5243 0	Climb-down;Entrance;20790					

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -927,6 +927,8 @@
 3237 9858 0	3236 3458 0	Climb-up;Ladder;11806					
 3236 3458 0	3237 9858 0	Open;Manhole;881					
 3236 3458 0	3237 9858 0	Climb-down;Manhole;882					
+3210 9899 0	3210 9898 0	Slash;Web;733		946		8	
+3210 9898 0	3210 9899 0	Slash;Web;733		946		8	
 							
 # Stronghold of Security							
 3081 3421 0	1859 5243 0	Climb-down;Entrance;20790					


### PR DESCRIPTION
## ShortestPathPlugin
- Added Transport to slash web inside of varrock sewers

## Shooting Star Plugin
- Add early return if BreakHandler Plugin is not enabled to fix useBreakAtBank method