### PR TITLE
Rs2Inventory: combineClosest fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
@@ -203,7 +203,11 @@ public class Rs2Inventory {
             }
         }
 
-        return combine(closestPrimaryItem, closestSecondaryItem);
+        boolean primaryItemInteracted = use(closestPrimaryItem);
+        sleep(100, 175);
+        boolean secondaryItemInteracted = use(closestSecondaryItem);
+        return primaryItemInteracted && secondaryItemInteracted;
+
     }
 
     /**
@@ -241,7 +245,10 @@ public class Rs2Inventory {
             }
         }
 
-        return combine(closestPrimaryItem, closestSecondaryItem);
+        boolean primaryItemInteracted = use(closestPrimaryItem);
+        sleep(100, 175);
+        boolean secondaryItemInteracted = use(closestSecondaryItem);
+        return primaryItemInteracted && secondaryItemInteracted;
     }
 
 


### PR DESCRIPTION
  Updated the combineClosest methods to no longer rely on the default combine method due to logic conflict