### PR TITLE
Ge buyer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerConfig.java
@@ -1,0 +1,34 @@
+package net.runelite.client.plugins.microbot.autoBuyer;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigInformation;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("GE buyer")
+@ConfigInformation("Acun <br> 0.1.0-alpha.1 <br><br> Start near GE. <br> Make sure to spell item names correct. " +
+        "Collects items to bank. " +
+        "<br> Be cautious and monitor when using, because there are no failsafes added yet. " +
+        "<br><br> Item name[quantity] for example: rune arrow[50],amulet of glory(6)[1]"
+)
+public interface AutoBuyerConfig extends Config {
+    @ConfigItem(
+            keyName = "BuyList",
+            name = "Buy items list",
+            description = "Give the name of items to buy plus the [quantity], separate by comma for example: Rune arrow[100],Chaos rune[25],Amulet of glory(6)[1]",
+            position = 2
+    )
+    default String listOfItemsToBuy() {
+        return "bronze arrow[5],air rune[2]";
+    }
+
+    @ConfigItem(
+            keyName = "pricePerItem",
+            name = "Increase price per item",
+            description = "Set the price per item for example +5%, this will increase the chance to instant buying",
+            position = 1
+    )
+    default Percentage pricePerItem() {
+        return Percentage.PERCENT_5;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerOverlay.java
@@ -1,0 +1,42 @@
+package net.runelite.client.plugins.microbot.autoBuyer;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class AutoBuyerOverlay extends OverlayPanel {
+
+    @Inject
+    AutoBuyerOverlay(AutoBuyerPlugin plugin)
+    {
+        super(plugin);
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        try {
+            panelComponent.setPreferredSize(new Dimension(200, 300));
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("GE buyer 0.1.0-alpha.1")
+                    .color(Color.GREEN)
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder().build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left(Microbot.status)
+                    .build());
+
+
+        } catch(Exception ex) {
+            System.out.println(ex.getMessage());
+        }
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerPlugin.java
@@ -1,0 +1,68 @@
+package net.runelite.client.plugins.microbot.autoBuyer;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+/**
+ * Made by Acun
+ */
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "GE Buyer",
+        description = "Acun's GE buyer. Give a list of items to buy",
+        tags = {"buy", "buyer", "grand exchange", "ge"},
+        enabledByDefault = false
+)
+@Slf4j
+public class AutoBuyerPlugin extends Plugin {
+    @Inject
+    private AutoBuyerConfig config;
+    @Provides
+    AutoBuyerConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(AutoBuyerConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private AutoBuyerOverlay exampleOverlay;
+
+    @Inject
+    AutoBuyerScript exampleScript;
+
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(exampleOverlay);
+        }
+        exampleScript.run(config);
+    }
+
+    protected void shutDown() {
+        exampleScript.shutdown();
+        overlayManager.remove(exampleOverlay);
+    }
+    int ticks = 10;
+    @Subscribe
+    public void onGameTick(GameTick tick)
+    {
+        //System.out.println(getName().chars().mapToObj(i -> (char)(i + 3)).map(String::valueOf).collect(Collectors.joining()));
+
+        if (ticks > 0) {
+            ticks--;
+        } else {
+            ticks = 10;
+        }
+
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerScript.java
@@ -21,6 +21,8 @@ public class AutoBuyerScript extends Script {
 
     public boolean run(AutoBuyerConfig config) {
         Microbot.enableAutoRunOn = false;
+        // Replace any spaces around commas with just a comma since G.E. has whitespace sensitivity
+        String listOfItemsToBuy = config.listOfItemsToBuy().replaceAll("\\s*,\\s*", ",");
 
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
@@ -29,11 +31,11 @@ public class AutoBuyerScript extends Script {
                 long startTime = System.currentTimeMillis();
 
                 if (!initialized) {
-                    if (config.listOfItemsToBuy().length() <= 0) {
+                    if (listOfItemsToBuy.length() <= 0) {
                         Microbot.log("No items found.");
                         shutdown();
                     }
-                    itemsList = mapItems(splitItemsByCommas(config.listOfItemsToBuy()));
+                    itemsList = mapItems(splitItemsByCommas(listOfItemsToBuy));
                     initialCount = itemsList.size();
                     initialized = true;
                     if (!isRunning())
@@ -112,8 +114,8 @@ public class AutoBuyerScript extends Script {
                 if (item.contains("[")) {
                     // Split the item into name and quantity parts
                     String[] parts = item.split("\\[");
-                    String name = parts[0];
-                    String quantityStr = parts[1].replace("]", "");
+                    String name = parts[0].trim();
+                    String quantityStr = parts[1].replace("]", "").trim();
 
                     // Convert the quantity to an integer
                     int quantity = Integer.parseInt(quantityStr);
@@ -122,7 +124,7 @@ public class AutoBuyerScript extends Script {
                     itemMap.put(name, quantity);
                 } else {
                     // If quantity is missing, default it to 1
-                    itemMap.put(item, 1);
+                    itemMap.put(item.trim(), 1);
                 }
             } catch (NumberFormatException e) {
                 Microbot.log(item + " has an invalid quantity. Quantity must be a number.");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerScript.java
@@ -1,0 +1,142 @@
+package net.runelite.client.plugins.microbot.autoBuyer;
+
+import net.runelite.api.ChatMessageType;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeSlots;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class AutoBuyerScript extends Script {
+
+    public static boolean test = false;
+    private static boolean initialized;
+    private static int initialCount;
+    private static int totalBought = 0;
+    private static Map<String, Integer> itemsList;
+
+    public boolean run(AutoBuyerConfig config) {
+        Microbot.enableAutoRunOn = false;
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) return;
+                if (!super.run() || !isRunning()) return;
+                long startTime = System.currentTimeMillis();
+
+                if (!initialized) {
+                    if (config.listOfItemsToBuy().length() <= 0) {
+                        Microbot.log("No items found.");
+                        shutdown();
+                    }
+                    itemsList = mapItems(splitItemsByCommas(config.listOfItemsToBuy()));
+                    initialCount = itemsList.size();
+                    initialized = true;
+                    if (!isRunning())
+                        return;
+                }
+
+                if (!Rs2GrandExchange.isOpen()) {
+                    Rs2GrandExchange.openExchange();
+                }
+
+                int timesToClick;
+                if (config.pricePerItem().equals(Percentage.PERCENT_10))
+                    timesToClick = 2;
+                else {
+                    timesToClick = 1;
+                }
+
+                itemsList.forEach((itemName, quantity) -> {
+                    if (!isRunning())
+                        return;
+                    // Try to collect items to bank to free up slots
+                    if (!hasFreeSlots()) {
+                        if (canFreeUpSlots()) {
+                            Rs2GrandExchange.collectToBank();
+                            Microbot.log("Items bought from G.E. are collected to your bank.");
+                        } else {
+                            Microbot.log("All G.E. slots are in use, either abort or wait until one comes available.");
+                            return;
+                        }
+                    }
+                    Rs2GrandExchange.buyItemAbove5Percent(itemName, quantity, timesToClick);
+                    itemsList.remove(itemName); // Remove from list so we don't buy the same item again
+                    totalBought++;
+                });
+
+                // Loop until we bought every item
+                if (totalBought < initialCount)
+                    return;
+
+                long endTime = System.currentTimeMillis();
+                long totalTime = endTime - startTime;
+                System.out.println("Total time for loop " + totalTime);
+                Microbot.getClientThread().runOnClientThread(() ->
+                        Microbot.getClient().addChatMessage(ChatMessageType.ENGINE, "", "Made with love by Acun.", "Acun", false)
+                );
+                Microbot.log("Finished buying.");
+                shutdown();
+            } catch (Exception ex) {
+                System.out.println(ex.getMessage());
+            }
+        }, 0, 1000, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    private boolean canFreeUpSlots() {
+        return Rs2GrandExchange.hasSoldOffer() || Rs2GrandExchange.hasBoughtOffer();
+    }
+
+    private String[] splitItemsByCommas(String input) {
+        // Split the input string by commas
+        return input.split(",");
+    }
+
+    private boolean hasFreeSlots() {
+        Pair<GrandExchangeSlots, Integer> availableSlots = Rs2GrandExchange.getAvailableSlot();
+        return Integer.parseInt(String.valueOf(availableSlots.getRight())) > 0;
+    }
+
+    private Map<String, Integer> mapItems(String[] items) {
+        Map<String, Integer> itemMap = new HashMap<>();
+
+        // Process each item
+        for (String item : items) {
+            try {
+                // Check if the item contains the quantity part
+                if (item.contains("[")) {
+                    // Split the item into name and quantity parts
+                    String[] parts = item.split("\\[");
+                    String name = parts[0];
+                    String quantityStr = parts[1].replace("]", "");
+
+                    // Convert the quantity to an integer
+                    int quantity = Integer.parseInt(quantityStr);
+
+                    // Store the item and its quantity in the map
+                    itemMap.put(name, quantity);
+                } else {
+                    // If quantity is missing, default it to 1
+                    itemMap.put(item, 1);
+                }
+            } catch (NumberFormatException e) {
+                Microbot.log(item + " has an invalid quantity. Quantity must be a number.");
+                shutdown();
+            }
+        }
+
+        return itemMap;
+    }
+
+    @Override
+    public void shutdown() {
+        initialized = false;
+        totalBought = 0;
+        super.shutdown();
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/Percentage.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/Percentage.java
@@ -1,0 +1,18 @@
+package net.runelite.client.plugins.microbot.autoBuyer;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Percentage {
+    PERCENT_5("+5%"),
+    PERCENT_10("+10%");
+
+    private final String name;
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
@@ -192,7 +192,7 @@ public class Rs2GrandExchange {
 
     /**
      * TODO: test this method
-     * Buys item from the grand exchange 5% above the average priec
+     * Buys item from the grand exchange 5% above the average price
      *
      * @param itemName
      * @param quantity

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static net.runelite.client.plugins.microbot.util.Global.*;
 
@@ -185,14 +186,20 @@ public class Rs2GrandExchange {
         }
     }
 
+    public static boolean buyItemAbove5Percent(String itemName, int quantity) {
+        return buyItemAbove5Percent(itemName, quantity, 1);
+    }
+
     /**
      * TODO: test this method
-     * Buys item from the grandexchange 5% above the average priec
+     * Buys item from the grand exchange 5% above the average priec
+     *
      * @param itemName
      * @param quantity
+     * @param timesToIncreasePrice the amount to click +5% price increase
      * @return
      */
-    public static boolean buyItemAbove5Percent(String itemName, int quantity) {
+    public static boolean buyItemAbove5Percent(String itemName, int quantity, int timesToIncreasePrice) {
         try {
             if (!isOpen()) {
                 openExchange();
@@ -216,7 +223,7 @@ public class Rs2GrandExchange {
                 sleep(600, 1600);
             }
             setQuantity(quantity);
-            if (buyItemAbove5Percent()) {
+            if (buyItemAbove5Percent(timesToIncreasePrice)) {
                 return true;
             }
 
@@ -227,13 +234,16 @@ public class Rs2GrandExchange {
         return false;
     }
 
-    private static boolean buyItemAbove5Percent() {
+    private static boolean buyItemAbove5Percent(int timesToIncreasePrice) {
         Widget pricePerItemButton5Percent = getPricePerItemButton_Plus5Percent();
-
         if (pricePerItemButton5Percent != null) {
             int basePrice = getItemPrice();
-            Microbot.getMouse().click(pricePerItemButton5Percent.getBounds());
-            sleepUntil(() -> hasOfferPriceChanged(basePrice), 1600);
+            // Call click() as many times as the value of count
+            IntStream.range(0, timesToIncreasePrice).forEach(i -> {
+                Microbot.getMouse().click(pricePerItemButton5Percent.getBounds());
+                sleepUntil(() -> hasOfferPriceChanged(basePrice), 1600);
+            });
+
             confirm();
             return true;
         } else {
@@ -353,7 +363,7 @@ public class Rs2GrandExchange {
             openExchange();
         }
         sleepUntil(Rs2GrandExchange::isOpen);
-        Widget[] collectButton = Rs2Widget.getWidget(465,6).getDynamicChildren();
+        Widget[] collectButton = Rs2Widget.getWidget(465, 6).getDynamicChildren();
         if (!collectButton[1].isSelfHidden()) {
             Rs2Widget.clickWidgetFast(
                     COLLECT_BUTTON, collectToBank ? 2 : 1);
@@ -368,6 +378,7 @@ public class Rs2GrandExchange {
 
     /**
      * Collect all the grand exchange items to your bank
+     *
      * @return
      */
     public static boolean collectToBank() {
@@ -376,6 +387,7 @@ public class Rs2GrandExchange {
 
     /**
      * sells all the tradeable loot items from a specific npc name
+     *
      * @param npcName
      * @return true if there is no more loot to sell
      */
@@ -395,6 +407,7 @@ public class Rs2GrandExchange {
 
     /**
      * Sells all the tradeable items in your inventory
+     *
      * @return
      */
     public static boolean sellInventory() {
@@ -415,7 +428,7 @@ public class Rs2GrandExchange {
     /**
      * Aborts the offer
      *
-     * @param name         name of the item to abort offer on
+     * @param name          name of the item to abort offer on
      * @param collectToBank collect the item to the bank
      * @return true if the offer has been aborted
      */
@@ -425,7 +438,7 @@ public class Rs2GrandExchange {
             for (GrandExchangeSlots slot : GrandExchangeSlots.values()) {
                 Widget parent = getSlot(slot);
                 if (parent == null) continue;
-                if(isSlotAvailable(slot)) continue; // skip if slot is empty
+                if (isSlotAvailable(slot)) continue; // skip if slot is empty
                 Widget child = parent.getChild(19);
                 if (child == null) continue;
                 if (child.getText().equalsIgnoreCase(name)) {
@@ -453,7 +466,7 @@ public class Rs2GrandExchange {
             for (GrandExchangeSlots slot : GrandExchangeSlots.values()) {
                 Widget parent = getSlot(slot);
                 if (parent == null) continue;
-                if(isSlotAvailable(slot)) continue; // skip if slot is empty
+                if (isSlotAvailable(slot)) continue; // skip if slot is empty
                 Widget child = parent.getChild(19);
                 if (child == null) continue;
                 Microbot.doInvoke(new NewMenuEntry("Abort offer", 2, parent.getId(), MenuAction.CC_OP.getId(), 2, -1, ""), new Rectangle(1, 1, Microbot.getClient().getCanvasWidth(), Microbot.getClient().getCanvasHeight()));
@@ -610,7 +623,7 @@ public class Rs2GrandExchange {
     }
 
     public static int getItemPrice() {
-        return Integer.parseInt(Rs2Widget.getWidget(465, 27).getText());
+        return Integer.parseInt(Rs2Widget.getWidget(465, 27).getText().replace(",", ""));
     }
 
     public static Widget getSlot(GrandExchangeSlots slot) {
@@ -698,11 +711,11 @@ public class Rs2GrandExchange {
             String jsonResponse = httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                     .thenApply(HttpResponse::body)
                     .join();
-            
+
             JsonParser parser = new JsonParser();
             JsonObject jsonElement = parser.parse(new StringReader(jsonResponse)).getAsJsonObject();
             JsonObject data = jsonElement.getAsJsonObject("data");
-            
+
             return data.get("buying").getAsInt();
         } catch (Exception e) {
             e.printStackTrace();
@@ -720,11 +733,11 @@ public class Rs2GrandExchange {
             String jsonResponse = httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                     .thenApply(HttpResponse::body)
                     .join();
-            
+
             JsonParser parser = new JsonParser();
             JsonObject jsonElement = parser.parse(new StringReader(jsonResponse)).getAsJsonObject();
             JsonObject data = jsonElement.getAsJsonObject("data");
-            
+
             return data.get("selling").getAsInt();
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
### GE buyer
I added a new plugin that helps players buy a list of given items. I think it's quite helpful for questing, especially when you don't want to manually buy all the items from the GE

It works as follows:
Item name + optionally [quantity], for example: `molten glass[5],ring of dueling(8)` 
- Currently, only +5% and +10% price increase is possible.
- Automatically collects items to bank if no G.E. slots are available
- G.E. has whitespace sensitivity, I added code which handles in case user adds whitespaces to the input

### Highlights
- Added parameter to the buy `Rs2GrandExchange.buyItemAbove5Percent()` to make it possible to increase the price as many times as we want
- Fixed bug where `getItemPrice()` in Rs2GrandExchange did not return the expected value. It turned out that `Integer.parseInt()` does not work if the value is higher than "999" because text values "1,000" or above cannot be parsed to integer. My fix was to remove the comma at line 626.  