### PR TITLE
fix an Rs2Npc.interact() usage in Pest Control script to "attack" the target

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/pestcontrol/PestControlScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/pestcontrol/PestControlScript.java
@@ -133,7 +133,7 @@ public class PestControlScript extends Script {
                     } else {
                         if (!Microbot.getClient().getLocalPlayer().isInteracting()) {
                             Optional<Rs2NpcModel> attackableNpc = Rs2Npc.getAttackableNpcs().findFirst();
-                            attackableNpc.ifPresent(rs2NpcModel -> Rs2Npc.interact(rs2NpcModel.getId()));
+                            attackableNpc.ifPresent(rs2NpcModel -> Rs2Npc.interact(rs2NpcModel.getId(),"attack"));
                         }
                     }
 


### PR DESCRIPTION
fixes an interact() that was missing "attack" specification, before it was just clicking on an npc and doing nothing