### PR TITLE
Uses config option in Web Walker to walk instead of run when banking.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathConfig.java
@@ -277,6 +277,18 @@ public interface ShortestPathConfig extends Config {
         return 1;
     }
 
+    @ConfigItem(
+            keyName = "runToBanks",
+            name = "Activate Run When Banking",
+            description = "Toggle run to on if it's off when banking",
+            position = 22,
+            section = sectionSettings
+    )
+    default boolean runToBanks() {
+        return true;
+    }
+
+
     @Units(
             value = Units.TICKS
     )

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
@@ -47,6 +47,7 @@ import static net.runelite.client.plugins.microbot.util.npc.Rs2Npc.hoverOverActo
 @SuppressWarnings("unused")
 @Slf4j
 public class Rs2Bank {
+
     public static final int BANK_ITEM_WIDTH = 36;
     public static final int BANK_ITEM_HEIGHT = 32;
     public static final int BANK_ITEM_Y_PADDING = 4;
@@ -1358,7 +1359,7 @@ public class Rs2Bank {
      */
     public static boolean walkToBank(BankLocation bankLocation) {
         if (Rs2Bank.isOpen()) return true;
-        Rs2Player.toggleRunEnergy(true);
+        if(Rs2Walker.config.runToBanks()){Rs2Player.toggleRunEnergy(true);}
         Microbot.status = "Walking to nearest bank " + bankLocation.toString();
         Rs2Walker.walkTo(bankLocation.getWorldPoint(), 4);
         return bankLocation.getWorldPoint().distanceTo2D(Microbot.getClient().getLocalPlayer().getWorldLocation()) <= 4;
@@ -1403,7 +1404,13 @@ public class Rs2Bank {
      */
     public static boolean walkToBankAndUseBank(BankLocation bankLocation) {
         if (Rs2Bank.isOpen()) return true;
-        Rs2Player.toggleRunEnergy(true);
+
+        if (Rs2Walker.config.runToBanks()) {
+            Rs2Player.toggleRunEnergy(true);
+        } else if (!Rs2Walker.config.runToBanks()) {
+            Rs2Player.toggleRunEnergy(false);
+        }
+
         Microbot.status = "Walking to nearest bank " + bankLocation.toString();
         boolean result = bankLocation.getWorldPoint().distanceTo(Microbot.getClient().getLocalPlayer().getWorldLocation()) <= 8;
         if (result) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
@@ -1359,7 +1359,13 @@ public class Rs2Bank {
      */
     public static boolean walkToBank(BankLocation bankLocation) {
         if (Rs2Bank.isOpen()) return true;
-        if(Rs2Walker.config.runToBanks()){Rs2Player.toggleRunEnergy(true);}
+
+        if (Rs2Walker.config.runToBanks()) {
+            Rs2Player.toggleRunEnergy(true);
+        } else if (!Rs2Walker.config.runToBanks()) {
+            Rs2Player.toggleRunEnergy(false);
+        }
+        
         Microbot.status = "Walking to nearest bank " + bankLocation.toString();
         Rs2Walker.walkTo(bankLocation.getWorldPoint(), 4);
         return bankLocation.getWorldPoint().distanceTo2D(Microbot.getClient().getLocalPlayer().getWorldLocation()) <= 4;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -16,6 +16,7 @@ import net.runelite.client.plugins.microbot.shortestpath.ShortestPathPlugin;
 import net.runelite.client.plugins.microbot.shortestpath.Transport;
 import net.runelite.client.plugins.microbot.shortestpath.TransportType;
 import net.runelite.client.plugins.microbot.shortestpath.pathfinder.Pathfinder;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.coords.Rs2LocalPoint;
 import net.runelite.client.plugins.microbot.util.coords.Rs2WorldArea;
@@ -26,10 +27,8 @@ import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Item;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
-import net.runelite.client.plugins.microbot.util.math.Random;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
-import net.runelite.client.plugins.microbot.util.misc.Rs2UiHelper;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.player.Rs2Pvp;
@@ -42,7 +41,6 @@ import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
 import java.awt.*;
 import java.util.List;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
@@ -313,9 +311,18 @@ public class Rs2Walker {
                     var finalTile = moveableTiles.length > 0 ? moveableTiles[Rs2Random.between(0, moveableTiles.length)] : path.get(path.size() - 1);
 
                     if (Rs2Tile.isTileReachable(finalTile)) {
-                        if (Rs2Walker.walkFastCanvas(finalTile)) {
-                            sleepUntil(() -> Rs2Player.getWorldLocation().distanceTo(finalTile) < 2, 3000);
+                        if (Rs2Walker.config.runToBanks()) {
+                            if (Rs2Walker.walkFastCanvas(finalTile)) {
+                                sleepUntil(() -> Rs2Player.getWorldLocation().distanceTo(finalTile) < 2, 3000);
+                            }
                         }
+                        else if (Rs2Bank.isNearBank(10))
+                        {
+                            if (Rs2Walker.walkFastCanvas(finalTile, false)) {
+                                sleepUntil(() -> Rs2Player.getWorldLocation().distanceTo(finalTile) < 2, 3000);
+                            }
+                        }
+
                     }
 
                 }


### PR DESCRIPTION
1. One might wish to walk when banking to preserve energy. As it stands now it's automatic to run, however this PR will introduce a config option in the Web Walker that when de-selected allows the user to walk when banking.
 
2. This change does not intefere directly with the walkFastCanvas method but instead utilises it's (toggleRun) condition, setting it to false when the method is called during the final tile processing of the web walker.  