### PR TITLE
ACTUALLY FIXED looting for boss bryophyta

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerConfig.java
@@ -99,8 +99,7 @@ public interface MossKillerConfig extends Config {
             keyName = "wildySelector",
             name = "Wildy Mode",
             description = "Enable this for killing Moss Giants in the Wilderness.",
-            position = 2,
-            section = advancedGuideSection
+            position = 10
     )
     default boolean wildy() {
         return false;
@@ -122,7 +121,7 @@ public interface MossKillerConfig extends Config {
             keyName = "hideOverlay",
             name = "Overlay Hider",
             description = "Select this if you want to hide the overlay",
-            position = 9
+            position = 7
     )
     default boolean isHideOverlay() {
         return false;
@@ -133,7 +132,7 @@ public interface MossKillerConfig extends Config {
             keyName = "buryBones",
             name = "Bury Bones",
             description = "Select this if you want to bury bones",
-            position = 8
+            position = 9
     )
     default boolean buryBones() {
         return false;
@@ -141,10 +140,9 @@ public interface MossKillerConfig extends Config {
 
     @ConfigItem(
             keyName = "alchLoot",
-            name = "Alch's loot",
+            name = "Alch loot",
             description = "Select this if you want to loot alchables and alch them and loot coins",
-            position = 8,
-            section = basicGuideSection
+            position = 8
     )
     default boolean alchLoot() {
         return false;
@@ -168,7 +166,7 @@ public interface MossKillerConfig extends Config {
             keyName = "keyThreshold",
             name = "Key Threshold",
             description = "How many Mossy Keys should be collected before killing the boss.",
-            position = 10,
+            position = 8,
             section = basicGuideSection
     )
     default int keyThreshold() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -1454,7 +1454,8 @@ public class WildyKillerScript extends Script {
         if (Rs2Inventory.contains(NATURE_RUNE) &&
                 !Rs2Inventory.contains(STAFF_OF_FIRE) &&
                 mossKillerPlugin.currentTarget == null &&
-                Rs2Inventory.contains(ALCHABLES)) {
+                Rs2Inventory.contains(ALCHABLES) &&
+                config.alchLoot()){
 
             if (Microbot.getClient().getRealSkillLevel(MAGIC) > 54 && Rs2Magic.canCast(HIGH_LEVEL_ALCHEMY)) {
 


### PR DESCRIPTION
### Moss Killer Plugin

- Changed config to reflect "bury bones" and "alch loot" being shared between basic and advanced mode. Wildy mode as well is outside of advanced guide mode to avoid having to scroll down a lot to activate it. 
- Fixed repetitive clicking of growthlings in boss fight. 
- Implemented new method of looting in the boss instance by leveraging the true tile of bryo at 0 hp as the tile to loot from and then cycling through the drop table using normal looting api using the converted worldPoint. 

Also in the plugin class switched off a lot of processing and checks if wildy mode is not enabled and vica versa. 