### PR TITLE
Varrock anvil fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/sticktothescript/varrockanvil/VarrockAnvilScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/sticktothescript/varrockanvil/VarrockAnvilScript.java
@@ -106,7 +106,7 @@ public class VarrockAnvilScript extends Script {
                         debug("Using anvil");
 
                         // Wait until anvil screen is open
-                        sleepUntil(() -> Rs2Widget.getWidget(AnvilContainerWidgetID, 1) != null, 5000);
+                        sleepUntil(() -> Rs2Widget.getWidget(AnvilContainerWidgetID, 1) != null, 10000);
                         sleep(186, 480);
 
                         if (Rs2Widget.getWidget(AnvilContainerWidgetID, 1) != null) {


### PR DESCRIPTION
Increased the widget waiting time because when out of energy, char doesn't have enough time to get to anvil