### PR TITLE
Bug fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mahoganyhomez/MahoganyHomesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mahoganyhomez/MahoganyHomesConfig.java
@@ -6,7 +6,7 @@ import java.awt.*;
 
 @ConfigGroup(MahoganyHomesConfig.GROUP_NAME)
 @ConfigInformation("<h2>S-1D Home Raider</h2>\n" +
-        "<h3>BETA PREVIEW 4</h3>\n" +
+        "<h3>BETA PREVIEW 5</h3>\n" +
         "<p>1. <strong>Start anywhere:</strong> Just make sure to have teleports, saw and a hammer.</p>\n" +
         "<p>2. <strong>Contracts:</strong> Select your desired contract <em>BEFORE</em> starting.</p>\n" +
         "<p>3. <strong>Supplies:</strong> Stock up on the correct planks and Steel bars in the bank, the bot will handle resupplying on its own</p>\n" +

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mahoganyhomez/MahoganyHomesScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mahoganyhomez/MahoganyHomesScript.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class MahoganyHomesScript extends Script {
 
-    public static String version = "0.0.4";
+    public static String version = "0.0.5";
     @Inject
     MahoganyHomesPlugin plugin;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mahoganyhomez/MahoganyHomesScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mahoganyhomez/MahoganyHomesScript.java
@@ -261,7 +261,7 @@ public class MahoganyHomesScript extends Script {
                 && plugin.getCurrentHome().isInside(Rs2Player.getWorldLocation())
                 && Hotspot.isEverythingFixed()) {
             if(plugin.getConfig().usePlankSack() && planksInPlankSack() > 0){
-                if (Rs2Inventory.contains(ItemID.PLANK_SACK)) {
+                if (Rs2Inventory.contains(ItemID.PLANK_SACK) && Rs2Inventory.contains(ItemID.STEEL_BAR)) {
                     Rs2Item plankSack = Rs2Inventory.get(ItemID.PLANK_SACK);
                     if (plankSack != null) {
                         Rs2Inventory.interact(plankSack, "Empty");
@@ -351,7 +351,8 @@ public class MahoganyHomesScript extends Script {
             if (Rs2Bank.walkToBankAndUseBank(Rs2Bank.getNearestBank(currentHome.getLocation()))) {
                 sleep(600, 1200);
                 if(plugin.getConfig().usePlankSack()){
-
+                    if(Rs2Inventory.isFull() && !Rs2Inventory.contains(ItemID.STEEL_BAR))
+                        Rs2Bank.depositAll(plugin.getConfig().currentTier().getPlankSelection().getPlankId());
                     Rs2Bank.withdrawX(ItemID.STEEL_BAR, 4-steelBarsInInventory());
                     sleep(600, 1200);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
@@ -158,7 +158,7 @@ public class QoLPlugin extends Plugin {
         }
         if (config.autoStamina()) {
             Microbot.useStaminaPotsIfNeeded = true;
-            Microbot.runEnergyThreshold = config.staminaThreshold() * 1000;
+            Microbot.runEnergyThreshold = config.staminaThreshold() * 100;
         }
         autoRunScript.run(config);
         specialAttackScript.run(config);


### PR DESCRIPTION
# Changelog

### Improved Inventory Handling in Mahogany Homes Bot
- **Fixed bug with Plank Sack checks**: The bot no longer attempts to interact with the Plank Sack when Steel Bars are absent, preventing unnecessary actions.  
- **Updated bank interaction**: If the inventory is full and Steel Bars are missing, the bot automatically deposits specific plank types. This improves resource management and efficiency during runs.

### Adjusted Stamina Threshold Calculation in QoLPlugin
- **Corrected stamina threshold multiplier**: Changed from 1000 to 100 to ensure accurate energy level checks. This update helps prevent overuse or mismanagement of stamina potions.