### PR TITLE
WebWalker Changes + AutoSmelting Fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingScript.java
@@ -20,107 +20,107 @@ import java.text.MessageFormat;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+
 public class AutoSmeltingScript extends Script {
 
-	public static String version = "1.0.3";
+    public static String version = "1.0.3";
 
-	public boolean run(AutoSmeltingConfig config) {
-		initialPlayerLocation = null;
-		Rs2Walker.disableTeleports = true;
-		Rs2Antiban.resetAntibanSettings();
-		Rs2Antiban.antibanSetupTemplates.applySmithingSetup();
-		mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
-			try {
-				if (!super.run()) return;
-				if (!Microbot.isLoggedIn()) return;
-				if (config.SELECTED_BAR_TYPE().getRequiredSmithingLevel() > Rs2Player.getBoostedSkillLevel(Skill.SMITHING)) {
-					Microbot.showMessage("Your smithing level isn't high enough for " + config.SELECTED_BAR_TYPE().toString());
-					super.shutdown();
-					return;
-				}
+    public boolean run(AutoSmeltingConfig config) {
+        initialPlayerLocation = null;
+        Rs2Walker.disableTeleports = true;
+        Rs2Antiban.resetAntibanSettings();
+        Rs2Antiban.antibanSetupTemplates.applySmithingSetup();
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!super.run()) return;
+                if (!Microbot.isLoggedIn()) return;
+                if (config.SELECTED_BAR_TYPE().getRequiredSmithingLevel() > Rs2Player.getBoostedSkillLevel(Skill.SMITHING)) {
+                    Microbot.showMessage("Your smithing level isn't high enough for " + config.SELECTED_BAR_TYPE().toString());
+                    super.shutdown();
+                    return;
+                }
 
-				if (initialPlayerLocation == null) {
-					initialPlayerLocation = Rs2Player.getWorldLocation();
-				}
+                if (initialPlayerLocation == null) {
+                    initialPlayerLocation = Rs2Player.getWorldLocation();
+                }
 
-				if (Rs2Player.isMoving() || Rs2Player.isAnimating(6500) || Microbot.pauseAllScripts) return;
-				if (Rs2AntibanSettings.actionCooldownActive) return;
+                if (Rs2Player.isMoving() || Rs2Player.isAnimating(6500) || Microbot.pauseAllScripts) return;
+                if (Rs2AntibanSettings.actionCooldownActive) return;
 
-				// walk to bank until it's open then deposit everything and withdraw materials
-				if (!inventoryHasMaterialsForOneBar(config)) {
-					if (!Rs2Bank.isOpen()) {
-						Rs2Bank.walkToBankAndUseBank();
-						return;
-					}
-					Rs2Bank.depositAll();
-					if (config.SELECTED_BAR_TYPE().getId() == ItemID.IRON_BAR && Rs2Bank.hasItem(ItemID.RING_OF_FORGING) && !Rs2Equipment.isWearing(ItemID.RING_OF_FORGING)) {
-						Rs2Bank.withdrawAndEquip(ItemID.RING_OF_FORGING);
-						return;
-					}
-					withdrawRightAmountOfMaterials(config);
-					return;
-				}
+                // walk to bank until it's open then deposit everything and withdraw materials
+                if (!inventoryHasMaterialsForOneBar(config)) {
+                    if (!Rs2Bank.isOpen()) {
+                        Rs2Bank.walkToBankAndUseBank();
+                        return;
+                    }
+                    Rs2Bank.depositAll();
+                    if (config.SELECTED_BAR_TYPE().getId() == ItemID.IRON_BAR && Rs2Bank.hasItem(ItemID.RING_OF_FORGING) && !Rs2Equipment.isWearing(ItemID.RING_OF_FORGING)) {
+                        Rs2Bank.withdrawAndEquip(ItemID.RING_OF_FORGING);
+                        return;
+                    }
+                    withdrawRightAmountOfMaterials(config);
+                    return;
+                }
 
-				// walk to the initial position (near furnace)
-				if (initialPlayerLocation.distanceTo(Rs2Player.getWorldLocation()) > 4) {
-					if (Rs2Bank.isOpen())
-						Rs2Bank.closeBank();
-					Rs2Walker.walkTo(initialPlayerLocation, 4);
-					return;
-				}
+                // walk to the initial position (near furnace)
+                if (initialPlayerLocation.distanceTo(Rs2Player.getWorldLocation()) > 4) {
+                    if (Rs2Bank.isOpen())
+                        Rs2Bank.closeBank();
+                    Rs2Walker.walkTo(initialPlayerLocation, 4);
+                    return;
+                }
 
-				// interact with the furnace until the smelting dialogue opens in chat, click the selected bar icon
-				GameObject furnace = Rs2GameObject.findObject("furnace", true, 10, false, initialPlayerLocation);
-				if (furnace != null) {
-					Rs2GameObject.interact(furnace, "smelt");
-					Rs2Widget.sleepUntilHasWidgetText("What would you like to smelt?", 270, 5, false, 5000);
-					Rs2Widget.clickWidget(config.SELECTED_BAR_TYPE().getName());
-					Rs2Widget.sleepUntilHasNotWidgetText("What would you like to smelt?", 270, 5, false, 5000);
-					Rs2Antiban.actionCooldown();
-					Rs2Antiban.takeMicroBreakByChance();
-				}
+                // interact with the furnace until the smelting dialogue opens in chat, click the selected bar icon
+                GameObject furnace = Rs2GameObject.findObject("furnace", true, 10, false, initialPlayerLocation);
+                if (furnace != null) {
+                    Rs2GameObject.interact(furnace, "smelt");
+                    Rs2Widget.sleepUntilHasWidgetText("What would you like to smelt?", 270, 5, false, 5000);
+                    Rs2Widget.clickWidget(config.SELECTED_BAR_TYPE().getName());
+                    Rs2Widget.sleepUntilHasNotWidgetText("What would you like to smelt?", 270, 5, false, 5000);
+                    Rs2Antiban.actionCooldown();
+                    Rs2Antiban.takeMicroBreakByChance();
+                }
 
-			} catch (Exception ex) {
-				System.out.println(ex.getMessage());
-			}
-		}, 0, 100, TimeUnit.MILLISECONDS);
-		return true;
-	}
+            } catch (Exception ex) {
+                System.out.println(ex.getMessage());
+            }
+        }, 0, 100, TimeUnit.MILLISECONDS);
+        return true;
+    }
 
-	@Override
-	public void shutdown() {
-		Rs2Antiban.resetAntibanSettings();
-		super.shutdown();
-	}
+    @Override
+    public void shutdown() {
+        Rs2Antiban.resetAntibanSettings();
+        super.shutdown();
+    }
 
