### PR TITLE
Some fixes to Vorkath

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/vorkath/VorkathScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/vorkath/VorkathScript.java
@@ -224,7 +224,7 @@ public class VorkathScript extends Script {
                             Rs2Npc.interact(NpcID.VORKATH_8059, "Poke");
                             Rs2Player.waitForWalking();
                             Rs2Npc.interact(NpcID.VORKATH_8059, "Poke");
-                            Rs2Player.waitForAnimation(10000);
+                            Rs2Player.waitForAnimation(4000);
                             walkToCenter();
                             Rs2Player.waitForWalking();
                             handlePrayer();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/vorkath/VorkathScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/vorkath/VorkathScript.java
@@ -299,7 +299,10 @@ public class VorkathScript extends Script {
                             Rs2Tab.switchToInventoryTab();
                             state = State.FIGHT_VORKATH;
                             sleepUntil(() -> Rs2Npc.getNpc("Zombified Spawn") == null);
-                            
+                            if (doesProjectileExistById(redProjectileId)) {
+                                handleRedBall();
+                                sleep(300);
+                            }
                         }
                         break;
                     case ACID:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/vorkath/VorkathScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/vorkath/VorkathScript.java
@@ -299,7 +299,7 @@ public class VorkathScript extends Script {
                             Rs2Tab.switchToInventoryTab();
                             state = State.FIGHT_VORKATH;
                             sleepUntil(() -> Rs2Npc.getNpc("Zombified Spawn") == null);
-                            sleep(1000);
+                            
                         }
                         break;
                     case ACID:
@@ -407,7 +407,7 @@ public class VorkathScript extends Script {
             } catch (Exception ex) {
                 System.out.println(ex.getMessage());
             }
-        }, 0, 100, TimeUnit.MILLISECONDS);
+        }, 0, 90, TimeUnit.MILLISECONDS);
         return true;
     }
 
@@ -580,7 +580,7 @@ public class VorkathScript extends Script {
             if (playerLocation.equals(safeTile)) {
                 Rs2Npc.interact(vorkath, "attack");
             } else {
-                Rs2Player.eatAt(75);
+                Rs2Player.eatAt(60);
                 Rs2Walker.walkFastLocal(LocalPoint.fromWorld(Microbot.getClient(), safeTile));
             }
         }


### PR DESCRIPTION
fix: adjust Vorkath interaction timing and not dodging fireball after Zombie phase.
fix: reduce wait time for Vorkath animation to avoid melee attack at the start.
fix: issue with  timing and eating that cause death during wooxwalk.