### PR TITLE
Bf/fix/dispenser spam click

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceConfig.java
@@ -49,6 +49,6 @@ public interface BlastoiseFurnaceConfig extends Config {
             section = "Credits"
     )
     default String Credits() {
-        return "Creator by: Fishy \n\nUpdated by: Acun";
+        return "Created by: Fishy \n\nUpdated by: Acun";
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceConfig.java
@@ -8,7 +8,7 @@ import net.runelite.client.config.*;
 import net.runelite.client.plugins.microbot.blastoisefurnace.enums.Bars;
 
 @ConfigGroup("blastoisefurnace")
-@ConfigInformation("must have Ice Gloves or smiths gloves (i) equiped<br />+<br />coalbag, stamina potions and energy potions in bank<br /><br />| if doing gold bars; must have Goldsmiths Gauntlet and bank your coalbag |<br /><br />(makes 1.5m an hour minimum with steel and should cover expenses)<br /><br />current version does not support foremen or coffer refill<br /><br />im working on that aswell as full native use of antiban<br />Enjoy! :)")
+@ConfigInformation("Must have Ice Gloves or smiths gloves (i) equiped<br /><br />If not doing gold bars coal bag is required. <br /><br /> Must have stamina and energy potions in bank<br /><br /> If doing gold bars you must have Goldsmiths Gauntlet and bank your coal bag<br /><br />Current version does not support foremen or coffer refill<br /><br />")
 public interface BlastoiseFurnaceConfig extends Config {
     @ConfigSection(
             name = "Blast Furnace Settings",
@@ -49,6 +49,6 @@ public interface BlastoiseFurnaceConfig extends Config {
             section = "Credits"
     )
     default String Credits() {
-        return "Special thanks to:\n\nExioStorm, MrPecan, george\n\nfor building the backbone of this plugin!\nand teaching me how to java while doing so\ni will forever be gratefull.\nFishy ^_^";
+        return "Creator by: Fishy \n\nUpdated by: Acun";
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnacePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnacePlugin.java
@@ -56,14 +56,7 @@ public class BlastoiseFurnacePlugin extends Plugin {
             BlastoiseFurnaceScript.staminaTimer = event.getValue();
         }
     }
-    @Subscribe
-    public void onStatChanged(StatChanged event) {
-        if(event.getXp()> BlastoiseFurnaceScript.previousXP){
-            if(BlastoiseFurnaceScript.waitingXpDrop) {
-                //BlastoiseFurnaceScript.waitingXpDrop = false;
-            }
-        }
-    }
+
     @Subscribe
     public void onChatMessage(ChatMessage chatMessage) {
         if (chatMessage.getType() == ChatMessageType.GAMEMESSAGE) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
@@ -247,6 +247,7 @@ public class BlastoiseFurnaceScript extends Script {
         sleep(3400);
         sleepUntil(() -> barsInDispenser(config.getBars()) > 0, 10000);
         Rs2Inventory.interact(ItemID.ICE_GLOVES, "wear");
+        Rs2Inventory.waitForInventoryChanges(2000);
     }
 
     private void retrieveItemsForCurrentFurnaceInteraction() {
@@ -265,6 +266,7 @@ public class BlastoiseFurnaceScript extends Script {
                 break;
             case RUNITE_BAR:
                 handleRunite();
+                break;
         }
 
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
@@ -161,12 +161,11 @@ public class BlastoiseFurnaceScript extends Script {
             sleepUntil(() ->
                     Rs2Widget.hasWidget("What would you like to take?") ||
                     Rs2Widget.hasWidget("How many would you like") ||
-                    Rs2Widget.hasWidget("The bars are still molten!"), 10000);
+                    Rs2Widget.hasWidget("The bars are still molten!"), 5000);
 
+            boolean noIceGlovesEquipped = Rs2Widget.hasWidget("The bars are still molten!");
 
-            boolean noIceGlovesEquiped = Rs2Widget.hasWidget("The bars are still molten!");
-
-            if (noIceGlovesEquiped){
+            if (noIceGlovesEquipped){
                 if (!Rs2Inventory.interact(ItemID.ICE_GLOVES, "Wear") && !Rs2Inventory.interact(ItemID.SMITHS_GLOVES_I, "Wear")) {
                     Microbot.showMessage("Ice gloves or smith gloves required to loot the hot bars.");
                     Rs2Player.logout();
@@ -176,7 +175,7 @@ public class BlastoiseFurnaceScript extends Script {
                 Rs2GameObject.interact(BAR_DISPENSER, "Take");
             }
 
-            sleepUntil(() -> Rs2Widget.hasWidget("What would you like to take?") || Rs2Widget.hasWidget("How many would you like"), 10000);
+            sleepUntil(() -> Rs2Widget.hasWidget("What would you like to take?") || Rs2Widget.hasWidget("How many would you like"), 3000);
 
             // If somehow multiple type of bars are created we need to clean up the dispenser.
             boolean multipleBarTypes = Rs2Widget.hasWidget("What would you like to take?");
@@ -210,6 +209,7 @@ public class BlastoiseFurnaceScript extends Script {
         Rs2Walker.walkFastCanvas(new WorldPoint(1940, 4962, 0));
         sleep(3400);
         sleepUntil(() -> barsInDispenser(config.getBars()) > 0, 10000);
+        sleep(400, 700);
     }
 
     private void retrievePrimary() {
@@ -222,6 +222,7 @@ public class BlastoiseFurnaceScript extends Script {
         Rs2Walker.walkFastCanvas(new WorldPoint(1940, 4962, 0));
         sleep(3400);
         sleepUntil(() -> barsInDispenser(this.config.getBars()) > 0, 10000);
+        sleep(400, 700);
     }
 
     private void retrieveDoubleCoal() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
@@ -157,8 +157,11 @@ public class BlastoiseFurnaceScript extends Script {
         if (!Rs2Inventory.isFull()) {
             Rs2GameObject.interact(BAR_DISPENSER, "Take");
 
-            sleepUntil(Rs2Player::isMoving, 10000);
-            sleepUntil(()->!Rs2Player.isMoving(), 10000);
+            sleepUntil(() ->
+                    Rs2Widget.hasWidget("What would you like to take?") ||
+                    Rs2Widget.hasWidget("How many would you like") ||
+                    Rs2Widget.hasWidget("The bars are still molten!"), 10000);
+
 
             boolean noIceGlovesEquiped = Rs2Widget.hasWidget("The bars are still molten!");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
@@ -32,7 +32,7 @@ import static net.runelite.api.ItemID.GOLD_ORE;
 
 public class BlastoiseFurnaceScript extends Script {
     static final int BAR_DISPENSER = 9092;
-    int coalBag = ItemID.COAL_BAG_25627;
+    static final int coalBag = 12019;
     private static final int MAX_ORE_PER_INTERACTION = 27;
     public static double version = 1.0;
     public static State state;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
@@ -59,7 +59,7 @@ public class BlastoiseFurnaceScript extends Script {
         staminaTimer = 0;
         this.config = config;
         Microbot.enableAutoRunOn = false;
-//        state = State.BANKING;
+        state = State.BANKING;
         primaryOreEmpty = !Rs2Inventory.hasItem(config.getBars().getPrimaryOre());
         secondaryOreEmpty = !Rs2Inventory.hasItem(config.getBars().getSecondaryOre());
         Rs2Antiban.resetAntibanSettings();
@@ -141,6 +141,7 @@ public class BlastoiseFurnaceScript extends Script {
                         }
 
                         state = State.BANKING;
+                        break;
                 }
             } catch (Exception ex) {
 
@@ -354,7 +355,6 @@ public class BlastoiseFurnaceScript extends Script {
                 break;
             case 7:
             case 6:
-
             case 5:
             case 4:
             case 3:
@@ -466,14 +466,13 @@ public class BlastoiseFurnaceScript extends Script {
     private void depositOre() {
         Rs2GameObject.interact(ObjectID.CONVEYOR_BELT, "Put-ore-on");
         Rs2Inventory.waitForInventoryChanges(10000);
-//        sleepUntil(() -> !Rs2Inventory.isFull(), 10000); // Wait until the player stops moving
 
         if (this.config.getBars().isRequiresCoalBag()) {
             Rs2Inventory.interact(coalBag, "Empty");
-            sleepUntil(() -> Rs2Inventory.isFull(), 3000); // Wait for animation to finish
+            Rs2Inventory.waitForInventoryChanges(3000);
 
             Rs2GameObject.interact(ObjectID.CONVEYOR_BELT, "Put-ore-on");
-            sleepUntil(() -> !Rs2Inventory.isFull(), 3000); // Wait until the player stops moving
+            Rs2Inventory.waitForInventoryChanges(3000);
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
@@ -2,8 +2,10 @@
 
 package net.runelite.client.plugins.microbot.blastoisefurnace;
 
+import java.awt.event.KeyEvent;
 import java.util.concurrent.TimeUnit;
 
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.client.plugins.microbot.shortestpath.ShortestPathPlugin;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
@@ -30,13 +32,11 @@ import static net.runelite.api.ItemID.GOLD_ORE;
 
 public class BlastoiseFurnaceScript extends Script {
     static final int BAR_DISPENSER = 9092;
+    int coalBag = ItemID.COAL_BAG_25627;
     private static final int MAX_ORE_PER_INTERACTION = 27;
     public static double version = 1.0;
     public static State state;
     static int staminaTimer;
-    static int previousXP;
-    static boolean waitingnexttick;
-    static boolean waitingXpDrop;
     static boolean coalBagEmpty;
     static boolean primaryOreEmpty;
     static boolean secondaryOreEmpty;
@@ -45,11 +45,7 @@ public class BlastoiseFurnaceScript extends Script {
         state = State.BANKING;
     }
 
-    boolean initScript = false;
     private BlastoiseFurnaceConfig config;
-
-    public BlastoiseFurnaceScript() {
-    }
 
     private boolean hasRequiredOresForSmithing() {
         int primaryOre = this.config.getBars().getPrimaryOre();
@@ -61,18 +57,13 @@ public class BlastoiseFurnaceScript extends Script {
 
     public boolean run(BlastoiseFurnaceConfig config) {
         staminaTimer = 0;
-        this.initScript = true;
         this.config = config;
         Microbot.enableAutoRunOn = false;
-        state = State.BANKING;
-        previousXP = 0;
-        waitingXpDrop = true;
-        waitingnexttick = false;
+//        state = State.BANKING;
         primaryOreEmpty = !Rs2Inventory.hasItem(config.getBars().getPrimaryOre());
         secondaryOreEmpty = !Rs2Inventory.hasItem(config.getBars().getSecondaryOre());
         Rs2Antiban.resetAntibanSettings();
         applyAntiBanSettings();
-
 
         this.mainScheduledFuture = this.scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
@@ -85,7 +76,6 @@ public class BlastoiseFurnaceScript extends Script {
                 }
 
 
-
                 boolean hasGauntlets;
                 switch (state) {
                     case BANKING:
@@ -93,24 +83,24 @@ public class BlastoiseFurnaceScript extends Script {
                         if (!Rs2Bank.isOpen()) {
                             System.out.println("Opening bank");
                             Rs2Bank.openBank();
-                            this.sleepUntil(Rs2Bank::isOpen, 60000);
+                            sleepUntil(Rs2Bank::isOpen, 20000);
                         }
 
-                        if (config.getBars().isRequiresCoalBag() && !Rs2Inventory.contains(ItemID.COAL_BAG_12019)) {
-                            if (!Rs2Bank.hasItem(ItemID.COAL_BAG_12019)) {
-                                Microbot.showMessage("get a coal bag");
+                        if (config.getBars().isRequiresCoalBag() && !Rs2Inventory.contains(coalBag)) {
+                            if (!Rs2Bank.hasItem(coalBag)) {
+                                Microbot.showMessage("No coal bag found in inventory and bank.");
                                 this.shutdown();
                                 return;
                             }
 
-                            Rs2Bank.withdrawItem(ItemID.COAL_BAG_12019);
+                            Rs2Bank.withdrawItem(coalBag);
                         }
 
                         if (config.getBars().isRequiresGoldsmithGloves()) {
                             hasGauntlets = Rs2Inventory.contains(ItemID.GOLDSMITH_GAUNTLETS) || Rs2Equipment.isWearing(ItemID.GOLDSMITH_GAUNTLETS);
                             if (!hasGauntlets) {
                                 if (!Rs2Bank.hasItem(ItemID.GOLDSMITH_GAUNTLETS)) {
-                                    Microbot.showMessage("Need goldsmith gauntlets");
+                                    Microbot.showMessage("No goldsmith gauntlets found.");
                                     this.shutdown();
                                     return;
                                 }
@@ -120,13 +110,11 @@ public class BlastoiseFurnaceScript extends Script {
                         }
 
                         if (Rs2Inventory.hasItem("bar")) {
-                            Rs2Bank.depositAllExcept(ItemID.COAL_BAG_12019, ItemID.GOLDSMITH_GAUNTLETS, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I);
-
-
+                            Rs2Bank.depositAllExcept(coalBag, ItemID.GOLDSMITH_GAUNTLETS, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I);
                         }
 
                         if (!this.hasRequiredOresForSmithing()) {
-                            System.err.println("not enough required shit");
+                            System.err.println("Out of ores.");
                             Rs2Player.logout();
                             this.shutdown();
                         }
@@ -135,46 +123,23 @@ public class BlastoiseFurnaceScript extends Script {
                             this.useStaminaPotions();
                         }
 
-                        this.retrieveItemsForCurrentFurnaceInteraction();
-                        state = State.SMITHING;
+                        // Check here if dispenser contains bars. If so we need to clean-up
+                        if (dispenserContainsBars()) {
+                            Rs2Bank.depositAllExcept(coalBag, ItemID.GOLDSMITH_GAUNTLETS, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I);
+                            handleDispenserLooting();
+                            return;
+                        }else {
+                            this.retrieveItemsForCurrentFurnaceInteraction();
+                            state = State.SMITHING;
+                        }
                         break;
                     case SMITHING:
                         System.out.println("clicking conveyor");
-                        int primaryOre = this.config.getBars().getPrimaryOre();
 
                         if (barsInDispenser(config.getBars()) > 0) {
-                            hasGauntlets = Rs2Widget.hasWidget("How many would you like");
-
-                            while (true) {
-                                if (hasGauntlets && super.run()) {
-                                    Rs2Keyboard.keyPress(32);
-
-                                    if (config.getBars().isRequiresGoldsmithGloves()) {
-                                        Rs2Inventory.interact(ItemID.GOLDSMITH_GAUNTLETS, "Wear");
-                                    }
-
-                                    sleepUntil(() -> Rs2Inventory.contains(config.getBars().getBarID()), 2000);
-                                    break;
-                                }
-
-                                // Check if the inventory is full before interacting with the dispenser
-                                if (!Rs2Inventory.isFull()) {
-                                    Rs2GameObject.interact(BAR_DISPENSER, "Take");
-
-                                    hasGauntlets = sleepUntil(
-                                            () -> Rs2Widget.hasWidget("How many would you like"),
-                                            () -> Rs2Player.isMoving(),
-                                            600
-                                    );
-                                } else {
-                                    System.out.println("Inventory is full, stopping interaction.");
-                                    break; // Stop taking if the inventory is full
-                                }
-                            }
+                            handleDispenserLooting();
                         }
 
-                        this.openBank();
-                        this.sleepUntil(Rs2Bank::isOpen, Rs2Player::isMoving, 300);
                         state = State.BANKING;
                 }
             } catch (Exception ex) {
@@ -186,6 +151,47 @@ public class BlastoiseFurnaceScript extends Script {
         return true;
     }
 
+    private void handleDispenserLooting() {
+
+        // Check if the inventory is full before interacting with the dispenser
+        if (!Rs2Inventory.isFull()) {
+            Rs2GameObject.interact(BAR_DISPENSER, "Take");
+
+            sleepUntil(Rs2Player::isMoving, 10000);
+            sleepUntil(()->!Rs2Player.isMoving(), 10000);
+
+            boolean noIceGlovesEquiped = Rs2Widget.hasWidget("The bars are still molten!");
+
+            if (noIceGlovesEquiped){
+                if (!Rs2Inventory.interact(ItemID.ICE_GLOVES, "Wear") && !Rs2Inventory.interact(ItemID.SMITHS_GLOVES_I, "Wear")) {
+                    Microbot.showMessage("Ice gloves or smith gloves required to loot the hot bars.");
+                    Rs2Player.logout();
+                    this.shutdown();
+                    return;
+                }
+                Rs2GameObject.interact(BAR_DISPENSER, "Take");
+            }
+
+            sleepUntil(() -> Rs2Widget.hasWidget("What would you like to take?") || Rs2Widget.hasWidget("How many would you like"), 10000);
+
+            // If somehow multiple type of bars are created we need to clean up the dispenser.
+            boolean multipleBarTypes = Rs2Widget.hasWidget("What would you like to take?");
+            boolean canLootBar = Rs2Widget.hasWidget("How many would you like");
+
+            if (super.run()) {
+                if (canLootBar) {
+                    Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
+                } else if (multipleBarTypes) {
+                    Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
+                }
+                Rs2Inventory.waitForInventoryChanges(5000);
+                equipGoldSmithGauntlets(); // Optionally
+            }
+        }
+
+        state = State.BANKING;
+    }
+
     private void retrieveCoalAndPrimary() {
         int primaryOre = this.config.getBars().getPrimaryOre();
         if (!Rs2Inventory.hasItem(primaryOre)) {
@@ -193,15 +199,13 @@ public class BlastoiseFurnaceScript extends Script {
             return;
         }
 
-      boolean fullCoalBag = Rs2Inventory.interact(ItemID.COAL_BAG_12019, "Fill");
+        boolean fullCoalBag = Rs2Inventory.interact(coalBag, "Fill");
         if (!fullCoalBag)
             return;
         depositOre();
         Rs2Walker.walkFastCanvas(new WorldPoint(1940, 4962, 0));
         sleep(3400);
-        sleepUntil(() -> {
-            return barsInDispenser(config.getBars()) > 0;
-        }, 20000);
+        sleepUntil(() -> barsInDispenser(config.getBars()) > 0, 10000);
     }
 
     private void retrievePrimary() {
@@ -213,9 +217,7 @@ public class BlastoiseFurnaceScript extends Script {
         depositOre();
         Rs2Walker.walkFastCanvas(new WorldPoint(1940, 4962, 0));
         sleep(3400);
-        sleepUntil(() -> {
-            return barsInDispenser(this.config.getBars()) > 0;
-        }, 300000);
+        sleepUntil(() -> barsInDispenser(this.config.getBars()) > 0, 10000);
     }
 
     private void retrieveDoubleCoal() {
@@ -223,16 +225,9 @@ public class BlastoiseFurnaceScript extends Script {
             Rs2Bank.withdrawAll(COAL);
             return;
         }
-        boolean fullCoalBag = Rs2Inventory.interact(ItemID.COAL_BAG_12019, "Fill");
+        boolean fullCoalBag = Rs2Inventory.interact(coalBag, "Fill");
         if (!fullCoalBag)
             return;
-        depositOre();
-
-    }
-
-    private void retrieveCoal() {
-        Rs2Bank.withdrawAll(ItemID.COAL);
-        sleep(600);
         depositOre();
 
     }
@@ -242,21 +237,16 @@ public class BlastoiseFurnaceScript extends Script {
             Rs2Bank.withdrawAll(GOLD_ORE);
             return;
         }
-       depositOre();
+        depositOre();
 
         Rs2Walker.walkFastCanvas(new WorldPoint(1940, 4962, 0));
 
         sleep(3400);
-        sleepUntil(() -> {
-            return barsInDispenser(config.getBars()) > 5;
-        }, 300000);
+        sleepUntil(() -> barsInDispenser(config.getBars()) > 0, 10000);
         Rs2Inventory.interact(ItemID.ICE_GLOVES, "wear");
     }
 
     private void retrieveItemsForCurrentFurnaceInteraction() {
-        if (GOLD_ORE == config.getBars().getPrimaryOre()) {
-        }
-
         switch (config.getBars()) {
             case GOLD_BAR:
                 handleGold();
@@ -289,10 +279,9 @@ public class BlastoiseFurnaceScript extends Script {
             case 1:
             case 0:
                 retrieveGold();
-            break;
+                break;
             default:
                 assert false : "how did you get there";
-
         }
     }
 
@@ -363,8 +352,9 @@ public class BlastoiseFurnaceScript extends Script {
 
             case 5:
             case 4:
-            case 3:retrieveCoalAndPrimary();
-            break;
+            case 3:
+                retrieveCoalAndPrimary();
+                break;
             case 2:
                 retrieveDoubleCoal();
                 break;
@@ -406,14 +396,10 @@ public class BlastoiseFurnaceScript extends Script {
             case 0:
                 retrieveDoubleCoal();
                 break;
-                default:
+            default:
                 assert false : "how did you get there";
         }
 
-    }
-
-    private void openBank() {
-        Rs2Bank.openBank(Rs2GameObject.findObjectById(26707));
     }
 
     private void useStaminaPotions() {
@@ -473,29 +459,17 @@ public class BlastoiseFurnaceScript extends Script {
     }
 
     private void depositOre() {
-
         Rs2GameObject.interact(ObjectID.CONVEYOR_BELT, "Put-ore-on");
-        sleepUntil(() -> !Rs2Inventory.isFull(), 7000); // Wait until the player stops moving
+        Rs2Inventory.waitForInventoryChanges(10000);
+//        sleepUntil(() -> !Rs2Inventory.isFull(), 10000); // Wait until the player stops moving
 
         if (this.config.getBars().isRequiresCoalBag()) {
-            Rs2Inventory.interact(ItemID.COAL_BAG_12019, "Empty");
-            sleepUntil(() -> Rs2Inventory.isFull(), 1000); // Wait for animation to finish
+            Rs2Inventory.interact(coalBag, "Empty");
+            sleepUntil(() -> Rs2Inventory.isFull(), 3000); // Wait for animation to finish
 
             Rs2GameObject.interact(ObjectID.CONVEYOR_BELT, "Put-ore-on");
-            sleepUntil(() -> !Rs2Inventory.isFull(), 2000); // Wait until the player stops moving
+            sleepUntil(() -> !Rs2Inventory.isFull(), 3000); // Wait until the player stops moving
         }
-    }
-
-    private boolean hasNoCoalOrOre() {
-        return !Rs2Inventory.contains(ItemID.COAL) && !Rs2Inventory.contains(this.config.getBars().getPrimaryOre());
-    }
-
-    private boolean hasCoalOrOre() {
-        return Rs2Inventory.contains(ItemID.COAL) || Rs2Inventory.contains(this.config.getBars().getPrimaryOre());
-    }
-
-    private boolean hasCoalOre() {
-        return Rs2Inventory.contains(ItemID.COAL);
     }
 
     public int barsInDispenser(Bars bar) {
@@ -515,12 +489,38 @@ public class BlastoiseFurnaceScript extends Script {
         }
     }
 
+    public boolean dispenserContainsBars() {
+        int[] allBarVarbits = {
+                Varbits.BLAST_FURNACE_IRON_BAR,
+                Varbits.BLAST_FURNACE_STEEL_BAR,
+                Varbits.BLAST_FURNACE_GOLD_BAR,
+                Varbits.BLAST_FURNACE_MITHRIL_BAR,
+                Varbits.BLAST_FURNACE_ADAMANTITE_BAR,
+                Varbits.BLAST_FURNACE_RUNITE_BAR
+        };
+
+        // Iterate through each bar and check its value
+        for (int bar : allBarVarbits) {
+            if (Microbot.getVarbitValue(bar) > 0) {
+                // Return if bar is found
+                return true;
+            }
+        }
+
+        // Return true if no bars found
+        return false;
+    }
+
+    private void equipGoldSmithGauntlets() {
+        if (config.getBars().isRequiresGoldsmithGloves()) {
+            Rs2Inventory.interact(ItemID.GOLDSMITH_GAUNTLETS, "Wear");
+        }
+    }
 
     private void applyAntiBanSettings() {
         Rs2AntibanSettings.antibanEnabled = true;
         Rs2AntibanSettings.naturalMouse = true;
         Rs2AntibanSettings.devDebug = true;
-
     }
 
 
@@ -536,9 +536,7 @@ public class BlastoiseFurnaceScript extends Script {
         }
 
 
-
         state = State.BANKING;
-        this.initScript = false;
         primaryOreEmpty = false;
         secondaryOreEmpty = false;
         super.shutdown();


### PR DESCRIPTION
# This PR is to improve the official Blast Furnace plugin 

## Known BF bugs:
- When smithing gold bars, sometimes not equipping the right gloves
- When lag spikes occur, it fails looting the bars from dispenser. Script was continuing smelting bars, this creates the issue that two types of bars were made. The plugin was not made to handle this edge case.

## Fixed:
- If it fails looting the dispenser because no ice gloves equipped the message will occur "The bars are still molten!". Logic added to equip the ice gloves and try again
- Logic added to handle the scenario where multiple bar types are created. It will empty the dispenser and loot each type one by one
- Logic added to check if the dispenser already contains bars before doing another "deposit ores" run

### Code improvements
- Removed crazy high timeout times like (300.000) and replaced with like 10s time outs
- Removed almost all unused code
- Improved readability

Tested by two people so far works flawlessly.