-	private boolean inventoryHasMaterialsForOneBar(AutoSmeltingConfig config) {
-		for (Map.Entry<Ores, Integer> requiredMaterials : config.SELECTED_BAR_TYPE().getRequiredMaterials().entrySet()) {
-			Integer amount = requiredMaterials.getValue();
-			String name = requiredMaterials.getKey().toString();
-			if (!Rs2Inventory.hasItemAmount(name, amount)) {
-				return false;
-			}
-		}
-		return true;
-	}
+    private boolean inventoryHasMaterialsForOneBar(AutoSmeltingConfig config) {
+        for (Map.Entry<Ores, Integer> requiredMaterials : config.SELECTED_BAR_TYPE().getRequiredMaterials().entrySet()) {
+            Integer amount = requiredMaterials.getValue();
+            String name = requiredMaterials.getKey().toString();
+            if (!Rs2Inventory.hasItemAmount(name, amount)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    private void withdrawRightAmountOfMaterials(AutoSmeltingConfig config) {
+        for (Map.Entry<Ores, Integer> requiredMaterials : config.SELECTED_BAR_TYPE().getRequiredMaterials().entrySet()) {
+            Integer amountForOne = requiredMaterials.getValue();
+            String name = requiredMaterials.getKey().toString();
+            int totalAmount = config.SELECTED_BAR_TYPE().maxBarsForFullInventory() * amountForOne;
+            if (!Rs2Bank.hasBankItem(name, totalAmount)) {
+                Microbot.showMessage(MessageFormat.format("Required Materials not in bank. You need {1} {0}.", name, totalAmount));
+                super.shutdown();
+            }
+            Rs2Bank.withdrawX(name, totalAmount);
+            sleepUntil(() -> Rs2Inventory.hasItemAmount(name, totalAmount), 3500);
 
-	private void withdrawRightAmountOfMaterials(AutoSmeltingConfig config) {
-		for (Map.Entry<Ores, Integer> requiredMaterials : config.SELECTED_BAR_TYPE().getRequiredMaterials().entrySet()) {
-			Integer amountForOne = requiredMaterials.getValue();
-			String name = requiredMaterials.getKey().toString();
-			int totalAmount = config.SELECTED_BAR_TYPE().maxBarsForFullInventory() * amountForOne;
-			if (!Rs2Bank.hasBankItem(name, totalAmount)) {
-				Microbot.showMessage(MessageFormat.format("Required Materials not in bank. You need {1} {0}.", name, totalAmount));
-				super.shutdown();
-			}
-			Rs2Bank.withdrawX(name, totalAmount);
-			sleepUntil(() -> Rs2Inventory.hasItemAmount(name, totalAmount), 3500);
-
-			// Exit if we did not end up finding it.
-			if (!Rs2Inventory.hasItemAmount(name, totalAmount)) {
-				Microbot.showMessage("Could not find item in bank.");
-				shutdown();
-			}
-		}
-	}
+            // Exit if we did not end up finding it.
+            if (!Rs2Inventory.hasItemAmount(name, totalAmount)) {
+                Microbot.showMessage("Could not find item in bank.");
+                shutdown();
+            }
+        }
+    }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingScript.java
@@ -7,6 +7,7 @@ import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.smelting.enums.Ores;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
@@ -19,108 +20,107 @@ import java.text.MessageFormat;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-
 public class AutoSmeltingScript extends Script {
 
-    public static String version = "1.0.2";
-    private boolean expectingXPDrop = false;
+	public static String version = "1.0.3";
 
-    public boolean run(AutoSmeltingConfig config) {
+	public boolean run(AutoSmeltingConfig config) {
+		initialPlayerLocation = null;
+		Rs2Walker.disableTeleports = true;
+		Rs2Antiban.resetAntibanSettings();
+		Rs2Antiban.antibanSetupTemplates.applySmithingSetup();
+		mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+			try {
+				if (!super.run()) return;
+				if (!Microbot.isLoggedIn()) return;
+				if (config.SELECTED_BAR_TYPE().getRequiredSmithingLevel() > Rs2Player.getBoostedSkillLevel(Skill.SMITHING)) {
+					Microbot.showMessage("Your smithing level isn't high enough for " + config.SELECTED_BAR_TYPE().toString());
+					super.shutdown();
+					return;
+				}
 
-        initialPlayerLocation = null;
-        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
-            try {
-                if (!super.run()) return;
-                if (!Microbot.isLoggedIn()) return;
-                if (config.SELECTED_BAR_TYPE().getRequiredSmithingLevel() > Rs2Player.getBoostedSkillLevel(Skill.SMITHING)) {
-                    Microbot.showMessage("Your smithing level isn't high enough for " + config.SELECTED_BAR_TYPE().toString());
-                    super.shutdown();
-                    return;
-                }
+				if (initialPlayerLocation == null) {
+					initialPlayerLocation = Rs2Player.getWorldLocation();
+				}
 
-                if (initialPlayerLocation == null) {
-                    initialPlayerLocation = Rs2Player.getWorldLocation();
-                }
+				if (Rs2Player.isMoving() || Rs2Player.isAnimating(6500) || Microbot.pauseAllScripts) return;
+				if (Rs2AntibanSettings.actionCooldownActive) return;
 
-                if (Rs2Player.isMoving() || Rs2Player.isAnimating() || Microbot.pauseAllScripts) return;
+				// walk to bank until it's open then deposit everything and withdraw materials
+				if (!inventoryHasMaterialsForOneBar(config)) {
+					if (!Rs2Bank.isOpen()) {
+						Rs2Bank.walkToBankAndUseBank();
+						return;
+					}
+					Rs2Bank.depositAll();
+					if (config.SELECTED_BAR_TYPE().getId() == ItemID.IRON_BAR && Rs2Bank.hasItem(ItemID.RING_OF_FORGING) && !Rs2Equipment.isWearing(ItemID.RING_OF_FORGING)) {
+						Rs2Bank.withdrawAndEquip(ItemID.RING_OF_FORGING);
+						return;
+					}
+					withdrawRightAmountOfMaterials(config);
+					return;
+				}
 
-                // walk to bank until it's open then deposit everything and withdraw materials
-                if (!inventoryHasMaterialsForOneBar(config)) {
-                    expectingXPDrop = false;
-                    if (!Rs2Bank.isOpen()) {
-                        Rs2Bank.walkToBankAndUseBank();
-                        return;
-                    }
-                    Rs2Bank.depositAll();
-                    if (config.SELECTED_BAR_TYPE().getId() == ItemID.IRON_BAR && Rs2Bank.hasItem(ItemID.RING_OF_FORGING) && !Rs2Equipment.isWearing(ItemID.RING_OF_FORGING)) {
-                        Rs2Bank.withdrawAndEquip(ItemID.RING_OF_FORGING);
-                        return;
-                    }
-                    withdrawRightAmountOfMaterials(config);
-                    return;
-                }
+				// walk to the initial position (near furnace)
+				if (initialPlayerLocation.distanceTo(Rs2Player.getWorldLocation()) > 4) {
+					if (Rs2Bank.isOpen())
+						Rs2Bank.closeBank();
+					Rs2Walker.walkTo(initialPlayerLocation, 4);
+					return;
+				}
 
-                if (expectingXPDrop && Rs2Inventory.waitForInventoryChanges(4500)) {
-                    Rs2Antiban.actionCooldown();
-                    Rs2Antiban.takeMicroBreakByChance();
-                    return;
-                }
+				// interact with the furnace until the smelting dialogue opens in chat, click the selected bar icon
+				GameObject furnace = Rs2GameObject.findObject("furnace", true, 10, false, initialPlayerLocation);
+				if (furnace != null) {
+					Rs2GameObject.interact(furnace, "smelt");
+					Rs2Widget.sleepUntilHasWidgetText("What would you like to smelt?", 270, 5, false, 5000);
+					Rs2Widget.clickWidget(config.SELECTED_BAR_TYPE().getName());
+					Rs2Widget.sleepUntilHasNotWidgetText("What would you like to smelt?", 270, 5, false, 5000);
+					Rs2Antiban.actionCooldown();
+					Rs2Antiban.takeMicroBreakByChance();
+				}
 
-                // walk to the initial position (near furnace)
-                if (initialPlayerLocation.distanceTo(Rs2Player.getWorldLocation()) > 4) {
-                    if (Rs2Bank.isOpen())
-                        Rs2Bank.closeBank();
-                    Rs2Walker.walkTo(initialPlayerLocation, 4);
-                    return;
-                }
+			} catch (Exception ex) {
+				System.out.println(ex.getMessage());
+			}
+		}, 0, 100, TimeUnit.MILLISECONDS);
+		return true;
+	}
 
-                // interact with the furnace until the smelting dialogue opens in chat, click the selected bar icon
-                // then wait for animation to finish
-                GameObject furnace = Rs2GameObject.findObject("furnace", true, 10, false, initialPlayerLocation);
-                if (furnace != null) {
-                    Rs2GameObject.interact(furnace, "smelt");
-                    sleepUntilOnClientThread(() -> Rs2Widget.getWidget(17694733) != null);
-                    if (Rs2Widget.getWidget(17694733) != null) {
-                        Rs2Widget.clickWidget(config.SELECTED_BAR_TYPE().getName());
-                        Rs2Player.waitForAnimation();
-                        expectingXPDrop = true;
-                    }
-                }
+	@Override
+	public void shutdown() {
+		Rs2Antiban.resetAntibanSettings();
+		super.shutdown();
+	}
 
-            } catch (Exception ex) {
-                System.out.println(ex.getMessage());
-            }
-        }, 0, 100, TimeUnit.MILLISECONDS);
-        return true;
-    }
+	private boolean inventoryHasMaterialsForOneBar(AutoSmeltingConfig config) {
+		for (Map.Entry<Ores, Integer> requiredMaterials : config.SELECTED_BAR_TYPE().getRequiredMaterials().entrySet()) {
+			Integer amount = requiredMaterials.getValue();
+			String name = requiredMaterials.getKey().toString();
+			if (!Rs2Inventory.hasItemAmount(name, amount)) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-    private boolean inventoryHasMaterialsForOneBar(AutoSmeltingConfig config) {
-        for (Map.Entry<Ores, Integer> requiredMaterials : config.SELECTED_BAR_TYPE().getRequiredMaterials().entrySet()) {
-            Integer amount = requiredMaterials.getValue();
-            String name = requiredMaterials.getKey().toString();
-            if (!Rs2Inventory.hasItemAmount(name, amount)) {
-                return false;
-            }
-        }
-        return true;
-    }
-    private void withdrawRightAmountOfMaterials(AutoSmeltingConfig config) {
-        for (Map.Entry<Ores, Integer> requiredMaterials : config.SELECTED_BAR_TYPE().getRequiredMaterials().entrySet()) {
-            Integer amountForOne = requiredMaterials.getValue();
-            String name = requiredMaterials.getKey().toString();
-            int totalAmount = config.SELECTED_BAR_TYPE().maxBarsForFullInventory() * amountForOne;
-            if (!Rs2Bank.hasBankItem(name, totalAmount)) {
-                Microbot.showMessage(MessageFormat.format("Required Materials not in bank. You need {1} {0}.", name, totalAmount));
-                super.shutdown();
-            }
-            Rs2Bank.withdrawX(name, totalAmount);
-            sleepUntil(() -> Rs2Inventory.hasItemAmount(name, totalAmount), 3500);
+	private void withdrawRightAmountOfMaterials(AutoSmeltingConfig config) {
+		for (Map.Entry<Ores, Integer> requiredMaterials : config.SELECTED_BAR_TYPE().getRequiredMaterials().entrySet()) {
+			Integer amountForOne = requiredMaterials.getValue();
+			String name = requiredMaterials.getKey().toString();
+			int totalAmount = config.SELECTED_BAR_TYPE().maxBarsForFullInventory() * amountForOne;
+			if (!Rs2Bank.hasBankItem(name, totalAmount)) {
+				Microbot.showMessage(MessageFormat.format("Required Materials not in bank. You need {1} {0}.", name, totalAmount));
+				super.shutdown();
+			}
+			Rs2Bank.withdrawX(name, totalAmount);
+			sleepUntil(() -> Rs2Inventory.hasItemAmount(name, totalAmount), 3500);
 
-            // Exit if we did not end up finding it.
-            if (!Rs2Inventory.hasItemAmount(name, totalAmount)) {
-                Microbot.showMessage("Could not find item in bank.");
-                shutdown();
-            }
-        }
-    }
+			// Exit if we did not end up finding it.
+			if (!Rs2Inventory.hasItemAmount(name, totalAmount)) {
+				Microbot.showMessage("Could not find item in bank.");
+				shutdown();
+			}
+		}
+	}
 }

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/quetzals.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/quetzals.tsv
@@ -1,23 +1,23 @@
 # Origin	Destination	Skills	Items	Quests	Varbits	Duration	Display info
-1389 2901 0				Twilight's Promise		30	
-1697 3140 0				Twilight's Promise	9958=1	30	
-1585 3053 0				Twilight's Promise		30	
-1510 3221 0				Twilight's Promise		30	
-1548 2995 0				Twilight's Promise		30	
-1437 3171 0				Twilight's Promise		30	
-1779 3111 0				Twilight's Promise		30	
-1700 3037 0				Twilight's Promise	9957=1	30	
-1670 2933 0				Twilight's Promise	9956=1	30	
-1446 3108 0				Twilight's Promise	9955=1	30	
-1613 3300 0				Twilight's Promise	11379=1	30	
-	1389 2901 0			Twilight's Promise		30	Aldarin
-	1697 3140 0			Twilight's Promise	9958=1	30	Civitas illa Fortis
-	1585 3053 0			Twilight's Promise		30	Hunter Guild
-	1510 3221 0			Twilight's Promise		30	Quetzacalli Gorge
-	1548 2995 0			Twilight's Promise		30	Sunset Coast
-	1437 3171 0			Twilight's Promise		30	The Teomat
-	1779 3111 0			Twilight's Promise		30	Fortis Colosseum
-	1700 3037 0			Twilight's Promise	9957=1	30	Outer Fortis
-	1670 2933 0			Twilight's Promise	9956=1	30	Colossal Wyrm Remains
-	1446 3108 0			Twilight's Promise	9955=1	30	Cam Torum Entrance
-	1613 3300 0			Twilight's Promise	11379=1	30	Salvager Overlook
+1389 2901 0				Twilight's Promise		6	
+1697 3140 0				Twilight's Promise	9958=1	6	
+1585 3053 0				Twilight's Promise		6	
+1510 3221 0				Twilight's Promise		6	
+1548 2995 0				Twilight's Promise		6	
+1437 3171 0				Twilight's Promise		6	
+1779 3111 0				Twilight's Promise		6	
+1700 3037 0				Twilight's Promise	9957=1	6	
+1670 2933 0				Twilight's Promise	9956=1	6	
+1446 3108 0				Twilight's Promise	9955=1	6	
+1613 3300 0				Twilight's Promise	11379=1	6	
+	1389 2901 0			Twilight's Promise		6	Aldarin
+	1697 3140 0			Twilight's Promise	9958=1	6	Civitas illa Fortis
+	1585 3053 0			Twilight's Promise		6	Hunter Guild
+	1510 3221 0			Twilight's Promise		6	Quetzacalli Gorge
+	1548 2995 0			Twilight's Promise		6	Sunset Coast
+	1437 3171 0			Twilight's Promise		6	The Teomat
+	1779 3111 0			Twilight's Promise		6	Fortis Colosseum
+	1700 3037 0			Twilight's Promise	9957=1	6	Outer Fortis
+	1670 2933 0			Twilight's Promise	9956=1	6	Colossal Wyrm Remains
+	1446 3108 0			Twilight's Promise	9955=1	6	Cam Torum Entrance
+	1613 3300 0			Twilight's Promise	11379=1	6	Salvager Overlook

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
@@ -1,332 +1,333 @@
-# Destination	Skills	Item IDs	Quests	Duration	Display info	Consumable	Wilderness level	Varbits
+# Destination	Skills	Item IDs	Quests	Varbits	Consumable	Wilderness level	Duration	Display info
 # Ardougne Cloaks (2-4's farm teleport is limited to 3,5, or infinite times - can this be validated?)								
-2606 3221 0		13121;13122;13123;13124;20760		4	Ardougne cloak: Kandarin Monastery	F	19	
-2664 3374 0		13122;13123;13124;20760		4	Ardougne cloak: Ardougne Farm	F	19	
+2606 3221 0		13121;13122;13123;13124;20760			F	19	4	Ardougne cloak: Kandarin Monastery
+2664 3374 0		13122;13123;13124;20760			F	19	4	Ardougne cloak: Ardougne Farm
 # Karamja Gloves								
-2840 9387 0		11140;13103		4	Karamja gloves	F	19	
+2840 9387 0		11140;13103			F	19	4	Karamja gloves
 # Desert Amulets (2 and 3 have one teleport per day, 4 is unlimited)								
-3420 2917 0		13134;13135		4	Desert amulet	F	19	4558=0
-3426 2927 0		13136		4	Desert amulet	F	19	
+3420 2917 0		13134;13135		4558=0	F	19	4	Desert amulet
+3426 2927 0		13136			F	19	4	Desert amulet
 # Morytania Legs (2 and 3 have 5 teleports per day to slime, 4 is unlimited)								
-3683 9888 0		13112		4	Morytania legs: Ectofuntus Pit	F	19	4542<2
-3683 9888 0		13113;13114		4	Morytania legs: Ectofuntus Pit	F	19	4542<5
-3683 9888 0		13115		4	Morytania legs: Ectofuntus Pit	F	19	
-3482 3230 0		13114;13115		4	Morytania legs: Burgh de Rott	F	19	
+3683 9888 0		13112		4542<2	F	19	4	Morytania legs: Ectofuntus Pit
+3683 9888 0		13113;13114		4542<5	F	19	4	Morytania legs: Ectofuntus Pit
+3683 9888 0		13115			F	19	4	Morytania legs: Ectofuntus Pit
+3482 3230 0		13114;13115			F	19	4	Morytania legs: Burgh de Rott
 # Fremennik sea boots (1,2,3 have 1 teleport per day, 4 is unlimited)								
-2643 3675 0		13129;13130;13131		4	Fremennik sea boots	F	19	5005=0
-2643 3675 0		13132		4	Fremennik sea boots	F	19	
+2643 3675 0		13129;13130;13131		5005=0	F	19	4	Fremennik sea boots
+2643 3675 0		13132			F	19	4	Fremennik sea boots
 # Kandarin headgear (3 has 1 teleport per day, 4 is unlimited)								
-2729 3409 0		13137;13138;13139;13140		4	Kandarin headgear	F	19	
+2729 3409 0		13137;13138;13139;13140			F	19	4	Kandarin headgear
 # Wilderness Sword (3 has 1 teleport per day, 4 is unlimited)								
-3377 3890 0		13110;13111		4	Wilderness sword	F	19	
+3377 3890 0		13110;13111			F	19	4	Wilderness sword
 # Western Banner (3 has 1 teleport per day, 4 is unlimited)								
-2339 3649 0		13143;13144		4	Western banner	F	19	
+2339 3649 0		13143;13144			F	19	4	Western banner
 # Explorer's Ring (2 has 3 teleports per day, 3 and 4 are unlimited)								
-3052 3291 0		13126		4	Explorer's ring	F	19	4552<3
-3052 3291 0		13127;13128		4	Explorer's ring	F	19	
+3052 3291 0		13126		4552<3	F	19	4	Explorer's ring
+3052 3291 0		13127;13128			F	19	4	Explorer's ring
 # Rada's Blessing (Kourend Woodland, 1 has 3 teleports, 2 has 5 teleports, 3 and 4 have unlimited. For Mount Karuulum, 3 has 3 teleports and 4 has unlimited)								
-1554 3457 0		22941		4	Rada's blessing: Kourend Woodland	F	19	7937<3
-1554 3457 0		22943		4	Rada's blessing: Kourend Woodland	F	19	7937<5
-1554 3457 0		22945;22947		4	Rada's blessing: Kourend Woodland	F	19	
-1311 3799 0		22945		4	Rada's blessing: Mount Karuulm	F	19	7938<3
-1311 3799 0		22947		4	Rada's blessing: Mount Karuulm	F	19	
+1554 3457 0		22941		7937<3	F	19	4	Rada's blessing: Kourend Woodland
+1554 3457 0		22943		7937<5	F	19	4	Rada's blessing: Kourend Woodland
+1554 3457 0		22945;22947			F	19	4	Rada's blessing: Kourend Woodland
+1311 3799 0		22945		7938<3	F	19	4	Rada's blessing: Mount Karuulm
+1311 3799 0		22947			F	19	4	Rada's blessing: Mount Karuulm
 								
 # Games Necklace								
-2520 3571 0		3853;3855;3857;3859;3861;3863;3865;3867		4	Games necklace: Barbarian Outpost	T	19	
-2898 3553 0		3853;3855;3857;3859;3861;3863;3865;3867		4	Games necklace: Burthorpe	T	19	
-2965 4254 2		3853;3855;3857;3859;3861;3863;3865;3867		4	Games necklace: Corporeal Beast	T	19	
-3245 9500 2		3853;3855;3857;3859;3861;3863;3865;3867		4	Games necklace: Tears of Guthix	T	19	
-1631 3940 0		3853;3855;3857;3859;3861;3863;3865;3867		4	Games necklace: Wintertodt Camp	T	19	
+2520 3571 0		3853;3855;3857;3859;3861;3863;3865;3867			T	19	4	Games necklace: Barbarian Outpost
+2898 3553 0		3853;3855;3857;3859;3861;3863;3865;3867			T	19	4	Games necklace: Burthorpe
+2965 4254 2		3853;3855;3857;3859;3861;3863;3865;3867			T	19	4	Games necklace: Corporeal Beast
+3245 9500 2		3853;3855;3857;3859;3861;3863;3865;3867			T	19	4	Games necklace: Tears of Guthix
+1631 3940 0		3853;3855;3857;3859;3861;3863;3865;3867			T	19	4	Games necklace: Wintertodt Camp
 								
 # Ring of Dueling (1-8)								
-3315 3235 0		2566;2564;2562;2560;2558;2556;2554;2552		6	Ring of dueling: Emir's Arena	T	19	
-2440 3090 0		2566;2564;2562;2560;2558;2556;2554;2552		6	Ring of dueling: Castle Wars	T	19	
-3151 3635 0		2566;2564;2562;2560;2558;2556;2554;2552		6	Ring of dueling: Ferox Enclave	T	19	
+3315 3235 0		2566;2564;2562;2560;2558;2556;2554;2552			T	19	6	Ring of dueling: Emir's Arena
+2440 3090 0		2566;2564;2562;2560;2558;2556;2554;2552			T	19	6	Ring of dueling: Castle Wars
+3151 3635 0		2566;2564;2562;2560;2558;2556;2554;2552			T	19	6	Ring of dueling: Ferox Enclave
 								
 # Combat Bracelet (1-6) (uncharged is 11126)								
-2882 3547 0		11118;11120;11122;11124;11972;11974		4	Combat bracelet: Warriors' Guild	T	29	
-3192 3368 0		11118;11120;11122;11124;11972;11974		4	Combat bracelet: Champions' Guild	T	29	
-3052 3490 0		11118;11120;11122;11124;11972;11974		4	Combat bracelet: Monastery	T	29	
-2653 3439 0		11118;11120;11122;11124;11972;11974		4	Combat bracelet: Ranging Guild	T	29	
+2882 3547 0		11118;11120;11122;11124;11972;11974			T	29	4	Combat bracelet: Warriors' Guild
+3192 3368 0		11118;11120;11122;11124;11972;11974			T	29	4	Combat bracelet: Champions' Guild
+3052 3490 0		11118;11120;11122;11124;11972;11974			T	29	4	Combat bracelet: Monastery
+2653 3439 0		11118;11120;11122;11124;11972;11974			T	29	4	Combat bracelet: Ranging Guild
 								
 # Skills Necklace (1-6) (uncharged is 11113)								
-2611 3390 0		11105;11107;11109;11111;11968;11970		4	1. Skills necklace: Fishing Guild	T	29	
-3049 9763 0		11105;11107;11109;11111;11968;11970		4	2. Skills necklace: Mining Guild	T	29	
-2933 3295 0		11105;11107;11109;11111;11968;11970		4	3. Skills necklace: Crafting Guild	T	29	
-3144 3438 0		11105;11107;11109;11111;11968;11970		4	4. Skills necklace: Cooks' Guild	T	29	
-1662 3505 0		11105;11107;11109;11111;11968;11970		4	5. Skills necklace: Woodcutting Guild	T	29	
-1248 3725 0	45 Farming	11105;11107;11109;11111;11968;11970		4	6. Skills necklace: Farming Guild	T	29	
-1248 3719 0		11105;11107;11109;11111;11968;11970		4	6. Skills necklace: Farming Guild	T	29	
+2611 3390 0		11105;11107;11109;11111;11968;11970			T	29	4	1. Skills necklace: Fishing Guild
+3049 9763 0		11105;11107;11109;11111;11968;11970			T	29	4	2. Skills necklace: Mining Guild
+2933 3295 0		11105;11107;11109;11111;11968;11970			T	29	4	3. Skills necklace: Crafting Guild
+3144 3438 0		11105;11107;11109;11111;11968;11970			T	29	4	4. Skills necklace: Cooks' Guild
+1662 3505 0		11105;11107;11109;11111;11968;11970			T	29	4	5. Skills necklace: Woodcutting Guild
+1248 3725 0	45 Farming	11105;11107;11109;11111;11968;11970			T	29	4	6. Skills necklace: Farming Guild
+1248 3719 0		11105;11107;11109;11111;11968;11970			T	29	4	6. Skills necklace: Farming Guild
 								
 # Amulet of Glory (1-6, 1t-6t, Eternal) (uncharged is 1704, trimmed 10362)								
-3087 3496 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707		4	Amulet of glory: Edgeville	T	29	
-2918 3176 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707		4	Amulet of glory: Karamja	T	29	
-3105 3251 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707		4	Amulet of glory: Draynor Village	T	29	
-3293 3163 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707		4	Amulet of glory: Al Kharid	T	29	
+3087 3496 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707			T	29	4	Amulet of glory: Edgeville
+2918 3176 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707			T	29	4	Amulet of glory: Karamja
+3105 3251 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707			T	29	4	Amulet of glory: Draynor Village
+3293 3163 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707			T	29	4	Amulet of glory: Al Kharid
 								
 # Ring of Wealth (1-5, 1i-5i) (uncharged is 2572, trimmed 12785)								
-2534 3862 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786	Throne of Miscellania	4	Ring of wealth: Miscellania	T	29	
-3163 3478 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786		4	Ring of wealth: Grand Exchange	T	29	
-2995 3375 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786		4	Ring of wealth: Falador	T	29	
-2824 10168 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786	Between a Rock...	4	Ring of wealth: Dondakan	T	29	
+2534 3862 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786	Throne of Miscellania		T	29	4	Ring of wealth: Miscellania
+3163 3478 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786			T	29	4	Ring of wealth: Grand Exchange
+2995 3375 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786			T	29	4	Ring of wealth: Falador
+2824 10168 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786	Between a Rock...		T	29	4	Ring of wealth: Dondakan
 								
 # Slayer Ring (1-8, eternal)								
-2432 3423 0		11866;11867;11868;11869;11870;11871;11872;11873;21268		4	Slayer ring: Stronghold	T	29	
-3421 3537 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Priest in Peril	4	Slayer ring: Slayer Tower	T	29	
-2802 10000 0		11866;11867;11868;11869;11870;11871;11872;11873;21268		4	Slayer ring: Fremennik	T	29	
-3185 4601 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Haunted Mine	4	Slayer ring: Tarn's Lair	T	29	
-2028 4636 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Mourning's End Part II	4	Slayer ring: Dark Beasts	T	29	
+2432 3423 0		11866;11867;11868;11869;11870;11871;11872;11873;21268			T	29	4	Slayer ring: Stronghold
+3421 3537 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Priest in Peril		T	29	4	Slayer ring: Slayer Tower
+2802 10000 0		11866;11867;11868;11869;11870;11871;11872;11873;21268			T	29	4	Slayer ring: Fremennik
+3185 4601 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Haunted Mine		T	29	4	Slayer ring: Tarn's Lair
+2028 4636 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Mourning's End Part II		T	29	4	Slayer ring: Dark Beasts
 								
 # Digsite Pendant (can't find a varbit for the other location's activation)								
-3341 3445 0		11190;11191;11192;11193;11194		4	Digsite pendant: Digsite	T	19	
-3763 3869 1		11190;11191;11192;11193;11194	Bone Voyage	4	Digsite pendant: Fossil Island	T	19	
-3549 10456 0		11190;11191;11192;11193;11194	Dragon Slayer II	4	Digsite pendant: Lithkren	T	19	
+3341 3445 0		11190;11191;11192;11193;11194			T	19	4	Digsite pendant: Digsite
+3763 3869 1		11190;11191;11192;11193;11194	Bone Voyage		T	19	4	Digsite pendant: Fossil Island
+3549 10456 0		11190;11191;11192;11193;11194	Dragon Slayer II		T	19	4	Digsite pendant: Lithkren
 								
 # Necklace of Passage (1-5)								
-3114 3179 0		21146;21149;21151;21153;21155		4	Necklace of passage: Wizards' Tower	T	19	
-2428 3350 0		21146;21149;21151;21153;21155		4	Necklace of passage: The Outpost	T	19	
-3405 3158 0		21146;21149;21151;21153;21155		4	Necklace of passage: Eagle's Eyrie	T	19	
+3114 3179 0		21146;21149;21151;21153;21155			T	19	4	Necklace of passage: Wizards' Tower
+2428 3350 0		21146;21149;21151;21153;21155			T	19	4	Necklace of passage: The Outpost
+3405 3158 0		21146;21149;21151;21153;21155			T	19	4	Necklace of passage: Eagle's Eyrie
 								
 # Burning Amulet								
-3234 3634 0		21166;21169;21171;21173;21175		4	Burning amulet: Chaos Temple	T	19	
-3038 3651 0		21166;21169;21171;21173;21175		4	Burning amulet: Bandit Camp	T	19	
-3028 3842 0		21166;21169;21171;21173;21175		4	Burning amulet: Lava Maze	T	19	
+3234 3634 0		21166;21169;21171;21173;21175			T	19	4	Burning amulet: Chaos Temple
+3038 3651 0		21166;21169;21171;21173;21175			T	19	4	Burning amulet: Bandit Camp
+3028 3842 0		21166;21169;21171;21173;21175			T	19	4	Burning amulet: Lava Maze
 								
 # Teleport to House tablet - These depend on the current player's home location, determined by varbit 2187.								
 # 0 - None								
 # 1 - Rimmington								
-2952 3224 0		8013		4	Teleport to House tablet	T	19	2187=1
+2952 3224 0		8013		2187=1	T	19	4	Teleport to House tablet
 # 2 - Taverly								
-2892 3465 0		8013		4	Teleport to House tablet	T	19	2187=2
+2892 3465 0		8013		2187=2	T	19	4	Teleport to House tablet
 # 3 - Pollnivneach								
-3339 3001 0		8013		4	Teleport to House tablet	T	19	2187=3
+3339 3001 0		8013		2187=3	T	19	4	Teleport to House tablet
 # 4 - Rellekka								
-2669 3629 0		8013		4	Teleport to House tablet	T	19	2187=4
+2669 3629 0		8013		2187=4	T	19	4	Teleport to House tablet
 # 5 - Brimhaven								
-2756 3176 0		8013		4	Teleport to House tablet	T	19	2187=5
+2756 3176 0		8013		2187=5	T	19	4	Teleport to House tablet
 # 6 - Yanille								
-2545 3097 0		8013		4	Teleport to House tablet	T	19	2187=6
+2545 3097 0		8013		2187=6	T	19	4	Teleport to House tablet
 # 7 - Prifddinas								
-3239 6077 0		8013		4	Teleport to House tablet	T	19	2187=7
+3239 6077 0		8013		2187=7	T	19	4	Teleport to House tablet
 # 8 - Hosidius								
-1740 3517 0		8013		4	Teleport to House tablet	T	19	2187=8
+1740 3517 0		8013		2187=8	T	19	4	Teleport to House tablet
 								
 #  Teleport tablets								
-3213 3424 0		8007		4	Varrock tablet	T	19	4070=0;4585=0
-2965 3378 0		8009		4	Falador tablet	T	19	
-3221 3218 0		8008		4	Lumbridge tablet	T	19	
-2757 3478 0		8010		4	Camelot tablet	T	19	
-2661 3302 0		8011	Plague City	4	Ardougne tablet	T	19	
-2549 3112 0		8012	Watchtower	4	Watchtower tablet	T	19	
+3213 3424 0		8007		4585=0	T	19	4	Varrock tablet
+2965 3378 0		8009			T	19	4	Falador tablet
+3221 3218 0		8008			T	19	4	Lumbridge tablet
+2757 3478 0		8010			T	19	4	Camelot tablet
+2661 3302 0		8011	Plague City		T	19	4	Ardougne tablet
+2549 3112 0		8012	Watchtower		T	19	4	Watchtower tablet
 # Varbit 4460 is DIARY_ARDOUGNE_HARD								
-2584 3097 0		8012	Watchtower	4	Watchtower tablet: Yanille	T	19	4460=1
-2953 3224 0		11741		4	Rimmington tablet	T	19	
-2893 3465 0		11742		4	Taverley tablet	T	19	
-3340 3004 0		11743		4	Pollnivneach tablet	T	19	
-2670 3631 0		11744		4	Rellekka tablet	T	19	
-2757 3179 0		11745		4	Brimhaven tablet	T	19	
-2544 3096 0		11746		4	Yanille tablet	T	19	
-2890 3679 0		11747		4	Trollheim tablet	T	19	
-1743 3517 0		19651		4	Hosidius tablet	T	19	
-3239 6077 0		23771		4	Prifddinas tablet	T	19	
-3100 9883 0		12781	Desert Treasure I	4	Paddewwa tablet	T	19	
-3320 3337 0		12782	Desert Treasure I	4	Senntisten tablet	T	19	
-3494 3473 0		12779	Desert Treasure I	4	Kharyrll tablet	T	19	
-3002 3470 0		12780	Desert Treasure I	4	Lassar tablet	T	19	
-2968 3696 0		12777	Desert Treasure I	4	Dareeyak tablet	T	19	
-3158 3666 0		12776	Desert Treasure I	4	Carrallanger tablet	T	19	
-3287 3888 0		12775	Desert Treasure I	4	Annakarl tablet	T	19	
-2974 3873 0		12778	Desert Treasure I	4	Ghorrock tablet	T	19	
-2113 3915 0		24949	Lunar Diplomacy	4	Moonclan tablet	T	19	
-2468 3246 0		24951	Lunar Diplomacy	4	Ourania tablet	T	19	
-2546 3756 0		24953		4	Waterbirth tablet	T	19	
-2543 3569 0		24955		4	Barbarian tablet	T	19	
-2636 3167 0		24957		4	Khazard tablet	T	19	
-2613 3391 0		24959		4	Fishing guild tablet	T	19	
-2801 3449 0		24961		4	Catherby tablet	T	19	
-2975 3938 0		24963		4	Ice plateau tablet	T	19	
-1633 3838 0		19613		4	Arceuus Library tablet	T	19	
-3110 3350 0		19615		4	Draynor Manor tablet	T	19	
-1347 3740 0		22949		4	Battlefront tablet	T	19	
-2980 3509 0		19617		4	Mind Altar tablet	T	19	
-3432 3461 0		19619	Priest in Peril	4	Salve Graveyard tablet	T	19	
-3548 3529 0		19621	Priest in Peril	4	Fenkenstrain's Castle tablet	T	19	
-2500 3291 0		19623	Biohazard	4	West Ardougne tablet	T	19	
-3797 2867 0		19625	The Great Brain Robbery	4	Harmony Island tablet	T	19	
-2980 3763 0		19627		4	Cemetery tablet	T	19	
-3565 3314 0		19629	Priest in Peril	4	Barrows tablet	T	19	
-2771 9102 0		19631	Monkey Madness I	4	Ape Atoll tablet	T	19	
-3811 3813 0		21541		4	Volcanic Mine tablet	T	19	
-3352 3782 0		24251		4	Wilderness Crabs tablet	T	19	
+2584 3097 0		8012	Watchtower	4460=1	T	19	4	Watchtower tablet: Yanille
+2953 3224 0		11741			T	19	4	Rimmington tablet
+2893 3465 0		11742			T	19	4	Taverley tablet
+3340 3004 0		11743			T	19	4	Pollnivneach tablet
+2670 3631 0		11744			T	19	4	Rellekka tablet
+2757 3179 0		11745			T	19	4	Brimhaven tablet
+2544 3096 0		11746			T	19	4	Yanille tablet
+2890 3679 0		11747			T	19	4	Trollheim tablet
+1743 3517 0		19651			T	19	4	Hosidius tablet
+3239 6077 0		23771			T	19	4	Prifddinas tablet
+3100 9883 0		12781	Desert Treasure I		T	19	4	Paddewwa tablet
+3320 3337 0		12782	Desert Treasure I		T	19	4	Senntisten tablet
+3494 3473 0		12779	Desert Treasure I		T	19	4	Kharyrll tablet
+3002 3470 0		12780	Desert Treasure I		T	19	4	Lassar tablet
+2968 3696 0		12777	Desert Treasure I		T	19	4	Dareeyak tablet
+3158 3666 0		12776	Desert Treasure I		T	19	4	Carrallanger tablet
+3287 3888 0		12775	Desert Treasure I		T	19	4	Annakarl tablet
+2974 3873 0		12778	Desert Treasure I		T	19	4	Ghorrock tablet
+2113 3915 0		24949	Lunar Diplomacy		T	19	4	Moonclan tablet
+2468 3246 0		24951	Lunar Diplomacy		T	19	4	Ourania tablet
+2546 3756 0		24953			T	19	4	Waterbirth tablet
+2543 3569 0		24955			T	19	4	Barbarian tablet
+2636 3167 0		24957			T	19	4	Khazard tablet
+2613 3391 0		24959			T	19	4	Fishing guild tablet
+2801 3449 0		24961			T	19	4	Catherby tablet
+2975 3938 0		24963			T	19	4	Ice plateau tablet
+1633 3838 0		19613			T	19	4	Arceuus Library tablet
+3110 3350 0		19615			T	19	4	Draynor Manor tablet
+1347 3740 0		22949			T	19	4	Battlefront tablet
+2980 3509 0		19617			T	19	4	Mind Altar tablet
+3432 3461 0		19619	Priest in Peril		T	19	4	Salve Graveyard tablet
+3548 3529 0		19621	Priest in Peril		T	19	4	Fenkenstrain's Castle tablet
+2500 3291 0		19623	Biohazard		T	19	4	West Ardougne tablet
+3797 2867 0		19625	The Great Brain Robbery		T	19	4	Harmony Island tablet
+2980 3763 0		19627			T	19	4	Cemetery tablet
+3565 3314 0		19629	Priest in Peril		T	19	4	Barrows tablet
+2771 9102 0		19631	Monkey Madness I		T	19	4	Ape Atoll tablet
+3811 3813 0		21541			T	19	4	Volcanic Mine tablet
+3352 3782 0		24251			T	19	4	Wilderness Crabs tablet
+1680 3134 0		28824	Twilight's Promise		T	19	4	Civitas illa Fortis tablet
 								
 #  Teleport Scrolls (todo: how to detect these in the master scroll book?)								
-3419 2917 0		12402		4	Nardah teleport	T	19	
-3325 3412 0		12403		4	Digsite teleport	T	19	
-2541 2925 0		12404		4	Feldip hills teleport	T	19	
-2094 3913 0		12405	Lunar Diplomacy	4	Lunar isle teleport	T	19	
-3488 3288 0		12406	Priest in Peril	4	Mort'ton teleport	T	19	
-2658 2659 0		12407		4	Pest control teleport	T	19	
-2339 3649 0		12408		4	Piscatoris teleport	T	19	
-2789 3066 0		12409	Tai Bwo Wannai Trio	4	Tai bwo wannai teleport	T	19	
-2194 3258 0		12410	Regicide	4	Iorwerth camp teleport	T	19	
-3701 2996 0		12411	Cabin Fever	4	Mos le'harmless teleport	T	19	
-3302 3487 0		12642		4	Lumberyard teleport	T	19	
-2196 3056 0		12938	Regicide	4	Zul-andra teleport	T	19	
-1310 1250 0		13249		4	Key master teleport	T	19	
-3128 3832 0		21802		4	Revenant cave teleport	T	19	
-1645 3580 0		23387		4	Watson teleport	T	19	
+3419 2917 0		12402			T	19	4	Nardah teleport
+3325 3412 0		12403			T	19	4	Digsite teleport
+2541 2925 0		12404			T	19	4	Feldip hills teleport
+2094 3913 0		12405	Lunar Diplomacy		T	19	4	Lunar isle teleport
+3488 3288 0		12406	Priest in Peril		T	19	4	Mort'ton teleport
+2658 2659 0		12407			T	19	4	Pest control teleport
+2339 3649 0		12408			T	19	4	Piscatoris teleport
+2789 3066 0		12409	Tai Bwo Wannai Trio		T	19	4	Tai bwo wannai teleport
+2194 3258 0		12410	Regicide		T	19	4	Iorwerth camp teleport
+3701 2996 0		12411	Cabin Fever		T	19	4	Mos le'harmless teleport
+3302 3487 0		12642			T	19	4	Lumberyard teleport
+2196 3056 0		12938	Regicide		T	19	4	Zul-andra teleport
+1310 1250 0		13249			T	19	4	Key master teleport
+3128 3832 0		21802			T	19	4	Revenant cave teleport
+1645 3580 0		23387			T	19	4	Watson teleport
 								
 # capes								
-2931 3286 0		9780;9781		4	Crafting cape	F	19	
+2931 3286 0		9780;9781			F	19	4	Crafting cape: Teleport
 # The Construction cape's home teleports, determined by varbit 2187								
 # 0 - None								
 # 1 - Rimmington								
-2952 3224 0		9789;9790		4	Construction cape: Home	F	19	2187=1
+2952 3224 0		9789;9790		2187=1	F	19	4	Construction cape: Home
 # 2 - Taverly								
-2892 3465 0		9789;9790		4	Construction cape: Home	F	19	2187=2
+2892 3465 0		9789;9790		2187=2	F	19	4	Construction cape: Home
 # 3 - Pollnivneach								
-3339 3001 0		9789;9790		4	Construction cape: Home	F	19	2187=3
+3339 3001 0		9789;9790		2187=3	F	19	4	Construction cape: Home
 # 4 - Rellekka								
-2669 3629 0		9789;9790		4	Construction cape: Home	F	19	2187=4
+2669 3629 0		9789;9790		2187=4	F	19	4	Construction cape: Home
 # 5 - Brimhaven								
-2756 3176 0		9789;9790		4	Construction cape: Home	F	19	2187=5
+2756 3176 0		9789;9790		2187=5	F	19	4	Construction cape: Home
 # 6 - Yanille								
-2545 3097 0		9789;9790		4	Construction cape: Home	F	19	2187=6
+2545 3097 0		9789;9790		2187=6	F	19	4	Construction cape: Home
 # 7 - Prifddinas								
-3239 6077 0		9789;9790		4	Construction cape: Home	F	19	2187=7
+3239 6077 0		9789;9790		2187=7	F	19	4	Construction cape: Home
 # 8 - Hosidius								
-1740 3517 0		9789;9790		4	Construction cape: Home	F	19	2187=8
-2952 3224 0		9789;9790		4	Construction cape: Rimmington	F	19	
-2892 3465 0		9789;9790		4	Construction cape: Taverley	F	19	
-3339 3001 0		9789;9790		4	Construction cape: Pollnivneach	F	19	
-1743 3517 0		9789;9790		4	Construction cape: Hosidius	F	19	
-2669 3629 0		9789;9790		4	Construction cape: Rellekka	F	19	
-2756 3176 0		9789;9790		4	Construction cape: Brimhaven	F	19	
-2545 3097 0		9789;9790		4	Construction cape: Yanille	F	19	
-3239 6077 0		9789;9790		4	Construction cape: Prifddinas	F	19	
-2604 3401 0		9798;9799		4	Fishing cape	F	19	
-1248 3725 0		9810;9811		4	Farming cape	F	19	
-2556 2917 0		9948;9949		4	Hunter cape: Feldip Hills	F	19	
-3144 3772 0		9948;9949		4	Hunter cape: Black chinchompa	F	19	
-2865 3546 0		9750;9751		4	Strength cape	F	19	
+1740 3517 0		9789;9790		2187=8	F	19	4	Construction cape: Home
+2952 3224 0		9789;9790			F	19	4	Construction cape: Rimmington
+2892 3465 0		9789;9790			F	19	4	Construction cape: Taverley
+3339 3001 0		9789;9790			F	19	4	Construction cape: Pollnivneach
+1743 3517 0		9789;9790			F	19	4	Construction cape: Hosidius
+2669 3629 0		9789;9790			F	19	4	Construction cape: Rellekka
+2756 3176 0		9789;9790			F	19	4	Construction cape: Brimhaven
+2545 3097 0		9789;9790			F	19	4	Construction cape: Yanille
+3239 6077 0		9789;9790			F	19	4	Construction cape: Prifddinas
+2604 3401 0		9798;9799			F	19	4	Fishing cape
+1248 3725 0		9810;9811			F	19	4	Farming cape
+2556 2917 0		9948;9949			F	19	4	Hunter cape: Feldip Hills
+3144 3772 0		9948;9949			F	19	4	Hunter cape: Black chinchompa
+2865 3546 0		9750;9751			F	19	4	Strength cape
 # Max capes								
 # The Max cape's home teleports, determined by varbit 2187								
 # 0 - None								
 # 1 - Rimmington								
-2952 3224 0		13280;13342		4	Max cape: Home	F	19	2187=1
+2952 3224 0		13280;13342		2187=1	F	19	4	Max cape: Home
 # 2 - Taverly								
-2892 3465 0		13280;13342		4	Max cape: Home	F	19	2187=2
+2892 3465 0		13280;13342		2187=2	F	19	4	Max cape: Home
 # 3 - Pollnivneach								
-3339 3001 0		13280;13342		4	Max cape: Home	F	19	2187=3
+3339 3001 0		13280;13342		2187=3	F	19	4	Max cape: Home
 # 4 - Rellekka								
-2669 3629 0		13280;13342		4	Max cape: Home	F	19	2187=4
+2669 3629 0		13280;13342		2187=4	F	19	4	Max cape: Home
 # 5 - Brimhaven								
-2756 3176 0		13280;13342		4	Max cape: Home	F	19	2187=5
+2756 3176 0		13280;13342		2187=5	F	19	4	Max cape: Home
 # 6 - Yanille								
-2545 3097 0		13280;13342		4	Max cape: Home	F	19	2187=6
+2545 3097 0		13280;13342		2187=6	F	19	4	Max cape: Home
 # 7 - Prifddinas								
-3239 6077 0		13280;13342		4	Max cape: Home	F	19	2187=7
+3239 6077 0		13280;13342		2187=7	F	19	4	Max cape: Home
 # 8 - Hosidius								
-1740 3517 0		13280;13342		4	Max cape: Home	F	19	2187=8
-2952 3224 0		13280;13342		4	Max cape: Rimmington	F	19	
-2892 3465 0		13280;13342		4	Max cape: Taverley	F	19	
-3339 3001 0		13280;13342		4	Max cape: Pollnivneach	F	19	
-1743 3517 0		13280;13342		4	Max cape: Hosidius	F	19	
-2669 3629 0		13280;13342		4	Max cape: Rellekka	F	19	
-2756 3176 0		13280;13342		4	Max cape: Brimhaven	F	19	
-2545 3097 0		13280;13342		4	Max cape: Yanille	F	19	
-3239 6077 0		13280;13342		4	Max cape: Prifddinas	F	19	
-2865 3546 0		13280;13342		4	Max cape: Warriors' Guild	F	19	
-2604 3401 0		13280;13342		4	Max cape: Fishing Guild	F	19	
-2931 3286 0		13280;13342		4	Max cape: Crafting Guild	F	19	
-2556 2917 0		13280;13342		4	Max cape: Feldip Hills	F	19	
-3144 3772 0		13280;13342		4	Max cape: Black chinchompa	F	19	
-3144 3772 0		13280;13342		4	Max cape: Black chinchompa	F	19	
+1740 3517 0		13280;13342		2187=8	F	19	4	Max cape: Home
+2952 3224 0		13280;13342			F	19	4	Max cape: Rimmington
+2892 3465 0		13280;13342			F	19	4	Max cape: Taverley
+3339 3001 0		13280;13342			F	19	4	Max cape: Pollnivneach
+1743 3517 0		13280;13342			F	19	4	Max cape: Hosidius
+2669 3629 0		13280;13342			F	19	4	Max cape: Rellekka
+2756 3176 0		13280;13342			F	19	4	Max cape: Brimhaven
+2545 3097 0		13280;13342			F	19	4	Max cape: Yanille
+3239 6077 0		13280;13342			F	19	4	Max cape: Prifddinas
+2865 3546 0		13280;13342			F	19	4	Max cape: Warriors' Guild
+2604 3401 0		13280;13342			F	19	4	Max cape: Fishing Guild
+2931 3286 0		13280;13342			F	19	4	Max cape: Crafting Guild
+2556 2917 0		13280;13342			F	19	4	Max cape: Feldip Hills
+3144 3772 0		13280;13342			F	19	4	Max cape: Black chinchompa
+3144 3772 0		13280;13342			F	19	4	Max cape: Black chinchompa
 #Quest point cape (instead of using the item name we use the action teleport, we use the itemids to verifiy the item)								
-3144 3772 0		9813;13068		4	Quest point cape: Teleport	F	19	
-2689 3547 0		13221;13222		4	Music cape: Teleport	F	19	
-2574 3323 0		13069;19476		4	1. Achievement diary cape: Two-pints	F	19	
-3302 3122 0		13069;19476		4	2. Achievement diary cape: Jarr	F	19	
-2978 3347 0		13069;19476		4	3. Achievement diary cape: Sir Rebral	F	19	
-#2689 3547 0		13069;19476		4	4. Achievement diary cape: Thorodin	F	19	
-#2978 3347 0		13069;19476		4	3. Achievement diary cape: Sir Rebral	F	19	
-2659 3627 0		13069;19476		4	4. Achievement diary cape: Thorodin	F	19	
-2744 3443 0		13069;19476		4	5. Achievement diary cape: Flax keeper	F	19	
-2808 3192 0		13069;19476		4	6. Achievement diary cape: Pirate Jackie the Fruit	F	19	
+3144 3772 0		9813;13068			F	19	4	Quest point cape: Teleport
+2689 3547 0		13221;13222			F	19	4	Music cape: Teleport
+2574 3323 0		13069;19476			F	19	4	1. Achievement diary cape: Two-pints
+3302 3122 0		13069;19476			F	19	4	2. Achievement diary cape: Jarr
+2978 3347 0		13069;19476			F	19	4	3. Achievement diary cape: Sir Rebral
+#2689 3547 0		13069;19476			F	19	4	4. Achievement diary cape: Thorodin
+#2978 3347 0		13069;19476			F	19	4	3. Achievement diary cape: Sir Rebral
+2659 3627 0		13069;19476			F	19	4	4. Achievement diary cape: Thorodin
+2744 3443 0		13069;19476			F	19	4	5. Achievement diary cape: Flax keeper
+2808 3192 0		13069;19476			F	19	4	6. Achievement diary cape: Pirate Jackie the Fruit
 # The wiki lists these as (retired), so they are left out								
-#2862 2997 0		13069;19476		4	7. Achievement diary cape: Kaleb Paramaya	F	19	
-#2795 2947 0		13069;19476		4	8. Achievement diary cape: Jungle forester	F	19	
-#2453 5133 0		13069;19476		4	9. Achievement diary cape: TzHaar-Mej	F	19	
-1648 3665 0		13069;19476		4	A. Achievement diary cape: Elise	F	19	
-3234 3214 0		13069;19476		4	B. Achievement diary cape: Hatius Cosaintus	F	19	
-3465 3478 0		13069;19476		4	C. Achievement diary cape: Le-sabrè	F	19	
-3225 3415 0		13069;19476		4	D. Achievement diary cape: Toby	F	19	
-3121 3516 0		13069;19476		4	E. Achievement diary cape: Lesser Fanatic	F	19	
-2467 3459 0		13069;19476		4	F. Achievement diary cape: Elder Gnome child	F	19	
-3096 3227 0		13069;19476		4	G. Achievement diary cape: Twiggy O'Korn	F	19	
+#2862 2997 0		13069;19476			F	19	4	7. Achievement diary cape: Kaleb Paramaya
+#2795 2947 0		13069;19476			F	19	4	8. Achievement diary cape: Jungle forester
+#2453 5133 0		13069;19476			F	19	4	9. Achievement diary cape: TzHaar-Mej
+1648 3665 0		13069;19476			F	19	4	A. Achievement diary cape: Elise
+3234 3214 0		13069;19476			F	19	4	B. Achievement diary cape: Hatius Cosaintus
+3465 3478 0		13069;19476			F	19	4	C. Achievement diary cape: Le-sabrè
+3225 3415 0		13069;19476			F	19	4	D. Achievement diary cape: Toby
+3121 3516 0		13069;19476			F	19	4	E. Achievement diary cape: Lesser Fanatic
+2467 3459 0		13069;19476			F	19	4	F. Achievement diary cape: Elder Gnome child
+3096 3227 0		13069;19476			F	19	4	G. Achievement diary cape: Twiggy O'Korn
 								
 # Quest Items								
 # Ectophial - includes the empty version								
-3659 3523 0		4251;4252		4	Ectophial	F	19	
-2330 3171 0		6099;6100;6101;6102;13102		4	Teleport crystal: Lletya	T	19	
-3264 6066 0		6099;6100;6101;6102;13102	Song of the Elves	4	Teleport crystal: Prifddinas	T	19	
-2330 3171 0		23946		4	Eternal teleport crystal: Lletya	F	19	
-3264 6066 0		23946	Song of the Elves	4	Eternal teleport crystal: Prifddinas	F	19	
-2465 3495 0		19564		4	Royal seed pod	F	29	
-2465 3495 0		9469		4	Grand seed pod	T	29	
+3659 3523 0		4251;4252			F	19	4	Ectophial
+2330 3171 0		6099;6100;6101;6102;13102			T	19	4	Teleport crystal: Lletya
+3264 6066 0		6099;6100;6101;6102;13102	Song of the Elves		T	19	4	Teleport crystal: Prifddinas
+2330 3171 0		23946			F	19	4	Eternal teleport crystal: Lletya
+3264 6066 0		23946	Song of the Elves		F	19	4	Eternal teleport crystal: Prifddinas
+2465 3495 0		19564			F	29	4	Royal seed pod
+2465 3495 0		9469			T	29	4	Grand seed pod
 # Enchanted lyre - 4493 is DIARY_FREMENNIK_HARD, 4494 is DIARY_FREMENNIK_ELITE								
-2662 3644 0		3691;6125;6126;6127;13079		4	Enchanted lyre: Rellekka	T	19	
-2551 3755 0		3691;6125;6126;6127;13079		4	Enchanted lyre: Waterbirth Island	T	19	4493=1
-2409 3809 0		3691;6125;6126;6127;13079		4	Enchanted lyre: Jatizso	T	19	4494=1
-2336 3802 0		3691;6125;6126;6127;13079		4	Enchanted lyre: Neitiznot	T	19	4494=1
-2662 3644 0		23458		4	Enchanted lyre(i): Rellekka	F	19	
-2551 3755 0		23458		4	Enchanted lyre(i): Waterbirth Island	F	19	4493=1
-2409 3809 0		23458		4	Enchanted lyre(i): Jatizso	F	19	4494=1
-2336 3802 0		23458		4	Enchanted lyre(i): Neitiznot	F	19	4494=1
-3105 9315 0		6707		4	Camulet: Enakhra's Temple	F	19	
-3191 2924 0		6707		4	Camulet: Bandit Camp Quarry	F	19	
-1713 3612 0		21760;25818	The Depths of Despair	4	Kharedst's memoirs: Lunch by the Lancalliums	T	19	6035>1
-1802 3748 0		21760;25818	The Queen of Thieves	4	Kharedst's memoirs: The Fisher's Flute	T	19	6035>1
-1478 3576 0		21760;25818	Tale of the Righteous	4	Kharedst's memoirs: History and Hearsay	T	19	6035>1
-1544 3762 0		21760;25818	The Forsaken Tower	4	Kharedst's memoirs: Jewelry of Jubilation	T	19	6035>1
-1680 3746 0		21760;25818	The Ascent of Arceuus	4	Kharedst's memoirs: A Dark Disposition	T	19	6035>1
-3649 3230 0		22400		4	Drakan's medallion: Ver Sinhaza	F	19	
-3592 3337 0		22400	Sins of the Father	4	Drakan's medallion: Darkmeyer	F	19	
+2662 3644 0		3691;6125;6126;6127;13079			T	19	4	Enchanted lyre: Rellekka
+2551 3755 0		3691;6125;6126;6127;13079		4493=1	T	19	4	Enchanted lyre: Waterbirth Island
+2409 3809 0		3691;6125;6126;6127;13079		4494=1	T	19	4	Enchanted lyre: Jatizso
+2336 3802 0		3691;6125;6126;6127;13079		4494=1	T	19	4	Enchanted lyre: Neitiznot
+2662 3644 0		23458			F	19	4	Enchanted lyre(i): Rellekka
+2551 3755 0		23458		4493=1	F	19	4	Enchanted lyre(i): Waterbirth Island
+2409 3809 0		23458		4494=1	F	19	4	Enchanted lyre(i): Jatizso
+2336 3802 0		23458		4494=1	F	19	4	Enchanted lyre(i): Neitiznot
+3105 9315 0		6707			F	19	4	Camulet: Enakhra's Temple
+3191 2924 0		6707			F	19	4	Camulet: Bandit Camp Quarry
+1713 3612 0		21760;25818	The Depths of Despair	6035>1	T	19	4	Kharedst's memoirs: Lunch by the Lancalliums
+1802 3748 0		21760;25818	The Queen of Thieves	6035>1	T	19	4	Kharedst's memoirs: The Fisher's Flute
+1478 3576 0		21760;25818	Tale of the Righteous	6035>1	T	19	4	Kharedst's memoirs: History and Hearsay
+1544 3762 0		21760;25818	The Forsaken Tower	6035>1	T	19	4	Kharedst's memoirs: Jewelry of Jubilation
+1680 3746 0		21760;25818	The Ascent of Arceuus	6035>1	T	19	4	Kharedst's memoirs: A Dark Disposition
+3649 3230 0		22400			F	19	4	Drakan's medallion: Ver Sinhaza
+3592 3337 0		22400	Sins of the Father		F	19	4	Drakan's medallion: Darkmeyer
 # todo: this only works if you've used a Slepey tablet on the medallion								
-3808 9700 0		22400		4	Drakan's medallion: Slepe	F	19	
+3808 9700 0		22400			F	19	4	Drakan's medallion: Slepe
 #mythical cape (instead of using the item name we use the action teleport, we use the itemids to verifiy the item)								
-2457 2850 0		21913;22114;24855		4	Mythical cape: Teleport	F	19	
+2457 2850 0		21913;22114;24855			F	19	4	Mythical cape: Teleport
 # Stony Basalt - 4493 is DIARY_FREMENNIK_HARD								
-2845 3694 0		22601		4	Stony basalt	T	19	
-2837 3695 0	73 Agility	22601		4	Stony basalt: Roof	T	19	4493=1
-2846 3938 0		22599		4	Icy basalt	T	19	
+2845 3694 0		22601			T	19	4	Stony basalt
+2837 3695 0	73 Agility	22601		4493=1	T	19	4	Stony basalt: Roof
+2846 3938 0		22599			T	19	4	Icy basalt
 								
 # Other								
-1934 4428 0		26948		4	Pharaoh's sceptre: Jalsavrah	T	19	
-3341 2827 0		26948		4	Pharaoh's sceptre: Jaleustrophos	T	19	
-3232 2897 0		26948		4	Pharaoh's sceptre: Jaldraocht	T	19	
-3313 2718 0		26948		4	Pharaoh's sceptre: Jaltevas	T	19	
-3081 3421 0		9013;21276		4	Skull sceptre	T	19	
-1579 3530 0		13393		4	1. Xeric's talisman: Xeric's Lookout	T	19	
-1752 3566 0		13393		4	2. Xeric's talisman: Xeric's Glade	T	19	
-1504 3815 0		13393		4	3. Xeric's talisman: Xeric's Inferno	T	19	
-1644 3673 0		13393		4	4. Xeric's talisman: Xeric's Heart	T	19	
+1934 4428 0		26948			T	19	4	Pharaoh's sceptre: Jalsavrah
+3341 2827 0		26948			T	19	4	Pharaoh's sceptre: Jaleustrophos
+3232 2897 0		26948			T	19	4	Pharaoh's sceptre: Jaldraocht
+3313 2718 0		26948			T	19	4	Pharaoh's sceptre: Jaltevas
+3081 3421 0		9013;21276			T	19	4	Skull sceptre
+1579 3530 0		13393			T	19	4	1. Xeric's talisman: Xeric's Lookout
+1752 3566 0		13393			T	19	4	2. Xeric's talisman: Xeric's Glade
+1504 3815 0		13393			T	19	4	3. Xeric's talisman: Xeric's Inferno
+1644 3673 0		13393			T	19	4	4. Xeric's talisman: Xeric's Heart
 # Requires the use of an ancient tablet to activate								
-1254 3560 0		13393		4	5. Xeric's talisman: Xeric's Honour	T	19	
-3200 3355 0		13660		4	Chronicle: Teleport	T	19	
-3615 9461 0		26914		4	Amulet of the eye	F	19	
-2981 3276 0		26818		4	Ring of the elements: Air	T	19	
-3170 3155 0		26818		4	Ring of the elements: Water	T	19	
-3288 3468 0		26818		4	Ring of the elements: Earth	T	19	
-3314 3279 0		26818		4	Ring of the elements: Fire	T	19	
-2400 5982 0		24709		4	Hallowed crystal shard	T	19	
-3296 6436 0		28327		4	Ring of shadows: Ancient Vault	T	19	
+1254 3560 0		13393			T	19	4	5. Xeric's talisman: Xeric's Honour
+3200 3355 0		13660			T	19	4	Chronicle: Teleport
+3615 9461 0		26914			F	19	4	Amulet of the eye
+2981 3276 0		26818			T	19	4	Ring of the elements: Air
+3170 3155 0		26818			T	19	4	Ring of the elements: Water
+3288 3468 0		26818			T	19	4	Ring of the elements: Earth
+3314 3279 0		26818			T	19	4	Ring of the elements: Fire
+2400 5982 0		24709			T	19	4	Hallowed crystal shard
+3296 6436 0		28327			T	19	4	Ring of shadows: Ancient Vault
 # todo: The remaining Ring of shadows teleports require using a tablet on it once								
-2912 10336 0		28327		4	Ring of shadows: Ghorrock Dungeon	T	19	
-2019 6434 0		28327		4	Ring of shadows: The Scar	T	19	
-2588 6435 0		28327		4	Ring of shadows: Lassar Undercity	T	19	
-1175 3424 0		28327		4	Ring of shadows: The Stranglewood	T	19	
+2912 10336 0		28327			T	19	4	Ring of shadows: Ghorrock Dungeon
+2019 6434 0		28327			T	19	4	Ring of shadows: The Scar
+2588 6435 0		28327			T	19	4	Ring of shadows: Lassar Undercity
+1175 3424 0		28327			T	19	4	Ring of shadows: The Stranglewood
 								
 #Quetzal Whistle								
-1585 3053 0		29271;29273;29275	Children of the Sun	4	Quetzal whistle	T	19
-3164 3478 0		8007		4	Varrock tablet: Grand exchange	T	19	4070=0;4480=1;4585=1
+1585 3053 0		29271;29273;29275	Children of the Sun		T	19	4	Quetzal whistle
+3164 3478 0		8007		4480=1;4585=1	T	19	4	Varrock tablet: Grand exchange


### PR DESCRIPTION
## ShortestPathPlugin
- Add Civitas illa Fortis tablet
- Fix crafting cape teleport option for when equipped
- Reduced distance cost of quetzals now that we have all the varbits for locked quetzals
- Removed Standard Spellbook varbit for Varrock Tablet

**Also moved around the fields in this tsv to bring the varbits off of the end of the file to match up with others**

## AutoSmelting 
- Reworked logic in this script to not rely on waitForInventoryChanges, as with ring of forging this does not work because waitForInventoryChanges is checking for size changes in the inventory