### PR TITLE
Added break handling support for AutoHunter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
@@ -153,6 +153,14 @@ public class AutoChinScript extends Script {
 
     public void handleBreaks() {
          int secondsUntilBreak = BreakHandlerScript.breakIn; // Time until the break
+
+        //Clear list incase user changed trap layout This should run about 2-4 minutes before break
+        if(secondsUntilBreak > 61 && secondsUntilBreak <200){
+            if(!boxtiles.isEmpty()){
+                boxtiles.clear();
+            }
+        }
+
         if (secondsUntilBreak > 0 && secondsUntilBreak <= 60) {
             // We're going on break in 1 minute or less.
             // Save Trap locations

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
@@ -29,6 +29,7 @@ public class AutoChinScript extends Script {
 
     public static boolean test = false;
     public static String version = "1.1.0";
+    private boolean oneRun = false;
     private List<WorldPoint> boxtiles = new ArrayList<>();
     private List<Integer> trapIds = Arrays.asList(
             ItemID.BOX_TRAP,
@@ -190,10 +191,11 @@ public class AutoChinScript extends Script {
                     }
                 }
             }
+            oneRun=true;
         }
 
         //We're back from our break
-        if (secondsUntilBreak > 60) {
+        if (secondsUntilBreak > 60&&oneRun) {
             if(!boxtiles.isEmpty()) {
                 //Setting traps down
                 for (WorldPoint LayTrapTile : boxtiles) {
@@ -211,22 +213,14 @@ public class AutoChinScript extends Script {
                         }
                         //we need to put a trap.
                         Microbot.log("Placing trap");
-                        if(!Rs2GroundItem.exists("Box trap", 0)) {
-                            if (Rs2Inventory.contains("Box trap")) {
+                        if (Rs2Inventory.contains("Box trap")) {
                                 Rs2Inventory.interact("Box trap", "Lay");
                                 sleep(3000, 5000);
-                            }
                         }
-                        //Stops the bot from putting too many traps down and spam click but also making it
-                        //susceptible to griefers
-                        if (Rs2GroundItem.exists("Box trap", 6)) {
-                            Rs2GroundItem.take("Box trap", 6);
-                            sleep(1000, 3000);
-                        }
-
                     }
                 }
             }
+            oneRun=false;
         }
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
@@ -158,7 +158,6 @@ public class AutoChinScript extends Script {
             // Save Trap locations
             for (int trapId : trapIds) {
                 List<GameObject> gameObjects = Rs2GameObject.getGameObjects(trapId);
-                if(boxtiles.isEmpty()) {
                     if (gameObjects != null) {
                         for (GameObject gameObject : gameObjects) {
                             if (gameObject != null) {
@@ -172,7 +171,6 @@ public class AutoChinScript extends Script {
                             }
                         }
                     }
-                }
             }
 
             // At this point, boxtiles should be populated with the world points of the old traps.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
@@ -152,39 +152,40 @@ public class AutoChinScript extends Script {
     }
 
     public void handleBreaks() {
-        int secondsUntilBreak = BreakHandlerScript.breakIn; // Time until the break
+         int secondsUntilBreak = BreakHandlerScript.breakIn; // Time until the break
         if (secondsUntilBreak > 0 && secondsUntilBreak <= 60) {
             // We're going on break in 1 minute or less.
             // Save Trap locations
-
             for (int trapId : trapIds) {
                 List<GameObject> gameObjects = Rs2GameObject.getGameObjects(trapId);
-
-                if (gameObjects != null) {
-                    for (GameObject gameObject : gameObjects) {
-                        if (gameObject != null) {
-                            WorldPoint location = gameObject.getWorldLocation();
-                            if (Rs2Player.distanceTo(gameObject.getWorldLocation()) > 6) {
-                                continue; // Skip traps beyond the range
-                            }
-                            if (!boxtiles.contains(location)) {
-                                boxtiles.add(location);
+                if(boxtiles.isEmpty()) {
+                    if (gameObjects != null) {
+                        for (GameObject gameObject : gameObjects) {
+                            if (gameObject != null) {
+                                WorldPoint location = gameObject.getWorldLocation();
+                                if (Rs2Player.getWorldLocation().distanceTo(location) > 5) {
+                                    continue; // Skip traps beyond the range
+                                }
+                                if (!boxtiles.contains(location)) {
+                                    boxtiles.add(location);
+                                }
                             }
                         }
                     }
                 }
             }
+
             // At this point, boxtiles should be populated with the world points of the old traps.
 
             // Dismantling traps for our break.
                 for (WorldPoint oldTile : boxtiles) {
                     if (Rs2GameObject.getGameObject(oldTile) != null) {
                         //Dismantle or Reset
-                        if (Rs2Player.distanceTo(oldTile) > 6) {
+                        if (Rs2Player.getWorldLocation().distanceTo(oldTile) > 5) {
                             continue; // Skip traps beyond the range
                         }
                         while (Rs2GameObject.getGameObject(oldTile) != null) {
-                            if (Rs2Player.distanceTo(oldTile) > 6) {
+                            if (Rs2Player.getWorldLocation().distanceTo(oldTile) > 5) {
                                 break; // Skip traps beyond the range
                             }
                             if (Rs2GameObject.interact(oldTile, "Dismantle")) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
@@ -9,6 +9,8 @@ import net.runelite.client.plugins.microbot.hunter.AutoHunterConfig;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.npc.Rs2NpcManager;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 
@@ -161,7 +163,7 @@ public class AutoChinScript extends Script {
                 if (gameObjects != null) {
                     for (GameObject gameObject : gameObjects) {
                         if (gameObject != null) {
-                            if(Rs2Player.distanceTo(gameObject.getWorldLocation())<6) {
+                            if(Rs2Player.distanceTo(gameObject.getWorldLocation())<=6) {
                                 WorldPoint location = gameObject.getWorldLocation();
                                 if (!boxtiles.contains(location)) {
                                     boxtiles.add(location);
@@ -177,15 +179,17 @@ public class AutoChinScript extends Script {
             if (Rs2GameObject.get("Box trap") != null||Rs2GroundItem.exists("Box trap", 6)||Rs2GameObject.get("Shaking box") != null) {
                 for (WorldPoint oldTile : boxtiles) {
                     if (Rs2GameObject.getGameObject(oldTile) != null) {
-                        //Dismantle or Reset
-                        while (Rs2GameObject.getGameObject(oldTile) != null) {
-                            if (Rs2GameObject.interact(oldTile, "Dismantle")) {
-                                sleep(1000, 3000);
-                                break;
-                            }
-                            if (Rs2GameObject.interact(oldTile, "Reset")) {
-                                sleep(1000, 3000);
-                                break;
+                        if(Rs2Player.distanceTo(oldTile) <=6) {
+                            //Dismantle or Reset
+                            while (Rs2GameObject.getGameObject(oldTile) != null) {
+                                if (Rs2GameObject.interact(oldTile, "Dismantle")) {
+                                    sleep(1000, 3000);
+                                    break;
+                                }
+                                if (Rs2GameObject.interact(oldTile, "Reset")) {
+                                    sleep(1000, 3000);
+                                    break;
+                                }
                             }
                         }
                     }
@@ -213,9 +217,22 @@ public class AutoChinScript extends Script {
                         }
                         //we need to put a trap.
                         Microbot.log("Placing trap");
-                        if (Rs2Inventory.contains("Box trap")) {
-                                Rs2Inventory.interact("Box trap", "Lay");
-                                sleep(3000, 5000);
+                        int maxTries = 0;
+                        while(Rs2GameObject.getGameObject(LayTrapTile) == null) {
+                            if(!Rs2GroundItem.exists("Box trap", 0)) {
+                                if (Rs2Inventory.contains("Box trap")) {
+                                    Rs2Inventory.interact("Box trap", "Lay");
+                                    sleep(4000, 6000);
+                                }
+                            } else {
+                                //Box trap item is on the ground letting main script handle setting it up.
+                                break;
+                            }
+                            if(maxTries>=3){
+                                Microbot.log("Failed, placing the trap");
+                                break;
+                            }
+                            maxTries++;
                         }
                     }
                 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
@@ -223,14 +223,14 @@ public class AutoChinScript extends Script {
                         Microbot.log("Placing trap");
                         int maxTries = 0;
                         while(Rs2GameObject.getGameObject(LayTrapTile) == null) {
-                            if(!Rs2GroundItem.exists("Box trap", 0)) {
+                            if(!Rs2GroundItem.exists("Box trap", 6)) {
                                 if (Rs2Inventory.contains("Box trap")) {
                                     Rs2Inventory.interact("Box trap", "Lay");
                                     sleep(4000, 6000);
                                 }
                             } else {
-                                //Box trap item is on the ground letting main script handle setting it up.
-                                break;
+                                Rs2GroundItem.take("Box trap", 6);
+                                sleep(4000, 6000);
                             }
                             if(maxTries>=3){
                                 Microbot.log("Failed, placing the trap");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/hunter/scripts/AutoChinScript.java
@@ -163,11 +163,12 @@ public class AutoChinScript extends Script {
                 if (gameObjects != null) {
                     for (GameObject gameObject : gameObjects) {
                         if (gameObject != null) {
-                            if(Rs2Player.distanceTo(gameObject.getWorldLocation())<=6) {
-                                WorldPoint location = gameObject.getWorldLocation();
-                                if (!boxtiles.contains(location)) {
-                                    boxtiles.add(location);
-                                }
+                            WorldPoint location = gameObject.getWorldLocation();
+                            if (Rs2Player.distanceTo(gameObject.getWorldLocation()) > 6) {
+                                continue; // Skip traps beyond the range
+                            }
+                            if (!boxtiles.contains(location)) {
+                                boxtiles.add(location);
                             }
                         }
                     }
@@ -176,25 +177,27 @@ public class AutoChinScript extends Script {
             // At this point, boxtiles should be populated with the world points of the old traps.
 
             // Dismantling traps for our break.
-            if (Rs2GameObject.get("Box trap") != null||Rs2GroundItem.exists("Box trap", 6)||Rs2GameObject.get("Shaking box") != null) {
                 for (WorldPoint oldTile : boxtiles) {
                     if (Rs2GameObject.getGameObject(oldTile) != null) {
-                        if(Rs2Player.distanceTo(oldTile) <=6) {
-                            //Dismantle or Reset
-                            while (Rs2GameObject.getGameObject(oldTile) != null) {
-                                if (Rs2GameObject.interact(oldTile, "Dismantle")) {
-                                    sleep(1000, 3000);
-                                    break;
-                                }
-                                if (Rs2GameObject.interact(oldTile, "Reset")) {
-                                    sleep(1000, 3000);
-                                    break;
-                                }
+                        //Dismantle or Reset
+                        if (Rs2Player.distanceTo(oldTile) > 6) {
+                            continue; // Skip traps beyond the range
+                        }
+                        while (Rs2GameObject.getGameObject(oldTile) != null) {
+                            if (Rs2Player.distanceTo(oldTile) > 6) {
+                                break; // Skip traps beyond the range
+                            }
+                            if (Rs2GameObject.interact(oldTile, "Dismantle")) {
+                                sleep(1000, 3000);
+                                break;
+                            }
+                            if (Rs2GameObject.interact(oldTile, "Reset")) {
+                                sleep(1000, 3000);
+                                break;
                             }
                         }
                     }
                 }
-            }
             oneRun=true;
         }
 


### PR DESCRIPTION
The script will now take the last minute before break to:

Save current trap locations.
Dismantle the traps so they're not lost when we break.
When we're back from the break set the traps back down. Making sure nothing else is there first. 

Then it'll continue like normal.

Tested with 8 breaks in a row no issue.
