### PR TITLE
ClientSessionManager to respect disableTelemetry launch param

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ClientSessionManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ClientSessionManager.java
@@ -34,6 +34,7 @@ import net.runelite.client.util.RunnableExceptionLogger;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.util.UUID;
@@ -48,6 +49,7 @@ public class ClientSessionManager
 	private final ScheduledExecutorService executorService;
 	private final Client client;
 	private final SessionClient sessionClient;
+	private final boolean disableTelemetry;
 
 	private ScheduledFuture<?> scheduledFuture;
 	private ScheduledFuture<?> scheduledFutureMicroBot;
@@ -58,33 +60,36 @@ public class ClientSessionManager
 
 	@Inject
 	ClientSessionManager(ScheduledExecutorService executorService,
-		@Nullable Client client,
-		SessionClient sessionClient, MicrobotApi microbotApi)
-	{
+						 @Nullable Client client,
+						 SessionClient sessionClient, MicrobotApi microbotApi,
+						 @Named("disableTelemetry") boolean disableTelemetry) {
 		this.executorService = executorService;
 		this.client = client;
 		this.sessionClient = sessionClient;
 		this.microbotApi = microbotApi;
+		this.disableTelemetry = disableTelemetry;
 	}
 
-	public void start()
-	{
-		executorService.execute(() ->
-		{
-			try
-			{
+	public void start() {
+		if (disableTelemetry) {
+			log.info("Telemetry is disabled. ClientSessionManager will not start.");
+			return;
+		}
+
+		executorService.execute(() -> {
+			try {
 				sessionId = sessionClient.open();
 				microbotSessionId = microbotApi.microbotOpen();
 				log.debug("Opened session {}", sessionId);
-			}
-			catch (IOException ex)
-			{
+			} catch (IOException ex) {
 				log.warn("error opening session", ex);
 			}
 		});
 
-		scheduledFuture = executorService.scheduleWithFixedDelay(RunnableExceptionLogger.wrap(this::ping), 1, 10, TimeUnit.MINUTES);
-		scheduledFutureMicroBot = executorService.scheduleWithFixedDelay(RunnableExceptionLogger.wrap(this::microbotPing), 1, 5, TimeUnit.MINUTES);
+		scheduledFuture = executorService.scheduleWithFixedDelay(
+				RunnableExceptionLogger.wrap(this::ping), 1, 10, TimeUnit.MINUTES);
+		scheduledFutureMicroBot = executorService.scheduleWithFixedDelay(
+				RunnableExceptionLogger.wrap(this::microbotPing), 1, 5, TimeUnit.MINUTES);
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/ClientSessionManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ClientSessionManager.java
@@ -95,6 +95,7 @@ public class ClientSessionManager
 	@Subscribe
 	private void onClientShutdown(ClientShutdown e)
 	{
+		if (disableTelemetry) return;
 		scheduledFuture.cancel(true);
 		scheduledFutureMicroBot.cancel(true);
 		e.waitFor(executorService.submit(() ->

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -504,7 +504,10 @@ public class PathfinderConfig {
 
     /** Checks if the Chronicle has charges */
     private boolean hasChronicleCharges() {
-        if (!Rs2Equipment.isWearing(ItemID.CHRONICLE) || !Rs2Inventory.hasItem(ItemID.CHRONICLE)) return false;
+        if (!Rs2Equipment.hasEquipped(ItemID.CHRONICLE)) {
+            if (!Rs2Inventory.hasItem(ItemID.CHRONICLE))
+                return false;
+        }
         
         String charges = Microbot.getConfigManager()
                 .getRSProfileConfiguration(ItemChargeConfig.GROUP, ItemChargeConfig.KEY_CHRONICLE);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/InteractOrder.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/InteractOrder.java
@@ -5,6 +5,7 @@ public enum InteractOrder {
     EFFICIENT_ROW,
     COLUMN,
     EFFICIENT_COLUMN,
+    ZIGZAG,
     RANDOM;
 
     // return a random DropOrder

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
@@ -25,9 +25,7 @@ import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import org.apache.commons.lang3.NotImplementedException;
 
 import java.awt.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.*;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -2364,7 +2362,27 @@ public class Rs2Inventory {
                     }
                 });
                 return rs2Items;
+                
+            case ZIGZAG:
+                int[] customOrder = {
+                        0, 4, 1, 5, 2, 6, 3, 7,
+                        11, 15, 10, 14, 9, 13, 8, 12,
+                        16, 20, 17, 21, 18, 22, 19, 23,
+                        27, 26, 25, 24
+                };
+                
+                Map<Integer, Integer> orderMap = new HashMap<>();
+                for (int i = 0; i < customOrder.length; i++) {
+                    orderMap.put(customOrder[i], i);
+                }
 
+                rs2Items.sort((item1, item2) -> {
+                    int index1 = item1.getSlot();
+                    int index2 = item2.getSlot();
+                    return Integer.compare(orderMap.getOrDefault(index1, Integer.MAX_VALUE),
+                            orderMap.getOrDefault(index2, Integer.MAX_VALUE));
+                });
+                return rs2Items;
             case STANDARD:
                 return rs2Items;
 


### PR DESCRIPTION
## ClientSessionManager
- Adjusted ClientSessionManager to respect the -disable-telemetry launch param

## Rs2Inventory
- Created a new interact order called 'zigzag'

## ShortestPathPlugin
- Chronicle conditions have been changed again to first check equipped, then check inventory if not equipped.