### PR TITLE
Option to drop ores when using autominer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningConfig.java
@@ -14,7 +14,9 @@ import net.runelite.client.plugins.microbot.mining.enums.Rocks;
         "<p></p>"+
         "<p>4. <strong>Items to Bank:</strong> Specify the items to be banked, separated by commas. The default value is <em>'ore'</em>.</p>"+
         "<p></p>"+
-        "<p>5. <strong>Basalt:</strong> If mining basalt, ensure UseBank is checked and it will automatically note at Snowflake</em>.</p>")
+        "<p>5. <strong>Basalt:</strong> If mining basalt, ensure UseBank is checked and it will automatically note at Snowflake</em>.</p>"+
+        "<p></p>"+
+        "<p>6. <strong>Drop ores in inventory:</strong> If enabled, the bot will drop all ores in the inventory when its full. The default setting is <em>disabled</em>.</p>")
 
 public interface AutoMiningConfig extends Config {
     @ConfigSection(
@@ -70,4 +72,15 @@ public interface AutoMiningConfig extends Config {
         return "ore";
     }
 
+    @ConfigItem(
+            keyName = "dropOres",
+            name = "dropOres",
+            description = "Drop all ores in inventory once full",
+            position = 5,
+            section = generalSection
+    )
+    default boolean dropOres()
+    {
+        return false;
+    }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningScript.java
@@ -30,7 +30,7 @@ enum State {
 
 public class AutoMiningScript extends Script {
 
-    public static final String version = "1.4.3";
+    public static final String version = "1.4.4";
     private static final int GEM_MINE_UNDERGROUND = 11410;
     private static final int BASALT_MINE = 11425;
     State state = State.MINING;
@@ -96,6 +96,8 @@ public class AutoMiningScript extends Script {
                                     return;
                             }
 
+                        } else if (config.dropOres()) {
+                            Rs2Inventory.dropAll(config.ORE().getName());
                         } else {
                             Rs2Inventory.dropAllExcept("pickaxe");
                         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningScript.java
@@ -98,6 +98,10 @@ public class AutoMiningScript extends Script {
 
                         } else if (config.dropOres()) {
                             Rs2Inventory.dropAll(config.ORE().getName());
+                            Rs2Inventory.dropAll("Uncut sapphire");
+                            Rs2Inventory.dropAll("Uncut emerald");
+                            Rs2Inventory.dropAll("Uncut ruby");
+                            Rs2Inventory.dropAll("Uncut diamond");
                         } else {
                             Rs2Inventory.dropAllExcept("pickaxe");
                         }


### PR DESCRIPTION
This pull request includes a new feature to the `AutoMining` plugin. The new change is auto drop all ores once the inventory is full. By default, it would drop the entire inventory except the pickaxe.

### New Feature Addition:
* Added a new configuration option `dropOres` to the `AutoMiningConfig` interface, which allows users to enable or disable the automatic dropping of ores when the inventory is full. The default setting for this option is disabled.