### PR TITLE
Fix Rs2Npc.interact() to work with using item on npc and for no input…

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/npc/Rs2Npc.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/npc/Rs2Npc.java
@@ -6,6 +6,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.game.npcoverlay.HighlightedNpc;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
 import net.runelite.client.plugins.microbot.util.coords.Rs2WorldPoint;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/npc/Rs2Npc.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/npc/Rs2Npc.java
@@ -576,27 +576,42 @@ public class Rs2Npc {
                 Microbot.log("Error: Could not get NPC composition or actions for NPC: " + npc.getName());
                 return false;
             }
+   MenuAction menuAction;
+            if (Rs2Inventory.isItemSelected()) {
+                menuAction = MenuAction.WIDGET_TARGET_ON_NPC;
+            } else {
+                int index = -1;
+                String[] actions = npcComposition.getActions();
 
-            int index = -1;
-            String[] actions = npcComposition.getActions();
-            if (actions != null) {
-                for (int i = 0; i < actions.length; i++) {
-                    if (actions[i] != null && actions[i].equalsIgnoreCase(action)) {
-                        index = i;
-                        break;
+                if (action == null || action.isEmpty()) {
+                    for (int i = 0; i < actions.length; i++) {
+                        if (actions[i] != null && !actions[i].isEmpty()) {
+                            index = i;
+                            action = actions[i];
+                            break;
+                        }
+                    }
+                } else {
+                    if (actions != null) {
+                        for (int i = 0; i < actions.length; i++) {
+                            if (actions[i] != null && actions[i].equalsIgnoreCase(action)) {
+                                index = i;
+                                break;
+                            }
+                        }
                     }
                 }
-            }
 
-            if (index == -1) {
-                Microbot.log("Error: Action '" + action + "' not found for NPC: " + npc.getName());
-                return false;
-            }
+                if (index == -1) {
+                    Microbot.log("Error: Action '" + action + "' not found for NPC: " + npc.getName());
+                    return false;
+                }
 
-            MenuAction menuAction = getMenuAction(index);
-            if (menuAction == null) {
-                Microbot.log("Error: Could not get menu action for action '" + action + "' on NPC: " + npc.getName());
-                return false;
+                menuAction = getMenuAction(index);
+                if (menuAction == null) {
+                    Microbot.log("Error: Could not get menu action for action '" + action + "' on NPC: " + npc.getName());
+                    return false;
+                }
             }
 
             Microbot.doInvoke(new NewMenuEntry(0, 0, menuAction.getId(), npc.getIndex(), -1, npc.getName(), npc),


### PR DESCRIPTION
… .interact()

Previous refactor had oversight for using items on npcs (quest, phials unnoting, etc.) where "use" was not in the list of actions, and for blank .interact(), which in both cases the index stayed at -1 and returns false. The way the method now works: .interact() interacts the first menu action option of the npc .interact("[correct action]") interacts with the inputted menu action .interact("[wrong action]") returns false if "wrong action" isn't in the list of actions for the npc .interact() or interact(npc,"use") will use an item on the npc if the item is already selected. Otherwise, interact(npc,"use") will return false

fix by slest