### PR TITLE
Birdhunter Fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/birdhunter/BirdHunterScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/birdhunter/BirdHunterScript.java
@@ -78,7 +78,7 @@ public class BirdHunterScript extends Script {
     }
 
     public void updateHuntingArea(BirdHunterConfig config) {
-        int radius = 1;
+        int radius = 2;
         dynamicHuntingArea = new WorldArea(
                 huntingCenter.getX() - radius,
                 huntingCenter.getY() - radius,


### PR DESCRIPTION
Fixed radius issue, was accidentally set to 1 which caused issues when all 4 snares were taking up all 4 tiles.