### PR TITLE
feat: add new fruit patch

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/farmTreeRun/FarmTreeRunConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/farmTreeRun/FarmTreeRunConfig.java
@@ -10,7 +10,7 @@ import net.runelite.client.plugins.microbot.farmTreeRun.enums.TreeEnums;
 @ConfigGroup("example")
 @ConfigInformation("Start anywhere you want. <br><br> Required items in bank:\n" +
         "<ol>\n" +
-        "    <li>3.000 gp</li>\n" +
+        "    <li>5.000 gp</li>\n" +
         "    <li>Selected saplings</li>\n" +
         "    <li>Spade</li>\n" +
         "    <li>Rake</li>\n" +
@@ -272,8 +272,8 @@ public interface FarmTreeRunConfig extends Config {
 
     @ConfigItem(
             keyName = "farmingGuildFruitTree",
-            name = "[Not implemented] Farming Guild",
-            description = "[Not tested] FarmingGuild fruit tree patch",
+            name = "Farming Guild",
+            description = "Farming guild fruit tree patch",
             position = 6,
             section = fruitTreePatchesSection
     )


### PR DESCRIPTION
This PR is created to add new fruit tree patch to the Farm Tree Runner plugin.

## Feature:
- Added new farming guild fruit tree patch

### Improved:
- Added`handleExoticGardeners()` to handle exotic gardeners
- Changed 3.000 gp -> 5.000 gp. Money was not enough if player was not on Standard spellbook
- Shutting down script while it was banking, caused weird bug when reactivated it was acting crazy. Fixed by `break`ing the loop if items list is empty
- Lowered random sleeps