### PR TITLE
Blocking Event Manager Fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEvent.java
@@ -3,4 +3,5 @@ package net.runelite.client.plugins.microbot;
 public interface BlockingEvent {
     boolean validate();
     boolean execute();
+    BlockingEventPriority priority();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEventManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEventManager.java
@@ -5,6 +5,7 @@ import net.runelite.client.plugins.microbot.util.events.DisableLevelUpInterfaceE
 import net.runelite.client.plugins.microbot.util.events.WelcomeScreenEvent;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Getter
@@ -14,6 +15,7 @@ public class BlockingEventManager {
     public BlockingEventManager() {
         blockingEvents.add(new WelcomeScreenEvent());
         blockingEvents.add(new DisableLevelUpInterfaceEvent());
+        sortBlockingEvents();
     }
     
     public void remove(BlockingEvent blockingEvent) {
@@ -22,5 +24,10 @@ public class BlockingEventManager {
     
     public void add(BlockingEvent blockingEvent) {
         blockingEvents.add(blockingEvent);
+        sortBlockingEvents();
+    }
+
+    private void sortBlockingEvents() {
+        blockingEvents.sort(Comparator.comparingInt(e -> -e.priority().getLevel()));
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEventPriority.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEventPriority.java
@@ -6,9 +6,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum BlockingEventPriority {
+    HIGHEST(20),
     HIGH(10),
     NORMAL(0),
-    LOW(-10);
+    LOW(-10),
+    LOWEST(-20);
 
     private final int level;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEventPriority.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEventPriority.java
@@ -1,0 +1,14 @@
+package net.runelite.client.plugins.microbot;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BlockingEventPriority {
+    HIGH(10),
+    NORMAL(0),
+    LOW(-10);
+
+    private final int level;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tutorialisland/TutorialIslandScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tutorialisland/TutorialIslandScript.java
@@ -315,7 +315,7 @@ public class TutorialIslandScript extends Script {
                 return;
             }
 
-            if (plugin.isToggleLevelUp() && !isLevelUpNotificationsEnabled()) {
+            if (plugin.isToggleLevelUp() && isLevelUpNotificationsEnabled()) {
                 disableLevelUpNotifications(true);
                 Rs2Random.waitEx(1200, 300);
                 return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DisableLevelUpInterfaceEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DisableLevelUpInterfaceEvent.java
@@ -1,16 +1,22 @@
 package net.runelite.client.plugins.microbot.util.events;
 
 import net.runelite.client.plugins.microbot.BlockingEvent;
+import net.runelite.client.plugins.microbot.BlockingEventPriority;
 import net.runelite.client.plugins.microbot.util.settings.Rs2Settings;
 
 public class DisableLevelUpInterfaceEvent implements BlockingEvent {
     @Override
     public boolean validate() {
-        return !Rs2Settings.isLevelUpNotificationsEnabled();
+        return Rs2Settings.isLevelUpNotificationsEnabled();
     }
 
     @Override
     public boolean execute() {
-        return Rs2Settings.disableLevelUpInterface();
+        return Rs2Settings.disableLevelUpNotifications();
+    }
+
+    @Override
+    public BlockingEventPriority priority() {
+        return BlockingEventPriority.NORMAL;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DisableLevelUpInterfaceEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DisableLevelUpInterfaceEvent.java
@@ -17,6 +17,6 @@ public class DisableLevelUpInterfaceEvent implements BlockingEvent {
 
     @Override
     public BlockingEventPriority priority() {
-        return BlockingEventPriority.NORMAL;
+        return BlockingEventPriority.HIGH;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/WelcomeScreenEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/WelcomeScreenEvent.java
@@ -3,6 +3,7 @@ package net.runelite.client.plugins.microbot.util.events;
 import net.runelite.api.annotations.Component;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.plugins.microbot.BlockingEvent;
+import net.runelite.client.plugins.microbot.BlockingEventPriority;
 import net.runelite.client.plugins.microbot.util.Global;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
@@ -23,5 +24,10 @@ public class WelcomeScreenEvent implements BlockingEvent {
 
         Global.sleepUntil(() -> !Rs2Widget.isWidgetVisible(WELCOME_SCREEN_COMPONENT_ID), 10000);
         return true;
+    }
+
+    @Override
+    public BlockingEventPriority priority() {
+        return BlockingEventPriority.HIGH;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/WelcomeScreenEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/WelcomeScreenEvent.java
@@ -28,6 +28,6 @@ public class WelcomeScreenEvent implements BlockingEvent {
 
     @Override
     public BlockingEventPriority priority() {
-        return BlockingEventPriority.HIGH;
+        return BlockingEventPriority.HIGHEST;
     }
 }


### PR DESCRIPTION
## Blocking Event Manager
- Add Priority to Blocking Event Manager, this will sort them to ensure that events are sorted by High -> Low

## Rs2Settings
- Remove disableLevelUpInterface & clean up disableLevelUpNotifications
- Fixed Varbit Value for isLevelUpNotificationsEnabled