### PR TITLE
Roguesden add lower level

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/roguesden/Obstacles.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/roguesden/Obstacles.java
@@ -43,7 +43,7 @@ public class Obstacles {
 
     static class Obstacle {
         @Getter
-        private final WorldPoint tile;
+        public final WorldPoint tile;
         @Getter
         private final String hint;
         @Getter

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenConfig.java
@@ -5,6 +5,6 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigInformation;
 
 @ConfigGroup("RoguesDen")
-@ConfigInformation("This plugin requires atleast 80 thieving. Start at the rogues den.")
+@ConfigInformation("Start at the rogues den. Stamina supported and recommended!")
 public interface RoguesDenConfig extends Config {
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenOverlay.java
@@ -6,14 +6,15 @@ import net.runelite.api.GameObject;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
-import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
 
 import javax.inject.Inject;
 import java.awt.*;
 
-public class RoguesDenOverlay extends Overlay {
+public class RoguesDenOverlay extends OverlayPanel {
     private static final Color OBJECT_BORDER_COLOR;
     private static final Color OBJECT_COLOR;
     private static final Color OBJECT_BORDER_HOVER_COLOR;
@@ -22,16 +23,21 @@ public class RoguesDenOverlay extends Overlay {
 
     @Inject
     public RoguesDenOverlay(Client client, RoguesDenPlugin plugin) {
+        super(plugin);
         this.setPosition(OverlayPosition.DYNAMIC);
         this.setLayer(OverlayLayer.ABOVE_SCENE);
         this.client = client;
         this.plugin = plugin;
     }
 
+    @Override
     public Dimension render(Graphics2D graphics) {
-        if (!this.plugin.isHasGem()) {
-            return null;
-        } else {
+        panelComponent.setPreferredSize(new Dimension(200, 300));
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Maze runs: ")
+                .right(String.valueOf(RoguesDenScript.mazeRunsCompleted))
+                .build());
+        if (this.plugin.isHasGem()) {
             this.plugin.getObstaclesHull().forEach((obstaclex, tile) -> {
                 if (tile.getPlane() == this.client.getPlane()) {
                     Shape clickBox = obstaclex.getClickbox();
@@ -83,9 +89,8 @@ public class RoguesDenOverlay extends Overlay {
                     }
                 }
             }
-
-            return null;
         }
+        return super.render(graphics);
     }
 
     static {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenScript.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.roguesden;
 
+import lombok.Getter;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -17,7 +18,10 @@ import net.runelite.client.plugins.microbot.util.math.Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.walker.WalkerState;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
@@ -26,6 +30,8 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepGaussian;
 
 public class RoguesDenScript extends Script {
 
+    @Getter
+    public static int mazeRunsCompleted = 0;
     int currentObstacleIndex;
     boolean hasStaminaPotionInBank = true;
 
@@ -33,7 +39,7 @@ public class RoguesDenScript extends Script {
 
     private void initObstacles() {
         currentObstacleIndex = 0;
-        OBSTACLES = new Obstacles.Obstacle[]{
+        Obstacles.Obstacle[] originalObstacles = new Obstacles.Obstacle[]{
                 new Obstacles.Obstacle(3048, 4997, 7251),
                 new Obstacles.Obstacle(3039, 4999, "Stand"),
                 new Obstacles.Obstacle(3029, 5003, "Run"),
@@ -47,16 +53,81 @@ public class RoguesDenScript extends Script {
                 new Obstacles.Obstacle(2958, 5035, "Stand"),
                 new Obstacles.Obstacle(2962, 5050, "Stand"),
                 new Obstacles.Obstacle(2963, 5056, "Run"),
-                new Obstacles.Obstacle(2968, 5061, "Stand", 7246, 0),
-                new Obstacles.Obstacle(2974, 5059, "Stand",7251, 0),
-                new Obstacles.Obstacle(2989, 5058, "Stand"),
-                new Obstacles.Obstacle(2990, 5058, "Open", 7255, 0),
+                new Obstacles.Obstacle(2968, 5061, "Stand", 7246, 0), // Above 80 thieving
+                new Obstacles.Obstacle(2974, 5059, "Stand",7251, 0),  // Above 80 thieving
+                new Obstacles.Obstacle(2989, 5058, "Stand"),  // Above 80 thieving
+                new Obstacles.Obstacle(2990, 5058, "Open", 7255, 0),  // Above 80 thieving
+                new Obstacles.Obstacle(2957, 5072, "Open", 7219, 0),
+                new Obstacles.Obstacle(2957, 5076, "Run", 2000),
+                new Obstacles.Obstacle(2955, 5092, "Stand"),
+                new Obstacles.Obstacle(2955, 5098, "Open", 7219, 0),
+                new Obstacles.Obstacle(2963, 5105, "Stand"),
+                new Obstacles.Obstacle(2972, 5098, "Stand"),
+                new Obstacles.Obstacle(2972, 5094, "Open", 7219, 0),
+                new Obstacles.Obstacle(2972, 5093, "Open", 7255, 0),
+                new Obstacles.Obstacle(2976, 5087, "Stand", 250),
+                new Obstacles.Obstacle(2982, 5087, "Climb", 7240, 250),
+                new Obstacles.Obstacle(2992, 5088, "Stand"),
+                new Obstacles.Obstacle(2992, 5088, "Search", 7249, 750),
+                new Obstacles.Obstacle(2993, 5088, "Stand"),
+                new Obstacles.Obstacle(2997, 5088, "Run"),
+                new Obstacles.Obstacle(3006, 5088, "Run"),
+                new Obstacles.Obstacle(3018, 5080, "tile"),
+                new Obstacles.Obstacle(3024, 5082, "Stand"),
+                new Obstacles.Obstacle(3031, 5079, "Open", 7255, 0),
+                new Obstacles.Obstacle(3032, 5078, "Stand"),
+                new Obstacles.Obstacle(3032, 5077, "Open", 7255, 0),
+                new Obstacles.Obstacle(3036, 5076, "Stand"),
+                new Obstacles.Obstacle(3037, 5076, "Open", 7255, 0),
+                new Obstacles.Obstacle(3039, 5079, "Stand"),
+                new Obstacles.Obstacle(3040, 5079, "Open", 7255, 0),
+                new Obstacles.Obstacle(3042, 5076, "Stand"),
+                new Obstacles.Obstacle(3043, 5076, "Open", 7255, 0),
+                new Obstacles.Obstacle(3044, 5069, "Stand"),
+                new Obstacles.Obstacle(3044, 5068, "Open", 7255, 0),
+                new Obstacles.Obstacle(3041, 5068, "Stand"),
+                new Obstacles.Obstacle(3041, 5069, "Open", 7255, 0),
+                new Obstacles.Obstacle(3040, 5070, "Stand"),
+                new Obstacles.Obstacle(3039, 5070, "Open", 7255, 0),
+                new Obstacles.Obstacle(3038, 5069, "Stand"),
+                new Obstacles.Obstacle(3038, 5068, "Open", 7255, 0),
+                new Obstacles.Obstacle(3034, 5033, "Stand"),
+                new Obstacles.Obstacle(3028, 5034, "Stand"),
+                new Obstacles.Obstacle(3024, 5034, "Run"),
+                new Obstacles.Obstacle(3014, 5033, "Open", 7255, 0),
+                new Obstacles.Obstacle(3010, 5033, "Stand"),
+                new Obstacles.Obstacle(3009, 5033, "Open", 7255, 0),
+                new Obstacles.Obstacle(3000, 5034, "Run"),
+                new Obstacles.Obstacle(2992, 5045, "Stand"),
+                new Obstacles.Obstacle(2992, 5053, "Run"),
                 new Obstacles.Obstacle(2992, 5067, "Stand"),
                 new Obstacles.Obstacle(2992, 5075, "Run"),
                 new Obstacles.Obstacle(3009, 5063, "Take"),
                 new Obstacles.Obstacle(3028, 5056, "Run"),
                 new Obstacles.Obstacle(3028, 5047, "Walk", 1200),
-                new Obstacles.Obstacle(3018, 5047, "Crack", 7237, 2000)};
+                new Obstacles.Obstacle(3018, 5047, "Crack", 7237, 2000)
+        };
+
+        // Temporary list to store filtered obstacles based on Thieving level
+        List<Obstacles.Obstacle> filteredObstacles = new ArrayList<>();
+
+        // Iterate through the original array and conditionally add obstacles
+        for (Obstacles.Obstacle obstacle : originalObstacles) {
+            if (Microbot.getClient().getRealSkillLevel(Skill.THIEVING) < 80) {
+                // Include all obstacles except those marked for 80+ thieving
+                if (!isAbove80ThievingObstacle(obstacle)) {
+                    filteredObstacles.add(obstacle);
+                }
+            } else {
+                // Include all obstacles except those marked for below 80 thieving
+                if (!isBelow80ThievingObstacle(obstacle)) {
+                    filteredObstacles.add(obstacle);
+                }
+            }
+        }
+
+        // Convert the list back
+        OBSTACLES = filteredObstacles.toArray(new Obstacles.Obstacle[0]);
     }
 
     public boolean run() {
@@ -67,11 +138,6 @@ public class RoguesDenScript extends Script {
                 long startTime = System.currentTimeMillis();
 
                 if (!init) {
-                    if (!Rs2Player.getSkillRequirement(Skill.THIEVING, 80)) {
-                        Microbot.log("RoguesDen script requires atleast 80 thieving...shutting down.");
-                        shutdown();
-                        return;
-                    }
                     Rs2Camera.setPitch(Random.random(300, 383));
                     initObstacles();
                     Microbot.enableAutoRunOn = false;
@@ -79,7 +145,7 @@ public class RoguesDenScript extends Script {
                     init = true;
                 }
 
-                if (Rs2Player.isAnimating() || Rs2Player.isWalking()) return;
+                if (Rs2Player.isAnimating() || Rs2Player.isMoving()) return;
 
                 boolean isInMinigame = Rs2Inventory.hasItem(ItemID.MYSTIC_JEWEL);
 
@@ -95,7 +161,7 @@ public class RoguesDenScript extends Script {
                 }
 
                 if (useFlashPowder()) return;
-
+                if (useTileObject()) return;
 
                 if (clickObstacle()) return;
 
@@ -121,7 +187,6 @@ public class RoguesDenScript extends Script {
                     return Double.compare(distanceToO1, distanceToO2);
                 })
                 .orElse(-1); // Return null if OBSTACLES array is empty
-
         if (closestIndex + 1 > OBSTACLES.length) {
             Microbot.log("wrong index!");
             return true;
@@ -164,6 +229,18 @@ public class RoguesDenScript extends Script {
                 }
                 return true;
             }
+        }
+        return false;
+    }
+
+    private boolean useTileObject() {
+        if (Rs2Inventory.hasItem(ItemID.TILE_5568)) {
+            Microbot.log("Handle tile door");
+            Rs2GameObject.interact(7234, "Open");
+            Rs2Widget.sleepUntilHasWidget("Select");
+            Rs2Widget.clickWidget("Select");
+            Rs2Inventory.waitForInventoryChanges(3000);
+            sleep(1250, 1650);
         }
         return false;
     }
@@ -211,6 +288,9 @@ public class RoguesDenScript extends Script {
     }
 
     private void handleObstacle(Obstacles.Obstacle obstacle) {
+        if (obstacle.getHint().equalsIgnoreCase("Crack"))
+            mazeRunsCompleted++;
+
         if ((obstacle.getHint().equalsIgnoreCase("run") || obstacle.getHint().equalsIgnoreCase("take")) && Rs2Player.getRunEnergy() < 10) {
             Microbot.log("Restoring run energy...");
             sleep(60_000, 120_000);
@@ -219,13 +299,21 @@ public class RoguesDenScript extends Script {
         if (Random.random(1, 10) == 7) {
             Rs2Camera.angleToTile(obstacle.getTile());
         }
+
         if (obstacle.getObjectId() != -1) {
-            Rs2GameObject.interact(obstacle.getObjectId());
-                Rs2Player.waitForWalking();
+            if (obstacle.getObjectId() == 7249) {
+                Rs2GameObject.interact(obstacle.getObjectId(), "search"); // Handles wall searching
+            } else {
+                Rs2GameObject.interact(obstacle.getObjectId());
+            }
+            Rs2Player.waitForWalking();
 
         } else if (obstacle.getHint().equalsIgnoreCase("take") && !Rs2Inventory.hasItem(ItemID.FLASH_POWDER)) {
             Rs2GroundItem.loot(obstacle.getTile(), ItemID.FLASH_POWDER);
             sleepUntil(() -> Rs2Inventory.hasItem(ItemID.FLASH_POWDER));
+        } else if (obstacle.getHint().equalsIgnoreCase("tile") && !Rs2Inventory.hasItem(ItemID.TILE_5568)) {
+            Rs2GroundItem.loot(obstacle.getTile(), ItemID.TILE_5568);
+            sleepUntil(() -> Rs2Inventory.hasItem(ItemID.TILE_5568));
         } else {
             if (!Rs2Walker.walkFastCanvas(obstacle.getTile())) {
                 Rs2Walker.walkTo(obstacle.getTile());
@@ -233,6 +321,60 @@ public class RoguesDenScript extends Script {
         }
 
         sleepGaussian(obstacle.getWait(), obstacle.getWait() / 4);
+    }
+
+    // Helper method to check if an obstacle is for above 80 thieving
+    private static boolean isAbove80ThievingObstacle(Obstacles.Obstacle obstacle) {
+        return (obstacle.tile.getX() == 2968 && obstacle.tile.getY() == 5061) ||
+                (obstacle.tile.getX() == 2974 && obstacle.tile.getY() == 5059) ||
+                (obstacle.tile.getX() == 2989 && obstacle.tile.getY() == 5058) ||
+                (obstacle.tile.getX() == 2990 && obstacle.tile.getY() == 5058);
+    }
+
+    // Helper method to check if an obstacle is for below 80 thieving
+    private static boolean isBelow80ThievingObstacle(Obstacles.Obstacle obstacle) {
+        return (obstacle.tile.getX() == 2957 && obstacle.tile.getY() == 5072) ||
+                (obstacle.tile.getX() == 2957 && obstacle.tile.getY() == 5076) ||
+                (obstacle.tile.getX() == 2955 && obstacle.tile.getY() == 5092) ||
+                (obstacle.tile.getX() == 2955 && obstacle.tile.getY() == 5098) ||
+                (obstacle.tile.getX() == 2963 && obstacle.tile.getY() == 5105) ||
+                (obstacle.tile.getX() == 2972 && obstacle.tile.getY() == 5098) ||
+                (obstacle.tile.getX() == 2972 && obstacle.tile.getY() == 5094) ||
+                (obstacle.tile.getX() == 2972 && obstacle.tile.getY() == 5093) ||
+                (obstacle.tile.getX() == 2976 && obstacle.tile.getY() == 5087) ||
+                (obstacle.tile.getX() == 2982 && obstacle.tile.getY() == 5087) ||
+                (obstacle.tile.getX() == 2992 && obstacle.tile.getY() == 5088) ||
+                (obstacle.tile.getX() == 2993 && obstacle.tile.getY() == 5088) ||
+                (obstacle.tile.getX() == 2997 && obstacle.tile.getY() == 5088) ||
+                (obstacle.tile.getX() == 3006 && obstacle.tile.getY() == 5088) ||
+                (obstacle.tile.getX() == 3018 && obstacle.tile.getY() == 5080) ||
+                (obstacle.tile.getX() == 3024 && obstacle.tile.getY() == 5082) ||
+                (obstacle.tile.getX() == 3031 && obstacle.tile.getY() == 5079) ||
+                (obstacle.tile.getX() == 3032 && obstacle.tile.getY() == 5078) ||
+                (obstacle.tile.getX() == 3032 && obstacle.tile.getY() == 5077) ||
+                (obstacle.tile.getX() == 3036 && obstacle.tile.getY() == 5076) ||
+                (obstacle.tile.getX() == 3037 && obstacle.tile.getY() == 5076) ||
+                (obstacle.tile.getX() == 3039 && obstacle.tile.getY() == 5079) ||
+                (obstacle.tile.getX() == 3040 && obstacle.tile.getY() == 5079) ||
+                (obstacle.tile.getX() == 3042 && obstacle.tile.getY() == 5076) ||
+                (obstacle.tile.getX() == 3043 && obstacle.tile.getY() == 5076) ||
+                (obstacle.tile.getX() == 3044 && obstacle.tile.getY() == 5069) ||
+                (obstacle.tile.getX() == 3044 && obstacle.tile.getY() == 5068) ||
+                (obstacle.tile.getX() == 3041 && obstacle.tile.getY() == 5068) ||
+                (obstacle.tile.getX() == 3041 && obstacle.tile.getY() == 5069) ||
+                (obstacle.tile.getX() == 3040 && obstacle.tile.getY() == 5070) ||
+                (obstacle.tile.getX() == 3039 && obstacle.tile.getY() == 5070) ||
+                (obstacle.tile.getX() == 3038 && obstacle.tile.getY() == 5069) ||
+                (obstacle.tile.getX() == 3038 && obstacle.tile.getY() == 5068) ||
+                (obstacle.tile.getX() == 3034 && obstacle.tile.getY() == 5033) ||
+                (obstacle.tile.getX() == 3028 && obstacle.tile.getY() == 5034) ||
+                (obstacle.tile.getX() == 3024 && obstacle.tile.getY() == 5034) ||
+                (obstacle.tile.getX() == 3014 && obstacle.tile.getY() == 5033) ||
+                (obstacle.tile.getX() == 3010 && obstacle.tile.getY() == 5033) ||
+                (obstacle.tile.getX() == 3009 && obstacle.tile.getY() == 5033) ||
+                (obstacle.tile.getX() == 3000 && obstacle.tile.getY() == 5034) ||
+                (obstacle.tile.getX() == 2992 && obstacle.tile.getY() == 5045) ||
+                (obstacle.tile.getX() == 2992 && obstacle.tile.getY() == 5053);
     }
 
     @Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenScript.java
@@ -6,6 +6,7 @@ import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
@@ -54,7 +55,7 @@ public class RoguesDenScript extends Script {
                 new Obstacles.Obstacle(2962, 5050, "Stand"),
                 new Obstacles.Obstacle(2963, 5056, "Run"),
                 new Obstacles.Obstacle(2968, 5061, "Stand", 7246, 0), // Above 80 thieving
-                new Obstacles.Obstacle(2974, 5059, "Stand",7251, 0),  // Above 80 thieving
+                new Obstacles.Obstacle(2974, 5059, "Stand", 7251, 0),  // Above 80 thieving
                 new Obstacles.Obstacle(2989, 5058, "Stand"),  // Above 80 thieving
                 new Obstacles.Obstacle(2990, 5058, "Open", 7255, 0),  // Above 80 thieving
                 new Obstacles.Obstacle(2957, 5072, "Open", 7219, 0),
@@ -138,6 +139,13 @@ public class RoguesDenScript extends Script {
                 long startTime = System.currentTimeMillis();
 
                 if (!init) {
+                    if (!Rs2Player.getSkillRequirement(Skill.THIEVING, 50)
+                            && !Rs2Player.getSkillRequirement(Skill.AGILITY, 50)) {
+                        Microbot.showMessage("Rogues Den requires at least 50 thieving and agility. Shutting down.");
+                        shutdown();
+                        return;
+                    }
+
                     Rs2Camera.setPitch(Random.random(300, 383));
                     initObstacles();
                     Microbot.enableAutoRunOn = false;


### PR DESCRIPTION
### Added support for lower level Rogues Den by extending the original plugin, which had only support for +80 thieving.
- Based on player's thieving level it decide which maze path to take. 
- Add overlay for "Maze runs" completed counter
- Changed skill requirement to 50 thieving & agility

### Note
The original code was not easily open for extension, so I have added  `originalObstacles` and some filtering to make it work. I am not happy about it but it does the job.

### Highlight
Unfortunately, I have no account to test if level 80 thieving path still works