### PR TITLE
Add Deposit Boxes & Update Bank Requirements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/aiomagic/scripts/SuperHeatScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magic/aiomagic/scripts/SuperHeatScript.java
@@ -57,7 +57,7 @@ public class SuperHeatScript extends Script {
                     shutdown();
                     return;
                 }
-                
+
                 if (!plugin.getSuperHeatItem().hasRequiredLevel()) {
                     Microbot.showMessage("You do not have the required level for this item");
                     shutdown();
@@ -161,7 +161,8 @@ public class SuperHeatScript extends Script {
     private boolean hasStateChanged() {
         if (state == null) return true;
         if (state == MagicState.BANKING && hasRequiredItems()) return true;
-        return state == MagicState.CASTING && !hasRequiredItems();
+        if (state == MagicState.CASTING && !hasRequiredItems()) return true;
+        return false;
     }
 
     private MagicState updateState() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/shootingstar/ShootingStarPlugin.java
@@ -23,6 +23,7 @@ import net.runelite.client.plugins.microbot.mining.shootingstar.enums.ShootingSt
 import net.runelite.client.plugins.microbot.mining.shootingstar.model.Star;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.security.Login;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -422,7 +423,7 @@ public class ShootingStarPlugin extends Plugin {
                 
                 // Set distance to the distance that is found in the map for the duplicate location or calculate shortest distance if not found
                 int distance;
-                distance = Objects.requireNonNullElseGet(existingDistance, () -> Rs2Player.distanceTo(starLocation));
+                distance = Objects.requireNonNullElseGet(existingDistance, () -> Rs2Walker.getTotalTiles(Rs2Player.getWorldLocation(), starLocation));
 
                 distanceMap.computeIfAbsent(distance, k -> new ArrayList<>()).add(star);
             }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
@@ -1304,28 +1304,22 @@ public class Rs2Bank {
 
     public static BankLocation getNearestBank(WorldPoint worldPoint) {
         Microbot.log("Calculating nearest bank path...");
-        BankLocation nearest = null;
-        double dist = Double.MAX_VALUE;
-        WorldPoint location;
-        double currDist;
-        for (BankLocation bankLocation : BankLocation.values()) {
-            if (!bankLocation.hasRequirements()) continue;
-
-            currDist = Rs2Walker.getTotalTiles(bankLocation.getWorldPoint());
-
-            if (nearest == null || currDist < dist) {
-                dist = currDist;
-                nearest = bankLocation;
-            }
-        }
-        if (nearest != null) {
-            Microbot.log("Found nearest bank: " + nearest.name());
+        
+        BankLocation bankLocation = Arrays.stream(BankLocation.values())
+                .parallel()
+                .filter(BankLocation::hasRequirements)
+                .min(Comparator.comparingDouble(bl ->
+                        Rs2Walker.getTotalTiles(worldPoint, bl.getWorldPoint())))
+                .orElse(null);
+        
+        if (bankLocation != null) {
+            Microbot.log("Found nearest bank: " + bankLocation.name());
+            return bankLocation;
         } else {
-            Microbot.log("Unable to find a bank");
+            Microbot.log("Unable to find nearest bank");
+            return null;
         }
-        return nearest;
     }
-
 
     /**
      * Walk to the closest bank

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/enums/BankLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/enums/BankLocation.java
@@ -2,10 +2,7 @@ package net.runelite.client.plugins.microbot.util.bank.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.runelite.api.Quest;
-import net.runelite.api.QuestState;
-import net.runelite.api.Skill;
-import net.runelite.api.Varbits;
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
@@ -14,6 +11,7 @@ import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 @Getter
 @RequiredArgsConstructor
 public enum BankLocation {
+    ALDARIN(new WorldPoint(1398, 2927, 0)),
     AL_KHARID(new WorldPoint(3270, 3166, 0)),
     ARCEUUS(new WorldPoint(1624, 3745, 0)),
     ARDOUGNE_NORTH(new WorldPoint(2616, 3332, 0)),
@@ -32,13 +30,12 @@ public enum BankLocation {
     COOKS_GUILD(new WorldPoint(3147,3450,0)),
     CORSAIR_COVE(new WorldPoint(2570, 2864, 0)),
     CRAFTING_GUILD(new WorldPoint(2936, 3281, 0)),
+    DARKMEYER(new WorldPoint(3604, 3366, 0)),
     DIHN_BANK(new WorldPoint(1640, 3944, 0)),
-    DRAYNOR(new WorldPoint(3092, 3243, 0)),
+    DORGESH_KAAN_BANK(new WorldPoint(2702, 5350, 0)),
     DRAYNOR_VILLAGE(new WorldPoint(3093, 3245, 0)),
     DUEL_ARENA(new WorldPoint(3381, 3268, 0)),
     DWARF_MINE_BANK(new WorldPoint(2837, 10207, 0)),
-    EAST_ARDOUGNE_NORTH(new WorldPoint(2618, 3332, 0)),
-    EAST_ARDOUGNE_SOUTH(new WorldPoint(2652, 3283, 0)),
     EDGEVILLE(new WorldPoint(3094, 3492, 0)),
     FALADOR_EAST(new WorldPoint(3014, 3355, 0)),
     FALADOR_WEST(new WorldPoint(2945, 3369, 0)),
@@ -70,6 +67,7 @@ public enum BankLocation {
     MOR_UL_REK(new WorldPoint(2541, 5140, 0)),
     MOTHERLOAD(new WorldPoint(3760, 5666, 0)),
     MOUNT_KARUULM(new WorldPoint(1324, 3824, 0)),
+    MYTHS_GUILD(new WorldPoint(2463, 2847, 1)),
     NARDAH(new WorldPoint(3428, 2892, 0)),
     NEITIZNOT(new WorldPoint(2337, 3807, 0)),
     PEST_CONTROL(new WorldPoint(2667, 2653, 0)),
@@ -92,7 +90,6 @@ public enum BankLocation {
     VARLAMORE_WEST(new WorldPoint(1647, 3118, 0)),
     VARROCK_EAST(new WorldPoint(3253, 3422, 0)),
     VARROCK_WEST(new WorldPoint(3183, 3441, 0)),
-    VINERY(new WorldPoint(1808, 3570, 0)),
     VINERY_BANK(new WorldPoint(1809, 3566, 0)),
     VOLCANO_BANK(new WorldPoint(3819, 3809, 0)),
     WINTERTODT(new WorldPoint(1640, 3944, 0)),
@@ -174,13 +171,104 @@ public enum BankLocation {
                 return Microbot.getVarbitValue(933) > 1;
             case LLETYA:
                 // Requires Mournings End Part 1 in progress or completed
-                return Rs2Player.getQuestState(Quest.MOURNINGS_END_PART_I) == QuestState.IN_PROGRESS || Rs2Player.getQuestState(Quest.MOURNINGS_END_PART_I) == QuestState.FINISHED;
+                return Rs2Player.getQuestState(Quest.MOURNINGS_END_PART_I) != QuestState.NOT_STARTED;
             case PRIFDDINAS:
                 // Requires Song of the elves to be completed
                 return Rs2Player.getQuestState(Quest.SONG_OF_THE_ELVES) == QuestState.FINISHED;
+            case SHILO_VILLAGE:
+                // Requires Shilo Village to enter the village & use the bank
+                return Rs2Player.getQuestState(Quest.SHILO_VILLAGE) == QuestState.FINISHED;
+            case LUNAR_ISLE:
+                // Requires Lunar Diplomacy & Seal of passage OR Dream Mentor
+                if (Rs2Player.getQuestState(Quest.DREAM_MENTOR) != QuestState.FINISHED) {
+                    return Rs2Player.getQuestState(Quest.LUNAR_DIPLOMACY) == QuestState.FINISHED && Rs2Equipment.hasEquipped(ItemID.SEAL_OF_PASSAGE);
+                } else {
+                    return Rs2Player.getQuestState(Quest.DREAM_MENTOR) == QuestState.FINISHED;
+                }
+            case JATIZSO:
+            case NEITIZNOT:
+                // Requires The Fremennik Trials & The Fremennik Isles
+                return Rs2Player.getQuestState(Quest.THE_FREMENNIK_TRIALS) == QuestState.FINISHED && Rs2Player.getQuestState(Quest.THE_FREMENNIK_ISLES) == QuestState.FINISHED;
+            case BURGH_DE_ROTT:
+                // Requires Priest in Peril & In Aid of the Myreque
+                return Rs2Player.getQuestState(Quest.PRIEST_IN_PERIL) == QuestState.FINISHED && Rs2Player.getQuestState(Quest.IN_AID_OF_THE_MYREQUE) != QuestState.NOT_STARTED;
+            case CANIFIS:
+                // Requires Priest in Peril
+                return Rs2Player.getQuestState(Quest.PRIEST_IN_PERIL) == QuestState.FINISHED;
+            case CAM_TORUM:
+                // Requires Perilous Moons to be started
+                return Rs2Player.getQuestState(Quest.PERILOUS_MOONS) != QuestState.NOT_STARTED;
+            case ZANARIS:
+                // Requires Lost City, Fairytale part 1 & starting Fairytale part 2
+                return Rs2Player.getQuestState(Quest.LOST_CITY) == QuestState.FINISHED && 
+                        Rs2Player.getQuestState(Quest.FAIRYTALE_I__GROWING_PAINS) == QuestState.FINISHED && 
+                        Rs2Player.getQuestState(Quest.FAIRYTALE_II__CURE_A_QUEEN) != QuestState.NOT_STARTED;
+            case FOSSIL_ISLAND:
+                // TODO: How to check if the chest has been built? maybe there is a varbit?
+            case VOLCANO_BANK:
+            case FOSSIL_ISLAND_WRECK:
+                // Requires Bone Voyage
+                return Rs2Player.getQuestState(Quest.BONE_VOYAGE) == QuestState.FINISHED;
+            case ALDARIN:
+            case VARLAMORE_EAST:
+            case VARLAMORE_WEST:
+                // Requires Children of the Sun
+                return Rs2Player.getQuestState(Quest.CHILDREN_OF_THE_SUN) == QuestState.FINISHED;
+            case LOVAKENGJ:
+            case HOSIDIUS:
+            case PISCARILIUS:
+            case ARCEUUS:
+            case DIHN_BANK:
+            case WINTERTODT:
+            case SULPHUR_MINE:
+            case ZEAH_SAND_BANK:
+            case BLAST_MINE:
+            case SHAYZIEN_BANK:
+            case SHAYZIEN_CHEST:
+            case GREAT_KOUREND_CASTLE:
+            case MOUNT_KARUULM:
+                // Requires Client of Kourend
+                return Rs2Player.getQuestState(Quest.CLIENT_OF_KOUREND) == QuestState.FINISHED;
+            case DWARF_MINE_BANK:
+            case BLAST_FURNACE_BANK:
+                // Requires The Giant Dwarf
+                return Rs2Player.getQuestState(Quest.THE_GIANT_DWARF) == QuestState.FINISHED;
+            case CAMODZAAL:
+                // Requires Below Ice Mountain
+                return Rs2Player.getQuestState(Quest.BELOW_ICE_MOUNTAIN) == QuestState.FINISHED;
+            case DORGESH_KAAN_BANK:
+                // Requires Death to the Dorgeshuun
+                return Rs2Player.getQuestState(Quest.DEATH_TO_THE_DORGESHUUN) == QuestState.FINISHED;
+            case DARKMEYER:
+                // Requires Sins of the Father
+                return Rs2Player.getQuestState(Quest.SINS_OF_THE_FATHER) == QuestState.FINISHED;
+            case MYTHS_GUILD:
+                // Requires Dragon Slayer 2
+                return Rs2Player.getQuestState(Quest.DRAGON_SLAYER_II) == QuestState.FINISHED;
             case ROGUES_DEN_CHEST:
             case CAMELOT:
             case HALLOWED_SEPULCHRE:
+            case RUINS_OF_UNKAH:
+            case ISLE_OF_SOULS:
+            case PORT_KHAZARD:
+            case MOR_UL_REK:
+            case CATHERBY:
+            case NARDAH:
+            case LANDS_END:
+            case TZHAAR:
+            case YANILLE:
+            case GNOME_BANK:
+            case MOTHERLOAD:
+            case VINERY_BANK:
+            case PEST_CONTROL:
+            case ARDOUGNE_NORTH:
+            case ARDOUGNE_SOUTH:
+            case HOSIDIUS_KITCHEN:
+            case GNOME_TREE_BANK_WEST:
+            case BARBARIAN_OUTPOST:
+            case GNOME_TREE_BANK_SOUTH:
+            case ROGUES_DEN_EMERALD_BENEDICT:
+            case TREE_GNOME_STRONGHOLD_NIEVE:
                 return isMember();
             default:
                 return true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/depositbox/DepositBoxLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/depositbox/DepositBoxLocation.java
@@ -1,0 +1,225 @@
+package net.runelite.client.plugins.microbot.util.depositbox;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.*;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+@Getter
+@RequiredArgsConstructor
+public enum DepositBoxLocation {
+    CLAN_HALL(new WorldPoint(1744, 5475, 0)),
+    CORSAIR_COVE(new WorldPoint(2569, 2862, 0)),
+    SHANTAY_PASS(new WorldPoint(3309, 3124, 0)),
+    DRAYNOR_VILLAGE(new WorldPoint(3094, 3240, 0)),
+    EMIRS_ARENA(new WorldPoint(3383, 3273, 0)),
+    EDGEVILLE(new WorldPoint(3098, 3499, 0)),
+    FALADOR(new WorldPoint(3018, 3358, 0)),
+    GRAND_EXCHANGE(new WorldPoint(3174, 3493, 0)),
+    LUMBRIDGE(new WorldPoint(3210, 3217, 2)),
+    PORT_SARIM(new WorldPoint(3045, 3234, 0)),
+    VARROCK(new WorldPoint(3180, 3433, 0)),
+    ALDARIN(new WorldPoint(1395, 2925, 0)),
+    ARCEUUS(new WorldPoint(1626, 3737, 0)),
+    ARDOUGNE(new WorldPoint(2654, 3280, 0)),
+    BARBARIAN_ASSAULT(new WorldPoint(2537, 3572, 0)),
+    BLAST_FURNACE(new WorldPoint(1950, 4956, 0)),
+    BURGH_DE_ROTT(new WorldPoint(3498, 3210, 0)),
+    CAM_TORUM(new WorldPoint(1449, 9570, 1)),
+    CANIFIS(new WorldPoint(3509, 3474, 0)),
+    CATHERBY(new WorldPoint(2806, 3439, 0)),
+    CIVITAS_ILLA_FORTIS_EAST(new WorldPoint(1781, 3100, 0)),
+    CIVITAS_ILLA_FORTIS_WEST(new WorldPoint(1646, 3112, 0)),
+    CRAFTING_GUILD(new WorldPoint(2929, 3286, 0)),
+    DARKMEYER(new WorldPoint(3602, 3366, 0)),
+    DORGESH_KAAN(new WorldPoint(2705, 5345, 0)),
+    DWARVEN_MINE(new WorldPoint(3013, 9720, 0)),
+    ETCETERIA(new WorldPoint(2619, 3896, 0)),
+    FARMING_GUILD(new WorldPoint(1254, 3740, 0)),
+    FISHING_GUILD(new WorldPoint(2588, 3416, 0)),
+    THE_GAUNTLET_LOBBY(new WorldPoint(3038, 6129, 1)),
+    GWENITH(new WorldPoint(2202, 3409, 0)),
+    HOSIDIUS(new WorldPoint(1753, 3596, 0)),
+    ISLE_OF_SOULS(new WorldPoint(2210, 2861, 0)),
+    KELDAGRIM(new WorldPoint(2834, 10209, 0)),
+    KOUREND_CASTLE(new WorldPoint(1610, 3683, 2)),
+    LANDS_END(new WorldPoint(1507, 3421, 0)),
+    LEGENDS_GUILD(new WorldPoint(2731, 3376, 2)),
+    LLETYA(new WorldPoint(2350, 3162, 0)),
+    LOVAKENGJ(new WorldPoint(1533, 3741, 0)),
+    LUNAR_ISLE(new WorldPoint(2102, 3917, 0)),
+    MAGE_ARENA(new WorldPoint(3108, 10351, 0)),
+    MISTROCK(new WorldPoint(1383, 2869, 0)),
+    MOR_UL_REK(new WorldPoint(2451, 5179, 0)),
+    MOS_LE_HARMLESS(new WorldPoint(3679, 2984, 0)),
+    MOTHERLODE_MINE(new WorldPoint(3759, 5664, 0)),
+    MOUNT_KARUULM(new WorldPoint(1322, 3824, 0)),
+    MOUNT_QUIDAMORTEM(new WorldPoint(1252, 3571, 0)),
+    MYTHS_GUILD(new WorldPoint(2462, 2845, 1)),
+    NARDAH(new WorldPoint(3429, 2894, 0)),
+    PISCATORIS_FISHING_COLONY(new WorldPoint(2330, 3686, 0)),
+    PORT_KHAZARD(new WorldPoint(2664, 3159, 0)),
+    PORT_PHASMATYS(new WorldPoint(3686, 3471, 0)),
+    PORT_PISCARILIUS(new WorldPoint(1806, 3785, 0)),
+    PRIFDDINAS(new WorldPoint(3295, 6062, 0)),
+    QUETZACALLI_GORGE(new WorldPoint(1518, 3226, 0)),
+    ROGUES_DEN(new WorldPoint(3041, 4964, 1)),
+    RUINS_OF_UNKAH(new WorldPoint(3159, 2834, 0)),
+    SALTPETRE_MINE(new WorldPoint(1702, 3527, 0)),
+    SEERS_VILLAGE(new WorldPoint(2730, 3492, 0)),
+    SHAYZIEN(new WorldPoint(1501, 3613, 0)),
+    SHILO_VILLAGE(new WorldPoint(2852, 2951, 0)),
+    VER_SINHAZA(new WorldPoint(3655, 3209, 0)),
+    VOID_KNIGHTS_OUTPOST(new WorldPoint(2669, 2655, 0)),
+    OUTSIDE_THE_VOLCANIC_MINE(new WorldPoint(3820, 3808, 0)),
+    WARRIORS_GUILD(new WorldPoint(2846, 3536, 0)),
+    WINTERTODT_CAMP(new WorldPoint(1636, 3948, 0)),
+    WOODCUTTING_GUILD(new WorldPoint(1589, 3476, 0)),
+    YANILLE(new WorldPoint(2611, 3088, 0)),
+    ZANARIS(new WorldPoint(2382, 4462, 0));
+
+    private final WorldPoint worldPoint;
+
+    private boolean isMember() {
+        return Rs2Player.isMember() && Rs2Player.isInMemberWorld();
+    }
+    
+    public boolean hasRequirements() {
+        boolean hasLineOfSight = Microbot.getClient().getLocalPlayer().getWorldArea().hasLineOfSightTo(Microbot.getClient().getTopLevelWorldView(), worldPoint);
+        switch (this) {
+            case CRAFTING_GUILD:
+                boolean hasFaladorHardDiary = Microbot.getVarbitValue(Varbits.DIARY_FALADOR_HARD) == 1;
+                boolean hasMaxedCrafting = Rs2Player.getSkillRequirement(Skill.CRAFTING, 99, false);
+                boolean isWearingCraftingGuild = (Rs2Equipment.isWearing("brown apron") || Rs2Equipment.isWearing("golden apron")) ||
+                        (Rs2Equipment.isWearing("max cape") || Rs2Equipment.isWearing("max hood")) ||
+                        (Rs2Equipment.isWearing("crafting cape") || Rs2Equipment.isWearing("crafting hood"));
+
+                if (hasLineOfSight && isMember() && (hasMaxedCrafting || hasFaladorHardDiary)) return true;
+                return isMember() && isWearingCraftingGuild &&
+                        (hasMaxedCrafting || hasFaladorHardDiary);
+            case WARRIORS_GUILD:
+                if (hasLineOfSight && isMember()) return true;
+                return isMember() &&
+                        (Rs2Player.getSkillRequirement(Skill.ATTACK, 99, false) || Rs2Player.getSkillRequirement(Skill.STRENGTH, 99, false)) ||
+                        (Rs2Player.getRealSkillLevel(Skill.ATTACK) + Rs2Player.getRealSkillLevel(Skill.STRENGTH) >= 130);
+            case WOODCUTTING_GUILD:
+                if (hasLineOfSight && isMember()) return true;
+                return isMember() && Rs2Player.getSkillRequirement(Skill.WOODCUTTING, 60, true);
+            case FARMING_GUILD:
+                if (hasLineOfSight && isMember()) return true;
+                return isMember() && Rs2Player.getSkillRequirement(Skill.FARMING, 45, true);
+            case FISHING_GUILD:
+                if (hasLineOfSight && isMember()) return true;
+                return isMember() && Rs2Player.getSkillRequirement(Skill.FISHING, 68, true);
+            case LEGENDS_GUILD:
+                if (hasLineOfSight && isMember()) return true;
+                return isMember() && Rs2Player.getQuestState(Quest.LEGENDS_QUEST) == QuestState.FINISHED;
+            case PORT_PHASMATYS:
+                if (hasLineOfSight && isMember()) return true;
+                return isMember() && Rs2Player.getQuestState(Quest.GHOSTS_AHOY) == QuestState.FINISHED;
+            case CORSAIR_COVE:
+                // Requires The Corsair Curse
+                return Rs2Player.getQuestState(Quest.THE_CORSAIR_CURSE) == QuestState.FINISHED;
+            case CLAN_HALL:
+                // Requires Clan Membership, varbit 933
+                return Microbot.getVarbitValue(933) > 1;
+            case LLETYA:
+                // Requires Mournings End Part 1 in progress or completed
+                return Rs2Player.getQuestState(Quest.MOURNINGS_END_PART_I) == QuestState.IN_PROGRESS || Rs2Player.getQuestState(Quest.MOURNINGS_END_PART_I) == QuestState.FINISHED;
+            case THE_GAUNTLET_LOBBY:
+            case GWENITH:
+            case PRIFDDINAS:
+                // Requires Song of the elves to be completed
+                return Rs2Player.getQuestState(Quest.SONG_OF_THE_ELVES) == QuestState.FINISHED;
+            case BURGH_DE_ROTT:
+                // Requires Priest in Peril & In Aid of the Myreque
+                return Rs2Player.getQuestState(Quest.PRIEST_IN_PERIL) == QuestState.FINISHED && Rs2Player.getQuestState(Quest.IN_AID_OF_THE_MYREQUE) == QuestState.FINISHED;
+            case CANIFIS:
+                // Requires Priest in Peril
+                return Rs2Player.getQuestState(Quest.PRIEST_IN_PERIL) == QuestState.FINISHED;
+            case ZANARIS:
+                // Requires Lost City, Fairytale part 1 & starting Fairytale part 2
+                return Rs2Player.getQuestState(Quest.LOST_CITY) == QuestState.FINISHED &&
+                        Rs2Player.getQuestState(Quest.FAIRYTALE_I__GROWING_PAINS) == QuestState.FINISHED &&
+                        Rs2Player.getQuestState(Quest.FAIRYTALE_II__CURE_A_QUEEN) != QuestState.NOT_STARTED;
+            case CAM_TORUM:
+                // Requires Perilous Moons to be started
+                return Rs2Player.getQuestState(Quest.PERILOUS_MOONS) != QuestState.NOT_STARTED;
+            case LUNAR_ISLE:
+                // Requires Lunar Diplomacy & Seal of passage OR Dream Mentor
+                if (Rs2Player.getQuestState(Quest.DREAM_MENTOR) != QuestState.FINISHED) {
+                    return Rs2Player.getQuestState(Quest.LUNAR_DIPLOMACY) == QuestState.FINISHED && Rs2Equipment.hasEquipped(ItemID.SEAL_OF_PASSAGE);
+                } else {
+                    return Rs2Player.getQuestState(Quest.DREAM_MENTOR) == QuestState.FINISHED;
+                }
+            case DARKMEYER:
+                // Requires Sins of the Father
+                return Rs2Player.getQuestState(Quest.SINS_OF_THE_FATHER) == QuestState.FINISHED;
+            case BLAST_FURNACE:
+            case KELDAGRIM:
+                // Requires The Giant Dwarf
+                return Rs2Player.getQuestState(Quest.THE_GIANT_DWARF) == QuestState.FINISHED;
+            case DORGESH_KAAN:
+                // Requires Death to the Dorgeshuun
+                return Rs2Player.getQuestState(Quest.DEATH_TO_THE_DORGESHUUN) == QuestState.FINISHED;
+            case ALDARIN:
+            case CIVITAS_ILLA_FORTIS_EAST:
+            case CIVITAS_ILLA_FORTIS_WEST:
+            case QUETZACALLI_GORGE:
+            case MISTROCK:
+                // Requires Children of the Sun
+                return Rs2Player.getQuestState(Quest.CHILDREN_OF_THE_SUN) == QuestState.FINISHED;
+            case ARCEUUS:
+            case LOVAKENGJ:
+            case SHAYZIEN:
+            case KOUREND_CASTLE:
+            case PORT_PISCARILIUS:
+            case WINTERTODT_CAMP:
+            case MOUNT_QUIDAMORTEM:
+            case MOUNT_KARUULM:
+                // Requires Client of Kourend
+                return Rs2Player.getQuestState(Quest.CLIENT_OF_KOUREND) == QuestState.FINISHED;
+            case SHILO_VILLAGE:
+                // Requires Shilo Village to enter the village & use the bank
+                return Rs2Player.getQuestState(Quest.SHILO_VILLAGE) == QuestState.FINISHED;
+            case MYTHS_GUILD:
+                // Requires Dragon Slayer 2
+                return Rs2Player.getQuestState(Quest.DRAGON_SLAYER_II) == QuestState.FINISHED;
+            case OUTSIDE_THE_VOLCANIC_MINE:
+                // Requires Bone Voyage
+                return Rs2Player.getQuestState(Quest.BONE_VOYAGE) == QuestState.FINISHED;
+            case PISCATORIS_FISHING_COLONY:
+                // Requires to start Swan Song
+                return Rs2Player.getQuestState(Quest.SWAN_SONG) != QuestState.NOT_STARTED;
+            case MOS_LE_HARMLESS:
+                // Requires Cabin Fever
+                return Rs2Player.getQuestState(Quest.CABIN_FEVER) == QuestState.FINISHED;
+            case ARDOUGNE:
+            case CATHERBY:
+            case HOSIDIUS:
+            case ETCETERIA:
+            case LANDS_END:
+            case MAGE_ARENA:
+            case MOR_UL_REK:
+            case ROGUES_DEN:
+            case VER_SINHAZA:
+            case PORT_KHAZARD:
+            case DWARVEN_MINE:
+            case ISLE_OF_SOULS:
+            case SEERS_VILLAGE:
+            case SALTPETRE_MINE:
+            case RUINS_OF_UNKAH:
+            case MOTHERLODE_MINE:
+            case BARBARIAN_ASSAULT:
+            case VOID_KNIGHTS_OUTPOST:
+            case NARDAH:
+            case YANILLE:
+                return isMember();
+            default:
+                return true;
+        }
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/magic/Rs2Magic.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/magic/Rs2Magic.java
@@ -631,6 +631,55 @@ public class Rs2Magic {
 
         return requiredRunes;
     }
+
+    /**
+     * Checks if the player has the required runes to cast a specified spell.
+     *
+     * @param spell          The spell to cast, represented as an {@link Rs2Spells} enum.
+     * @param checkRunePouch A boolean indicating whether to include runes from the rune pouch in the check.
+     * @return true if all required runes (including staff-provided runes) are available; false otherwise.
+     */
+    public static boolean hasRequiredRunes(Rs2Spells spell, boolean checkRunePouch) {
+        // Get the required runes for the spell
+        Map<Runes, Integer> requiredRunes = new HashMap<>(spell.getRequiredRunes());
+        
+        Rs2Staff equippedStaff = getRs2Staff(Rs2Equipment.get(EquipmentInventorySlot.WEAPON).getId());
+        if (equippedStaff != null) {
+            for (Runes providedRune : equippedStaff.getRunes()) {
+                requiredRunes.remove(providedRune);
+            }
+        }
+
+        // Collect available runes from inventory
+        Map<Runes, Integer> availableRunes = new HashMap<>();
+        for (Rs2Item item : Rs2Inventory.items()) {
+            Arrays.stream(Runes.values())
+                    .filter(rune -> rune.getItemId() == item.getId())
+                    .findFirst()
+                    .ifPresent(rune -> availableRunes.merge(rune, item.getQuantity(), Integer::sum));
+        }
+
+        // Optionally include runes from the rune pouch
+        if (checkRunePouch) {
+            RunePouch.getRunes().forEach((runeId, quantity) -> {
+                Arrays.stream(Runes.values())
+                        .filter(rune -> rune.getItemId() == runeId)
+                        .findFirst()
+                        .ifPresent(rune -> availableRunes.merge(rune, quantity, Integer::sum));
+            });
+        }
+
+        // Check if all required runes are available
+        for (Map.Entry<Runes, Integer> entry : requiredRunes.entrySet()) {
+            int requiredAmount = entry.getValue();
+            int availableAmount = availableRunes.getOrDefault(entry.getKey(), 0);
+            if (availableAmount < requiredAmount) {
+                return false; // Not enough of the required rune
+            }
+        }
+
+        return true; // All required runes are available
+    }
     
     //DATA
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -528,11 +528,11 @@ public class Rs2Walker {
      * @param destination
      * @return
      */
-    public static int getTotalTiles(WorldPoint destination) {
+    public static int getTotalTiles(WorldPoint start, WorldPoint destination) {
         if (ShortestPathPlugin.getPathfinderConfig().getTransports().isEmpty()) {
             ShortestPathPlugin.getPathfinderConfig().refresh();
         }
-        Pathfinder pathfinder = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), Rs2Player.getWorldLocation(), destination);
+        Pathfinder pathfinder = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), start, destination);
         pathfinder.run();
         List<WorldPoint> path = pathfinder.getPath();
 

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
@@ -53,7 +53,7 @@
 2611 3390 0		11105;11107;11109;11111;11968;11970			Y	T	29	4	1. Skills necklace: Fishing Guild
 3049 9763 0		11105;11107;11109;11111;11968;11970			Y	T	29	4	2. Skills necklace: Mining Guild
 2933 3295 0		11105;11107;11109;11111;11968;11970			Y	T	29	4	3. Skills necklace: Crafting Guild
-3144 3438 0		11105;11107;11109;11111;11968;11970			Y	T	29	4	4. Skills necklace: Cooks' Guild
+3144 3438 0		11105;11107;11109;11111;11968;11970			Y	T	29	4	4. Skills necklace: Cooking Guild
 1662 3505 0		11105;11107;11109;11111;11968;11970			Y	T	29	4	5. Skills necklace: Woodcutting Guild
 1248 3725 0	45 Farming	11105;11107;11109;11111;11968;11970			Y	T	29	4	6. Skills necklace: Farming Guild
 1248 3719 0		11105;11107;11109;11111;11968;11970			Y	T	29	4	6. Skills necklace: Farming Guild


### PR DESCRIPTION
## Rs2Bank
- Update getNearestBank to leverage java streams instead of a for loop

## BankLocation
- Add Various quest requirements to BankLocations

## Rs2DepositBox
- Add methods for getNearestDepositBox, walkToDepositBox, walkToAndUseDepositBox & bankItemsAndWalkBackToOriginalPosition

## DepositBoxLocation
- Create Enum for list of DepositBoxes with various quest requirements

## Rs2Walker
- Update getTotalTiles to accept start WorldPoint param & not just use Rs2Player.getWorldLocation()

## ShortestPathPlugin
- Add DepositBoxes to ShortestPathPanel
- Put getNearestBank & getNearestDepositBox to be ran on Separate Thread
- Update DisplayInfo to Cooking Guild on Skills Necklace

## Rs2Magic
- Add hasRequiredRunes method to check for 1 cast of a spell

## ShootingStarPlugin
- Leverage getTotalTiles instead of getDistanceBetween