### PR TITLE
feat: skip item if 'no matches found'.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/autoBuyer/AutoBuyerScript.java
@@ -72,10 +72,16 @@ public class AutoBuyerScript extends Script {
                         }
                     }
 
+                    boolean result;
                     if (timesToClickIncrease != null ) {
-                        Rs2GrandExchange.buyItemAbove5Percent(itemName, quantity, timesToClickIncrease);
+                        result = Rs2GrandExchange.buyItemAbove5Percent(itemName, quantity, timesToClickIncrease);
                     } else {
-                        Rs2GrandExchange.buyItemAboveXPercent(itemName, quantity, percent);
+                        result = Rs2GrandExchange.buyItemAboveXPercent(itemName, quantity, percent);
+                    }
+
+                    if (!result) {
+                        Microbot.log("Could not buy '" + itemName + "'. Skipping it.");
+                        Rs2GrandExchange.backToOverview();
                     }
                     itemsList.remove(itemName); // Remove from list so we don't buy the same item again
                     totalBought++;


### PR DESCRIPTION
- Add `backToOverview` method to Rs2GrandExchange
- Add `searchItemAndSetQuantity` method to Rs2GrandExchange, improves reusability and maintainability
- Add feature to skip 'item to buy' if it was not found in GE. 
    - This is nice to have when we add [Buy Quest Items](https://github.com/chsami/Microbot/pull/738), as some item names are not exact
    - Works well when users have typo in item names