### PR TITLE
Moss Killer Plugin antiban now on wildy mode, boss mode AND normal mode

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerConfig.java
@@ -67,9 +67,9 @@ public interface MossKillerConfig extends Config {
     default String instructionsGuide() {
         return  "Select Wildy Mode.\n"
                 + "For the first run start the plugin near a bank in f2p with no armor or weapons and every listed piece of equipment in the bank.\n"
-                + "Turn on Teleportation spells in Web Walker configuration. Turn on Breakhandler. Turn on PK skull prevention in OSRS settings and have fixed mode enabled.\n"
+                + "Turn on Breakhandler. Have fixed mode enabled.\n"
                 + "Minimum required skill levels:\n"
-                + "- 40 Range\n"
+                + "- 30 Range\n"
                 + "- 41 Mage\n"
                 + "- 40 Attack\n"
                 + "- 40 Defense\n"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
@@ -119,6 +119,12 @@ public class MossKillerScript extends Script {
 
                 Microbot.log(String.valueOf(state));
                 Microbot.log("BossMode: " + bossMode);
+                 if (bossMode) {
+                    Rs2AntibanSettings.actionCooldownChance = 0.00;
+                    Rs2AntibanSettings.actionCooldownActive = false;
+                } else {
+                    Rs2AntibanSettings.actionCooldownActive = true;
+                    Rs2AntibanSettings.actionCooldownChance = 0.06;}
 
                 if (Rs2Player.getRealSkillLevel(Skill.DEFENCE) >= config.defenseLevel()) {
                     moarShutDown();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
@@ -8,6 +8,8 @@ import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.bee.MossKiller.Enums.MossKillerState;
 import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerPlugin;
 import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
@@ -34,6 +36,8 @@ import java.util.stream.Collectors;
 
 import static net.runelite.api.ItemID.*;
 import static net.runelite.api.Skill.MAGIC;
+import static net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity.HIGH;
+import static net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity.LOW;
 import static net.runelite.client.plugins.microbot.util.player.Rs2Player.eatAt;
 import static net.runelite.client.plugins.skillcalculator.skills.MagicAction.HIGH_LEVEL_ALCHEMY;
 
@@ -87,6 +91,22 @@ public class MossKillerScript extends Script {
         MossKillerScript.config = config;
         Microbot.enableAutoRunOn = false;
         Rs2Walker.disableTeleports = true;
+        Rs2Antiban.resetAntibanSettings();
+        Rs2AntibanSettings.usePlayStyle = true;
+        Rs2AntibanSettings.simulateFatigue = true;
+        Rs2AntibanSettings.simulateAttentionSpan = true;
+        Rs2AntibanSettings.behavioralVariability = true;
+        Rs2AntibanSettings.nonLinearIntervals = true;
+        Rs2AntibanSettings.dynamicActivity = true;
+        Rs2AntibanSettings.profileSwitching = true;
+        Rs2AntibanSettings.naturalMouse = true;
+        Rs2AntibanSettings.simulateMistakes = true;
+        Rs2AntibanSettings.moveMouseOffScreen = true;
+        Rs2AntibanSettings.moveMouseOffScreenChance = 0.07;
+        Rs2AntibanSettings.moveMouseRandomly = true;
+        Rs2AntibanSettings.moveMouseRandomlyChance = 0.04;
+        Rs2AntibanSettings.actionCooldownChance = 0.06;
+        Rs2Antiban.setActivityIntensity(LOW);
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
                 if (!Microbot.isLoggedIn()) return;
@@ -344,6 +364,7 @@ public class MossKillerScript extends Script {
 
     public void handleBossFight(){
         toggleRunEnergy();
+        Rs2Antiban.setActivityIntensity(HIGH);
         boolean growthlingAttacked = false;
 
         if(!Rs2Inventory.contains(FOOD)){

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -138,6 +138,7 @@ public class WildyKillerScript extends Script {
         System.out.println("getting to run");
         WildyKillerScript.config = config;
         Microbot.enableAutoRunOn = false;
+        Rs2Walker.disableTeleports = false;
         Rs2Antiban.resetAntibanSettings();
         Rs2AntibanSettings.usePlayStyle = true;
         Rs2AntibanSettings.simulateFatigue = true;
@@ -153,6 +154,7 @@ public class WildyKillerScript extends Script {
         Rs2AntibanSettings.moveMouseRandomlyChance = 0.04;
         Rs2AntibanSettings.actionCooldownChance = 0.06;
         Rs2Antiban.setActivityIntensity(LOW);
+        Rs2AntibanSettings.dynamicActivity = true;
 
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {


### PR DESCRIPTION
# full anti-ban implemented for moss killer plugin

- updated script classes to auto-implement requirements such as having teleportation spells in walker on or off and specific anti-ban settings for fighting normal moss giants
- updated config to reflect minimum req level of 30 range instead of 40 and pk skull prevention no longer necessary for wildy mode as bryo staff is now optional equipment 