### PR TITLE
Walker Update: Minigame Teleports & Canoes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Restriction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Restriction.java
@@ -129,6 +129,12 @@ public class Restriction {
                 } else if (varbitCheck.contains("=")) {
                     parts = varbitCheck.split("=");
                     operator = TransportVarbit.Operator.EQUAL;
+                } else if (varbitCheck.contains("&")) {
+                    parts = varbitCheck.split("&");
+                    operator = TransportVarbit.Operator.BIT_SET;
+                } else if (varbitCheck.contains("@")) {
+                    parts = varbitCheck.split("@");
+                    operator = TransportVarbit.Operator.COOLDOWN_MINUTES;
                 } else {
                     throw new IllegalArgumentException("Invalid varbit format: " + varbitCheck);
                 }
@@ -153,6 +159,12 @@ public class Restriction {
                 } else if (varplayerCheck.contains("=")) {
                     parts =  varplayerCheck.split("=");
                     operator = TransportVarPlayer.Operator.EQUAL;
+                } else if (varplayerCheck.contains("&")) {
+                    parts = varplayerCheck.split("&");
+                    operator = TransportVarPlayer.Operator.BIT_SET;
+                } else if (varplayerCheck.contains("@")) {
+                    parts = varplayerCheck.split("@");
+                    operator = TransportVarPlayer.Operator.COOLDOWN_MINUTES;
                 } else {
                     throw new IllegalArgumentException("Invalid varplayer format: " + varplayerCheck);
                 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathConfig.java
@@ -19,7 +19,7 @@ public interface ShortestPathConfig extends Config {
             name = "Avoid wilderness",
             description = "Whether the wilderness should be avoided if possible<br>" +
                     "(otherwise, will e.g. use wilderness lever from Edgeville to Ardougne)",
-            position = 1,
+            position = 0,
             section = sectionSettings
     )
     default boolean avoidWilderness() {
@@ -31,7 +31,7 @@ public interface ShortestPathConfig extends Config {
             name = "Use agility shortcuts",
             description = "Whether to include agility shortcuts in the path.<br>" +
                     "You must also have the required agility level",
-            position = 2,
+            position = 1,
             section = sectionSettings
     )
     default boolean useAgilityShortcuts() {
@@ -43,7 +43,7 @@ public interface ShortestPathConfig extends Config {
             name = "Use grapple shortcuts",
             description = "Whether to include crossbow grapple agility shortcuts in the path.<br>" +
                     "You must also have the required agility, ranged and strength levels",
-            position = 3,
+            position = 2,
             section = sectionSettings
     )
     default boolean useGrappleShortcuts() {
@@ -55,7 +55,7 @@ public interface ShortestPathConfig extends Config {
             name = "Use boats",
             description = "Whether to include small boats in the path<br>" +
                     "(e.g. the boat to Fishing Platform)",
-            position = 4,
+            position = 3,
             section = sectionSettings
     )
     default boolean useBoats() {
@@ -66,7 +66,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "useCanoes",
             name = "Use canoes",
             description = "Whether to include canoes in the path",
-            position = 5,
+            position = 4,
             section = sectionSettings
     )
     default boolean useCanoes() {
@@ -77,7 +77,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "useCharterShips",
             name = "Use charter ships",
             description = "Whether to include charter ships in the path",
-            position = 6,
+            position = 5,
             section = sectionSettings
     )
     default boolean useCharterShips() {
@@ -89,7 +89,7 @@ public interface ShortestPathConfig extends Config {
             name = "Use ships",
             description = "Whether to include passenger ships in the path<br>" +
                     "(e.g. the customs ships to Karamja)",
-            position = 7,
+            position = 6,
             section = sectionSettings
     )
     default boolean useShips() {
@@ -101,7 +101,7 @@ public interface ShortestPathConfig extends Config {
             name = "Use fairy rings",
             description = "Whether to include fairy rings in the path.<br>" +
                     "You must also have completed the required quests or miniquests",
-            position = 8,
+            position = 7,
             section = sectionSettings
     )
     default boolean useFairyRings() {
@@ -112,7 +112,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "useGnomeGliders",
             name = "Use gnome gliders",
             description = "Whether to include gnome gliders in the path",
-            position = 9,
+            position = 8,
             section = sectionSettings
     )
     default boolean useGnomeGliders() {
@@ -124,7 +124,7 @@ public interface ShortestPathConfig extends Config {
             name = "Use minecarts",
             description = "Whether to include minecarts in the path<br>" +
                     "(e.g. the Keldagrim and Lovakengj minecart networks)",
-            position = 10,
+            position = 9,
             section = sectionSettings
     )
     default boolean useMinecarts() {
@@ -135,7 +135,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "useSpiritTrees",
             name = "Use spirit trees",
             description = "Whether to include spirit trees in the path",
-            position = 11,
+            position = 10,
             section = sectionSettings
     )
     default boolean useSpiritTrees() {
@@ -147,7 +147,7 @@ public interface ShortestPathConfig extends Config {
             name = "Use teleportation items",
             description = "Whether to include teleportation items from the player's inventory and equipment.<br>" +
                     "Options labelled (perm) only use permanent non-charge items.",
-            position = 12,
+            position = 11,
             section = sectionSettings
     )
     default TeleportationItem useTeleportationItems() {
@@ -159,7 +159,7 @@ public interface ShortestPathConfig extends Config {
             name = "Use teleportation levers",
             description = "Whether to include teleportation levers in the path<br>" +
                     "(e.g. the lever from Edgeville to Wilderness)",
-            position = 13,
+            position = 12,
             section = sectionSettings
     )
     default boolean useTeleportationLevers() {
@@ -171,7 +171,7 @@ public interface ShortestPathConfig extends Config {
             name = "Use teleportation portals",
             description = "Whether to include teleportation portals in the path<br>" +
                     "(e.g. the portal from Ferox Enclave to Castle Wars)",
-            position = 14,
+            position = 13,
             section = sectionSettings
     )
     default boolean useTeleportationPortals() {
@@ -182,11 +182,23 @@ public interface ShortestPathConfig extends Config {
             keyName = "useTeleportationSpells",
             name = "Use teleportation spells",
             description = "Whether to include teleportation spells in the path",
-            position = 15,
+            position = 14,
             section = sectionSettings
     )
     default boolean useTeleportationSpells() {
         return true;
+    }
+    
+    @ConfigItem(
+            keyName = "useTeleportationMinigames",
+            name = "Use teleportation to minigames",
+            description = "Whether to include teleportation to minigames/activities/grouping in the path<br>" +
+                    "(e.g. the Nightmare Zone minigame teleport). These teleports share a 20 minute cooldown.",
+            position = 15,
+            section = sectionSettings
+    )
+    default boolean useTeleportationMinigames() {
+        return false;
     }
 
     @ConfigItem(
@@ -201,11 +213,44 @@ public interface ShortestPathConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "useNpcs",
+            name = "Use npcs",
+            description = "Whether to include npc transports in the path<br>(e.g. Tree gnome village maze or Lumbridge cellar)",
+            position =  17,
+            section = sectionSettings
+    )
+    default boolean useNpcs() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "useQuetzals",
+            name = "Use quetzals",
+            description = "Whether to include quetzals in the path.<br>",
+            position = 18,
+            section = sectionSettings
+    )
+    default boolean useQuetzals() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "useMagicCarpets",
+            name = "Use Magic Carpets",
+            description = "Whether to include magic carpets in the path.<br>",
+            position = 19,
+            section = sectionSettings
+    )
+    default boolean useMagicCarpets() {
+        return true;
+    }
+
+    @ConfigItem(
             keyName = "cancelInstead",
             name = "Cancel instead of recalculating",
             description = "Whether the path should be cancelled rather than recalculated " +
                     "when the recalculate distance limit is exceeded",
-            position = 17,
+            position = 20,
             section = sectionSettings
     )
     default boolean cancelInstead() {
@@ -213,11 +258,22 @@ public interface ShortestPathConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "showTransportInfo",
+            name = "Show transport info",
+            description = "Whether to display transport destination hint info, e.g. which chat option and text to click",
+            position = 21,
+            section = sectionSettings
+    )
+    default boolean showTransportInfo() {
+        return true;
+    }
+
+    @ConfigItem(
             keyName = "distanceBeforeUsingTeleports",
             name = "Teleport distance",
             description = "Distance before using a teleport<br>" +
                     "(This is to avoid using teleports when you are to close",
-            position = 14,
+            position = 22,
             section = sectionSettings
     )
     default int distanceBeforeUsingTeleport() {
@@ -232,7 +288,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "recalculateDistance",
             name = "Recalculate distance",
             description = "Distance from the path the player should be for it to be recalculated (-1 for never)",
-            position = 18,
+            position = 23,
             section = sectionSettings
     )
     default int recalculateDistance() {
@@ -247,7 +303,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "finishDistance",
             name = "Finish distance",
             description = "Distance from the target tile at which the path should be ended (-1 for never)",
-            position = 19,
+            position = 24,
             section = sectionSettings
     )
     default int reachedDistance() {
@@ -258,7 +314,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "showTileCounter",
             name = "Show tile counter",
             description = "Whether to display the number of tiles travelled, number of tiles remaining or disable counting",
-            position = 20,
+            position = 25,
             section = sectionSettings
     )
     default TileCounter showTileCounter() {
@@ -269,7 +325,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "tileCounterStep",
             name = "Tile counter step",
             description = "The number of tiles between the displayed tile counter numbers",
-            position = 21,
+            position = 26,
             section = sectionSettings
     )
     default int tileCounterStep()
@@ -289,7 +345,7 @@ public interface ShortestPathConfig extends Config {
             name = "Calculation cutoff",
             description = "The cutoff threshold in number of ticks (0.6 seconds) of no progress being<br>" +
                     "made towards the path target before the calculation will be stopped",
-            position = 22,
+            position = 27,
             section = sectionSettings
     )
     default int calculationCutoff()
@@ -297,54 +353,10 @@ public interface ShortestPathConfig extends Config {
         return 5;
     }
 
-    @ConfigItem(
-            keyName = "showTransportInfo",
-            name = "Show transport info",
-            description = "Whether to display transport destination hint info, e.g. which chat option and text to click",
-            position = 23,
-            section = sectionSettings
-    )
-    default boolean showTransportInfo() {
-        return true;
-    }
-
-    @ConfigItem(
-            keyName = "useNpcs",
-            name = "Use npcs",
-            description = "Whether to include npc transports in the path<br>(e.g. Tree gnome village maze or Lumbridge cellar)",
-            position = 24,
-            section = sectionSettings
-    )
-    default boolean useNpcs() {
-        return true;
-    }
-
-    @ConfigItem(
-            keyName = "useQuetzals",
-            name = "Use quetzals",
-            description = "Whether to include quetzals in the path.<br>",
-            position = 25,
-            section = sectionSettings
-    )
-    default boolean useQuetzals() {
-        return true;
-    }
-
-    @ConfigItem(
-            keyName = "useMagicCarpets",
-            name = "Use Magic Carpets",
-            description = "Whether to include magic carpets in the path.<br>",
-            position = 26,
-            section = sectionSettings
-    )
-    default boolean useMagicCarpets() {
-        return true;
-    }
-
     @ConfigSection(
             name = "Display",
             description = "Options for displaying the path on the world map, minimap and scene tiles",
-            position = 24
+            position = 1
     )
     String sectionDisplay = "sectionDisplay";
 
@@ -352,7 +364,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "drawMap",
             name = "Draw path on world map",
             description = "Whether the path should be drawn on the world map",
-            position = 25,
+            position = 0,
             section = sectionDisplay
     )
     default boolean drawMap() {
@@ -363,7 +375,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "drawMinimap",
             name = "Draw path on minimap",
             description = "Whether the path should be drawn on the minimap",
-            position = 26,
+            position = 1,
             section = sectionDisplay
     )
     default boolean drawMinimap() {
@@ -374,7 +386,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "drawTiles",
             name = "Draw path on tiles",
             description = "Whether the path should be drawn on the game tiles",
-            position = 27,
+            position = 2,
             section = sectionDisplay
     )
     default boolean drawTiles() {
@@ -385,7 +397,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "pathStyle",
             name = "Path style",
             description = "Whether to display the path as tiles or a segmented line",
-            position = 28,
+            position = 3,
             section = sectionDisplay
     )
     default TileStyle pathStyle() {
@@ -396,7 +408,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "showETA",
             name = "Show ETA Overlay",
             description = "Whether to display the ETA in an overlay to your destination",
-            position = 29,
+            position = 4,
             section = sectionDisplay
     )
     default boolean showETA() {
@@ -407,7 +419,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "showETAInSeconds",
             name = "Show ETA in Seconds",
             description = "Whether to display the ETA in seconds vs mins:seconds",
-            position = 30,
+            position = 5,
             section = sectionDisplay
     )
     default boolean showInSeconds() {
@@ -417,7 +429,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
             name = "Colours",
             description = "Colours for the path map, minimap and scene tiles",
-            position = 29
+            position = 2
     )
     String sectionColours = "sectionColours";
 
@@ -426,7 +438,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "colourPath",
             name = "Path",
             description = "Colour of the path tiles on the world map, minimap and in the game scene",
-            position = 30,
+            position = 0,
             section = sectionColours
     )
     default Color colourPath() {
@@ -438,7 +450,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "colourPathCalculating",
             name = "Calculating",
             description = "Colour of the path tiles while the pathfinding calculation is in progress",
-            position = 31,
+            position = 1,
             section = sectionColours
     )
     default Color colourPathCalculating() {
@@ -450,7 +462,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "colourTransports",
             name = "Transports",
             description = "Colour of the transport tiles",
-            position = 32,
+            position = 2,
             section = sectionColours
     )
     default Color colourTransports() {
@@ -462,7 +474,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "colourCollisionMap",
             name = "Collision map",
             description = "Colour of the collision map tiles",
-            position = 33,
+            position = 3,
             section = sectionColours
     )
     default Color colourCollisionMap() {
@@ -474,7 +486,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "colourText",
             name = "Text",
             description = "Colour of the text of the tile counter and fairy ring codes",
-            position = 34,
+            position = 4,
             section = sectionColours
     )
     default Color colourText() {
@@ -484,7 +496,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
             name = "Debug Options",
             description = "Various options for debugging",
-            position = 35,
+            position = 3,
             closedByDefault = true
     )
     String sectionDebug = "sectionDebug";
@@ -493,7 +505,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "drawTransports",
             name = "Draw transports",
             description = "Whether transports should be drawn",
-            position = 36,
+            position = 0,
             section = sectionDebug
     )
     default boolean drawTransports() {
@@ -504,7 +516,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "drawCollisionMap",
             name = "Draw collision map",
             description = "Whether the collision map should be drawn",
-            position = 37,
+            position = 1,
             section = sectionDebug
     )
     default boolean drawCollisionMap() {
@@ -515,7 +527,7 @@ public interface ShortestPathConfig extends Config {
             keyName = "drawDebugPanel",
             name = "Show debug panel",
             description = "Toggles displaying the pathfinding debug stats panel",
-            position = 38,
+            position = 2,
             section = sectionDebug
     )
     default boolean drawDebugPanel() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Transport.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Transport.java
@@ -213,7 +213,7 @@ public class Transport {
         
         if ((value = fieldMap.get("Currency")) != null) {
             // Split the string by space
-            String[] parts = value.split(" ");
+            String[] parts = value.split(DELIM);
             if (parts.length > 1) {
                 // Parse the first part as an integer amount
                 currencyAmount = Integer.parseInt(parts[0]);
@@ -266,13 +266,10 @@ public class Transport {
             this.duration = Integer.parseInt(value);
         }
 
-        if (TransportType.TELEPORTATION_ITEM.equals(transportType)
-                || TransportType.TELEPORTATION_SPELL.equals(transportType)) {
-            // Teleportation items and spells should always have a non-zero wait,
+        if (TransportType.isTeleport(transportType)) {
+            // Teleports should always have a non-zero wait,
             // so the pathfinder doesn't calculate the cost by distance
-            //MICROBOT - The reason we commented this out is to avoid using teleport items when being to close to the target
-            // We overwrite this value based on a config "distance to teleport"
-            // this.duration = duration;
+            this.duration = Math.max(this.duration, 1);
         }
 
         if ((value = fieldMap.get("Display info")) != null) {
@@ -305,6 +302,12 @@ public class Transport {
                 } else if (varbitCheck.contains("=")) {
                     parts = varbitCheck.split("=");
                     operator = TransportVarbit.Operator.EQUAL;
+                } else if (varbitCheck.contains("&")) {
+                    parts = varbitCheck.split("&");
+                    operator = TransportVarbit.Operator.BIT_SET;
+                } else if (varbitCheck.contains("@")) {
+                    parts = varbitCheck.split("@");
+                    operator = TransportVarbit.Operator.COOLDOWN_MINUTES;
                 } else {
                     throw new IllegalArgumentException("Invalid varbit format: " + varbitCheck);
                 }
@@ -326,9 +329,12 @@ public class Transport {
                 } else if (varplayerCheck.contains("<")) {
                     parts = varplayerCheck.split("<");
                     operator = TransportVarPlayer.Operator.LESS_THAN;
-                } else if (varplayerCheck.contains("=")) {
-                    parts = varplayerCheck.split("=");
-                    operator = TransportVarPlayer.Operator.EQUAL;
+                } else if (varplayerCheck.contains("&")) {
+                    parts = varplayerCheck.split("&");
+                    operator = TransportVarPlayer.Operator.BIT_SET;
+                } else if (varplayerCheck.contains("@")) {
+                    parts = varplayerCheck.split("@");
+                    operator = TransportVarPlayer.Operator.COOLDOWN_MINUTES;
                 } else {
                     throw new IllegalArgumentException("Invalid varplayer format: " + varplayerCheck);
                 }
@@ -485,6 +491,7 @@ public class Transport {
         addTransports(transports, "spirit_trees.tsv", TransportType.SPIRIT_TREE, 5);
         addTransports(transports, "quetzals.tsv", TransportType.QUETZAL, 6);
         addTransports(transports, "teleportation_items.tsv", TransportType.TELEPORTATION_ITEM);
+        addTransports(transports, "teleportation_minigames.tsv", TransportType.TELEPORTATION_MINIGAME);
         addTransports(transports, "teleportation_levers.tsv", TransportType.TELEPORTATION_LEVER);
         addTransports(transports, "teleportation_portals.tsv", TransportType.TELEPORTATION_PORTAL);
         addTransports(transports, "teleportation_spells.tsv", TransportType.TELEPORTATION_SPELL);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Transport.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Transport.java
@@ -329,6 +329,9 @@ public class Transport {
                 } else if (varplayerCheck.contains("<")) {
                     parts = varplayerCheck.split("<");
                     operator = TransportVarPlayer.Operator.LESS_THAN;
+                } else if (varplayerCheck.contains("=")) {
+                    parts = varplayerCheck.split("=");
+                    operator = TransportVarPlayer.Operator.EQUAL;
                 } else if (varplayerCheck.contains("&")) {
                     parts = varplayerCheck.split("&");
                     operator = TransportVarPlayer.Operator.BIT_SET;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/TransportType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/TransportType.java
@@ -15,9 +15,30 @@ public enum TransportType {
     SPIRIT_TREE,
     TELEPORTATION_LEVER,
     TELEPORTATION_PORTAL,
+    TELEPORTATION_MINIGAME,
     TELEPORTATION_ITEM,
     TELEPORTATION_SPELL,
     WILDERNESS_OBELISK,
     MAGIC_CARPET,
-    NPC
+    NPC;
+
+    /*
+     * Indicates whether a TransportType is a teleport.
+     * Levers, portals and wilderness obelisks are considered transports
+     * and not teleports because they have a pre-defined origin and no
+     * wilderness level limit.
+     */
+    public static boolean isTeleport(TransportType transportType) {
+        if (transportType == null) {
+            return false;
+        }
+        switch (transportType) {
+            case TELEPORTATION_ITEM:
+            case TELEPORTATION_MINIGAME:
+            case TELEPORTATION_SPELL:
+                return true;
+            default:
+                return false;
+        }
+    }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/TransportVarPlayer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/TransportVarPlayer.java
@@ -23,12 +23,18 @@ public class TransportVarPlayer {
                 return actualValue > value;
             case LESS_THAN:
                 return actualValue < value;
+            case BIT_SET:
+                return (actualValue & value) > 0;
+            case COOLDOWN_MINUTES:
+                return ((System.currentTimeMillis() / 60000) - actualValue) > value;
             default:
                 throw new IllegalArgumentException("Unsupported operator: " + operator);
         }
     }
 
     public enum Operator {
+        BIT_SET,
+        COOLDOWN_MINUTES,
         EQUAL,
         GREATER_THAN,
         LESS_THAN

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/TransportVarbit.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/TransportVarbit.java
@@ -23,12 +23,18 @@ public class TransportVarbit {
                 return actualValue > value;
             case LESS_THAN:
                 return actualValue < value;
+            case BIT_SET:
+                return (actualValue & value) > 0;
+            case COOLDOWN_MINUTES:
+                return ((System.currentTimeMillis() / 60000) - actualValue) > value;
             default:
                 throw new IllegalArgumentException("Unsupported operator: " + operator);
         }
     }
 
     public enum Operator {
+        BIT_SET,
+        COOLDOWN_MINUTES,
         EQUAL,
         GREATER_THAN,
         LESS_THAN

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/CollisionMap.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/CollisionMap.java
@@ -112,9 +112,7 @@ public class CollisionMap {
         for (Transport transport : transports) {
             //START microbot variables
             if (visited.get(transport.getDestination())) continue;
-            if (config.isIgnoreTeleportAndItems() &&
-                    (transport.getType() == TransportType.TELEPORTATION_SPELL ||
-                            transport.getType() == TransportType.TELEPORTATION_ITEM)) continue;
+            if (config.isIgnoreTeleportAndItems() && TransportType.isTeleport(transport.getType())) continue;
 
             //EXCEPTION
             if (transport.getType() == TransportType.MINECART) {
@@ -125,7 +123,7 @@ public class CollisionMap {
                 }
             }
 
-            if (transport.getType() == TransportType.TELEPORTATION_ITEM || transport.getType() == TransportType.TELEPORTATION_SPELL) {
+            if (TransportType.isTeleport(transport.getType())) {
                 neighbors.add(new TransportNode(transport.getDestination(), node, config.getDistanceBeforeUsingTeleport() + transport.getDuration(), transport.getType(), transport.getDisplayInfo()));
             } else {
                 neighbors.add(new TransportNode(transport.getDestination(), node, transport.getDuration(), transport.getType(), transport.getDisplayInfo()));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/Pathfinder.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/Pathfinder.java
@@ -130,7 +130,7 @@ public class Pathfinder implements Runnable {
 
             node = boundary.removeFirst();
 
-            if (wildernessLevel > 19) {
+            if (wildernessLevel > 0) {
                 // We don't need to remove teleports when going from 20 to 21 or higher,
                 // because the teleport is either used at the very start of the
                 // path or when going from 31 or higher to 30, or from 21 or higher to 20.
@@ -145,6 +145,10 @@ public class Pathfinder implements Runnable {
                 }
                 if (wildernessLevel > 19 && !config.isInLevel19Wilderness(node.packedPosition)) {
                     wildernessLevel = 19;
+                    update = true;
+                }
+                if (wildernessLevel > 0 && !config.isInWilderness(node.packedPosition)) {
+                    wildernessLevel = 0;
                     update = true;
                 }
                 if (update) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/dialogues/Rs2Dialogue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/dialogues/Rs2Dialogue.java
@@ -659,14 +659,24 @@ public class Rs2Dialogue {
         }
         return false;
     }
-    
+
+    /**
+     * Waits for a cutscene to start and end using default polling and timeout values.
+     */
     public static void waitForCutScene() {
         waitForCutScene(100, 5000);
     }
 
+    /**
+     * Waits for a cutscene to start and end using the specified polling interval and timeout.
+     *
+     * @param time    the polling interval in milliseconds
+     * @param timeout the maximum time to wait in milliseconds
+     */
     public static void waitForCutScene(int time, int timeout) {
         boolean result = sleepUntilTrue(Rs2Dialogue::isInCutScene, time, timeout);
         if (!result) return;
         sleepUntilTrue(() -> !Rs2Dialogue.isInCutScene(), time, timeout);
     }
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/dialogues/Rs2Dialogue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/dialogues/Rs2Dialogue.java
@@ -84,7 +84,7 @@ public class Rs2Dialogue {
      *
      * @return true if the "Continue" option is visible in either sprite-based dialogue, false otherwise.
      */
-
+    
     private static boolean hasSpriteContinue() {
         return Rs2Widget.isWidgetVisible(InterfaceID.DIALOG_SPRITE, 0) || Rs2Widget.isWidgetVisible(InterfaceID.DIALOG_SPRITE, 3) || Rs2Widget.isWidgetVisible(InterfaceID.DIALOG_DOUBLE_SPRITE, 4);
     }
@@ -129,10 +129,10 @@ public class Rs2Dialogue {
     public static boolean hasSelectAnOption() {
         boolean isWidgetVisible = Rs2Widget.isWidgetVisible(InterfaceID.DIALOG_OPTION, 1);
         if (!isWidgetVisible) return false;
-
+        
         Widget widget = Rs2Widget.getWidget(InterfaceID.DIALOG_OPTION, 1);
         if (widget == null) return false;
-
+        
         return widget.getDynamicChildren() != null;
     }
 
@@ -440,7 +440,7 @@ public class Rs2Dialogue {
     public static boolean sleepUntilHasQuestion(String text) {
         return sleepUntilHasQuestion(text, false);
     }
-
+    
     /**
      * Checks if the combination dialogue widget is currently visible.
      *
@@ -578,11 +578,11 @@ public class Rs2Dialogue {
         if (!hasCombinationDialogue()) return false;
 
         Widget option = getCombinationOption(text, exact);
-
+        
         if (option == null) return false;
-
+        
         return Rs2Widget.clickWidget(option);
-
+        
     }
 
     /**
@@ -608,7 +608,7 @@ public class Rs2Dialogue {
      * Pauses the current thread until a specific combination dialogue option becomes available.
      *
      * <p>This method continuously checks for a combination dialogue option that matches the specified
-     * text. If an exact match is required, it will search for an option that exactly matches the text;
+     * text. If an exact match is required, it will search for an option that exactly matches the text; 
      * otherwise, it will look for an option containing the text.
      *
      * @param text  the text to search for within the combination dialogue options.
@@ -630,7 +630,7 @@ public class Rs2Dialogue {
     public static boolean sleepUntilHasCombinationOption(String text) {
         return sleepUntilHasCombinationOption(text, false);
     }
-
+    
     /**
      * Determines whether the game is currently in a cutscene.
      * <p>
@@ -658,5 +658,15 @@ public class Rs2Dialogue {
             }
         }
         return false;
+    }
+    
+    public static void waitForCutScene() {
+        waitForCutScene(100, 5000);
+    }
+
+    public static void waitForCutScene(int time, int timeout) {
+        boolean result = sleepUntilTrue(Rs2Dialogue::isInDialogue, time, timeout);
+        if (!result) return;
+        sleepUntilTrue(() -> !Rs2Dialogue.isInCutScene(), time, timeout);
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/dialogues/Rs2Dialogue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/dialogues/Rs2Dialogue.java
@@ -665,7 +665,7 @@ public class Rs2Dialogue {
     }
 
     public static void waitForCutScene(int time, int timeout) {
-        boolean result = sleepUntilTrue(Rs2Dialogue::isInDialogue, time, timeout);
+        boolean result = sleepUntilTrue(Rs2Dialogue::isInCutScene, time, timeout);
         if (!result) return;
         sleepUntilTrue(() -> !Rs2Dialogue.isInCutScene(), time, timeout);
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Point;
 import net.runelite.api.*;
+import net.runelite.api.annotations.Component;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
@@ -12,6 +13,7 @@ import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.plugins.devtools.MovementFlag;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
 import net.runelite.client.plugins.microbot.shortestpath.ShortestPathConfig;
 import net.runelite.client.plugins.microbot.shortestpath.ShortestPathPlugin;
 import net.runelite.client.plugins.microbot.shortestpath.Transport;
@@ -30,6 +32,7 @@ import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
+import net.runelite.client.plugins.microbot.util.misc.Rs2UiHelper;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
@@ -1006,12 +1009,10 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
                     if (origin != null && origin.getPlane() != Rs2Player.getWorldLocation().getPlane())
                         continue;
                     if (path.stream().noneMatch(x -> x.equals(transport.getDestination()))) continue;
-                    if ((transport.getType() == TransportType.TELEPORTATION_ITEM ||
-                            transport.getType() == TransportType.TELEPORTATION_SPELL) &&
-                                    Rs2Player.getWorldLocation().distanceTo(transport.getDestination()) < 3) continue;
+                    if (TransportType.isTeleport(transport.getType()) && Rs2Player.getWorldLocation().distanceTo(transport.getDestination()) < 3) continue;
 
                     // we don't need to check for teleportation_item & teleportation_spell as they will be set on the first tile
-                    if (transport.getType() != TransportType.TELEPORTATION_ITEM && transport.getType() != TransportType.TELEPORTATION_SPELL) {
+                    if (!TransportType.isTeleport(transport.getType())) {
                         int indexOfOrigin = IntStream.range(0, path.size())
                                 .filter(f -> path.get(f).equals(transport.getOrigin()))
                                 .findFirst()
@@ -1064,6 +1065,13 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
                             sleep(600 * 2); // wait 2 ticks befor einteracting, this is a delay of ships
                         }
                     }
+                    
+                    if (transport.getType() == TransportType.CANOE) {
+                        if (handleCanoe(transport)) {
+                            sleep(600 * 2); // wait 2 extra ticks before walking
+                            break;
+                        }
+                    }
 
                     if (transport.getType() == TransportType.SPIRIT_TREE) {
                         if (handleSpiritTree(transport)) {
@@ -1106,6 +1114,14 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
                     if (transport.getType() == TransportType.FAIRY_RING && !Rs2Player.getWorldLocation().equals(transport.getDestination())) {
                         handleFairyRing(transport);
                     }
+                    
+                    if (transport.getType() == TransportType.TELEPORTATION_MINIGAME) {
+                        if (handleMinigameTeleport(transport)) {
+                            sleepUntil(() -> !Rs2Player.isAnimating());
+                            sleepUntilTrue(() -> Rs2Player.getWorldLocation().distanceTo(transport.getDestination()) < (OFFSET * 2), 100, 20000);
+                            break;
+                        }
+                    }
 
                     if (transport.getType() == TransportType.TELEPORTATION_ITEM) {
                         if (handleTeleportItem(transport)) {
@@ -1116,7 +1132,6 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
                     }
 
                     if (transport.getType() == TransportType.TELEPORTATION_SPELL) {
-                        //if (Rs2Player.getWorldLocation().distanceTo(transport.getDestination()) < config.distanceBeforeUsingTeleport()) break;
                         if (handleTeleportSpell(transport)) {
                             sleepUntil(() -> !Rs2Player.isAnimating());
                             sleepUntilTrue(() -> Rs2Player.getWorldLocation().distanceTo(transport.getDestination()) < 10);
@@ -1551,6 +1566,193 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
 
         return false;
 
+    }
+
+    private static boolean handleMinigameTeleport(Transport transport) {
+        final Object[] selectedOpListener = new Object[]{489, 0, 0};
+        @Component
+        final int GROUPING_BUTTON_COMPONENT_ID = 46333957; // 707.5
+        
+        @Component
+        final int DROPDOWN_BUTTON_COMPONENT_ID = 4980760; // 76.24
+        final int DROPDOWN_SELECTED_SPRITE_ID = 773;
+        
+        @Component
+        final int MINIGAME_LIST = 4980758; // 76.22
+        @Component
+        final int SELECTED_MINIGAME = 4980747; // 76.11
+        @Component
+        final int TELEPORT_BUTTON = 4980768; // 76.32
+
+        if (Rs2Tab.getCurrentTab() != InterfaceTab.CHAT) {
+            Rs2Tab.switchToGroupingTab();
+            sleepUntil(() -> Rs2Tab.getCurrentTab() == InterfaceTab.CHAT);
+        }
+
+        Widget groupingBtn = Rs2Widget.getWidget(GROUPING_BUTTON_COMPONENT_ID);
+        if (groupingBtn == null) return false;
+
+        if (!Arrays.equals(groupingBtn.getOnOpListener(), selectedOpListener)) {
+            Rs2Widget.clickWidget(groupingBtn);
+            sleepUntil(() -> Arrays.equals(groupingBtn.getOnOpListener(), selectedOpListener));
+        }
+
+        boolean hasMultipleDestination = transport.getDisplayInfo().contains(":");
+        String destination = hasMultipleDestination
+                ? transport.getDisplayInfo().split(":")[0].trim().toLowerCase()
+                : transport.getDisplayInfo().trim().toLowerCase();
+
+        Widget selectedWidget = Rs2Widget.getWidget(SELECTED_MINIGAME);
+        if (selectedWidget == null) return false;
+        if (!selectedWidget.getText().equalsIgnoreCase(destination)) {
+            Widget dropdownBtn = Rs2Widget.getWidget(DROPDOWN_BUTTON_COMPONENT_ID);
+            if (dropdownBtn == null) return false;
+
+            if (dropdownBtn.getSpriteId() != DROPDOWN_SELECTED_SPRITE_ID) {
+                Rs2Widget.clickWidget(dropdownBtn);
+                sleepUntil(() -> Rs2Widget.findWidget(DROPDOWN_SELECTED_SPRITE_ID, List.of(Rs2Widget.getWidget(DROPDOWN_BUTTON_COMPONENT_ID))) != null);
+            }
+
+            Widget minigameWidgetParent = Rs2Widget.getWidget(MINIGAME_LIST);
+            if (minigameWidgetParent == null) return false;
+            List<Widget> minigameWidgetList = Arrays.stream(minigameWidgetParent.getDynamicChildren())
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+
+            Widget destinationWidget = Rs2Widget.findWidget(destination, minigameWidgetList);
+            if (destinationWidget == null) return false;
+
+            Rectangle minigameWidgetParentBounds = minigameWidgetParent.getBounds();
+            Rectangle destinationWidgetBounds = destinationWidget.getBounds();
+            if (!Rs2UiHelper.isRectangleWithinRectangle(minigameWidgetParentBounds, destinationWidgetBounds)) {
+                Microbot.log("Destination widget is not fully visible inside the minigame widget parent, scrolling...");
+                boolean isWidgetInView = sleepUntil(() -> Rs2UiHelper.isRectangleWithinRectangle(minigameWidgetParentBounds, Rs2Widget.findWidget(destination, minigameWidgetList).getBounds()), () -> {
+                    boolean isBelow = destinationWidgetBounds.y > minigameWidgetParentBounds.y;
+                    if (isBelow)
+                        Microbot.getMouse().scrollDown(Rs2UiHelper.getClickingPoint(minigameWidgetParent.getBounds(), false));
+                    else
+                        Microbot.getMouse().scrollUp(Rs2UiHelper.getClickingPoint(minigameWidgetParent.getBounds(), false));
+                }, 5000, 300);
+                
+                if (!isWidgetInView) {
+                    Microbot.log("Destination widget is not found within timeout period");
+                    return false;
+                }
+
+                destinationWidget = Rs2Widget.findWidget(destination, minigameWidgetList);
+            }
+            Rs2Widget.clickWidget(destinationWidget);
+            sleepUntil(() -> Rs2Widget.getWidget(SELECTED_MINIGAME).getText().equalsIgnoreCase(destination));
+        }
+
+        Widget teleportBtn = Rs2Widget.getWidget(TELEPORT_BUTTON);
+        if (teleportBtn == null) return false;
+        Rs2Widget.clickWidget(teleportBtn);
+
+        if (transport.getDisplayInfo().toLowerCase().contains("rat pits")) {
+            Rs2Dialogue.sleepUntilSelectAnOption();
+            Rs2Dialogue.clickOption(transport.getDisplayInfo().split(":")[1].trim().toLowerCase());
+        }
+
+        return sleepUntilTrue(Rs2Player::isAnimating);
+    }
+
+    private static boolean handleCanoe(Transport transport) {
+        String displayInfo = transport.getDisplayInfo();
+        if (displayInfo == null || displayInfo.isEmpty()) return false;
+
+        List<String> validActions = List.of("chop-down", "shape-canoe", "float canoe", "paddle canoe");
+        ObjectComposition CANOE_COMPOSITION = Rs2GameObject.getObjectComposition(transport.getObjectId());
+        if (CANOE_COMPOSITION == null) return false;
+
+        String currentAction = Arrays.stream(CANOE_COMPOSITION.getActions())
+                .filter(Objects::nonNull)
+                .filter(act -> validActions.contains(act.toLowerCase())).findFirst().orElse(null);
+        if (currentAction == null || currentAction.isEmpty()) {
+            Microbot.log("Unable to find canoe action");
+            return false;
+        }
+
+        System.out.println("Current Action: " + currentAction);
+
+        switch (currentAction) {
+            case "Chop-down":
+                Rs2GameObject.interact(transport.getObjectId(), "Chop-down");
+                return sleepUntilTrue(() -> {
+                    ObjectComposition composition = Rs2GameObject.findObjectComposition(transport.getObjectId());
+
+                    if (composition == null) return false;
+                    return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals);
+                }, () -> Rs2Player.isMoving() || Rs2Player.isAnimating(1200), 300, 10000);
+            case "Shape-Canoe":
+                @Component
+                final int CANOE_SELECTION_PARENT = 27262976; // 416.3
+                @Component
+                final int CANOE_SHAPING_TEXT = 27262986; // 416.10
+
+                Rs2GameObject.interact(transport.getObjectId(), "Shape-Canoe");
+                boolean isCanoeShapeTextVisible = sleepUntilTrue(() -> Rs2Widget.isWidgetVisible(CANOE_SHAPING_TEXT), 100, 10000);
+                if (!isCanoeShapeTextVisible) {
+                    Microbot.log("Canoe shape text is not visible within timeout period");
+                    return false;
+                }
+
+                final int woodcuttingLevel = Rs2Player.getRealSkillLevel(Skill.WOODCUTTING);
+                String canoeOption;
+                if (woodcuttingLevel >= 57) {
+                    canoeOption = "Waka canoe";
+                } else if (woodcuttingLevel >= 42) {
+                    canoeOption = "Stable dugout canoe";
+                } else if (woodcuttingLevel >= 27) {
+                    canoeOption = "Dugout canoe";
+                } else if (woodcuttingLevel >= 12) {
+                    canoeOption = "Log canoe";
+                } else {
+                    // Not high enough level to make any canoe
+                    return false;
+                }
+                
+                Widget canoeSelectionParentWidget = Rs2Widget.getWidget(CANOE_SELECTION_PARENT);
+                if (canoeSelectionParentWidget == null) return false;
+                Widget canoeSelectionWidget = Rs2Widget.findWidget("Make " + canoeOption, List.of(canoeSelectionParentWidget), false);
+                Rs2Widget.clickWidget(canoeSelectionWidget);
+                return sleepUntilTrue(() -> {
+                    ObjectComposition composition = Rs2GameObject.findObjectComposition(transport.getObjectId());
+                    
+                    if (composition == null) return false;
+                    return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals);
+                }, () -> Rs2Player.isAnimating(1200), 300, 10000);
+            case "Float Canoe":
+                Rs2GameObject.interact(transport.getObjectId(), "Float Canoe");
+                return sleepUntilTrue(() -> {
+                    ObjectComposition composition = Rs2GameObject.findObjectComposition(transport.getObjectId());
+                    
+                    if (composition == null) return false;
+                    return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals);
+                }, () -> Rs2Player.isAnimating(1200), 100, 10000);
+            case "Paddle Canoe":
+                @Component
+                final int DESTINATION_MAP_PARENT = 42401792; // 647.3
+                @Component
+                final int DESTINATION_LIST = 42401795; // 647.13
+
+                Rs2GameObject.interact(transport.getObjectId(), "Paddle Canoe");
+
+                boolean isDestinationMapVisible = sleepUntilTrue(() -> Rs2Widget.isWidgetVisible(DESTINATION_MAP_PARENT), 100, 10000);
+                if (!isDestinationMapVisible) {
+                    Microbot.log("Destination map is not visible within timeout period");
+                    return false;
+                }
+
+                Widget destinationListWidget = Rs2Widget.getWidget(DESTINATION_LIST);
+                if (destinationListWidget == null) return false;
+                Widget destination = Rs2Widget.findWidget("Travel to " + displayInfo, List.of(destinationListWidget), false);
+                Rs2Widget.clickWidget(destination);
+
+                Rs2Dialogue.waitForCutScene(100, 15000);
+                return sleepUntilTrue(() -> Rs2Player.getWorldLocation().distanceTo2D(transport.getDestination()) < (OFFSET * 2), 100, 5000);
+        }
+        return false;
     }
     
     private static boolean handleQuetzal(Transport transport) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1569,21 +1569,16 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
 
     private static boolean handleMinigameTeleport(Transport transport) {
         final Object[] selectedOpListener = new Object[]{489, 0, 0};
-        final List<Integer> teleportGraphics = List.of(800,802,803,804);
-        
-        @Component
-        final int GROUPING_BUTTON_COMPONENT_ID = 46333957; // 707.5
-        
-        @Component
-        final int DROPDOWN_BUTTON_COMPONENT_ID = 4980760; // 76.24
+        final List<Integer> teleportGraphics = List.of(800, 802, 803, 804);
+
+        @Component final int GROUPING_BUTTON_COMPONENT_ID = 46333957; // 707.5
+
+        @Component final int DROPDOWN_BUTTON_COMPONENT_ID = 4980760; // 76.24
         final int DROPDOWN_SELECTED_SPRITE_ID = 773;
-        
-        @Component
-        final int MINIGAME_LIST = 4980758; // 76.22
-        @Component
-        final int SELECTED_MINIGAME = 4980747; // 76.11
-        @Component
-        final int TELEPORT_BUTTON = 4980768; // 76.32
+
+        @Component final int MINIGAME_LIST = 4980758; // 76.22
+        @Component final int SELECTED_MINIGAME = 4980747; // 76.11
+        @Component final int TELEPORT_BUTTON = 4980768; // 76.32
 
         if (Rs2Tab.getCurrentTab() != InterfaceTab.CHAT) {
             Rs2Tab.switchToGroupingTab();
@@ -1624,7 +1619,7 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
             if (destinationWidget == null) return false;
 
             NewMenuEntry destinationMenuEntry = new NewMenuEntry("Select", "", 1, MenuAction.CC_OP, destinationWidget.getIndex(), minigameWidgetParent.getId(), false);
-            Microbot.doInvoke(destinationMenuEntry, new Rectangle(1,1));
+            Microbot.doInvoke(destinationMenuEntry, new Rectangle(1, 1));
             sleepUntil(() -> Rs2Widget.getWidget(SELECTED_MINIGAME).getText().equalsIgnoreCase(destination));
         }
 
@@ -1636,11 +1631,11 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
             Rs2Dialogue.sleepUntilSelectAnOption();
             Rs2Dialogue.clickOption(transport.getDisplayInfo().split(":")[1].trim().toLowerCase());
         }
-        
+
         sleepUntil(Rs2Player::isAnimating);
         return sleepUntilTrue(() -> !Rs2Player.isAnimating() && teleportGraphics.stream().noneMatch(Rs2Player::hasSpotAnimation), 100, 20000);
     }
-    
+
     private static boolean handleCanoe(Transport transport) {
         String displayInfo = transport.getDisplayInfo();
         if (displayInfo == null || displayInfo.isEmpty()) return false;
@@ -1666,12 +1661,10 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
 
                     if (composition == null) return false;
                     return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals) && !Rs2Player.isAnimating();
-                },300, 10000);
+                }, 300, 10000);
             case "Shape-Canoe":
-                @Component
-                final int CANOE_SELECTION_PARENT = 27262976; // 416.3
-                @Component
-                final int CANOE_SHAPING_TEXT = 27262986; // 416.10
+                @Component final int CANOE_SELECTION_PARENT = 27262976; // 416.3
+                @Component final int CANOE_SHAPING_TEXT = 27262986; // 416.10
 
                 Rs2GameObject.interact(transport.getObjectId(), "Shape-Canoe");
                 boolean isCanoeShapeTextVisible = sleepUntilTrue(() -> Rs2Widget.isWidgetVisible(CANOE_SHAPING_TEXT), 100, 10000);
@@ -1694,7 +1687,7 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
                     // Not high enough level to make any canoe
                     return false;
                 }
-                
+
                 Widget canoeSelectionParentWidget = Rs2Widget.getWidget(CANOE_SELECTION_PARENT);
                 if (canoeSelectionParentWidget == null) return false;
                 Widget canoeSelectionWidget = Rs2Widget.findWidget("Make " + canoeOption, List.of(canoeSelectionParentWidget));
@@ -1702,7 +1695,7 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
                 sleepUntil(() -> Rs2Player.isAnimating(1200));
                 return sleepUntilTrue(() -> {
                     ObjectComposition composition = Rs2GameObject.findObjectComposition(transport.getObjectId());
-                    
+
                     if (composition == null) return false;
                     return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals) && !Rs2Player.isAnimating();
                 }, 300, 10000);
@@ -1711,15 +1704,13 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
                 sleepUntil(() -> Rs2Player.isAnimating(1200));
                 return sleepUntilTrue(() -> {
                     ObjectComposition composition = Rs2GameObject.findObjectComposition(transport.getObjectId());
-                    
+
                     if (composition == null) return false;
                     return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals) && !Rs2Player.isAnimating();
                 }, 300, 10000);
             case "Paddle Canoe":
-                @Component
-                final int DESTINATION_MAP_PARENT = 42401792; // 647.3
-                @Component
-                final int DESTINATION_LIST = 42401795; // 647.13
+                @Component final int DESTINATION_MAP_PARENT = 42401792; // 647.3
+                @Component final int DESTINATION_LIST = 42401795; // 647.13
 
                 Rs2GameObject.interact(transport.getObjectId(), "Paddle Canoe");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1637,12 +1637,10 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
             Rs2Dialogue.clickOption(transport.getDisplayInfo().split(":")[1].trim().toLowerCase());
         }
         
+        sleepUntil(Rs2Player::isAnimating);
         return sleepUntilTrue(() -> !Rs2Player.isAnimating() && teleportGraphics.stream().noneMatch(Rs2Player::hasSpotAnimation), 100, 20000);
     }
     
-    /*
-        TODO: Fix delays in-order for this to function properly.
-     */
     private static boolean handleCanoe(Transport transport) {
         String displayInfo = transport.getDisplayInfo();
         if (displayInfo == null || displayInfo.isEmpty()) return false;
@@ -1659,17 +1657,16 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
             return false;
         }
 
-        System.out.println("Current Action: " + currentAction);
-
         switch (currentAction) {
             case "Chop-down":
                 Rs2GameObject.interact(transport.getObjectId(), "Chop-down");
+                sleepUntil(() -> Rs2Player.isAnimating(1200));
                 return sleepUntilTrue(() -> {
                     ObjectComposition composition = Rs2GameObject.findObjectComposition(transport.getObjectId());
 
                     if (composition == null) return false;
-                    return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals);
-                }, () -> Rs2Player.isMoving() || Rs2Player.isAnimating(1200), 300, 10000);
+                    return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals) && !Rs2Player.isAnimating();
+                },300, 10000);
             case "Shape-Canoe":
                 @Component
                 final int CANOE_SELECTION_PARENT = 27262976; // 416.3
@@ -1700,22 +1697,24 @@ public static List<WorldPoint> getWalkPath(WorldPoint target) {
                 
                 Widget canoeSelectionParentWidget = Rs2Widget.getWidget(CANOE_SELECTION_PARENT);
                 if (canoeSelectionParentWidget == null) return false;
-                Widget canoeSelectionWidget = Rs2Widget.findWidget("Make " + canoeOption, List.of(canoeSelectionParentWidget), false);
+                Widget canoeSelectionWidget = Rs2Widget.findWidget("Make " + canoeOption, List.of(canoeSelectionParentWidget));
                 Rs2Widget.clickWidget(canoeSelectionWidget);
+                sleepUntil(() -> Rs2Player.isAnimating(1200));
                 return sleepUntilTrue(() -> {
                     ObjectComposition composition = Rs2GameObject.findObjectComposition(transport.getObjectId());
                     
                     if (composition == null) return false;
-                    return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals);
-                }, () -> Rs2Player.isAnimating(1200), 300, 10000);
+                    return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals) && !Rs2Player.isAnimating();
+                }, 300, 10000);
             case "Float Canoe":
                 Rs2GameObject.interact(transport.getObjectId(), "Float Canoe");
+                sleepUntil(() -> Rs2Player.isAnimating(1200));
                 return sleepUntilTrue(() -> {
                     ObjectComposition composition = Rs2GameObject.findObjectComposition(transport.getObjectId());
                     
                     if (composition == null) return false;
-                    return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals);
-                }, () -> Rs2Player.isAnimating(1200), 100, 10000);
+                    return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals) && !Rs2Player.isAnimating();
+                }, 300, 10000);
             case "Paddle Canoe":
                 @Component
                 final int DESTINATION_MAP_PARENT = 42401792; // 647.3

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/boats.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/boats.tsv
@@ -100,28 +100,44 @@
 1229 3469 0	1194 3452 0	Travel;Rowboat;48721				Desert Treasure II - The Fallen Empire		7	
 1194 3452 0	1229 3469 0	Travel;Rowboat;48720				Desert Treasure II - The Fallen Empire		7	
 1195 3452 0	1229 3469 0	Travel;Rowboat;48720				Desert Treasure II - The Fallen Empire		7	
+									
+# Molch Island, Molch, Battlefront, Shayzien									
+1384 3665 0	1369 3639 0	Board;Boaty;33614						4	Molch Island
+1384 3665 0	1341 3645 0	Board;Boaty;33614						4	Battlefront
+1384 3665 0	1408 3612 0	Board;Boaty;33614						4	Shayzien
+1342 3645 0	1369 3639 0	Board;Boaty;33614						4	Molch Island
+1342 3645 0	1384 3665 0	Board;Boaty;33614						4	Molch
+1342 3645 0	1408 3612 0	Board;Boaty;33614						4	Shayzien
+1408 3612 0	1369 3639 0	Board;Boaty;33614						4	Molch Island
+1408 3612 0	1384 3665 0	Board;Boaty;33614						4	Molch
+1408 3612 0	1341 3645 0	Board;Boaty;33614						4	Battlefront
+1369 3639 0	1384 3665 0	Board;Boaty;33614						4	Molch
+1369 3639 0	1341 3645 0	Board;Boaty;33614						4	Battlefront
+1369 3639 0	1408 3612 0	Board;Boaty;33614						4	Shayzien
+									
+# Burgh de Rott, Meiyerditch, Icyene Graveyard, Slepe									
+3525 3170 0	3605 3161 1	Board;Boat;38089					7255>41	13	1: Meiyerditch.
+3525 3170 0	3684 3176 0	Board;Boat;38089					7255>41	13	2: Icyene Graveyard.
+3525 3170 0	3663 3277 0	Board;Boat;38089					7255>87	13	3: Slepe.
+3605 3161 1	3525 3170 0	Board;Boat;38089					7255>41	13	1: Burgh de Rott.
+3605 3161 1	3684 3176 0	Board;Boat;38089					7255>41	13	2: Icyene Graveyard.
+3605 3161 1	3663 3277 0	Board;Boat;38089					7255>87	13	3: Slepe.
+3684 3176 0	3525 3170 0	Board;Boat;38089					7255>41	13	1: Burgh de Rott.
+3684 3176 0	3605 3161 1	Board;Boat;38089					7255>41	13	2: Meiyerditch.
+3684 3176 0	3663 3277 0	Board;Boat;38089					7255>87	13	3: Slepe.
+3684 3175 0	3525 3170 0	Board;Boat;38089					7255>41	13	1: Burgh de Rott.
+3684 3175 0	3605 3161 1	Board;Boat;38089					7255>41	13	2: Meiyerditch.
+3684 3175 0	3663 3277 0	Board;Boat;38089					7255>87	13	3: Slepe.
+3684 3174 0	3525 3170 0	Board;Boat;38089					7255>41	13	1: Burgh de Rott.
+3684 3174 0	3605 3161 1	Board;Boat;38089					7255>41	13	2: Meiyerditch.
+3684 3174 0	3663 3277 0	Board;Boat;38089					7255>87	13	3: Slepe.
+3663 3277 0	3525 3170 0	Board;Boat;38089					7255>87	13	1: Burgh de Rott.
+3663 3277 0	3605 3161 1	Board;Boat;38089					7255>87	13	2: Meiyerditch.
+3663 3277 0	3684 3176 0	Board;Boat;38089					7255>87	13	3: Icyene Graveyard.
+									
 # Port Phasmatys, Slepe									
 3671 3544 0	3661 3277 0	Travel;Row boat;32601			10000 Coins			5	
 3672 3544 0	3661 3277 0	Travel;Row boat;32601			10000 Coins			5	
 3661 3278 0	3671 3542 0	Travel;Row boat;32602			10000 Coins			5	
 3661 3278 0	3671 3542 0	Travel;Row boat;32602			10000 Coins			5	
 3661 3278 0	3671 3542 0	Travel;Row boat;32602			10000 Coins			5	
-# Burgh de Rott, Meiyerditch, Icyene Graveyard, Slepe									
-3525 3170 0	3605 3161 1	Board;Boat;38089					7255=42	13	1: Meiyerditch.
-3525 3170 0	3684 3176 0	Board;Boat;38089					7255=42	13	2: Icyene Graveyard.
-3525 3170 0	3663 3277 0	Board;Boat;38089					7255=88	13	3: Slepe.
-3605 3161 1	3525 3170 0	Board;Boat;38089					7255=42	13	1: Burgh de Rott.
-3605 3161 1	3684 3176 0	Board;Boat;38089					7255=42	13	2: Icyene Graveyard.
-3605 3161 1	3663 3277 0	Board;Boat;38089					7255=88	13	3: Slepe.
-3684 3176 0	3525 3170 0	Board;Boat;38089					7255=42	13	1: Burgh de Rott.
-3684 3176 0	3605 3161 1	Board;Boat;38089					7255=42	13	2: Meiyerditch.
-3684 3176 0	3663 3277 0	Board;Boat;38089					7255=88	13	3: Slepe.
-3684 3175 0	3525 3170 0	Board;Boat;38089					7255=42	13	1: Burgh de Rott.
-3684 3175 0	3605 3161 1	Board;Boat;38089					7255=42	13	2: Meiyerditch.
-3684 3175 0	3663 3277 0	Board;Boat;38089					7255=88	13	3: Slepe.
-3684 3174 0	3525 3170 0	Board;Boat;38089					7255=42	13	1: Burgh de Rott.
-3684 3174 0	3605 3161 1	Board;Boat;38089					7255=42	13	2: Meiyerditch.
-3684 3174 0	3663 3277 0	Board;Boat;38089					7255=88	13	3: Slepe.
-3663 3277 0	3525 3170 0	Board;Boat;38089					7255=88	13	1: Burgh de Rott.
-3663 3277 0	3605 3161 1	Board;Boat;38089					7255=88	13	2: Meiyerditch.
-3663 3277 0	3684 3176 0	Board;Boat;38089					7255=88	13	3: Icyene Graveyard.

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/canoes.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/canoes.tsv
@@ -1,35 +1,35 @@
-# Origin	Destination	menuOption menuTarget objectID	Skills	Item IDs	Quest	Duration	Info
+# Origin	Destination	menuOption menuTarget objectID	Skills	Item IDs	Quest	Duration	Display info
 # Edgeville							
-3132 3510 0	3109 3415 0	Paddle Canoe;Canoe Station;12166	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Barbarian Village
-3132 3510 0	3199 3344 0	Paddle Canoe;Canoe Station;12166	27 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Champions Guild
-3132 3510 0	3240 3242 0	Paddle Canoe;Canoe Station;12166	42 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Lumbridge
-3132 3510 0	3154 3638 0	Paddle Canoe;Canoe Station;12166	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Ferox Enclave
-3132 3510 0	3141 3796 0	Paddle Canoe;Canoe Station;12166	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Wilderness Pond
+3132 3510 0	3109 3415 0	Paddle Canoe;Canoe Station;12166	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Barbarian Village
+3132 3510 0	3199 3344 0	Paddle Canoe;Canoe Station;12166	27 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Champions Guild
+3132 3510 0	3240 3242 0	Paddle Canoe;Canoe Station;12166	42 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Lumbridge
+3132 3510 0	3154 3638 0	Paddle Canoe;Canoe Station;12166	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Ferox Enclave
+3132 3510 0	3141 3796 0	Paddle Canoe;Canoe Station;12166	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Wilderness Pond
 							
 # Barbarian Village							
-3112 3411 0	3199 3344 0	Paddle Canoe;Canoe Station;12165	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Champions Guild
-3112 3411 0	3128 3503 0	Paddle Canoe;Canoe Station;12165	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Edgeville
-3112 3411 0	3240 3242 0	Paddle Canoe;Canoe Station;12165	27 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Lumbridge
-3112 3411 0	3154 3638 0	Paddle Canoe;Canoe Station;12165	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Ferox Enclave
-3112 3411 0	3141 3796 0	Paddle Canoe;Canoe Station;12165	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Wilderness Pond
+3112 3411 0	3199 3344 0	Paddle Canoe;Canoe Station;12165	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Champions Guild
+3112 3411 0	3128 3503 0	Paddle Canoe;Canoe Station;12165	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Edgeville
+3112 3411 0	3240 3242 0	Paddle Canoe;Canoe Station;12165	27 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Lumbridge
+3112 3411 0	3154 3638 0	Paddle Canoe;Canoe Station;12165	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Ferox Enclave
+3112 3411 0	3141 3796 0	Paddle Canoe;Canoe Station;12165	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Wilderness Pond
 							
 # Champions' Guild							
-3202 3343 0	3240 3242 0	Paddle Canoe;Canoe Station;12164	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Lumbridge
-3202 3343 0	3109 3415 0	Paddle Canoe;Canoe Station;12164	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Barbarian Village
-3202 3343 0	3128 3503 0	Paddle Canoe;Canoe Station;12164	27 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Edgeville
-3202 3343 0	3154 3638 0	Paddle Canoe;Canoe Station;12164	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Ferox Enclave
-3202 3343 0	3141 3796 0	Paddle Canoe;Canoe Station;12164	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Wilderness Pond
+3202 3343 0	3240 3242 0	Paddle Canoe;Canoe Station;12164	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Lumbridge
+3202 3343 0	3109 3415 0	Paddle Canoe;Canoe Station;12164	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Barbarian Village
+3202 3343 0	3128 3503 0	Paddle Canoe;Canoe Station;12164	27 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Edgeville
+3202 3343 0	3154 3638 0	Paddle Canoe;Canoe Station;12164	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Ferox Enclave
+3202 3343 0	3141 3796 0	Paddle Canoe;Canoe Station;12164	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Wilderness Pond
 							
 # Lumbridge							
-3243 3237 0	3199 3344 0	Paddle Canoe;Canoe Station;12163	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Champions Guild
-3243 3237 0	3109 3415 0	Paddle Canoe;Canoe Station;12163	27 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Barbarian Village
-3243 3237 0	3128 3503 0	Paddle Canoe;Canoe Station;12163	42 Woodcutting	1351;1349;1361;1353;1355;1357;1359		30	Edgeville
-3243 3237 0	3154 3638 0	Paddle Canoe;Canoe Station;12163	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Ferox Enclave
-3243 3237 0	3141 3796 0	Paddle Canoe;Canoe Station;12163	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Wilderness Pond
+3243 3237 0	3199 3344 0	Paddle Canoe;Canoe Station;12163	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Champions Guild
+3243 3237 0	3109 3415 0	Paddle Canoe;Canoe Station;12163	27 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Barbarian Village
+3243 3237 0	3128 3503 0	Paddle Canoe;Canoe Station;12163	42 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Edgeville
+3243 3237 0	3154 3638 0	Paddle Canoe;Canoe Station;12163	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Ferox Enclave
+3243 3237 0	3141 3796 0	Paddle Canoe;Canoe Station;12163	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Wilderness Pond
 							
 # Ferox Enclave							
-3154 3630 0	3128 3503 0	Paddle Canoe;Canoe Station;39638	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Edgeville
-3154 3630 0	3109 3415 0	Paddle Canoe;Canoe Station;39638	27 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Barbarian Village
-3154 3630 0	3199 3344 0	Paddle Canoe;Canoe Station;39638	42 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Champions Guild
-3154 3630 0	3240 3242 0	Paddle Canoe;Canoe Station;39638	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Lumbridge
-3154 3630 0	3141 3796 0	Paddle Canoe;Canoe Station;39638	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		20	Wilderness Pond
+3154 3630 0	3128 3503 0	Paddle Canoe;Canoe Station;39638	12 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Edgeville
+3154 3630 0	3109 3415 0	Paddle Canoe;Canoe Station;39638	27 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Barbarian Village
+3154 3630 0	3199 3344 0	Paddle Canoe;Canoe Station;39638	42 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Champions Guild
+3154 3630 0	3240 3242 0	Paddle Canoe;Canoe Station;39638	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Lumbridge
+3154 3630 0	3141 3796 0	Paddle Canoe;Canoe Station;39638	57 Woodcutting	1351;1349;1361;1353;1355;1357;1359		12	Wilderness Pond

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
@@ -289,11 +289,11 @@
 2336 3802 0		23458		4494=1	Y	F	19	4	Enchanted lyre(i): Neitiznot
 3105 9315 2		6707		1574>0	Y	F	19	4	Camulet: Enakhra's Temple
 3191 2924 0		6707		4485=1;1574>0	Y	F	19	4	Camulet: Bandit Camp Quarry
-1713 3612 0		21760;25818	The Depths of Despair	6035>1	Y	T	19	4	Kharedst's memoirs: Lunch by the Lancalliums
-1802 3748 0		21760;25818	The Queen of Thieves	6035>1	Y	T	19	4	Kharedst's memoirs: The Fisher's Flute
-1478 3576 0		21760;25818	Tale of the Righteous	6035>1	Y	T	19	4	Kharedst's memoirs: History and Hearsay
-1544 3762 0		21760;25818	The Forsaken Tower	6035>1	Y	T	19	4	Kharedst's memoirs: Jewellery of Jubilation
-1680 3746 0		21760;25818	The Ascent of Arceuus	6035>1	Y	T	19	4	Kharedst's memoirs: A Dark Disposition
+1713 3612 0		21760;25818	The Depths of Despair	6028=1;6035>1	Y	T	19	4	Kharedst's memoirs: Lunch by the Lancalliums
+1802 3748 0		21760;25818	The Queen of Thieves	6038=1;6035>1	Y	T	19	4	Kharedst's memoirs: The Fisher's Flute
+1478 3576 0		21760;25818	Tale of the Righteous	6359=1;6035>1	Y	T	19	4	Kharedst's memoirs: History and Hearsay
+1544 3762 0		21760;25818	The Forsaken Tower	7801=1;6035>1	Y	T	19	4	Kharedst's memoirs: Jewellery of Jubilation
+1680 3746 0		21760;25818	The Ascent of Arceuus	7857=1;6035>1	Y	T	19	4	Kharedst's memoirs: A Dark Disposition
 3649 3230 0		22400			Y	F	19	4	Drakan's medallion: Ver Sinhaza
 3592 3337 0		22400	Sins of the Father		Y	F	19	4	Drakan's medallion: Darkmeyer
 # todo: this only works if you've used a Slepey tablet on the medallion									

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_minigames.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_minigames.tsv
@@ -1,0 +1,57 @@
+Destination	Skills	Quests	isMembers	Varbits	Varplayers	Wilderness level	Duration	Display info
+# Barbarian Assault - Barbarian Outpost								
+2531 3569 0			Y	3264=11	888@20	0	23	Barbarian Assault
+								
+# Blast Furnace - East Keldagrim								
+2894 10214 0		The Giant Dwarf	Y		888@20	0	23	Blast Furnace
+								
+# Burthorpe Games Room								
+2899 3553 0			Y		888@20	0	23	Burthorpe Games Room
+								
+# Castle Wars								
+2442 3093 0					888@20	0	23	Castle Wars
+								
+# Clan Wars - Ferox Enclave								
+3150 3635 0					888@20	0	23	Clan Wars
+								
+# Fishing Trawler - Port Khazard								
+2658 3157 0	15 Fishing		Y		888@20	0	23	Fishing Trawler
+								
+# Giants' Foundry - Giants' Plateau								
+3361 3149 0			Y		888@20	0	23	Giant's Foundry
+								
+# Guardians of the Rift - Temple of the Eye								
+3104 9573 0		Temple of the Eye	Y		888@20	0	23	Guardians of the Rift
+								
+# Last Man Standing - Ferox Enclave								
+3150 3635 0					888@20	0	23	Last Man Standing
+								
+# Mage Training Arena								
+3363 3295 0			Y	10670=1	888@20	0	23	Mage Training Arena
+								
+# Nightmare Zone - North of Yanille								
+2609 3114 0			Y		888@20	0	23	Nightmare Zone
+								
+# Pest Control - Void Knights' Outpost (requires 40 combat)								
+2658 2663 0			Y		888@20	0	23	Pest Control
+								
+# Rat Pits - East Ardougne, Keldagrim, Port Sarim, Varrock								
+2561 3319 0		Ratcatchers	Y		888@20	0	23	Rat Pits: Ardougne
+2914 10193 0		Ratcatchers	Y		888@20	0	23	Rat Pits: Keldagrim
+3018 3231 0		Ratcatchers	Y		888@20	0	23	Rat Pits: Port Sarim
+3267 3399 0		Ratcatchers	Y		888@20	0	23	Rat Pits: Varrock
+								
+# Shades of Mort'ton								
+3506 3304 0		Shades of Mort'ton	Y		888@20	0	23	Shades of Mort'ton
+								
+# Soul Wars - Isle of Souls								
+2018 5929 0			Y		888@20	0	23	Soul Wars
+								
+# Tithe Farm - Hosidius								
+1792 3501 0	34 Farming		Y		888@20	0	23	Tithe Farm
+								
+# Trouble Brewing - East Mos Le'Harmless								
+3801 3015 0	40 Cooking	Cabin Fever	Y		888@20	0	23	Trouble Brewing
+								
+# TzHaar Fight Pit - Outer Mor Ul Rek								
+2399 5177 0			Y		888@20	0	23	TzHaar Fight Pit

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_spells.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_spells.tsv
@@ -42,9 +42,9 @@
 1680 3134 0	54 Magic	Twilight's Promise	19	4070=0	Y	4	Civitas illa Fortis Teleport
 							
 # Watchtower Teleport							
-2549 3112 2	58 Magic	Watchtower Quest	19	4070=0	Y	10	Watchtower Teleport
+2549 3112 2	58 Magic	Watchtower Quest	19	4070=0;4548=0	Y	10	Watchtower Teleport
 # Varbit 4460 is DIARY_ARDOUGNE_HARD							
-2584 3097 0	58 Magic	Watchtower Quest	19	4070=0;4460=1	Y	10	Watchtower Teleport: Yanille
+2584 3097 0	58 Magic	Watchtower Quest	19	4070=0;4460=1;4548=1	Y	10	Watchtower Teleport: Yanille
 							
 # Trollheim Teleport							
 2890 3679 0	61 Magic	Eadgar's Ruse	19	4070=0	Y	10	Trollheim Teleport


### PR DESCRIPTION
## ShortestPathPlugin
- Add support for minigame teleport transports
- Add additional operators to varbit & varplayer checks
- Add method TransportType.isTeleport to simply checks whether a transport is a teleport or not (Teleport Spells, Teleport Items & Minigame Teleports are considered teleports)
- Decrease canoe duration so they can be preferred more often
- Reorganize config to fit new transport options & logically grouping settings together
- Add Varbits for pages used on Khardest Memoirs/Book of the dead
- Add Varbit for Watchtower teleport toggle between Yanille & Watchtower teleport.

## Rs2Walker
- Add methods handleCanoe & handleMinigameTeleport to support new transport types.

**Note**: Minigame teleports are disabled by default, due to not all the requirements being added for the respective minigames, but the user can decide if they would like to include them in the path.

**Note**: I will be adding home teleport soon, I just need to ponder on how it should be implemented as its currently would fit inside of teleportation spells, but this now checks for runes so I will probably need to make some sort of edge case to handle these properly.