### PR TITLE
Make Rs2Player.isInCombat rely on Hitsplats instead of interacting

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotPlugin.java
@@ -248,27 +248,27 @@ public class MicrobotPlugin extends Plugin {
             }
         }
     }
-    
+
     @Subscribe
-    public void onGameTick(GameTick event) {
-        if (client.getLocalPlayer().isInteracting()) {
-            Actor interactingActor = client.getLocalPlayer().getInteracting();
-            if (interactingActor instanceof Player) {
-                if (ticks.get() == 2) {
-                    ticks.set(0);
-                    Rs2Player.updateCombatTime();
-                    Rs2Player.lastInteractWasPlayer = true;
-                } else {
-                    ticks.incrementAndGet();
-                }
-            } else if (interactingActor instanceof NPC) {
-                if (ticks.get() == 2) {
-                    ticks.set(0);
-                    if (Rs2Player.lastInteractWasPlayer) Rs2Player.lastInteractWasPlayer = false;
-                    Rs2Player.updateCombatTime();
-                } else {
-                    ticks.incrementAndGet();
-                }
+    public void onHitsplatApplied(HitsplatApplied event) {
+        // Case 1: Hitsplat applied to the local player (indicates someone or something is attacking you)
+        if (event.getActor().equals(Rs2Player.getLocalPlayer())) {
+            if (!event.getHitsplat().isOthers()) {
+                Rs2Player.updateCombatTime();
+            }
+        }
+
+        // Case 2: Hitsplat is applied to another player (indicates you are attacking another player)
+        else if (event.getActor() instanceof Player) {
+            if (event.getHitsplat().isMine()) {
+                Rs2Player.updateCombatTime();
+            }
+        }
+
+        // Case 3: Hitsplat is applied to an NPC (indicates you are attacking an NPC)
+        else if (event.getActor() instanceof NPC) {
+            if (event.getHitsplat().isMine()) {
+                Rs2Player.updateCombatTime();
             }
         }
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotPlugin.java
@@ -91,7 +91,6 @@ public class MicrobotPlugin extends Plugin {
     private PouchScript pouchScript;
     @Inject
     private PouchOverlay pouchOverlay;
-    private volatile AtomicInteger ticks = new AtomicInteger(0);
 
     @Override
     protected void startUp() throws AWTException {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -54,7 +54,6 @@ public class Rs2Player {
     public static Instant lastAnimationTime = null;
     private static final long COMBAT_TIMEOUT_MS = 10000;
     private static long lastCombatTime = 0;
-    public static boolean lastInteractWasPlayer = false;
     @Getter
     public static int lastAnimationID = AnimationID.IDLE;
 
@@ -712,14 +711,19 @@ public class Rs2Player {
     }
 
     /**
+     * Get the local player
+     * @return player
+     */
+    public static Player getLocalPlayer() {
+        return Microbot.getClient().getLocalPlayer();
+    }
+
+    /**
      * Checks if the player is in combat based on recent activity.
      *
      * @return True if the player is in combat, false otherwise.
      */
     public static boolean isInCombat() {
-        if (lastInteractWasPlayer) {
-            return (System.currentTimeMillis() - lastCombatTime < COMBAT_TIMEOUT_MS) && Microbot.getVarbitPlayerValue(1075) != -1;
-        }
         return System.currentTimeMillis() - lastCombatTime < COMBAT_TIMEOUT_MS;
     }
 


### PR DESCRIPTION
## Rs2Player
- Adjust isInCombat to not rely on the Varplayer 1075 considering this only changes if the player attacks someone

## MicrobotPlugin
- Change onGameTick event that was used for combat detection with hitsplat detection