### PR TITLE
feat: support for higher price increasing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerConfig.java
@@ -6,7 +6,7 @@ import net.runelite.client.config.ConfigInformation;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup("GE buyer")
-@ConfigInformation("Acun <br> 0.1.0-alpha.1 <br><br> Start near GE. <br> Make sure to spell item names correct. " +
+@ConfigInformation("Acun's GE buyer <br><br> Start near GE. <br> Make sure to spell item names correct. " +
         "Collects items to bank. " +
         "<br> Be cautious and monitor when using, because there are no failsafes added yet. " +
         "<br><br> Item name[quantity] for example: rune arrow[50],amulet of glory(6)[1]"
@@ -29,6 +29,6 @@ public interface AutoBuyerConfig extends Config {
             position = 1
     )
     default Percentage pricePerItem() {
-        return Percentage.PERCENT_5;
+        return Percentage.PERCENT_10;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerOverlay.java
@@ -23,7 +23,7 @@ public class AutoBuyerOverlay extends OverlayPanel {
         try {
             panelComponent.setPreferredSize(new Dimension(200, 300));
             panelComponent.getChildren().add(TitleComponent.builder()
-                    .text("GE buyer 0.1.0-alpha.1")
+                    .text("GE buyer v1.1")
                     .color(Color.GREEN)
                     .build());
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/Percentage.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/Percentage.java
@@ -6,10 +6,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Percentage {
-    PERCENT_5("+5%"),
-    PERCENT_10("+10%");
+    PERCENT_5("+5%", 5),
+    PERCENT_10("+10%", 10),
+    PERCENT_50("+50%", 50),
+    PERCENT_99("+99%", 99); // GE does not accept higher value
 
     private final String name;
+    private final int value;
 
     @Override
     public String toString() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/misc/NumberExtractor.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/misc/NumberExtractor.java
@@ -1,0 +1,27 @@
+package net.runelite.client.plugins.microbot.util.misc;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NumberExtractor {
+    /**
+     * Extracts the first integer number from a given string.
+     * For example: "+1%", "123abc", "Price: 99 dollars" will result in 1, 123, 99
+     *
+     * @param input The input string containing a number.
+     * @return The extracted number, or -1 if no number is found.
+     */
+    public static int extractNumber(String input) {
+        // Define a regex pattern to match one or more digits
+        Pattern pattern = Pattern.compile("\\d+");
+        Matcher matcher = pattern.matcher(input);
+
+        // Find the first match and parse it as an integer
+        if (matcher.find()) {
+            return Integer.parseInt(matcher.group());
+        }
+
+        // Return -1 if no number is found
+        return -1;
+    }
+}


### PR DESCRIPTION
Plugin update: GE Buyer
Release version: v1.1.0

## features:
### Main
- Support for `+50%` and `+99%` increase price per item
- Resseting values like `initialCount` and `itemsList` when `shutdown()` is called to solve some bugs where given items were skipped sometimes

### Highlights
- Added new util class `NumberExtractor`
- Does use the 'Custom' percent widget of Grand Exchange