### PR TITLE
isincombat check before bryo gate and combat hotkeys boolean

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
@@ -1,6 +1,5 @@
 package net.runelite.client.plugins.microbot.bee.MossKiller;
 
-import net.runelite.api.NPC;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.PluginInstantiationException;
@@ -78,7 +77,7 @@ public class MossKillerScript extends Script {
     public static int CHAOS_RUNE = 562;
     // TODO: add stuff for boss too
     public int[] LOOT_LIST = new int[]{MOSSY_KEY, LAW_RUNE, AIR_RUNE, FIRE_RUNE, DEATH_RUNE, CHAOS_RUNE, NATURE_RUNE};
-    public static final int[] LOOT_LIST1 = new int[]{BIG_BONES, RUNE_PLATELEGS, RUNE_LONGSWORD, RUNE_MED_HELM, RUNE_CHAINBODY, RUNE_PLATESKIRT, RUNE_SQ_SHIELD, RUNE_SWORD, ADAMANT_PLATEBODY, ADAMANT_KITESHIELD, NATURE_RUNE, COSMIC_RUNE, LAW_RUNE, DEATH_RUNE, CHAOS_RUNE, ADAMANT_ARROW, RUNITE_BAR, UNCUT_RUBY, UNCUT_DIAMOND, STEEL_BAR, COINS, STRENGTH_POTION4, BRYOPHYTAS_ESSENCE, MOSSY_KEY};
+    public static final int[] LOOT_LIST1 = new int[]{STEEL_BAR, BIG_BONES, RUNE_PLATELEGS, RUNE_LONGSWORD, RUNE_MED_HELM, RUNE_CHAINBODY, RUNE_PLATESKIRT, RUNE_SQ_SHIELD, RUNE_SWORD, ADAMANT_PLATEBODY, ADAMANT_KITESHIELD, NATURE_RUNE, COSMIC_RUNE, LAW_RUNE, DEATH_RUNE, CHAOS_RUNE, ADAMANT_ARROW, RUNITE_BAR, RUNITE_BAR, UNCUT_RUBY, UNCUT_DIAMOND, STEEL_BAR, COINS, STRENGTH_POTION4, BRYOPHYTAS_ESSENCE, MOSSY_KEY};
     public int[] ALCHABLES = new int[]{STEEL_KITESHIELD, MITHRIL_SWORD, BLACK_SQ_SHIELD};
 
     public MossKillerState state = MossKillerState.BANK;
@@ -501,6 +500,7 @@ public class MossKillerScript extends Script {
                                 }
 
                                 if (bossMode && Rs2Walker.getDistanceBetween(playerLocation, OUTSIDE_BOSS_GATE_SPOT) < 5) {
+                                    if (Rs2Player.isInCombat()) {sleepUntil(()-> !Rs2Player.isInCombat(), 25000);}
                                     if (Rs2GameObject.exists(32534) && Rs2GameObject.interact(32534, "Open")) {
                                         sleepUntil(Rs2Dialogue::isInDialogue);
                                         if (Rs2Dialogue.isInDialogue()) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysConfig.java
@@ -202,6 +202,16 @@ public interface CombatHotkeysConfig extends Config {
         return "";
     }
 
+    @ConfigItem(
+            keyName = "dance boolean",
+            name = "dance",
+            description = "Select this if you want to setup dance",
+            position = 8
+    )
+    default boolean yesDance() {
+        return false;
+    }
+
     // config item for a keybind to enable the dance feature
     @ConfigItem(
             keyName = "dance",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysOverlay.java
@@ -38,10 +38,10 @@ public class CombatHotkeysOverlay extends Overlay {
 //                    .color(Color.GREEN)
 //                    .build());
 
-
-            drawTile(graphics, config.tile1(), Color.GREEN, "Tile 1", new BasicStroke(2));
-            drawTile(graphics, config.tile2(), Color.GREEN, "Tile 2", new BasicStroke(2));
-
+            if(config.yesDance()) {
+                drawTile(graphics, config.tile1(), Color.GREEN, "Tile 1", new BasicStroke(2));
+                drawTile(graphics, config.tile2(), Color.GREEN, "Tile 2", new BasicStroke(2));
+            }
         } catch(Exception ex) {
             System.out.println(ex.getMessage());
         }


### PR DESCRIPTION
moss killer plugin:

- some users were getting combat interrupted trying to enter boss gate so added an isincombat check before trying to open the boss gate.
- added rune  bar to be looted twice because of double drop 

combat hotkeys:

- the dance tiles don't let you use camera movement using right-click and drag so I put it as a boolean that it only affects the overlay when selected (when wanting to dance)