### PR TITLE
Fix DisableLevelUpInterfaceEvent + Add Piscatoris Fishing Colony transports & BankLocation

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/enums/BankLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/enums/BankLocation.java
@@ -72,6 +72,7 @@ public enum BankLocation {
     NEITIZNOT(new WorldPoint(2337, 3807, 0)),
     PEST_CONTROL(new WorldPoint(2667, 2653, 0)),
     PISCARILIUS(new WorldPoint(1803, 3790, 0)),
+    PISCATORIS_FISHING_COLONY(new WorldPoint(2330, 3689, 0)),
     PORT_KHAZARD(new WorldPoint(2664, 3161, 0)),
     PORT_PHASMATYS(new WorldPoint(3688, 3467, 0)),
     PRIFDDINAS(new WorldPoint(3257, 6106, 0)),
@@ -247,6 +248,9 @@ public enum BankLocation {
             case MYTHS_GUILD:
                 // Requires Dragon Slayer 2
                 return Rs2Player.getQuestState(Quest.DRAGON_SLAYER_II) == QuestState.FINISHED;
+            case PISCATORIS_FISHING_COLONY:
+                // Requires Swan Song
+                return Rs2Player.getQuestState(Quest.SWAN_SONG) == QuestState.FINISHED;
             case ROGUES_DEN_CHEST:
             case CAMELOT:
             case HALLOWED_SEPULCHRE:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DisableLevelUpInterfaceEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DisableLevelUpInterfaceEvent.java
@@ -1,12 +1,23 @@
 package net.runelite.client.plugins.microbot.util.events;
 
+import net.runelite.api.annotations.Component;
 import net.runelite.client.plugins.microbot.BlockingEvent;
 import net.runelite.client.plugins.microbot.BlockingEventPriority;
 import net.runelite.client.plugins.microbot.util.settings.Rs2Settings;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
 public class DisableLevelUpInterfaceEvent implements BlockingEvent {
+    /**
+     * Checking the Report button will ensure that we are logged in, as there seems to be a small moment in time
+     * when at the welcome screen that Rs2Settings.isLevelUpNotificationsEnabled() will return true then turn back to false
+     * even if {@code Varbits.DISABLE_LEVEL_UP_INTERFACE} is 1 after clicking play button
+     */
+    @Component
+    private final int REPORT_BUTTON_COMPONENT_ID = 10616833;
+    
     @Override
     public boolean validate() {
+        if (!Rs2Widget.isWidgetVisible(REPORT_BUTTON_COMPONENT_ID)) return false;
         return Rs2Settings.isLevelUpNotificationsEnabled();
     }
 

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -4696,6 +4696,14 @@
 3264 6024 0	2240 3269 0	Exit;City Gate;36523	 					
 2239 3269 0	3263 6024 0	Enter;City Gate;36518	 					
 3263 6024 0	2239 3269 0	Exit;City Gate;36522
+
+# Piscatoris Fishing Colony
+2344 3650 0	2344 3655 0	Enter;Hole;12656			Swan Song			
+2344 3655 0	2344 3650 0	Enter;Hole;12656			Swan Song			
+2343 3661 0	2343 3663 0	Open;Colony gate;12723			Swan Song			
+2343 3663 0	2343 3661 0	Open;Colony gate;12723			Swan Song			
+2344 3661 0	2344 3663 0	Open;Colony gate;12725			Swan Song			
+2344 3663 0	2344 3661 0	Open;Colony gate;12725			Swan Song			
 # f2p altars (earth, air, fire, body, water)
 2793 4828 0	2980 3511 0	Use;Portal;34749
 2726 4832 0	3182 3162 0	Use;Portal;34750


### PR DESCRIPTION
## DisableLevelUpInterfaceEvent
- Added a check for the report button, this will ensure that we are fully logged in as it seems that there is a small moment of time when checking `Microbot.getVarbitValue(Varbits.DISABLE_LEVEL_UP_INTERFACE)` that it will turn to 0 then back to 1 when at the play button.

## BankLocation
- Add Piscatoris Fishing Colony Bank

## ShortestPathPlugin
- Add Transports for Piscatoris Fishing Colony 