### PR TITLE
WebWalker Fixes + Air Orb Plugin Fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/orbcharger/OrbChargerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/orbcharger/OrbChargerConfig.java
@@ -1,6 +1,7 @@
 package net.runelite.client.plugins.microbot.magic.orbcharger;
 
 import net.runelite.client.config.*;
+import net.runelite.client.plugins.microbot.util.misc.Rs2Food;
 
 @ConfigGroup(OrbChargerConfig.configGroup)
 @ConfigInformation(
@@ -14,6 +15,8 @@ public interface OrbChargerConfig extends Config {
     String configGroup = "orb-charger";
     String useEnergyPotions = "useEnergyPotions";
     String useStaminaPotions = "useStaminaPotions";
+    String food = "food";
+    String eatAtPercent = "eatAtPercent";
 
     @ConfigSection(
             name = "General Settings",
@@ -23,10 +26,32 @@ public interface OrbChargerConfig extends Config {
     String generalSection = "general";
 
     @ConfigItem(
+            keyName = food,
+            name = "Food",
+            description = "Select food that should be used when low HP (eats when at bank)",
+            position = 0,
+            section = generalSection
+    )
+    default Rs2Food food() {
+        return Rs2Food.JUG_OF_WINE;
+    }
+
+    @ConfigItem(
+            keyName = eatAtPercent,
+            name = "Eat At",
+            description = "Percent health player should eat at the bank",
+            position = 1,
+            section = generalSection
+    )
+    default int eatAtPercent() {
+        return 65;
+    }
+
+    @ConfigItem(
             keyName = useEnergyPotions,
             name = "Use Energy Potions",
             description = "Should withdraw & use energy potions",
-            position = 0,
+            position = 2,
             section = generalSection
     )
     default boolean useEnergyPotions() {
@@ -37,7 +62,7 @@ public interface OrbChargerConfig extends Config {
             keyName = useStaminaPotions,
             name = "Use Stamina Potions",
             description = "Should withdraw & use stamina potions",
-            position = 0,
+            position = 3,
             section = generalSection
     )
     default boolean useStaminaPotions() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/orbcharger/OrbChargerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/orbcharger/OrbChargerPlugin.java
@@ -12,6 +12,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.magic.orbcharger.enums.OrbChargerState;
 import net.runelite.client.plugins.microbot.magic.orbcharger.scripts.AirOrbScript;
+import net.runelite.client.plugins.microbot.util.misc.Rs2Food;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
@@ -38,6 +39,10 @@ public class OrbChargerPlugin extends Plugin {
     private boolean useEnergyPotions;
     @Getter
     private boolean useStaminaPotions;
+    @Getter
+    private Rs2Food rs2Food;
+    @Getter
+    private int eatAtPercent;
 
     @Inject
     private OverlayManager overlayManager;
@@ -51,6 +56,8 @@ public class OrbChargerPlugin extends Plugin {
     protected void startUp() throws AWTException {
         useEnergyPotions = config.useEnergyPotions();
         useStaminaPotions = config.useStaminaPotions();
+        rs2Food = config.food();
+        eatAtPercent = config.eatAtPercent();
         if (overlayManager != null) {
             overlayManager.add(orbOverlay);
         }
@@ -73,6 +80,12 @@ public class OrbChargerPlugin extends Plugin {
         
         if (event.getKey().equals(OrbChargerConfig.useStaminaPotions)){
             useStaminaPotions = config.useStaminaPotions();
+        }
+        if (event.getKey().equals(OrbChargerConfig.food)){
+            rs2Food = config.food();
+        }
+        if (event.getKey().equals(OrbChargerConfig.eatAtPercent)) {
+            eatAtPercent = config.eatAtPercent();
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/orbcharger/scripts/AirOrbScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/orbcharger/scripts/AirOrbScript.java
@@ -263,6 +263,8 @@ public class AirOrbScript extends Script {
                 } else if ((shouldBank() && !hasRequiredItems()) || (!dangerousPlayers.isEmpty() || hasDied)) {
                     if (hasDied) {
                         dangerousPlayers.clear();
+                        Rs2Walker.setTarget(null);
+                        hasDied = false;
                     }
                     if (Rs2Player.isInCombat() || Rs2Player.isTeleBlocked()) {
                         Rs2Walker.walkTo(outsideOfWilderness, 2);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/orbcharger/scripts/AirOrbScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/orbcharger/scripts/AirOrbScript.java
@@ -164,6 +164,26 @@ public class AirOrbScript extends Script {
                             }
                         }
                         
+                        if (Rs2Player.getHealthPercentage() <= plugin.getEatAtPercent()) {
+                            while (Rs2Player.getHealthPercentage() < 100 && isRunning()) {
+                                if (!Rs2Bank.hasItem(plugin.getRs2Food().getId())) {
+                                    Microbot.showMessage("Missing Food in Bank!");
+                                    shutdown();
+                                    break;
+                                }
+
+                                Rs2Bank.withdrawOne(plugin.getRs2Food().getId());
+                                Rs2Inventory.waitForInventoryChanges(1200);
+                                Rs2Player.useFood();
+                                sleep(1000);
+                            }
+                            
+                            if (Rs2Inventory.hasItem(ItemID.JUG)) {
+                                Rs2Bank.depositAll(ItemID.JUG);
+                                Rs2Inventory.waitForInventoryChanges(1200);
+                            }
+                        }
+                        
                         if (plugin.isUseEnergyPotions()) {
                             if (!Rs2Inventory.hasItem(Rs2Potion.getRestoreEnergyPotionsVariants())){
                                 if (!Rs2Bank.hasItem(Rs2Potion.getRestoreEnergyPotionsVariants())) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -411,6 +411,7 @@ public class PathfinderConfig {
                 case GNOME_GLIDER:
                 case MINECART:
                 case QUETZAL:
+                case WILDERNESS_OBELISK:
                 case SPIRIT_TREE:
                     return false; // Not enabled without membership
             }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
@@ -1228,7 +1228,7 @@ public class Rs2Inventory {
      */
     public static String getSelectedItemName() {
         if (Microbot.getClient().getSelectedWidget() == null) return null;
-        return Microbot.getClient().getSelectedWidget().getName();
+        return Rs2UiHelper.stripColTags(Microbot.getClient().getSelectedWidget().getName());
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -126,11 +126,16 @@ public class Rs2Player {
         }
     }
     
+    /**
+     * Handles updates to the teleblock timer based on changes to the {@link Varbits#TELEBLOCK} varbit.
+     *
+     * @see Varbits#TELEBLOCK
+     */
     public static void handleTeleblockTimer(VarbitChanged event){
         if (event.getVarbitId() == Varbits.TELEBLOCK) {
             int time = event.getValue();
             
-            if (time == 0) {
+            if (time < 101) {
                 teleBlockTime = -1;
             } else {
                 teleBlockTime = time;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -482,7 +482,7 @@ public class Rs2Player {
      * @return
      */
     public static boolean eatAt(int percentage) {
-        double treshHold = (double) (Microbot.getClient().getBoostedSkillLevel(Skill.HITPOINTS) * 100) / Microbot.getClient().getRealSkillLevel(Skill.HITPOINTS);
+        double treshHold = getHealthPercentage();
         if (treshHold <= percentage) {
             return useFood();
         }
@@ -501,6 +501,16 @@ public class Rs2Player {
             }
         }
         return false;
+    }
+
+    /**
+     * Calculates the player's current health as a percentage of their real (base) health.
+     *
+     * @return the health percentage as a double. For example:
+     *         150.0 if boosted, 80.0 if drained, or 100.0 if unchanged.
+     */
+    public static double getHealthPercentage() {
+        return (double) (Microbot.getClient().getBoostedSkillLevel(Skill.HITPOINTS) * 100) / Microbot.getClient().getRealSkillLevel(Skill.HITPOINTS);
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1127,6 +1127,13 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
             if (itemAction.equalsIgnoreCase("rub") && (itemId == ItemID.XERICS_TALISMAN || transport.getDisplayInfo().toLowerCase().contains("skills necklace"))) {
                 return interactWithAdventureLog(transport);
             }
+            
+            if (itemAction.equalsIgnoreCase("rub") && transport.getDisplayInfo().toLowerCase().contains("burning amulet")) {
+                Rs2Dialogue.sleepUntilInDialogue();
+                Rs2Dialogue.clickOption(destination);
+                Rs2Dialogue.sleepUntilHasDialogueOption("Okay, teleport to level");
+                Rs2Dialogue.clickOption("Okay, teleport to level");
+            }
 
             if (itemAction.equalsIgnoreCase("rub") || itemAction.equalsIgnoreCase("reminisce")) {
                 sleepUntil(() -> Rs2Widget.getWidget(219, 1) != null);
@@ -1148,6 +1155,10 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
                 String destination = values[1].trim().toLowerCase();
                 Rs2Item rs2Item = Rs2Equipment.get(itemId);
                 Rs2Equipment.invokeMenu(rs2Item, destination);
+                if (transport.getDisplayInfo().toLowerCase().contains("burning amulet")) {
+                    Rs2Dialogue.sleepUntilInDialogue();
+                    Rs2Dialogue.clickOption("Okay, teleport to level");
+                }
                 Microbot.log("Traveling to " + transport.getDisplayInfo());
                 return sleepUntilTrue(() -> Rs2Player.getWorldLocation().distanceTo2D(transport.getDestination()) < OFFSET, 100, 5000);
             }

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/restrictions.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/restrictions.tsv
@@ -28,3 +28,10 @@
 2936 9810 0		63 Agility
 # Tree near Draynor Manor			
 3138 3352 0			
+# Fenkenstrain Castle			
+3537 3541 0			
+3537 3542 0			
+3537 3543 0			
+3537 3544 0			
+3538 3544 0			
+3538 3540 0			


### PR DESCRIPTION
## ShortestPathPlugin
- Removed Wilderness Obelisks from useable transports if in Free to Play Worlds
- Added Restricted Tiles around wall near Fenkenstrain Castle to fix pathing when walking out of the Castle

## Rs2Walker
- Added logic to handle burning amulet dialogue 

## Rs2Inventory 
- Added Rs2UIHelper.stripColTags to getSelectedItemName() as these get added when an item is selected

## Air Orb Plugin
- Added Config Options & Logic to eat while at the bank to ensure you are full health when repeating runs