### PR TITLE
AIO Magic Fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/aiomagic/AIOMagicConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/aiomagic/AIOMagicConfig.java
@@ -21,7 +21,6 @@ public interface AIOMagicConfig extends Config {
 	String npcName = "npcName";
 	String staff = "staff";
 	String teleportSpell = "teleportSpell";
-	String castAmount = "castAmount";
 
 	@ConfigSection(
 			name = "General Settings",
@@ -133,16 +132,5 @@ public interface AIOMagicConfig extends Config {
 	)
 	default Rs2Staff staff() {
 		return Rs2Staff.STAFF_OF_AIR;
-	}
-
-	@ConfigItem(
-			keyName = castAmount,
-			name = "Total amount of casts",
-			description = "Define the amount of teleport casts",
-			position = 2,
-			section = teleportSection
-	)
-	default int castAmount() {
-		return 1000;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/aiomagic/AIOMagicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/aiomagic/AIOMagicPlugin.java
@@ -75,8 +75,6 @@ public class AIOMagicPlugin extends Plugin {
 	private TeleportSpell teleportSpell;
 	@Getter
 	private Rs2Staff staff;
-	@Getter
-	private int totalCasts;
 	
 	@Override
 	protected void startUp() throws AWTException {
@@ -86,7 +84,6 @@ public class AIOMagicPlugin extends Plugin {
 		npcName = config.npcName();
 		teleportSpell = config.teleportSpell();
 		staff = config.staff();
-		totalCasts = config.castAmount();
 
 		if (overlayManager != null) {
 			overlayManager.add(aioMagicOverlay);
@@ -145,10 +142,6 @@ public class AIOMagicPlugin extends Plugin {
 
 		if (event.getKey().equals(AIOMagicConfig.staff)) {
 			staff = config.staff();
-		}
-
-		if (event.getKey().equals(AIOMagicConfig.castAmount)) {
-			totalCasts = config.castAmount();
 		}
 	}
 	

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/aiomagic/AIOMagicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/aiomagic/AIOMagicPlugin.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import net.runelite.api.GraphicID;
 import net.runelite.api.NPC;
 import net.runelite.api.Player;
+import net.runelite.api.Skill;
 import net.runelite.api.events.GraphicChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -17,7 +18,9 @@ import net.runelite.client.plugins.microbot.magic.aiomagic.enums.SuperHeatItem;
 import net.runelite.client.plugins.microbot.magic.aiomagic.enums.TeleportSpell;
 import net.runelite.client.plugins.microbot.magic.aiomagic.scripts.*;
 import net.runelite.client.plugins.microbot.util.magic.Rs2CombatSpells;
+import net.runelite.client.plugins.microbot.util.magic.Rs2Spells;
 import net.runelite.client.plugins.microbot.util.magic.Rs2Staff;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
@@ -58,7 +61,7 @@ public class AIOMagicPlugin extends Plugin {
 	@Inject
 	private TeleAlchScript teleAlchScript;
 
-	public static String version = "1.0.0";
+	public static String version = "1.1.0";
 	
 	@Getter
 	private Rs2CombatSpells combatSpell;
@@ -160,6 +163,10 @@ public class AIOMagicPlugin extends Plugin {
 			if (event.getActor().getGraphic() == GraphicID.SPLASH && player.getInteracting().equals(npc)) {
 			}
 		}
+	}
+	
+	public Rs2Spells getAlchSpell() {
+		return Rs2Player.getRealSkillLevel(Skill.MAGIC) >= 55 ? Rs2Spells.HIGH_LEVEL_ALCHEMY : Rs2Spells.LOW_LEVEL_ALCHEMY;
 	}
 
 	private List<String> updateItemList(String items) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/aiomagic/scripts/SuperHeatScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/aiomagic/scripts/SuperHeatScript.java
@@ -59,7 +59,7 @@ public class SuperHeatScript extends Script {
                     shutdown();
                     return;
                 }
-                
+
                 if (!plugin.getSuperHeatItem().hasRequiredLevel()) {
                     Microbot.showMessage("You do not have the required level for this item");
                     shutdown();
@@ -163,18 +163,22 @@ public class SuperHeatScript extends Script {
     private boolean hasStateChanged() {
         if (state == null) return true;
         if (state == MagicState.BANKING && hasRequiredItems()) return true;
-        return state == MagicState.CASTING && !hasRequiredItems();
+        if (state == MagicState.CASTING && !hasRequiredItems()) return true;
+        return false;
     }
 
     private MagicState updateState() {
-        if (state == null) return MagicState.BANKING;
+        if (state == null) return hasRequiredItems() ? MagicState.CASTING : MagicState.BANKING;
         if (state == MagicState.BANKING && hasRequiredItems()) return MagicState.CASTING;
         if (state == MagicState.CASTING && !hasRequiredItems()) return MagicState.BANKING;
         return null;
     }
 
     private boolean hasRequiredItems() {
-        return Rs2Inventory.hasItem(plugin.getSuperHeatItem().getItemID()) && Rs2Inventory.hasItemAmount(ItemID.COAL, plugin.getSuperHeatItem().getCoalAmount());
+        if (plugin.getSuperHeatItem().getCoalAmount() > 0) {
+            return Rs2Inventory.hasItem(plugin.getSuperHeatItem().getItemID()) && Rs2Inventory.hasItemAmount(ItemID.COAL, plugin.getSuperHeatItem().getCoalAmount());
+        }
+        return Rs2Inventory.hasItem(plugin.getSuperHeatItem().getItemID());
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
@@ -1710,6 +1710,45 @@ public class Rs2Bank {
     }
 
     /**
+     * Retrieves an Rs2Item from the bank based on the specified item ID.
+     *
+     * @param itemId the ID of the item to search for.
+     * @return the Rs2Item matching the item ID, or null if not found.
+     */
+    public static Rs2Item getBankItem(int itemId) {
+        return bankItems().stream()
+                .filter(item -> item.getId() == itemId)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Retrieves an Rs2Item from the bank based on the specified item name.
+     *
+     * @param itemName the name of the item to search for.
+     * @param exact whether to search for an exact match (true) or a partial match (false).
+     * @return the Rs2Item matching the item name, or null if not found.
+     */
+    public static Rs2Item getBankItem(String itemName, boolean exact) {
+        return bankItems.stream()
+                .filter(item -> exact
+                        ? item.getName().equalsIgnoreCase(itemName)
+                        : item.getName().toLowerCase().contains(itemName.toLowerCase()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Retrieves an Rs2Item from the bank based on a partial match of the specified item name.
+     *
+     * @param itemName the name of the item to search for.
+     * @return the Rs2Item matching the item name (partial match), or null if not found.
+     */
+    public static Rs2Item getBankItem(String itemName) {
+        return getBankItem(itemName, false);
+    }
+
+    /**
      * Retrieves the list of bank tab widgets.
      * <p>
      * This method runs on the client thread to fetch the bank tab container widget

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/magic/Rs2Magic.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/magic/Rs2Magic.java
@@ -626,6 +626,55 @@ public class Rs2Magic {
 
         return requiredRunes;
     }
+
+    /**
+     * Checks if the player has the required runes to cast a specified spell.
+     *
+     * @param spell          The spell to cast, represented as an {@link Rs2Spells} enum.
+     * @param checkRunePouch A boolean indicating whether to include runes from the rune pouch in the check.
+     * @return true if all required runes (including staff-provided runes) are available; false otherwise.
+     */
+    public static boolean hasRequiredRunes(Rs2Spells spell, boolean checkRunePouch) {
+        // Get the required runes for the spell
+        Map<Runes, Integer> requiredRunes = new HashMap<>(spell.getRequiredRunes());
+        
+        Rs2Staff equippedStaff = getRs2Staff(Rs2Equipment.get(EquipmentInventorySlot.WEAPON).getId());
+        if (equippedStaff != null) {
+            for (Runes providedRune : equippedStaff.getRunes()) {
+                requiredRunes.remove(providedRune);
+            }
+        }
+
+        // Collect available runes from inventory
+        Map<Runes, Integer> availableRunes = new HashMap<>();
+        for (Rs2Item item : Rs2Inventory.items()) {
+            Arrays.stream(Runes.values())
+                    .filter(rune -> rune.getItemId() == item.getId())
+                    .findFirst()
+                    .ifPresent(rune -> availableRunes.merge(rune, item.getQuantity(), Integer::sum));
+        }
+
+        // Optionally include runes from the rune pouch
+        if (checkRunePouch) {
+            RunePouch.getRunes().forEach((runeId, quantity) -> {
+                Arrays.stream(Runes.values())
+                        .filter(rune -> rune.getItemId() == runeId)
+                        .findFirst()
+                        .ifPresent(rune -> availableRunes.merge(rune, quantity, Integer::sum));
+            });
+        }
+
+        // Check if all required runes are available
+        for (Map.Entry<Runes, Integer> entry : requiredRunes.entrySet()) {
+            int requiredAmount = entry.getValue();
+            int availableAmount = availableRunes.getOrDefault(entry.getKey(), 0);
+            if (availableAmount < requiredAmount) {
+                return false; // Not enough of the required rune
+            }
+        }
+
+        return true; // All required runes are available
+    }
     
     //DATA
 

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -1638,15 +1638,15 @@
 2418 3416 0	2418 3416 1	Climb-up;Staircase;16675						
 2420 3417 0	2418 3416 1	Climb-up;Staircase;16675						
 2420 3418 0	2418 3416 1	Climb-up;Staircase;16675						
-2443 3415 0	2445 3416 1	Climb-up;Staircase;16675						
+2443 3415 0	2445 3416 1	Climb-up;Staircase;16675					10	
 2445 3416 1	2446 3415 0	Climb-down;Staircase;16677						
-2446 3415 0	2445 3416 1	Climb-up;Staircase;16675						
-2446 3414 0	2445 3416 1	Climb-up;Staircase;16675						
-2445 3413 0	2445 3416 1	Climb-up;Staircase;16675						
-2444 3413 0	2445 3416 1	Climb-up;Staircase;16675						
-2443 3414 0	2445 3416 1	Climb-up;Staircase;16675						
-2445 3416 0	2445 3416 1	Climb-up;Staircase;16675						
-2444 3416 0	2445 3416 1	Climb-up;Staircase;16675						
+2446 3415 0	2445 3416 1	Climb-up;Staircase;16675					10	
+2446 3414 0	2445 3416 1	Climb-up;Staircase;16675					10	
+2445 3413 0	2445 3416 1	Climb-up;Staircase;16675					10	
+2444 3413 0	2445 3416 1	Climb-up;Staircase;16675					10	
+2443 3414 0	2445 3416 1	Climb-up;Staircase;16675					10	
+2445 3416 0	2445 3416 1	Climb-up;Staircase;16675					10	
+2444 3416 0	2445 3416 1	Climb-up;Staircase;16675					10	
 2445 3433 1	2444 3434 0	Climb-down;Staircase;16677						
 2444 3434 0	2445 3433 1	Climb-up;Staircase;16675					10	
 2444 3435 0	2445 3433 1	Climb-up;Staircase;16675					10	
@@ -4140,11 +4140,11 @@
 2696 5277 1	2488 5536 0	Enter;Doorway;23052						
 								
 # Slayer Cave								
-2796 3616 0	2808 10002 0	Enter;Cave Entrance;2123						
-2808 10002 0	2796 3615 0	Enter;Tunnel;2141						
-2796 3615 0	2808 10002 0	Enter;Cave Entrance;2123						
-2808 10003 0	2796 3615 0	Enter;Tunnel;2141						
-2796 3614 0	2808 10002 0	Enter;Cave Entrance;2123						
+2796 3616 0	2808 10002 0	Enter;Cave Entrance;2123					1	
+2808 10002 0	2796 3615 0	Enter;Tunnel;2141					1	
+2796 3615 0	2808 10002 0	Enter;Cave Entrance;2123					1	
+2808 10003 0	2796 3615 0	Enter;Tunnel;2141					1	
+2796 3614 0	2808 10002 0	Enter;Cave Entrance;2123					1	
 2808 10001 0	2796 3615 0	Enter;Tunnel;2141						
 2703 9991 0	2703 9989 0	Climb;Steps;29993						
 2703 9989 0	2703 9991 0	Climb;Steps;29993						

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -4140,11 +4140,11 @@
 2696 5277 1	2488 5536 0	Enter;Doorway;23052						
 								
 # Slayer Cave								
-2796 3616 0	2808 10002 0	Enter;Cave Entrance;2123					1	
-2808 10002 0	2796 3615 0	Enter;Tunnel;2141					1	
-2796 3615 0	2808 10002 0	Enter;Cave Entrance;2123					1	
-2808 10003 0	2796 3615 0	Enter;Tunnel;2141					1	
-2796 3614 0	2808 10002 0	Enter;Cave Entrance;2123					1	
+2796 3616 0	2808 10002 0	Enter;Cave Entrance;2123						
+2808 10002 0	2796 3615 0	Enter;Tunnel;2141						
+2796 3615 0	2808 10002 0	Enter;Cave Entrance;2123						
+2808 10003 0	2796 3615 0	Enter;Tunnel;2141						
+2796 3614 0	2808 10002 0	Enter;Cave Entrance;2123						
 2808 10001 0	2796 3615 0	Enter;Tunnel;2141						
 2703 9991 0	2703 9989 0	Climb;Steps;29993						
 2703 9989 0	2703 9991 0	Climb;Steps;29993						


### PR DESCRIPTION
## AIO Magic
- All Scripts: Simply State switching by checking if we have enough for 1 cast of the spell instead of defined number of casts/total amount of alch items
- SuperHeat Script: Fix hasRequiredItems to only check for Coal in Inventory if SuperHeatItem requires Coal
- Alch Script & TeleAlchScript: Fix stuck in CASTING state if there is no item in alch slot by interacting with the inventory once 
- Alch Script & TeleAlchScript: Switch between setWithdrawAsNote & setWithdrawAsItem based on if the item is stackable or not

## Rs2Magic
- Add hasRequiredRunes method for Rs2Spells, similar to the method that was created for Rs2CombatSpells

## Rs2Bank
- Add getBankItem to retrieve the Rs2Item Object from a bank item

## ShortestPathPlugin
- Increase Duration of staircase near gnome stronghold bank