### PR TITLE
String was not being recognised, changed to int, fixed energy potions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerConfig.java
@@ -91,9 +91,9 @@ public interface MossKillerConfig extends Config {
             section = basicGuideSection // Belongs to Basic Guide
     )
     default String GUIDE() {
-        return "NORMAL: Have runes for teleport to Varrock, swordfish, and bronze axe in the bank. Start in Varrock East Bank. Turn off Teleportation spells in Web Walker configuration.\n"
+        return "NORMAL: Have runes for teleport to Varrock, swordfish, and bronze axe in the bank. Start in Varrock East Bank. Turn off Teleportation spells in Web Walker configuration. Turn on Breakhandler.\n"
         + "ADVANCED: See Advanced Guide.\n"
-        + "TIPS: For tips with the plugin visit Microbot Discord -> Community Plugins -> Moss Killer Plugin";
+        + "TIPS: For tips with the plugin visit the Discord -> Community Plugins -> Moss Killer Plugin";
     }
 
     @ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
@@ -459,6 +459,8 @@ public class MossKillerPlugin extends Plugin {
     @Subscribe
     public void onHitsplatApplied(HitsplatApplied event) {
 
+        if(config.wildy()) {
+
         if (currentTarget != null) {
             wildyKillerScript.hitsplatApplied = event.getHitsplat().isMine();
         }
@@ -497,6 +499,7 @@ public class MossKillerPlugin extends Plugin {
 
             }
         }
+    }
     }
     /**
      * Determines which player caused the hitsplat based on interaction and proximity.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
@@ -67,7 +67,7 @@ public class MossKillerScript extends Script {
 
     // TODO: convert axe and food to be a list of all available stuff
     public int BRONZE_AXE = 1351;
-    public int FOOD = 373;
+    public int FOOD = SWORDFISH;
 
     public int MOSSY_KEY = 22374;
 
@@ -222,6 +222,8 @@ public class MossKillerScript extends Script {
 
         if (!Rs2Inventory.contains(FOOD) || BreakHandlerScript.breakIn <= 15){
             Microbot.log("Inventory does not contains FOOD or break in less than 15");
+            if (Rs2Inventory.contains(FOOD)) {Microbot.log("We have food");}
+                if (BreakHandlerScript.breakIn <= 15) {Microbot.log("Break in less than 15");}
             state = MossKillerState.TELEPORT;
             return;
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -1273,7 +1273,7 @@ public class WildyKillerScript extends Script {
         }
 
         int randomValue = (int) Rs2Random.truncatedGauss(60, 70, 4.0);
-        Rs2Player.eatAt(randomValue);
+        eatAt(randomValue);
 
         // Check if loot is nearby and pick it up if it's in LOOT_LIST
         for (int lootItem : LOOT_LIST) {
@@ -1441,7 +1441,7 @@ public class WildyKillerScript extends Script {
         state = MossKillerState.FIGHT_MOSS_GIANTS;
         }
 
-        if (!Rs2Inventory.hasItemAmount("Mind rune", 750) && mossKillerPlugin.currentTarget == null) {
+        if (!Rs2Inventory.hasItemAmount(MIND_RUNE, 750) && mossKillerPlugin.currentTarget == null) {
         Microbot.log("Inventory Empty or Not Recently Banked");
             int lobsterCount = Rs2Inventory.count(ItemID.SWORDFISH);
             if (lobsterCount < 17) {
@@ -1465,7 +1465,7 @@ public class WildyKillerScript extends Script {
         }
         }
 
-        if (Rs2Inventory.hasItemAmount("Mind rune", 750) && mossKillerPlugin.currentTarget == null) {
+        if (Rs2Inventory.hasItemAmount(MIND_RUNE, 750) && mossKillerPlugin.currentTarget == null) {
             if (MOSS_GIANT_AREA.contains(playerLocation) || CORRIDOR.contains(playerLocation) || TOTAL_FEROX_ENCLAVE.contains((playerLocation))){
                 Microbot.log("Looks like you're in the wilderness with 750 mind runes");
         if (Rs2Inventory.hasItem(FOOD) && Rs2Inventory.hasItem(LAW_RUNE) && Rs2Inventory.hasItem(AIR_RUNE) && !Rs2Inventory.hasItem(MOSSY_KEY)) {
@@ -1482,7 +1482,7 @@ public class WildyKillerScript extends Script {
         }
             }
         }
-        if (Rs2Inventory.hasItemAmount("Mind rune", 1500)) {
+        if (Rs2Inventory.hasItemAmount(MIND_RUNE, 1500)) {
             state = MossKillerState.BANK;
         }
             if (playerLocation.getY() < 3520) {
@@ -1538,7 +1538,7 @@ public class WildyKillerScript extends Script {
 
         sleep(1200);
 
-        if (Rs2Inventory.hasItemAmount("Mind rune", 1500) &&
+        if (Rs2Inventory.hasItemAmount(MIND_RUNE, 1500) &&
         Rs2Walker.getDistanceBetween(playerLocation, VARROCK_WEST_BANK) > 6)
         {state = MossKillerState.WALK_TO_BANK;}
 
@@ -1832,13 +1832,19 @@ public class WildyKillerScript extends Script {
             if (Rs2Inventory.hasItemAmount(ENERGY_POTION4, 1) && Rs2Player.getRunEnergy() <= 60) {
                 Rs2Inventory.interact(ENERGY_POTION4, "Drink");
                 sleepUntil(() -> Rs2Inventory.contains(ENERGY_POTION3));
+                sleep(900,1800);
                 Rs2Inventory.interact(ENERGY_POTION3, "Drink");
                 sleepUntil(() -> Rs2Inventory.contains(ENERGY_POTION2));
+                sleep(900,1800);
                 Rs2Inventory.interact(ENERGY_POTION2, "Drink");
                 sleepUntil(() -> Rs2Inventory.contains(ENERGY_POTION1));
+                sleep(900,1800);
                 Rs2Inventory.interact(ENERGY_POTION1, "Drink");
                 sleepUntil(() -> Rs2Inventory.contains(VIAL));
+                sleep(900,1800);
                 Rs2Bank.depositOne(VIAL);
+                sleep(900,1800);
+                Rs2Bank.withdrawOne(ENERGY_POTION4);
             }
 
             if (!Rs2Equipment.isWearing(STAFF_OF_FIRE))


### PR DESCRIPTION
Rs2Inventory.hasItemAmount in 1.6.9 didn't like "Mind rune" so hit it with MIND_RUNE and works now. A lot of conditions to run the script were dependant on the amount of mind runes in inventory being recognised. 

Drinking Energy Potion when banking when low energy only sipped 1 dose and now sips all doses, deposits vial and takes out another Energy Potion for the road.   