### PR TITLE
Crafting Script (StaffScript + AmethystScript Additions) - Antiban, Overlay Changes. All Script Updates, Bug Fixes, Improvements and Minor Changes

### DIFF
--- a/docs/api/Rs2Bank.md
+++ b/docs/api/Rs2Bank.md
@@ -43,7 +43,7 @@ The `Rs2Bank` class manages interactions with the banking system in the game, fa
 - **Signature**: `public static Rs2Item findBankItem(String name)`
 - **Description**: Searches for a bank item by its name, supporting both exact and partial matches.
 
-### `getNearestBank`
+### `getnearestbank`
 - **Signature**: `public static BankLocation getNearestBank()`
 - **Description**: Identifies the nearest bank location relative to the player's current position.
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingConfig.java
@@ -33,7 +33,7 @@ public interface CraftingConfig extends Config {
                 return Activities.NONE;
         }
 
-        @ConfigItem(keyName = "Afk", name = "Random AFKs", description = "Randomy afks between 3 and 60 seconds", position = 1, section = generalSection)
+        @ConfigItem(keyName = "Afk", name = "Random AFKs", description = "Randomy afks between 15 and 90 seconds", position = 1, section = generalSection)
         default boolean Afk() {
                 return false;
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingConfig.java
@@ -19,6 +19,8 @@ public interface CraftingConfig extends Config {
         String glassSection = "glass";
         @ConfigSection(name = "Amethyst", description = "Config for amethyst cutting", position = 4, closedByDefault = true)
         String amethystSection = "amethyst";
+        @ConfigSection(name = "Drift Net", description = "Config for crafting drift nets", position = 5, closedByDefault = true)
+        String driftNetSection = "driftnet";
 
         @ConfigItem(keyName = "fletchIntoBoltTips", name = "Fletch into Bolt Tips", description = "Fletch cut gems into bolt tips if possible", position = 1, section = gemSection)
         default boolean fletchIntoBoltTips() {
@@ -69,5 +71,10 @@ public interface CraftingConfig extends Config {
                         "to cut from Amethyst", position = 4, section = amethystSection)
         default Amethyst amethystType() {
                 return Amethyst.NONE;
+        }
+
+        @ConfigItem(keyName = "Loom", name = "Loom Location", description = "Location to weave the drift net", position = 1, section = driftNetSection)
+        default Loom loomLocation() {
+                return Loom.NONE;
         }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingConfig.java
@@ -9,7 +9,7 @@ import net.runelite.client.plugins.microbot.crafting.enums.*;
 @ConfigGroup(CraftingConfig.GROUP)
 public interface CraftingConfig extends Config {
 
-        String GROUP = "Crafting";
+        public String GROUP = "micro-crafting";
 
         @ConfigSection(name = "General", description = "General", position = 0)
         String generalSection = "general";
@@ -17,6 +17,8 @@ public interface CraftingConfig extends Config {
         String gemSection = "gem";
         @ConfigSection(name = "Glass", description = "Config for glass blowing", position = 2, closedByDefault = true)
         String glassSection = "glass";
+        @ConfigSection(name = "Amethyst", description = "Config for amethyst cutting", position = 4, closedByDefault = true)
+        String amethystSection = "amethyst";
 
         @ConfigItem(keyName = "fletchIntoBoltTips", name = "Fletch into Bolt Tips", description = "Fletch cut gems into bolt tips if possible", position = 1, section = gemSection)
         default boolean fletchIntoBoltTips() {
@@ -61,5 +63,11 @@ public interface CraftingConfig extends Config {
         @ConfigItem(keyName = "ChatMsgs", name = "Chat Messages", description = "Enable debug chatbox messages", position = 2, section = generalSection)
         default boolean chatMessages() {
                 return false;
+        }
+
+        @ConfigItem(keyName = "Amethyst", name = "Amethyst Item", description = "Item " +
+                        "to cut from Amethyst", position = 4, section = amethystSection)
+        default Amethyst amethystType() {
+                return Amethyst.NONE;
         }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingConfig.java
@@ -9,116 +9,57 @@ import net.runelite.client.plugins.microbot.crafting.enums.*;
 @ConfigGroup(CraftingConfig.GROUP)
 public interface CraftingConfig extends Config {
 
-    String GROUP = "Crafting";
+        String GROUP = "Crafting";
 
-    @ConfigSection(
-            name = "General",
-            description = "General",
-            position = 0
-    )
-    String generalSection = "general";
-    @ConfigSection(
-            name = "Gems",
-            description = "Config for gem cutting",
-            position = 1,
-            closedByDefault = true
-    )
-    String gemSection = "gem";
-    @ConfigSection(
-            name = "Glass",
-            description = "Config for glass blowing",
-            position = 2,
-            closedByDefault = true
-    )
-    String glassSection = "glass";
-    @ConfigItem(
-            keyName = "fletchIntoBoltTips",
-            name = "Fletch into Bolt Tips",
-            description = "Fletch cut gems into bolt tips if possible",
-            position = 1,
-            section = gemSection
-    )
-    default boolean fletchIntoBoltTips() {
-        return false;
-    }
-    @ConfigSection(
-            name = "Staffs",
-            description = "Config for staff making",
-            position = 2,
-            closedByDefault = true
-    )
-    String staffSection = "staff";
-    @ConfigSection(
-            name = "Flax",
-            description = "Configure Settings for Flax Spinning activity",
-            position = 3,
-            closedByDefault = true
-    )
-    String flaxSpinSection = "flaxspin";
+        @ConfigSection(name = "General", description = "General", position = 0)
+        String generalSection = "general";
+        @ConfigSection(name = "Gems", description = "Config for gem cutting", position = 1, closedByDefault = true)
+        String gemSection = "gem";
+        @ConfigSection(name = "Glass", description = "Config for glass blowing", position = 2, closedByDefault = true)
+        String glassSection = "glass";
 
-    @ConfigItem(
-            keyName = "Activity",
-            name = "Activity",
-            description = "Choose the type of crafting activity to perform",
-            position = 0,
-            section = generalSection
-    )
-    default Activities activityType() {
-        return Activities.NONE;
-    }
+        @ConfigItem(keyName = "fletchIntoBoltTips", name = "Fletch into Bolt Tips", description = "Fletch cut gems into bolt tips if possible", position = 1, section = gemSection)
+        default boolean fletchIntoBoltTips() {
+                return false;
+        }
 
-    @ConfigItem(
-            keyName = "Afk",
-            name = "Random AFKs",
-            description = "Randomy afks between 3 and 60 seconds",
-            position = 1,
-            section = generalSection
-    )
-    default boolean Afk() {
-        return false;
-    }
+        @ConfigSection(name = "Staffs", description = "Config for staff making", position = 2, closedByDefault = true)
+        String staffSection = "staff";
+        @ConfigSection(name = "Flax", description = "Configure Settings for Flax Spinning activity", position = 3, closedByDefault = true)
+        String flaxSpinSection = "flaxspin";
 
-    @ConfigItem(
-            keyName = "Gem",
-            name = "Gem",
-            description = "Choose the type of gem to cut",
-            position = 0,
-            section = gemSection
-    )
-    default Gems gemType() {
-        return Gems.NONE;
-    }
+        @ConfigItem(keyName = "Activity", name = "Activity", description = "Choose the type of crafting activity to perform", position = 0, section = generalSection)
+        default Activities activityType() {
+                return Activities.NONE;
+        }
 
-    @ConfigItem(
-            keyName = "Glass",
-            name = "Glass",
-            description = "Choose the type of glass item to blow",
-            position = 0,
-            section = glassSection
-    )
-    default Glass glassType() {
-        return Glass.NONE;
-    }
+        @ConfigItem(keyName = "Afk", name = "Random AFKs", description = "Randomy afks between 3 and 60 seconds", position = 1, section = generalSection)
+        default boolean Afk() {
+                return false;
+        }
 
-    @ConfigItem(
-            keyName = "Staffs",
-            name = "Staffs",
-            description = "Choose the type of battlestaff to make",
-            position = 0,
-            section = staffSection
-    )
-    default Staffs staffType() {
-        return Staffs.NONE;
-    }
+        @ConfigItem(keyName = "Gem", name = "Gem", description = "Choose the type of gem to cut", position = 0, section = gemSection)
+        default Gems gemType() {
+                return Gems.NONE;
+        }
 
-    @ConfigItem(
-            name = "Location",
-            description = "Choose Location where to spin flax",
-            keyName = "flaxSpinLocation",
-            position = 0,
-            section = flaxSpinSection
-    )
-    default FlaxSpinLocations flaxSpinLocation() {
-        return FlaxSpinLocations.NONE;
-    }
+        @ConfigItem(keyName = "Glass", name = "Glass", description = "Choose the type of glass item to blow", position = 0, section = glassSection)
+        default Glass glassType() {
+                return Glass.NONE;
+        }
+
+        @ConfigItem(keyName = "Staffs", name = "Staffs", description = "Choose the type of battlestaff to make", position = 0, section = staffSection)
+        default Staffs staffType() {
+                return Staffs.NONE;
+        }
+
+        @ConfigItem(name = "Location", description = "Choose Location where to spin flax", keyName = "flaxSpinLocation", position = 0, section = flaxSpinSection)
+        default FlaxSpinLocations flaxSpinLocation() {
+                return FlaxSpinLocations.NONE;
+        }
+
+        @ConfigItem(keyName = "ChatMsgs", name = "Chat Messages", description = "Enable debug chatbox messages", position = 2, section = generalSection)
+        default boolean chatMessages() {
+                return false;
+        }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingOverlay.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.crafting;
 
+import net.runelite.api.MenuAction;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -7,16 +8,19 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 
 import javax.inject.Inject;
+
 import java.awt.*;
 import java.time.Duration;
 
 public class CraftingOverlay extends OverlayPanel {
 
-    public long startTime = 0;
+    CraftingPlugin _plugin;
 
     @Inject
     CraftingOverlay(CraftingPlugin plugin) {
         super(plugin);
+        this._plugin = plugin;
+        setPreferredPosition(OverlayPosition.BOTTOM_LEFT);
         setPosition(OverlayPosition.BOTTOM_LEFT);
         setNaughty();
     }
@@ -24,7 +28,7 @@ public class CraftingOverlay extends OverlayPanel {
     @Override
     public Dimension render(Graphics2D graphics) {
         try {
-            panelComponent.setPreferredSize(new Dimension(150, 400));
+            panelComponent.setPreferredSize(new Dimension(175, 400));
             panelComponent.getChildren().add(TitleComponent.builder()
                     .text("[ Micro Crafter ]")
                     .color(Color.ORANGE)
@@ -39,11 +43,9 @@ public class CraftingOverlay extends OverlayPanel {
 
             addLine("");
 
-            long s = Duration.ofMillis(System.currentTimeMillis() - startTime).toSeconds();
             panelComponent.getChildren().add(LineComponent.builder()
                     .left("Run Time: ")
-                    .right(
-                            String.format("%02d:%02d:%02d", s / 3600, (s % 3600) / 60, (s % 60)))
+                    .right(_plugin.getTimeRunning())
                     .build());
 
             addLine("");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingOverlay.java
@@ -1,6 +1,5 @@
 package net.runelite.client.plugins.microbot.crafting;
 
-import net.runelite.api.Skill;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -9,34 +8,58 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 
 import javax.inject.Inject;
 import java.awt.*;
+import java.time.Duration;
 
 public class CraftingOverlay extends OverlayPanel {
 
+    public long startTime = 0;
 
     @Inject
-    CraftingOverlay(CraftingPlugin plugin)
-    {
+    CraftingOverlay(CraftingPlugin plugin) {
         super(plugin);
-        setPosition(OverlayPosition.TOP_LEFT);
+        setPosition(OverlayPosition.BOTTOM_LEFT);
         setNaughty();
     }
+
     @Override
     public Dimension render(Graphics2D graphics) {
         try {
-            panelComponent.setPreferredSize(new Dimension(275, 700));
+            panelComponent.setPreferredSize(new Dimension(150, 400));
             panelComponent.getChildren().add(TitleComponent.builder()
-                    .text("Micro Crafter")
+                    .text("[ Micro Crafter ]")
                     .color(Color.ORANGE)
                     .build());
 
+            addLine("");
+
             panelComponent.getChildren().add(LineComponent.builder()
-                    .left(Microbot.status)
+                    .left("Script Version: ")
+                    .right(CraftingPlugin.version)
                     .build());
 
+            addLine("");
 
-        } catch(Exception ex) {
+            long s = Duration.ofMillis(System.currentTimeMillis() - startTime).toSeconds();
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Run Time: ")
+                    .right(
+                            String.format("%02d:%02d:%02d", s / 3600, (s % 3600) / 60, (s % 60)))
+                    .build());
+
+            addLine("");
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Status: ")
+                    .right(Microbot.status)
+                    .build());
+
+        } catch (Exception ex) {
             System.out.println(ex.getMessage());
         }
         return super.render(graphics);
+    }
+
+    private void addLine(final String left) {
+        panelComponent.getChildren().add(LineComponent.builder().left(left).build());
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingPlugin.java
@@ -12,6 +12,7 @@ import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.crafting.enums.Activities;
 import net.runelite.client.plugins.microbot.crafting.scripts.*;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.mouse.VirtualMouse;
 import net.runelite.client.ui.overlay.OverlayManager;
 
@@ -63,6 +64,8 @@ public class CraftingPlugin extends Plugin {
         Microbot.setNotifier(notifier);
         Microbot.setMouse(new VirtualMouse());
         Rs2Antiban.antibanSetupTemplates.applyCraftingSetup();
+        // Everyone makes mistakes
+        Rs2AntibanSettings.simulateMistakes = true;
 
         if (overlayManager != null) {
             overlayManager.add(craftingOverlay);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingPlugin.java
@@ -6,8 +6,6 @@ import net.runelite.api.Client;
 import net.runelite.client.Notifier;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.Microbot;
@@ -44,6 +42,7 @@ public class CraftingPlugin extends Plugin {
     private final GlassblowingScript glassblowingScript = new GlassblowingScript();
     private final StaffScript staffScript = new StaffScript();
     private final FlaxSpinScript flaxSpinScript = new FlaxSpinScript();
+    private final AmethystScript amethystScript = new AmethystScript();
     @Inject
     private CraftingConfig config;
     @Inject
@@ -90,6 +89,8 @@ public class CraftingPlugin extends Plugin {
             staffScript.run(config);
         } else if (config.activityType() == Activities.FLAX_SPINNING) {
             flaxSpinScript.run(config);
+        } else if (config.activityType() == Activities.CUTTING_AMETHYST) {
+            amethystScript.run(config);
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingPlugin.java
@@ -43,6 +43,7 @@ public class CraftingPlugin extends Plugin {
     private final StaffScript staffScript = new StaffScript();
     private final FlaxSpinScript flaxSpinScript = new FlaxSpinScript();
     private final AmethystScript amethystScript = new AmethystScript();
+    private final DriftNetScript driftNetScript = new DriftNetScript();
     @Inject
     private CraftingConfig config;
     @Inject
@@ -91,6 +92,8 @@ public class CraftingPlugin extends Plugin {
             flaxSpinScript.run(config);
         } else if (config.activityType() == Activities.CUTTING_AMETHYST) {
             amethystScript.run(config);
+        } else if (config.activityType() == Activities.WEAVING_NETS) {
+            driftNetScript.run(config);
         }
     }
 
@@ -104,8 +107,11 @@ public class CraftingPlugin extends Plugin {
         gemsScript.shutdown();
         defaultScript.shutdown();
         flaxSpinScript.shutdown();
+        amethystScript.shutdown();
+        driftNetScript.shutdown();
         scriptStartTime = null;
         overlayManager.remove(craftingOverlay);
+        Microbot.pauseAllScripts = true;
         Rs2Antiban.resetAntibanSettings();
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingPlugin.java
@@ -3,7 +3,6 @@ package net.runelite.client.plugins.microbot.crafting;
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
-import net.runelite.api.Skill;
 import net.runelite.client.Notifier;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
@@ -12,20 +11,26 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.crafting.enums.Activities;
 import net.runelite.client.plugins.microbot.crafting.scripts.*;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.mouse.VirtualMouse;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
 import java.awt.*;
 
-@PluginDescriptor(
-        name = PluginDescriptor.Mocrosoft + "Crafting",
-        description = "Microbot crafting plugin",
-        tags = {"skilling", "microbot", "crafting"},
-        enabledByDefault = false
-)
+@PluginDescriptor(name = PluginDescriptor.Mocrosoft + "Crafting", description = "Microbot crafting plugin", tags = {
+        "skilling",
+        "microbot",
+        "crafting",
+        "staffs",
+        "gems",
+        "glass",
+        "flax"
+}, enabledByDefault = false)
 @Slf4j
 public class CraftingPlugin extends Plugin {
+
+    public static String version = "V1.1.0";
 
     private final DefaultScript defaultScript = new DefaultScript();
     private final GemsScript gemsScript = new GemsScript();
@@ -57,12 +62,13 @@ public class CraftingPlugin extends Plugin {
         Microbot.setClientThread(clientThread);
         Microbot.setNotifier(notifier);
         Microbot.setMouse(new VirtualMouse());
+        Rs2Antiban.antibanSetupTemplates.applyCraftingSetup();
+
         if (overlayManager != null) {
             overlayManager.add(craftingOverlay);
         }
 
-//        if (config.activityType() == Activities.DEFAULT) {
-
+        craftingOverlay.startTime = System.currentTimeMillis();
         if (config.activityType() == Activities.GEM_CUTTING) {
             gemsScript.run(config);
         } else if (config.activityType() == Activities.GLASSBLOWING) {
@@ -80,6 +86,8 @@ public class CraftingPlugin extends Plugin {
         gemsScript.shutdown();
         defaultScript.shutdown();
         flaxSpinScript.shutdown();
+        craftingOverlay.startTime = 0;
         overlayManager.remove(craftingOverlay);
+        Rs2Antiban.resetAntibanSettings();
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Activities.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Activities.java
@@ -7,18 +7,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Activities {
     NONE(" "),
-//    DEFAULT("Default Script"),
+    // DEFAULT("Default Script"),
     GEM_CUTTING("Cutting Gems"),
     GLASSBLOWING("Glassblowing"),
     STAFF_MAKING("Staff Making"),
     FLAX_SPINNING("Flax Spinning"),
-    CUTTING_AMETHYST("Cutting Amethyst");
+    CUTTING_AMETHYST("Cutting Amethyst"),
+    WEAVING_NETS("Weaving Nets");
 
     private final String name;
 
     @Override
-    public String toString()
-    {
+    public String toString() {
         return name;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Activities.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Activities.java
@@ -11,7 +11,8 @@ public enum Activities {
     GEM_CUTTING("Cutting Gems"),
     GLASSBLOWING("Glassblowing"),
     STAFF_MAKING("Staff Making"),
-    FLAX_SPINNING("Flax Spinning");
+    FLAX_SPINNING("Flax Spinning"),
+    CUTTING_AMETHYST("Cutting Amethyst");
 
     private final String name;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Amethyst.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Amethyst.java
@@ -1,0 +1,51 @@
+package net.runelite.client.plugins.microbot.crafting.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.ItemID;
+
+@Getter
+@RequiredArgsConstructor
+public enum Amethyst {
+    NONE(
+            "",
+            0,
+            0,
+            0
+    ),
+    PROGRESSIVE(
+            "Progressive",
+            0,
+            83,
+            0
+    ),
+    BOLT_TIPS(
+            "Bolt tips",
+            ItemID.AMETHYST_BOLT_TIPS,
+            83,
+            1
+    ),
+    ARROWTIPS(
+            "Arrowtips",
+            ItemID.AMETHYST_ARROWTIPS,
+            85,
+            2
+    ),
+    JAVELIN_HEADS(
+            "Javelin heads",
+            ItemID.AMETHYST_JAVELIN_HEADS,
+            87,
+            3
+    ),
+    DART_TIP(
+            "Dart tip",
+            ItemID.AMETHYST_DART_TIP,
+            89,
+            4
+    );
+
+    private final String itemName;
+    private final int itemId;
+    private final int requiredLevel;
+    private final int craftOptionKey;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Amethyst.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Amethyst.java
@@ -7,45 +7,39 @@ import net.runelite.api.ItemID;
 @Getter
 @RequiredArgsConstructor
 public enum Amethyst {
-    NONE(
-            "",
-            0,
-            0,
-            0
-    ),
-    PROGRESSIVE(
-            "Progressive",
-            0,
-            83,
-            0
-    ),
-    BOLT_TIPS(
-            "Bolt tips",
-            ItemID.AMETHYST_BOLT_TIPS,
-            83,
-            1
-    ),
-    ARROWTIPS(
-            "Arrowtips",
-            ItemID.AMETHYST_ARROWTIPS,
-            85,
-            2
-    ),
-    JAVELIN_HEADS(
-            "Javelin heads",
-            ItemID.AMETHYST_JAVELIN_HEADS,
-            87,
-            3
-    ),
-    DART_TIP(
-            "Dart tip",
-            ItemID.AMETHYST_DART_TIP,
-            89,
-            4
-    );
+        NONE(
+                        "",
+                        0,
+                        0,
+                        0),
+        PROGRESSIVE(
+                        "Progressive",
+                        0,
+                        83,
+                        0),
+        BOLT_TIPS(
+                        "Bolt tips",
+                        ItemID.AMETHYST_BOLT_TIPS,
+                        83,
+                        1),
+        ARROWTIPS(
+                        "Arrowtips",
+                        ItemID.AMETHYST_ARROWTIPS,
+                        85,
+                        2),
+        JAVELIN_HEADS(
+                        "Javelin heads",
+                        ItemID.AMETHYST_JAVELIN_HEADS,
+                        87,
+                        3),
+        DART_TIP(
+                        "Dart tip",
+                        ItemID.AMETHYST_DART_TIP,
+                        89,
+                        4);
 
-    private final String itemName;
-    private final int itemId;
-    private final int requiredLevel;
-    private final int craftOptionKey;
+        private final String itemName;
+        private final int itemId;
+        private final int requiredLevel;
+        private final int craftOptionKey;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Loom.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Loom.java
@@ -13,7 +13,7 @@ public enum Loom {
     HOSIDIUS("Hodidius", new WorldPoint(3033, 3288, 0), new WorldPoint(1676, 3617, 0)),
     SOUTH_FALADOR_FARM("South Falador Farm", new WorldPoint(3039, 3287, 0), new WorldPoint(1398, 2927, 0)),
     ALDARIN("Aldarin", new WorldPoint(3040, 3284, 0), new WorldPoint(1398, 2927, 0)),
-    MUSEUM_CAMP("Fossil Island", new WorldPoint(3033, 3285, 0), new WorldPoint(3739, 3804, 0));
+    MUSEUM_CAMP("Fossil Island", new WorldPoint(3730, 3822, 0), new WorldPoint(3739, 3804, 0));
 
     public final String label;
     public final WorldPoint loomWorldPoint;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Loom.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Loom.java
@@ -1,0 +1,26 @@
+package net.runelite.client.plugins.microbot.crafting.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.util.bank.enums.BankLocation;
+
+@Getter
+@RequiredArgsConstructor
+public enum Loom {
+    NONE("", null, null),
+    PRIFDDINAS("Prifddinas", new WorldPoint(3187, 3434, 0), new WorldPoint(3257, 6106, 0)),
+    HOSIDIUS("Hodidius", new WorldPoint(3033, 3288, 0), new WorldPoint(1676, 3617, 0)),
+    SOUTH_FALADOR_FARM("South Falador Farm", new WorldPoint(3039, 3287, 0), new WorldPoint(1398, 2927, 0)),
+    ALDARIN("Aldarin", new WorldPoint(3040, 3284, 0), new WorldPoint(1398, 2927, 0)),
+    MUSEUM_CAMP("Fossil Island", new WorldPoint(3033, 3285, 0), new WorldPoint(3739, 3804, 0));
+
+    public final String label;
+    public final WorldPoint loomWorldPoint;
+    public final WorldPoint bankLocation;
+
+    @Override
+    public String toString() {
+        return label;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Staffs.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/Staffs.java
@@ -1,24 +1,57 @@
 package net.runelite.client.plugins.microbot.crafting.enums;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.runelite.api.ItemID;
 
 @Getter
 @RequiredArgsConstructor
 public enum Staffs {
-    NONE(" ","",0,""),
-    PROGRESSIVE("Progressive Mode","None", 1, ""),
-    WATER_BATTLESTAFF("Water Battlestaff", "Water Battlestaff", 54, "Water Orb"),
-    EARTH_BATTLESTAFF("Earth Battlestaff", "Earth Battlestaff", 58, "Earth Orb"),
-    FIRE_BATTLESTAFF("Fire Battlestaff", "Fire Battlestaff", 62, "Fire Orb"),
-    AIR_BATTLESTAFF("Air Battlestaff", "Air Battlestaff", 66, "Air Orb");
+        NONE(
+                        " ",
+                        0,
+                        0,
+                        "",
+                        0),
+        PROGRESSIVE(
+                        "Progressive Mode",
+                        0,
+                        1,
+                        "",
+                        0),
+        WATER_BATTLESTAFF(
+                        "Water Battlestaff",
+                        ItemID.WATER_BATTLESTAFF,
+                        54,
+                        "Water Orb",
+                        ItemID.WATER_ORB),
+        EARTH_BATTLESTAFF(
+                        "Earth Battlestaff",
+                        ItemID.EARTH_BATTLESTAFF,
+                        58,
+                        "Earth Orb",
+                        ItemID.EARTH_ORB),
+        FIRE_BATTLESTAFF(
+                        "Fire Battlestaff",
+                        ItemID.FIRE_BATTLESTAFF,
+                        62,
+                        "Fire Orb",
+                        ItemID.FIRE_ORB),
+        AIR_BATTLESTAFF(
+                        "Air Battlestaff",
+                        ItemID.AIR_BATTLESTAFF,
+                        66,
+                        "Air Orb",
+                        ItemID.AIR_ORB);
 
-    private final String label;
-    private final String itemName;
-    private final int levelRequired;
-    private final String orb;
-    @Override
-    public String toString()
-    {
-        return label;
-    }
+        private final String label;
+        private final int itemID;
+        private final int levelRequired;
+        private final String orbName;
+        private final int orbID;
+
+        @Override
+        public String toString() {
+                return label;
+        }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/AmethystScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/AmethystScript.java
@@ -1,0 +1,222 @@
+package net.runelite.client.plugins.microbot.crafting.scripts;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.GameObject;
+import net.runelite.api.ItemID;
+import net.runelite.api.Skill;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.crafting.CraftingConfig;
+import net.runelite.client.plugins.microbot.crafting.enums.Amethyst;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
+import net.runelite.client.plugins.microbot.util.math.Rs2Random;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.tabs.Rs2Tab;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
+
+import java.awt.event.KeyEvent;
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@Setter
+class ProgressiveAmethystCuttingModel {
+    private Amethyst itemToCut;
+}
+
+public class AmethystScript extends Script {
+
+    ProgressiveAmethystCuttingModel model = new ProgressiveAmethystCuttingModel();
+
+    int chisel = ItemID.CHISEL;
+    Amethyst itemToCut;
+
+    private boolean debugMessages = false; // Controls chatbox debug messages
+    private boolean firstCut = false; // Controls make "All" widget click
+
+    public void run(CraftingConfig config) {
+        if (Rs2Player.getRealSkillLevel(Skill.CRAFTING) < Amethyst.BOLT_TIPS.getRequiredLevel()) {
+            debugMessage("Crafting level too low to cut amethyst");
+            this.shutdown();
+        }
+
+        sleepUntil(() -> Microbot.isLoggedIn(), 1500);
+        debugMessage("Starting amethyst item crafting script");
+
+        if (config.amethystType() == Amethyst.PROGRESSIVE)
+            calculateItemToCut();
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            if (!super.run())
+                return;
+
+            // Enable ingame chatbox debug messages according to config
+            debugMessages = config.chatMessages();
+
+            // If AFK config variable is set randomly sleep for a period between
+            // 15 and 120 seconds before moving on if the trigger occurs
+            if (config.Afk() && Rs2Random.nzRandom() < 0.15) {
+                int breakDuration = Rs2Random.between(15, 90);
+                debugMessage(String.format("Going AFK for: %02d seconds", breakDuration));
+                Rs2Antiban.moveMouseOffScreen();
+                Microbot.status = String.format("AFK break: %02ds", breakDuration);
+                sleep(breakDuration * 1000);
+            }
+
+            if (Rs2Random.nzRandom() < 0.1) {
+                debugMessage("Checking skills tab progress");
+                if (!Rs2Tab.switchToSkillsTab())
+                    Rs2Keyboard.keyPress(KeyEvent.VK_F1);
+                Microbot.status = "Checking skills tab";
+                sleep(Rs2Random.between(1, 3) * 1000);
+            }
+
+            try {
+                if (config.amethystType() == Amethyst.PROGRESSIVE)
+                    itemToCut = model.getItemToCut();
+                else
+                    itemToCut = config.amethystType();
+
+                if (Rs2Inventory.hasItem(chisel) &&
+                        Rs2Inventory.hasItem(ItemID.AMETHYST))
+                    craft(config);
+
+                bank(config);
+            } catch (Exception ex) {
+                System.out.println(ex.getMessage());
+            }
+        }, 0, 500, TimeUnit.MILLISECONDS);
+    }
+
+    private void bank(CraftingConfig config) {
+        // Find, walk and turn to the closest bank
+        GameObject bankObject = Rs2GameObject.findBank();
+        if (!Rs2Walker.canReach(bankObject.getWorldLocation())) {
+            debugMessage("Walking to closest bank");
+            Microbot.status = "Walking to bank";
+            Rs2Walker.walkCanvas(bankObject.getWorldLocation());
+        }
+        Rs2Camera.turnTo(bankObject.getLocalLocation());
+
+        debugMessage("Opening bank interface");
+        sleepUntil(() -> Rs2Bank.openBank(), 500);
+
+        debugMessage("Depositing inventory into bank");
+        Rs2Bank.depositAllExcept(chisel);
+        if (Rs2Inventory.count(chisel) > 1)
+            Rs2Bank.depositX(chisel, Rs2Inventory.count(chisel)-1);
+
+        // Ensure the bank contains at least 1 of each required item
+        verifyItemInBank("Chisel", chisel);
+        verifyItemInBank("Amethyst", ItemID.AMETHYST);
+
+        debugMessage("Withdrawing chisel and amethyst");
+        if (!Rs2Inventory.hasItem(chisel)) {
+            Rs2Bank.withdrawX(chisel, 1);
+            sleepUntil(() -> Rs2Inventory.hasItem(chisel), 1500);
+        }
+        Rs2Bank.withdrawAll(ItemID.AMETHYST);
+        sleepUntil(() -> Rs2Inventory.hasItem(ItemID.AMETHYST), 1500);
+
+        debugMessage("Exiting bank interface");
+        Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
+        if (Rs2Bank.isOpen())
+            Rs2Bank.closeBank();
+    }
+
+    private void verifyItemInBank(String name, int item) {
+        if (Rs2Bank.isOpen() && !Rs2Bank.hasItem(item)) {
+            // Double check the required items are not noted in player's inventory
+            if (Rs2Inventory.hasNotedItem(name) || Rs2Inventory.hasItem(item)) {
+                Rs2Bank.depositAll(item);
+                if (!Rs2Bank.closeBank())
+                    Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
+                return;
+            }
+            Microbot.status = "[Shutting down] - Reason: " + name + " not found in the bank.";
+            Microbot.showMessage(Microbot.status);
+            this.shutdown();
+        }
+    }
+
+    private void craft(CraftingConfig config) {
+        // If bank is open exit with escape key then continue
+        if (Rs2Bank.isOpen())
+            Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
+
+        debugMessage("Starting cutting amethyst");
+
+        if (!Rs2Tab.switchToInventoryTab())
+            Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
+
+        if (!Rs2Inventory.hasItem(chisel) || !Rs2Inventory.hasItem(ItemID.AMETHYST))
+            return;
+
+        Rs2Inventory.combine(chisel, ItemID.AMETHYST);
+
+        debugMessage("Waiting for crafting interface");
+        sleepUntil(() -> Rs2Widget.isWidgetVisible(17694734), 1500);
+
+        // Only on the first time crafting the make "All" widget should be pressed
+        if (!firstCut) {
+            firstCut = true;
+            debugMessage("First cut - selecting make all");
+            if (!Rs2Widget.clickWidget(17694732))
+                Rs2Widget.clickWidgetFast(Rs2Widget.getWidget(17694732, 17694732));
+        }
+
+        // Space triggers the make action to craft all battlestaffs
+        Rs2Keyboard.keyPress(itemToCut.getCraftOptionKey());
+
+        Microbot.status = "Crafting " + itemToCut.getItemName();
+
+        debugMessage("Waiting to finish cutting amethyst");
+
+        // Cutting any type of amethyst item is a 2 tick action
+        sleepUntilTick(Rs2Inventory.count(ItemID.AMETHYST) * 2);
+        // Ensure the cutting is complete before moving on
+        sleepUntil(() -> Rs2Inventory.hasItem(itemToCut.getItemId()) && !Rs2Player.isAnimating(), 1500);
+    }
+
+    public ProgressiveAmethystCuttingModel calculateItemToCut() {
+        int craftinglvl = Microbot.getClient().getRealSkillLevel(Skill.CRAFTING);
+        if (craftinglvl < Amethyst.ARROWTIPS.getRequiredLevel()) {
+            debugMessage("Crafting Amethyst Bolt Tips");
+            model.setItemToCut(Amethyst.BOLT_TIPS);
+        } else if (craftinglvl < Amethyst.JAVELIN_HEADS.getRequiredLevel()) {
+            debugMessage("Crafting Amethyst Arrowtips");
+            model.setItemToCut(Amethyst.ARROWTIPS);
+        } else if (craftinglvl < Amethyst.DART_TIP.getRequiredLevel()) {
+            debugMessage("Crafting Amethyst Javelin Heads");
+            model.setItemToCut(Amethyst.JAVELIN_HEADS);
+        } else {
+            debugMessage("Crafting Amethyst Dart Tips");
+            model.setItemToCut(Amethyst.DART_TIP);
+        }
+        return model;
+    }
+
+    @Override
+    public void shutdown() {
+        debugMessage("Shutting down amethyst item cutting script");
+        // Reset values
+        debugMessages = false;
+        firstCut = false;
+        if (mainScheduledFuture != null && !mainScheduledFuture.isDone()) {
+            mainScheduledFuture.cancel(true);
+        }
+        super.shutdown();
+    }
+
+    // Display debug messages in the ingame chatbox
+    private void debugMessage(String str) {
+        if (debugMessages)
+            Microbot.log(String.format("[Crafter] %s", str));
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/DefaultScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/DefaultScript.java
@@ -15,21 +15,26 @@ public class DefaultScript extends Script {
     public boolean run(CraftingConfig config) {
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                if (!Microbot.isLoggedIn()) return;
-                if (!super.run()) return;
+                if (!Microbot.isLoggedIn())
+                    return;
+                if (!super.run())
+                    return;
                 if (Random.random(1, 255) == 2)
                     sleep(3000, 60000);
                 String leather = "green dragon leather";
                 String craftedItem = "green d'hide body";
-                if (Microbot.isGainingExp) return;
+                if (Microbot.isGainingExp)
+                    return;
                 if (!Rs2Inventory.hasItem(craftedItem)) {
                     if (!Rs2Inventory.isFull()) {
                         Rs2Bank.openBank();
                         sleepUntil(() -> Rs2Bank.isOpen(), 5000);
-                        if (!Rs2Bank.isOpen()) return;
+                        if (!Rs2Bank.isOpen())
+                            return;
                         Rs2Bank.withdrawItem(true, "needle");
                         Rs2Bank.withdrawAll(true, "thread");
-                        if (!Rs2Inventory.hasItem("needle") || !Rs2Inventory.hasItem("thread")) return;
+                        if (!Rs2Inventory.hasItem("needle") || !Rs2Inventory.hasItem("thread"))
+                            return;
                         Rs2Bank.withdrawAll(leather);
                     } else if (Rs2Inventory.hasItem(leather)) {
                         Rs2Bank.closeBank();
@@ -47,7 +52,7 @@ public class DefaultScript extends Script {
                 }
             } catch (Exception ex) {
                 System.out.println(ex.getMessage());
-                //Microbot.getNotifier().notify("Script failure");
+                Microbot.getNotifier().notify("Script failure");
             }
 
         }, 0, 600, TimeUnit.MILLISECONDS);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/DefaultScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/DefaultScript.java
@@ -60,6 +60,9 @@ public class DefaultScript extends Script {
     }
 
     public void shutDown() {
+        if (mainScheduledFuture != null && !mainScheduledFuture.isDone()) {
+            mainScheduledFuture.cancel(true);
+        }
         super.shutdown();
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/DriftNetScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/DriftNetScript.java
@@ -1,21 +1,24 @@
 package net.runelite.client.plugins.microbot.crafting.scripts;
 
-import lombok.Getter;
-import lombok.Setter;
-
+import net.runelite.api.GameObject;
 import net.runelite.api.ItemID;
+import net.runelite.api.ObjectID;
+import net.runelite.api.Quest;
+import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
 import net.runelite.api.TileObject;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.coords.WorldArea;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.crafting.CraftingConfig;
-import net.runelite.client.plugins.microbot.crafting.enums.Staffs;
+import net.runelite.client.plugins.microbot.crafting.enums.Loom;
+import net.runelite.client.plugins.microbot.shortestpath.ShortestPathScript;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.bank.enums.BankLocation;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
+import net.runelite.client.plugins.microbot.util.coords.Rs2WorldPoint;
 import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
@@ -26,37 +29,32 @@ import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
-import java.awt.event.KeyEvent;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.ScheduledFuture;
-
 import static net.runelite.client.plugins.microbot.util.Global.sleepUntilTrue;
 
-@Getter
-@Setter
-class ProgressiveStaffmakingModel {
-    private Staffs itemToCraft;
-}
+import java.awt.event.KeyEvent;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
-public class StaffScript extends Script {
+public class DriftNetScript extends Script {
+    private int juteFibre = ItemID.JUTE_FIBRE;
 
-    ProgressiveStaffmakingModel model = new ProgressiveStaffmakingModel();
-
-    int battleStaff = ItemID.BATTLESTAFF;
-    Staffs itemToCraft;
-
-    private int staffsWithdrawn = 0; // Tracks how many staffs to expect
-    private int orbsWithdrawn = 0; // Tracks how many staffs to expect
+    private int fibreWithdrawn;
     private boolean debugMessages = false; // Controls chatbox debug messages
-    private boolean firstStaff = false; // Controls make "All" widget click
+    private boolean firstNet = false; // Controls make "All" widget click
 
     public void run(CraftingConfig config) {
         sleepUntil(() -> Microbot.isLoggedIn(), 1500);
-        debugMessage("Starting staff crafting script");
-        //
-        // Find, walk and turn to the closest bank
-        if (config.staffType() == Staffs.PROGRESSIVE)
-            calculateItemToCraft();
+        debugMessage("Starting drift net weaving script");
+
+        if (config.loomLocation() == Loom.MUSEUM_CAMP) {
+            debugMessage("Checking fossil island requirements are ment");
+            Microbot.status = "Checking bank and loom exist first";
+            boolean fossilLoom = Rs2GameObject.findObjectById(ObjectID.LOOM_30936) == null;
+            if (!fossilLoom || Rs2Bank.getNearestBank() != BankLocation.FOSSIL_ISLAND) {
+                Microbot.showMessage("You need to construct the Loom and Bank first", 60);
+                shutdown();
+            }
+        }
 
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             if (!super.run())
@@ -69,30 +67,26 @@ public class StaffScript extends Script {
             // 15 and 90 seconds before moving on if the trigger occurs
             if (config.Afk() && (!Rs2Player.isMoving() || !Rs2Player.isInteracting()) && Rs2Random.nzRandom() < 0.05) {
                 debugMessage(String.format("Going AFK for between 15 and 90 seconds"));
-                Microbot.status = String.format("Taking short AFK break");
+                int delay = Rs2Random.between(15000, 90000);
+                Microbot.status = String.format("Taking short AFK break %02s", delay / 1000);
                 Rs2Antiban.moveMouseOffScreen();
-                Rs2Random.wait(15000, 90000);
+                sleep(delay);
             }
 
-            if (Rs2Random.nzRandom() < 0.1) {
+            if (Rs2Random.nzRandom() < 0.025) {
                 debugMessage("Checking skills tab progress");
                 if (!Rs2Tab.switchToSkillsTab())
                     Rs2Keyboard.keyPress(KeyEvent.VK_F1);
                 Microbot.status = "Checking skills tab";
-                Rs2Random.wait(1000, 3000);
+                sleep(1000, 3000);
+                if (!Rs2Tab.switchToInventoryTab())
+                    Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
             }
 
             try {
-                if (config.staffType() == Staffs.PROGRESSIVE)
-                    itemToCraft = model.getItemToCraft();
-                else
-                    itemToCraft = config.staffType();
+                fibreWithdrawn = Rs2Inventory.count(juteFibre);
 
-                staffsWithdrawn = Rs2Inventory.count(battleStaff);
-                orbsWithdrawn = Rs2Inventory.count(itemToCraft.getOrbID());
-
-                if (Rs2Inventory.hasItem(battleStaff) &&
-                        Rs2Inventory.hasItem(itemToCraft.getOrbID()))
+                if (fibreWithdrawn >= 2)
                     craft(config);
 
                 bank(config);
@@ -106,36 +100,31 @@ public class StaffScript extends Script {
         // Find, walk and turn to the closest bank
         debugMessage("Walking to closest bank");
         Microbot.status = "Walking to bank";
-        Rs2Camera.turnTo(Rs2GameObject.findBank());
         Rs2Bank.walkToBank();
+        Rs2Player.waitForWalking(18000);
+        Rs2Camera.turnTo(Rs2GameObject.findBank());
 
         debugMessage("Opening bank interface");
         sleepUntil(() -> Rs2Bank.openBank(), 500);
         Microbot.status = "Banking";
-
         debugMessage("Depositing inventory into bank");
         Rs2Bank.depositAll();
 
         // Ensure the bank contains at least 1 of each required item
-        verifyItemInBank("Battlestaff", battleStaff);
-        verifyItemInBank(itemToCraft.getOrbName(), itemToCraft.getOrbID());
+        verifyItemInBank("Jute fibre", juteFibre);
 
-        debugMessage("Withdrawing staffs and orbs");
-        Rs2Bank.withdrawX(itemToCraft.getOrbID(), 14);
-        Rs2Inventory.waitForInventoryChanges(1800);
-        Rs2Bank.withdrawX(battleStaff, 14);
-        Rs2Inventory.waitForInventoryChanges(1800);
+        debugMessage("Withdrawing jute fibre");
+        Rs2Bank.withdrawAll(juteFibre);
+        Rs2Inventory.waitForInventoryChanges(18000);
+        Rs2Antiban.actionCooldown();
 
         debugMessage("Exiting bank interface");
         Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
         if (Rs2Bank.isOpen())
             Rs2Bank.closeBank();
-        Rs2Antiban.actionCooldown();
-        Rs2Antiban.takeMicroBreakByChance();
 
-        // Store how many staffs & orbs were withdrawn incase uneven total
-        staffsWithdrawn = Rs2Inventory.count(battleStaff);
-        orbsWithdrawn = Rs2Inventory.count(itemToCraft.getOrbID());
+        // Store how many jute fibres were withdrawn incase uneven total
+        fibreWithdrawn = Rs2Inventory.count(juteFibre);
     }
 
     private void verifyItemInBank(String name, int item) {
@@ -159,82 +148,97 @@ public class StaffScript extends Script {
         if (Rs2Bank.isOpen())
             Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
 
-        debugMessage("Starting crafting staffs");
+        debugMessage("Starting weaving drift nets");
 
         if (!Rs2Tab.switchToInventoryTab())
             Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
 
-        // Combine with orb first as battlestaffs have a skill requirement
-        // This is pointless because it will auto use the "use" menu item
-        if (!Rs2Inventory.hasItem(itemToCraft.getOrbID()) || !Rs2Inventory.hasItem(battleStaff))
+        if (!Rs2Inventory.hasItem(juteFibre))
             return;
 
-        if (!Rs2Inventory.combine(itemToCraft.getOrbID(), battleStaff))
-            Rs2Inventory.combine(itemToCraft.getOrbName(), "Battlestaff");
-
-        debugMessage("Waiting for crafting interface");
-        Rs2Dialogue.sleepUntilHasCombinationDialogue();
+        GameObject loom = Rs2GameObject.getGameObject(config.loomLocation().loomWorldPoint);
+        if (Rs2Walker.canReach(loom.getWorldLocation())) {
+            Rs2Walker.walkWithState(loom.getWorldLocation());
+            Rs2Player.waitForWalking(18000);
+        }
+        Rs2Camera.turnTo(loom.getLocalLocation());
+        Rs2Inventory.useItemOnObject(juteFibre, loom.getId());
 
         // Only on the first time crafting the make "All" widget should be pressed
-        if (!firstStaff) {
-            firstStaff = true;
-            debugMessage("First craft - selecting make all");
+        if (!firstNet) {
+            firstNet = true;
+            debugMessage("First net - selecting make all");
             if (!Rs2Widget.clickWidget(17694732))
                 Rs2Widget.clickWidgetFast(Rs2Widget.getWidget(17694732, 17694732));
         }
 
-        // Space triggers the make action to craft all battlestaffs
-        Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
+        // Keypress 2 after using on loom to trigger the make action to iiems otherwise
+        // its
+        // space once been used once as a repeat keycode
+        Microbot.status = "Weaving drift nets";
+        if (!Rs2Widget.sleepUntilHasWidgetText("Drift net", 17694736, 17694733, false, 300)) {
+            if (firstNet)
+                Rs2Keyboard.keyPress('2');
+            else
+                Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
+        }
 
-        Microbot.status = "Crafting " + itemToCraft.getLabel();
-
-        debugMessage("Waiting to finish crafting staffs");
-
-        // Crafting any type of battle staff is a 2 tick action
-        sleepUntilTick(Math.min(staffsWithdrawn, orbsWithdrawn) * 2);
-        // Ensure the crafting is complete before moving on
-        sleepUntil(() -> Rs2Inventory.hasItemAmount(itemToCraft.getItemID(),
-                Math.min(staffsWithdrawn, orbsWithdrawn)) && !Rs2Player.isAnimating(), 1500);
+        debugMessage("Waiting to finish weaving drift nets");
+        // Weaving a drift net is a 3 tick action
+        sleepUntilTick(fibreWithdrawn * 3);
         Rs2Antiban.actionCooldown();
         Rs2Antiban.takeMicroBreakByChance();
     }
 
-    public ProgressiveStaffmakingModel calculateItemToCraft() {
-        int craftinglvl = Microbot.getClient().getRealSkillLevel(Skill.CRAFTING);
-        if (craftinglvl < Staffs.EARTH_BATTLESTAFF.getLevelRequired()) {
-            debugMessage("Crafting Water Battlestaffs");
-            model.setItemToCraft(Staffs.WATER_BATTLESTAFF);
-        } else if (craftinglvl < Staffs.FIRE_BATTLESTAFF.getLevelRequired()) {
-            debugMessage("Crafting Earth Battlestaffs");
-            model.setItemToCraft(Staffs.EARTH_BATTLESTAFF);
-        } else if (craftinglvl < Staffs.AIR_BATTLESTAFF.getLevelRequired()) {
-            debugMessage("Crafting Fire Battlestaffs");
-            model.setItemToCraft(Staffs.FIRE_BATTLESTAFF);
-        } else {
-            debugMessage("Crafting Air Battlestaffs");
-            model.setItemToCraft(Staffs.AIR_BATTLESTAFF);
+    public boolean hasRequirements(CraftingConfig config) {
+        if (!Rs2Player.isMember())
+            return false;
+        if (Rs2Player.getRealSkillLevel(Skill.CRAFTING) < 26)
+            return false;
+        Loom loom = config.loomLocation();
+        switch (loom) {
+            case NONE:
+                return false;
+            case PRIFDDINAS:
+                if (Rs2Player.getQuestState(Quest.SONG_OF_THE_ELVES) != QuestState.FINISHED)
+                    return false;
+                return true;
+            case HOSIDIUS:
+                return true;
+            case SOUTH_FALADOR_FARM:
+                return true;
+            case ALDARIN:
+                return true;
+            case MUSEUM_CAMP:
+                if (Rs2Player.getQuestState(Quest.BONE_VOYAGE) != QuestState.FINISHED)
+                    return false;
+                if (Rs2Player.getRealSkillLevel(Skill.CONSTRUCTION) < 29)
+                    return false;
+                if (Rs2Inventory.count(ItemID.OAK_PLANK) < 2 &&
+                        Rs2Inventory.count("nails") < 5 &&
+                        !Rs2Inventory.hasItem("Rope"))
+                    return false;
+                return true;
         }
-        return model;
+        return true;
     }
 
     @Override
     public void shutdown() {
         Microbot.pauseAllScripts = true;
-        debugMessage("Shutting down staff crafter script");
+        debugMessage("Shutting down drift net weaver script");
         // Reset values
-        staffsWithdrawn = 0;
-        orbsWithdrawn = 0;
         debugMessages = false;
-        firstStaff = false;
+        firstNet = false;
         if (mainScheduledFuture != null && !mainScheduledFuture.isDone()) {
             mainScheduledFuture.cancel(true);
         }
         super.shutdown();
     }
 
-    // Display debug messages in the ingame chatbox
+    // Display debug messages in the in game chatbox
     private void debugMessage(String str) {
         if (debugMessages)
-            Microbot.log(String.format("[Battlestaffs] %s", str));
+            Microbot.log(String.format("[Drift Net] %s", str));
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/DriftNetScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/DriftNetScript.java
@@ -100,12 +100,14 @@ public class DriftNetScript extends Script {
         // Find, walk and turn to the closest bank
         debugMessage("Walking to closest bank");
         Microbot.status = "Walking to bank";
-        Rs2Bank.walkToBank();
-        Rs2Player.waitForWalking(18000);
+        if (!Rs2Bank.walkToBank())
+            Rs2Bank.openBank();
+        if (!Rs2Bank.isOpen())
+            Rs2Player.waitForWalking(18000);
         Rs2Camera.turnTo(Rs2GameObject.findBank());
 
         debugMessage("Opening bank interface");
-        sleepUntil(() -> Rs2Bank.openBank(), 500);
+        sleepUntil(() -> !Rs2Bank.isOpen() && Rs2Bank.openBank());
         Microbot.status = "Banking";
         debugMessage("Depositing inventory into bank");
         Rs2Bank.depositAll();
@@ -157,9 +159,11 @@ public class DriftNetScript extends Script {
             return;
 
         GameObject loom = Rs2GameObject.getGameObject(config.loomLocation().loomWorldPoint);
-        if (Rs2Walker.canReach(loom.getWorldLocation())) {
-            Rs2Walker.walkWithState(loom.getWorldLocation());
-            Rs2Player.waitForWalking(18000);
+        if (Rs2Player.distanceTo(loom.getWorldLocation()) > 4) {
+            if (Rs2Walker.canReach(loom.getWorldLocation())) {
+                Rs2Walker.walkWithState(loom.getWorldLocation());
+                Rs2Player.waitForWalking(18000);
+            }
         }
         Rs2Camera.turnTo(loom.getLocalLocation());
         Rs2Inventory.useItemOnObject(juteFibre, loom.getId());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/FlaxSpinScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/FlaxSpinScript.java
@@ -6,16 +6,22 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.crafting.CraftingConfig;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.enums.Activity;
+import net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.math.Random;
+import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
 import java.awt.event.KeyEvent;
+import java.net.StandardProtocolFamily;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -30,71 +36,100 @@ enum State {
 }
 
 public class FlaxSpinScript extends Script {
-    public static double version = 1.0;
-
     State state;
     boolean init = true;
+    boolean debugMessages = false;
 
     public boolean run(CraftingConfig config) {
+        Rs2Antiban.antibanSetupTemplates.applyUniversalAntibanSetup();
+        Rs2Antiban.setActivity(Activity.GENERAL_COLLECTING);
+        Rs2Antiban.moveMouseRandomly();
         Microbot.enableAutoRunOn = false;
         initialPlayerLocation = null;
+
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            if (!super.run())
+                return;
+            if (!Microbot.isLoggedIn())
+                return;
+
+            // Enable ingame chatbox debug messages according to config
+            debugMessages = config.chatMessages();
+
+            if (init) {
+                getState(config);
+            }
+
+            if (initialPlayerLocation == null) {
+                initialPlayerLocation = Rs2Player.getWorldLocation();
+            }
+
+            // If AFK config variable is set randomly sleep for a period between
+            // 15 and 90 seconds before moving on if the trigger occurs
+            if (config.Afk() && Rs2Random.nzRandom() < 0.05) {
+                debugMessage(String.format("Going AFK for between 15 and 90 seconds"));
+                Microbot.status = String.format("Taking short AFK break");
+                Rs2Antiban.moveMouseOffScreen();
+                Rs2Random.wait(15000, 90000);
+            }
+
             try {
-                if (!super.run()) return;
-                if (!Microbot.isLoggedIn()) return;
-                long startTime = System.currentTimeMillis();
-
-                if (init) {
-                    getState(config);
-                }
-
-                if (initialPlayerLocation == null) {
-                    initialPlayerLocation = Rs2Player.getWorldLocation();
-                }
-
                 switch (state) {
                     case SPINNING:
                         if (!Rs2Inventory.hasItem(ItemID.FLAX)) {
+                            debugMessage("No Flax left going to bank");
                             state = State.BANKING;
                             return;
                         }
+                        debugMessage("Spinning flax");
                         Rs2Inventory.useItemOnObject(ItemID.FLAX, config.flaxSpinLocation().getObjectID());
                         sleepUntil(() -> !Rs2Player.isMoving());
                         Rs2Widget.sleepUntilHasWidget("how many do you wish to make?");
                         Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
                         sleepUntilTrue(() -> !Rs2Inventory.hasItem(ItemID.FLAX), 600, 150000);
+                        debugMessage("Out of flax");
+                        Rs2Antiban.actionCooldown();
+                        Rs2Antiban.takeMicroBreakByChance();
                         state = State.BANKING;
                         break;
                     case BANKING:
+                        Rs2Camera.turnTo(Rs2GameObject.findBank());
                         boolean isBankOpen = Rs2Bank.walkToBankAndUseBank();
-                        if (!isBankOpen || !Rs2Bank.isOpen()) return;
+                        if (!isBankOpen || !Rs2Bank.isOpen())
+                            return;
 
+                        debugMessage("Banking bow strings");
                         Rs2Bank.depositAll(ItemID.BOW_STRING);
-                        sleep(Random.random(600, 800));
+                        Rs2Inventory.waitForInventoryChanges(1800);
+                        debugMessage("Withdrawing more flax");
                         Rs2Bank.withdrawAll(ItemID.FLAX);
-                        sleep(Random.random(600, 800));
-                        Rs2Bank.closeBank();
+                        Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
+                        if (!Rs2Bank.isOpen())
+                            Rs2Bank.closeBank();
+                        Rs2Antiban.actionCooldown();
+                        Rs2Antiban.takeMicroBreakByChance();
                         state = State.WALKING;
                         break;
                     case WALKING:
+                        debugMessage("Walking to spinning wheel");
                         Rs2Walker.walkTo(config.flaxSpinLocation().getWorldPoint(), 4);
                         sleepUntilTrue(() -> isNearSpinningWheel(config, 4) && !Rs2Player.isMoving(), 600, 300000);
-                        if (!isNearSpinningWheel(config, 4)) return;
+                        if (!isNearSpinningWheel(config, 4))
+                            return;
                         Optional<GameObject> spinningWheel = Rs2GameObject.getGameObjects().stream()
                                 .filter(obj -> obj.getId() == config.flaxSpinLocation().getObjectID())
-                                .sorted(Comparator.comparingInt(obj -> Rs2Player.getWorldLocation().distanceTo(obj.getWorldLocation())))
+                                .sorted(Comparator.comparingInt(
+                                        obj -> Rs2Player.getWorldLocation().distanceTo(obj.getWorldLocation())))
                                 .findFirst();
                         if (spinningWheel.isEmpty()) {
+                            debugMessage("No spinning wheel found walking to flax location");
                             Rs2Walker.walkFastCanvas(config.flaxSpinLocation().getWorldPoint());
+                            Rs2Antiban.takeMicroBreakByChance();
                             return;
                         }
                         state = State.SPINNING;
                         break;
                 }
-
-                long endTime = System.currentTimeMillis();
-                long totalTime = endTime - startTime;
-                System.out.println("Total time for loop " + totalTime);
 
             } catch (Exception ex) {
                 System.out.println(ex.getMessage());
@@ -105,26 +140,31 @@ public class FlaxSpinScript extends Script {
 
     @Override
     public void shutdown() {
+        debugMessage("Shutting down flax script");
+        Microbot.pauseAllScripts = true;
+        if (mainScheduledFuture != null && !mainScheduledFuture.isDone())
+            mainScheduledFuture.cancel(true);
+        Rs2Antiban.resetAntibanSettings();
         super.shutdown();
     }
 
     private void getState(CraftingConfig config) {
-        if (!Rs2Inventory.hasItem(ItemID.FLAX)) {
+        if (!Rs2Inventory.hasItem(ItemID.FLAX))
             state = State.BANKING;
-            init = false;
-            return;
-        }
-        if (!isNearSpinningWheel(config, 4)) {
+        if (!isNearSpinningWheel(config, 4))
             state = State.WALKING;
-            init = false;
-            return;
-        }
-
-        state = State.SPINNING;
+        else
+            state = State.SPINNING;
         init = false;
     }
 
     private boolean isNearSpinningWheel(CraftingConfig config, int distance) {
         return Rs2Player.getWorldLocation().distanceTo(config.flaxSpinLocation().getWorldPoint()) <= distance;
+    }
+
+    // Display debug messages in the ingame chatbox
+    private void debugMessage(String str) {
+        if (debugMessages)
+            Microbot.log(String.format("[Flax Spinner] %s", str));
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/GemsScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/GemsScript.java
@@ -1,71 +1,161 @@
 package net.runelite.client.plugins.microbot.crafting.scripts;
 
+import net.runelite.api.ItemID;
 import net.runelite.api.Skill;
+import net.runelite.api.TileObject;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.crafting.CraftingConfig;
 import net.runelite.client.plugins.microbot.crafting.enums.BoltTips;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.bank.enums.BankLocation;
+import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
+import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
+import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
 import java.awt.event.KeyEvent;
 import java.util.concurrent.TimeUnit;
+import java.util.jar.Attributes.Name;
 
 public class GemsScript extends Script {
-
-    public static double version = 1.0;
+    private boolean debugMessages = false;
+    private boolean firstCut = true;
+    private boolean init = true;
 
     public boolean run(CraftingConfig config) {
+        if (!Rs2Player.getSkillRequirement(Skill.CRAFTING, config.gemType().getLevelRequired())) {
+            Microbot.showMessage("Crafting level too low to craft " + config.gemType().getName());
+            shutdown();
+            return false;
+        }
+
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                if (!Microbot.isLoggedIn()) return;
-                if (!super.run()) return;
-                if (!Rs2Player.getSkillRequirement(Skill.CRAFTING, config.gemType().getLevelRequired())) {
-                    Microbot.showMessage("Crafting level too low to craft " + config.gemType().getName());
-                    shutdown();
+                if (!Microbot.isLoggedIn())
                     return;
+                if (!super.run())
+                    return;
+                //
+                // Enable ingame chatbox debug messages according to config
+                debugMessages = config.chatMessages();
+
+                // If AFK config variable is set randomly sleep for a period between
+                // 15 and 90 seconds before moving on if the trigger occurs
+                if (config.Afk() && (!Rs2Player.isMoving() || !Rs2Player.isInteracting())
+                        && Rs2Random.nzRandom() < 0.05) {
+                    debugMessage(String.format("Going AFK for between 15 and 90 seconds"));
+                    int delay = Rs2Random.between(15000, 90000);
+                    Microbot.status = String.format("Taking short AFK break %02s", delay / 1000);
+                    Rs2Antiban.moveMouseOffScreen();
+                    sleep(delay);
                 }
-                final String uncutGemName = "uncut " + config.gemType().getName();
-                if (!Rs2Inventory.hasItem(uncutGemName) || !Rs2Inventory.hasItem("chisel")) {
-                    Microbot.status = "BANKING";
-                    Rs2Bank.openBank();
-                    if (Rs2Bank.isOpen()) {
-                        Rs2Bank.depositAll("crushed gem");
-                        Rs2Bank.depositAll(config.gemType().getName());
-                        sleepUntil(() -> !Rs2Inventory.hasItem(config.gemType().getName()) && !Rs2Inventory.hasItem("crushed gem"));
-                        if (Rs2Bank.hasItem(uncutGemName)) {
-                            Rs2Bank.withdrawItem(true, "chisel");
-                            Rs2Bank.withdrawAll(true, uncutGemName);
-                        } else {
-                            Microbot.showMessage("You've ran out of materials!");
-                            shutdown();
-                        }
-                        Rs2Bank.closeBank();
-                        sleepUntil(() -> !Rs2Bank.isOpen());
+
+                if (init) {
+                    init = false;
+                    debugMessage("Initialising setup");
+                    Microbot.status = "INITIALISE";
+
+                    if (Rs2Bank.getNearestBank(Rs2Player.getWorldLocation()) == (BankLocation) null) {
+                        // Find, walk and turn to the closest bank
+                        debugMessage("Walking to closest bank");
+                        TileObject bank = Rs2GameObject.findReachableObject("Bank", true, 500,
+                                Rs2Player.getWorldLocation());
+                        Rs2Walker.walkWithState(bank.getWorldLocation());
+                        Rs2Player.waitForWalking(18000);
+                        Rs2Camera.turnTo(Rs2GameObject.findBank());
                     }
-                } else {
+
+                    debugMessage("Opening bank interface");
+                    sleepUntil(() -> Rs2Bank.openBank(), 500);
+
+                    debugMessage("Depositing inventory into bank");
+                    Rs2Bank.depositAllExcept(ItemID.CHISEL, ItemID.CHISEL_5601, ItemID.CHISEL_28414);
+
+                    // Ensure the chisel is in the inventory or fail without one
+                    debugMessage("Withdrawing chisel");
+                    if (!Rs2Inventory.hasItem("Chisel")) {
+                        Rs2Bank.withdrawOne("Chisel");
+                    }
+
+                    if (Rs2Inventory.count("Chisel") == 0) {
+                        Microbot.showMessage("Chisel missing and is essntial to all aspects of this script");
+                        this.shutdown();
+                    }
+
+                    debugMessage("Exiting bank interface");
+                    Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
+                    if (Rs2Bank.isOpen())
+                        Rs2Bank.closeBank();
+                }
+
+                final String uncutGemName = "uncut " + config.gemType().getName();
+                if (!Rs2Inventory.hasItem(uncutGemName)) {
+                    Microbot.status = "BANKING";
+                    Rs2Bank.depositAllExcept(ItemID.CHISEL, ItemID.CHISEL_5601, ItemID.CHISEL_28414);
+
+                    debugMessage("Withdrawing uncut gems");
+                    if (Rs2Bank.hasItem(uncutGemName)) {
+                        Rs2Bank.withdrawAll(true, uncutGemName);
+                    } else {
+                        Microbot.showMessage("You've ran out of materials!");
+                        shutdown();
+                    }
+                    debugMessage("Exiting bank interface");
+                    Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
+                    if (Rs2Bank.isOpen())
+                        Rs2Bank.closeBank();
+
+                    debugMessage("Beginning to cut gems");
                     Microbot.status = "CUTTING GEMS";
-                    Rs2Inventory.use("chisel");
-                    Rs2Inventory.use(uncutGemName);
-                    sleep(600);
-                    Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
-                    sleep(4000);
-                    sleepUntil(() -> !Microbot.isGainingExp || !Rs2Inventory.hasItem(uncutGemName), 30000);
+                    int gemCount = Rs2Inventory.count(uncutGemName);
+                    Rs2Inventory.combineClosest("Chisel", uncutGemName);
+                    Rs2Dialogue.sleepUntilHasCombinationDialogue();
+
+                    // Only on the first time crafting the make "All" widget should be pressed
+                    if (!firstCut) {
+                        firstCut = true;
+                        debugMessage("First cut - selecting make all");
+                        if (!Rs2Widget.clickWidget(17694732))
+                            Rs2Widget.clickWidgetFast(Rs2Widget.getWidget(17694732, 17694732));
+
+                        if (!Rs2Widget.clickChildWidget(17694733, 17694733))
+                            Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
+
+                        // Cutting any type of gem is a 2 tick action
+                        sleepUntilTick(gemCount * 2);
+                        sleepUntil(() -> !Rs2Inventory.hasItem(uncutGemName));
+
+                        Rs2Antiban.actionCooldown();
+                        Rs2Antiban.takeMicroBreakByChance();
+                    }
 
                     if (config.fletchIntoBoltTips()) {
                         Microbot.status = "FLETCHING BOLT TIPS";
+                        debugMessage("Fletching gems into bolt tips");
+
                         BoltTips boltTip = BoltTips.valueOf(config.gemType().name());
                         if (Rs2Player.getSkillRequirement(Skill.FLETCHING, boltTip.getFletchingLevelRequired()) &&
                                 Rs2Inventory.hasItem(config.gemType().getName()) &&
                                 Rs2Inventory.hasItem("chisel")) {
-                            Rs2Inventory.use("chisel");
+                            int cutGemCount = Rs2Inventory.count(config.gemType().getName());
+
+                            Rs2Inventory.combine("Chisel", config.gemType().getName());
                             Rs2Inventory.use(config.gemType().getName());
-                            sleep(600);
+                            Rs2Dialogue.sleepUntilHasCombinationDialogue();
                             Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
-                            sleep(4000);
-                            sleepUntil(() -> !Microbot.isGainingExp || !Rs2Inventory.hasItem(config.gemType().getName()), 30000);
+                            sleepUntilTick(cutGemCount * 2);
+                            sleepUntil(() -> !Rs2Inventory.hasItem(config.gemType().getName()));
+
+                            debugMessage("Make bolt tips of all cut gems");
+                            Rs2Antiban.actionCooldown();
+                            Rs2Antiban.takeMicroBreakByChance();
                         }
                     }
                 }
@@ -79,7 +169,20 @@ public class GemsScript extends Script {
 
     @Override
     public void shutdown() {
-        super.shutdown();
+        Microbot.pauseAllScripts = true;
+        debugMessage("Shutting down gem cutting script");
+        init = true;
+        firstCut = true;
+        debugMessages = false;
         Microbot.status = "IDLE";
+        if (mainScheduledFuture != null && !mainScheduledFuture.isDone())
+            mainScheduledFuture.cancel(true);
+        super.shutdown();
+    }
+
+    // Display debug messages in the ingame chatbox
+    private void debugMessage(String str) {
+        if (debugMessages)
+            Microbot.log(String.format("[Gem Cutter] %s", str));
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/GlassblowingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/GlassblowingScript.java
@@ -33,17 +33,22 @@ public class GlassblowingScript extends Script {
 
     public void run(CraftingConfig config) {
 
-        if (config.glassType() == Glass.PROGRESSIVE) calculateItemToCraft();
+        if (config.glassType() == Glass.PROGRESSIVE)
+            calculateItemToCraft();
 
         Rs2Antiban.resetAntibanSettings();
         Rs2Antiban.antibanSetupTemplates.applyCraftingSetup();
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                if (!Microbot.isLoggedIn()) return;
-                if (!super.run()) return;
+                if (!Microbot.isLoggedIn())
+                    return;
+                if (!super.run())
+                    return;
 
-                if (Rs2Player.isAnimating(3000) || Rs2Antiban.getCategory().isBusy() || Microbot.pauseAllScripts) return;
-                if (Rs2AntibanSettings.actionCooldownActive) return;
+                if (Rs2Player.isAnimating(3000) || Rs2Antiban.getCategory().isBusy() || Microbot.pauseAllScripts)
+                    return;
+                if (Rs2AntibanSettings.actionCooldownActive)
+                    return;
 
                 if (config.glassType() == Glass.PROGRESSIVE) {
                     itemToCraft = model.getItemToCraft();
@@ -128,6 +133,9 @@ public class GlassblowingScript extends Script {
 
     @Override
     public void shutdown() {
+        Microbot.pauseAllScripts = true;
+        if (mainScheduledFuture != null && !mainScheduledFuture.isDone())
+            mainScheduledFuture.cancel(true);
         Rs2Antiban.resetAntibanSettings();
         super.shutdown();
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/StaffScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/StaffScript.java
@@ -105,9 +105,14 @@ public class StaffScript extends Script {
 
         debugMessage("Withdrawing staffs and orbs");
         Rs2Bank.withdrawX(itemToCraft.getOrbID(), 14);
-        sleepUntil(() -> Rs2Inventory.hasItem(itemToCraft.getOrbID()), 500);
+        sleepUntil(() -> Rs2Inventory.hasItem(itemToCraft.getOrbID()), 1500);
         Rs2Bank.withdrawX(battleStaff, 14);
-        sleepUntil(() -> Rs2Inventory.hasItem(battleStaff), 500);
+        sleepUntil(() -> Rs2Inventory.hasItem(battleStaff), 1500);
+
+        if (!Rs2Inventory.hasItem(battleStaff) || !Rs2Inventory.hasItem(itemToCraft.getOrbID())) {
+            Rs2Bank.depositAll();
+            return;
+        }
 
         debugMessage("Exiting bank interface");
         Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/StaffScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/StaffScript.java
@@ -60,7 +60,7 @@ public class StaffScript extends Script {
 
             // If AFK config variable is set randomly sleep for a period between
             // 1 and 5 minutes before moving on if the trigger occurs
-            if (config.Afk() && Math.random() < 0.1) {
+            if (config.Afk() && Math.random() < 0.05) {
                 Rs2Antiban.moveMouseOffScreen();
                 int breakDuration = Rs2Random.between(1, 5);
                 debugMessage(String.format("Going AFK for: %d minutes", breakDuration));
@@ -181,12 +181,16 @@ public class StaffScript extends Script {
     public ProgressiveStaffmakingModel calculateItemToCraft() {
         int craftinglvl = Microbot.getClient().getRealSkillLevel(Skill.CRAFTING);
         if (craftinglvl < Staffs.EARTH_BATTLESTAFF.getLevelRequired()) {
+            debugMessage("Crafting Water Battlestaffs");
             model.setItemToCraft(Staffs.WATER_BATTLESTAFF);
         } else if (craftinglvl < Staffs.FIRE_BATTLESTAFF.getLevelRequired()) {
+            debugMessage("Crafting Earth Battlestaffs");
             model.setItemToCraft(Staffs.EARTH_BATTLESTAFF);
         } else if (craftinglvl < Staffs.AIR_BATTLESTAFF.getLevelRequired()) {
+            debugMessage("Crafting Fire Battlestaffs");
             model.setItemToCraft(Staffs.FIRE_BATTLESTAFF);
-        } else if (craftinglvl < 99) {
+        } else {
+            debugMessage("Crafting Air Battlestaffs");
             model.setItemToCraft(Staffs.AIR_BATTLESTAFF);
         }
         return model;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/StaffScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/crafting/scripts/StaffScript.java
@@ -70,6 +70,7 @@ public class StaffScript extends Script {
                 debugMessage("Checking skills tab progress");
                 if (!Rs2Tab.switchToSkillsTab())
                     Rs2Keyboard.keyPress(KeyEvent.VK_F1);
+                Microbot.status = "Checking skills tab";
                 sleep(Rs2Random.between(1, 3) * 1000);
             }
 
@@ -81,7 +82,9 @@ public class StaffScript extends Script {
 
                 staffsWithdrawn = Rs2Inventory.count(battleStaff);
                 orbsWithdrawn = Rs2Inventory.count(itemToCraft.getOrbID());
-                if (Rs2Inventory.hasItem(battleStaff) && Rs2Inventory.hasItem(itemToCraft.getOrbID()))
+
+                if (Rs2Inventory.hasItem(battleStaff) &&
+                        Rs2Inventory.hasItem(itemToCraft.getOrbID()))
                     craft(config);
 
                 bank(config);
@@ -148,8 +151,14 @@ public class StaffScript extends Script {
 
         debugMessage("Starting crafting staffs");
 
+        if (!Rs2Tab.switchToInventoryTab())
+            Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
+
         // Combine with orb first as battlestaffs have a skill requirement
         // This is pointless because it will auto use the "use" menu item
+        if (!Rs2Inventory.hasItem(itemToCraft.getOrbID()) || !Rs2Inventory.hasItem(battleStaff))
+            return;
+
         if (!Rs2Inventory.combine(itemToCraft.getOrbID(), battleStaff))
             Rs2Inventory.combine(itemToCraft.getOrbName(), "Battlestaff");
 
@@ -164,10 +173,8 @@ public class StaffScript extends Script {
                 Rs2Widget.clickWidgetFast(Rs2Widget.getWidget(17694732, 17694732));
         }
 
-        // If clicking the widget fails fallback to pressing space (1 would work too)
-        sleepUntil(() -> Rs2Widget.isWidgetVisible(17694733, 17694734), 1500);
-        if (!Rs2Widget.clickWidget(17694733, 17694734))
-            Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
+        // Space triggers the make action to craft all battlestaffs
+        Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
 
         debugMessage("Waiting to finish crafting staffs");
 


### PR DESCRIPTION
This PR fixes the staff crafting script as well as adding some minor changes and overall minor improvements

This PR focusses on the StaffScript of the Microbot Crafter plugin not its other scripts (I was only using this one so made improvements to just this one for now).

Overlay Changes:
- Added script runtime to overlay
- Added script version to overly
- Reduced overlay size to a more reasonable one
- Added descriptive status values to the overlay
- Moved to bottom left (personal choice but it is draggable)

Enum Changes:
- Replced string identifiers with `ItemID` specific identifiers

Config Changes:
- Add chatbox debug messages option to display current actions of the script in the ingame chatbox (via `Microbot.log`)

Plugin Changes:
- Add script runtime system
- Add antiban crafting profile
- Reset the above on shutdown

StaffScript Changes:
- Replace string identifiers with ItemIDs (this stops the script breaking with partial matches)
- Improve AFK config option with more realistic short AFK sessions
- Rarely check skills tab (feels realistic when skilling)
- Craft all possible staffs not just up to a final multiple of 14
  - For example if you end with 8 staffs and 3 orbs you can now make 3 battlestaffs
- Walk to nearest and face bank (as bankstanders do) when banking for first time
- Gracefully shutdown when out of either staffs or orbs
- On first craft select the "Make All" option
  - Ensuring you aren't making one staff each time wasting clicks
- Subsequent crafts simply click make/press space to make all
- Wait exact tick count for inventory to finish crafting then animations to end
- Stop future execution loop during shutdown to properly terminate the script
- Add chatbox debug/info messaging depending on config option (reactive to runtime changes)

AmethystScript Addition:
- Progression mode
- Individual amethyst craft item modes
- Walks to bank
- Similar to StaffScript

Overall this results in a fluid, antiban compliant efficient yet realistic playstyle of battlestaff crafting bankstanding. While developing I make 11k air battlestaves while rebuilding etc.

![image](https://github.com/user-attachments/assets/03520850-c296-42e2-90d6-66f0e1282619)

https://github.com/user-attachments/assets/e1047b54-f7e5-4a4d-8028-da3948ee750e

https://github.com/user-attachments/assets/5799a032-db90-49dd-858d-9d7f3be683f3