### PR TITLE
Added option to break now in breakhandler

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerConfig.java
@@ -8,31 +8,26 @@ import net.runelite.client.plugins.microbot.util.antiban.enums.PlaySchedule;
 
 @ConfigGroup(BreakHandlerConfig.configGroup)
 public interface BreakHandlerConfig extends Config {
+    // Group name constant for configuration grouping.
     String configGroup = "break-handler";
     String hideOverlay = "hideOverlay";
 
-    @ConfigItem(
-            keyName = "hideOverlay",
-            name = "Overlay Hider",
-            description = "Select this if you want to hide overlay"
-    )
-    default boolean isHideOverlay() {
-        return false;
-    }
-
-    // Play Schedule section
+    // ============================================================
+    // Break Timing Settings
+    // ============================================================
     @ConfigSection(
-            name = "Play Schedule",
-            description = "Options related to using a play schedule",
-            position = 51
+            name = "Break Timing",
+            description = "Configure when and how long breaks occur",
+            position = 0
     )
-    String usePlaySchedule = "usePlaySchedule";
+    String breakTimingSettings = "breakTimingSettings";
 
     @ConfigItem(
             keyName = "Min Playtime",
             name = "Min Playtime",
             description = "Time until break start in minutes",
-            position = 0
+            position = 0,
+            section = breakTimingSettings
     )
     default int timeUntilBreakStart() {
         return 60;
@@ -42,7 +37,8 @@ public interface BreakHandlerConfig extends Config {
             keyName = "Max Playtime",
             name = "Max Playtime",
             description = "Time until break ends in minutes",
-            position = 1
+            position = 1,
+            section = breakTimingSettings
     )
     default int timeUntilBreakEnd() {
         return 120;
@@ -52,7 +48,8 @@ public interface BreakHandlerConfig extends Config {
             keyName = "Min BreakTime",
             name = "Min BreakTime",
             description = "Break duration start in minutes",
-            position = 2
+            position = 2,
+            section = breakTimingSettings
     )
     default int breakDurationStart() {
         return 10;
@@ -62,18 +59,40 @@ public interface BreakHandlerConfig extends Config {
             keyName = "Max BreakTime",
             name = "Max BreakTime",
             description = "Break duration end in minutes",
-            position = 3
+            position = 3,
+            section = breakTimingSettings
     )
     default int breakDurationEnd() {
         return 15;
     }
 
-    // boolean to only use microbreaks
+    @ConfigItem(
+            keyName = "breakNow",
+            name = "Break Now",
+            description = "Toggle this to start a break immediately",
+            position = 4,
+            section = breakTimingSettings
+    )
+    default boolean breakNow() {
+        return false;
+    }
+
+    // ============================================================
+    // Break Behavior Options
+    // ============================================================
+    @ConfigSection(
+            name = "Break Behavior",
+            description = "Configure what happens during breaks",
+            position = 1
+    )
+    String breakBehaviorOptions = "breakBehaviorOptions";
+
     @ConfigItem(
             keyName = "OnlyMicroBreaks",
             name = "Micro Breaks Only",
             description = "Only use micro breaks if enabled",
-            position = 4
+            position = 0,
+            section = breakBehaviorOptions
     )
     default boolean onlyMicroBreaks() {
         return false;
@@ -83,7 +102,8 @@ public interface BreakHandlerConfig extends Config {
             keyName = "Logout",
             name = "Logout",
             description = "Logout when taking a break",
-            position = 5
+            position = 1,
+            section = breakBehaviorOptions
     )
     default boolean logoutAfterBreak() {
         return true;
@@ -93,11 +113,22 @@ public interface BreakHandlerConfig extends Config {
             keyName = "useRandomWorld",
             name = "Use RandomWorld",
             description = "Change to a random world once break is finished",
-            position = 6
+            position = 2,
+            section = breakBehaviorOptions
     )
     default boolean useRandomWorld() {
         return false;
     }
+
+    // ============================================================
+    // Play Schedule Configuration Section
+    // ============================================================
+    @ConfigSection(
+            name = "Play Schedule",
+            description = "Options related to using a play schedule",
+            position = 2
+    )
+    String usePlaySchedule = "usePlaySchedule";
 
     @ConfigItem(
             keyName = "UsePlaySchedule",
@@ -119,5 +150,18 @@ public interface BreakHandlerConfig extends Config {
     )
     default PlaySchedule playSchedule() {
         return PlaySchedule.MEDIUM_DAY;
+    }
+
+    // ============================================================
+    // Overlay Settings
+    // ============================================================
+    @ConfigItem(
+            keyName = "hideOverlay",
+            name = "Hide Overlay",
+            description = "Select this if you want to hide overlay",
+            position = 0
+    )
+    default boolean isHideOverlay() {
+        return false;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerPlugin.java
@@ -7,6 +7,9 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
+import net.runelite.client.plugins.skillcalculator.skills.MagicAction;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
@@ -74,7 +77,11 @@ public class BreakHandlerPlugin extends Plugin {
             if (event.getKey().equals("UsePlaySchedule")) {
                 breakHandlerScript.reset();
             }
-        }
+            
+            if (event.getKey().equals("breakNow")) {
+                boolean breakNowValue = config.breakNow();
+                log.debug("Break Now toggled: {}", breakNowValue);
+            }
 
             if (event.getKey().equals(BreakHandlerConfig.hideOverlay)) {
                 hideOverlay = config.isHideOverlay();
@@ -82,3 +89,4 @@ public class BreakHandlerPlugin extends Plugin {
             }
         }
     }
+}


### PR DESCRIPTION
### Changelog

### Feature

- **Added:**  A new "Break Now" option in the "Break Timing" settings. Toggling this option to `true` will immediately start a break, overriding the regular break schedule. This allows users to manually initiate a break whenever needed.


### Improvements
- **Configuration UI Restructuring:**
    - Reorganized the plugin configuration UI for better clarity and logical grouping.
    Behavior" settings section.
- **Break Trigger Logic Refinement:**
    - Improved the internal break triggering logic for better code maintainability and reliability.
    - Centralized the actions taken when a break starts into a dedicated `startBreak()` method for cleaner code.