### PR TITLE
Release: Chaos altar plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarConfig.java
@@ -1,0 +1,9 @@
+package net.runelite.client.plugins.microbot.bee.chaosaltar;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+
+@ConfigGroup("chaosaltar")
+public interface ChaosAltarConfig extends Config {
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarOverlay.java
@@ -5,18 +5,12 @@ import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
-import javax.inject.Inject;
 import java.awt.*;
 
 public class ChaosAltarOverlay extends OverlayPanel {
 
-    private final ChaosAltarScript script;
     private final PanelComponent panelComponent = new PanelComponent();
 
-    @Inject
-    public ChaosAltarOverlay(ChaosAltarScript script) {
-        this.script = script;
-    }
 
     @Override
     public Dimension render(Graphics2D graphics) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarOverlay.java
@@ -1,0 +1,40 @@
+package net.runelite.client.plugins.microbot.bee.chaosaltar;
+
+import net.runelite.client.plugins.microbot.util.player.Rs2Pvp;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class ChaosAltarOverlay extends OverlayPanel {
+
+    private final ChaosAltarScript script;
+    private final PanelComponent panelComponent = new PanelComponent();
+
+    @Inject
+    public ChaosAltarOverlay(ChaosAltarScript script) {
+        this.script = script;
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        panelComponent.getChildren().clear();
+
+        // Header
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Chaos Altar Bot")
+                .build());
+
+        // Wilderness Warning
+        if (Rs2Pvp.isInWilderness()) {
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("WARNING:")
+                    .right("In Wilderness! Keep LiteMode of Player Monitor ON")
+                    .build());
+        }
+
+        return panelComponent.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarPlugin.java
@@ -1,0 +1,64 @@
+package net.runelite.client.plugins.microbot.bee.chaosaltar;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Bee + "Chaos Altar",
+        description = "Automates bone offering at the Chaos Altar",
+        tags = {"prayer", "bones", "altar"},
+        enabledByDefault = false
+)
+@Slf4j
+public class ChaosAltarPlugin extends Plugin {
+    @Inject
+    private ChaosAltarScript chaosAltarScript;
+    @Inject
+    private ChaosAltarConfig config;
+    @Provides
+    ChaosAltarConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(ChaosAltarConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    ChaosAltarOverlay chaosAltarOverlay;
+
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(chaosAltarOverlay);
+        }
+        chaosAltarScript.run(config);
+    }
+
+    protected void shutDown() {
+        chaosAltarScript.shutdown();
+        overlayManager.remove(chaosAltarOverlay);
+    }
+    int ticks = 10;
+    @Subscribe
+    public void onGameTick(GameTick tick)
+    {
+        //System.out.println(getName().chars().mapToObj(i -> (char)(i + 3)).map(String::valueOf).collect(Collectors.joining()));
+
+        if (ticks > 0) {
+            ticks--;
+        } else {
+            ticks = 10;
+        }
+
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarPlugin.java
@@ -2,11 +2,13 @@ package net.runelite.client.plugins.microbot.bee.chaosaltar;
 
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.PluginInstantiationException;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.accountselector.AutoLoginPlugin;
+import net.runelite.client.plugins.microbot.storm.plugins.PlayerMonitor.PlayerMonitorPlugin;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
@@ -28,6 +30,10 @@ public class ChaosAltarPlugin extends Plugin {
     ChaosAltarConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(ChaosAltarConfig.class);
     }
+    @Inject
+    private PlayerMonitorPlugin playerMonitorPlugin;
+    @Inject
+    private AutoLoginPlugin autoLoginPlugin;
 
     @Inject
     private OverlayManager overlayManager;
@@ -36,10 +42,12 @@ public class ChaosAltarPlugin extends Plugin {
 
 
     @Override
-    protected void startUp() throws AWTException {
+    protected void startUp() throws AWTException, PluginInstantiationException {
         if (overlayManager != null) {
             overlayManager.add(chaosAltarOverlay);
         }
+            if (!Microbot.getPluginManager().isPluginEnabled(playerMonitorPlugin)) {Microbot.getPluginManager().startPlugin(playerMonitorPlugin);}
+            if (!Microbot.getPluginManager().isPluginEnabled(autoLoginPlugin)) {Microbot.getPluginManager().startPlugin(autoLoginPlugin);}
         chaosAltarScript.run(config);
     }
 
@@ -47,18 +55,6 @@ public class ChaosAltarPlugin extends Plugin {
         chaosAltarScript.shutdown();
         overlayManager.remove(chaosAltarOverlay);
     }
-    int ticks = 10;
-    @Subscribe
-    public void onGameTick(GameTick tick)
-    {
-        //System.out.println(getName().chars().mapToObj(i -> (char)(i + 3)).map(String::valueOf).collect(Collectors.joining()));
 
-        if (ticks > 0) {
-            ticks--;
-        } else {
-            ticks = 10;
-        }
-
-    }
 
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarPlugin.java
@@ -51,8 +51,10 @@ public class ChaosAltarPlugin extends Plugin {
         chaosAltarScript.run(config);
     }
 
-    protected void shutDown() {
+    protected void shutDown() throws PluginInstantiationException {
         chaosAltarScript.shutdown();
+        Microbot.getPluginManager().stopPlugin(playerMonitorPlugin);
+        Microbot.getPluginManager().stopPlugin(autoLoginPlugin);
         overlayManager.remove(chaosAltarOverlay);
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarScript.java
@@ -1,0 +1,181 @@
+package net.runelite.client.plugins.microbot.bee.chaosaltar;
+
+import net.runelite.api.ItemID;
+import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldArea;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.player.Rs2Pvp;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2Prayer;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2PrayerEnum;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+import java.util.concurrent.TimeUnit;
+
+import static net.runelite.api.ItemID.*;
+import static net.runelite.api.NpcID.CHAOS_FANATIC;
+import static net.runelite.client.plugins.microbot.util.walker.Rs2Walker.walkTo;
+
+
+public class ChaosAltarScript extends Script {
+
+    public static final WorldArea CHAOS_ALTAR_AREA = new WorldArea(2947, 3819, 11, 3, 0);
+    public static final WorldPoint CHAOS_ALTAR_POINT = new WorldPoint(2949, 3821,0);
+
+    private ChaosAltarConfig config;
+
+    private State currentState = State.UNKNOWN;
+
+    public static boolean test = false;
+    public boolean run(ChaosAltarConfig config) {
+        Microbot.enableAutoRunOn = false;
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) return;
+                if (!super.run()) return;
+                long startTime = System.currentTimeMillis();
+
+                // Determine current state
+                currentState = determineState();
+                System.out.println("Current state: " + currentState);
+
+                // Execute state action
+                switch (currentState) {
+                    case BANK:
+                        handleBanking();
+                        break;
+                    case TELEPORT_TO_WILDERNESS:
+                        teleportToWilderness();
+                        break;
+                    case OFFER_BONES:
+                        offerBones();
+                        break;
+                    case DIE_TO_NPC:
+                        dieToNpc();
+                        break;
+                    default:
+                        System.out.println("Unknown state. Resetting...");
+                        break;
+                }
+
+                long endTime = System.currentTimeMillis();
+                long totalTime = endTime - startTime;
+                System.out.println("Total time for loop " + totalTime);
+
+            } catch (Exception ex) {
+                System.out.println(ex.getMessage());
+            }
+        }, 0, 1000, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    public boolean isAtChaosAltar() {
+        return CHAOS_ALTAR_AREA.contains(Rs2Player.getWorldLocation());
+    }
+
+    private void dieToNpc() {
+        System.out.println("Walking to dangerous NPC to die");
+        Rs2Walker.walkTo(2978, 3854,0);
+        sleepUntil(() -> Rs2Npc.getNpc(CHAOS_FANATIC) != null, 15000);
+        // Attack chaos fanatic to die
+        Rs2Npc.attack("Chaos Fanatic");
+        // Wait until player dies
+        sleepUntil(() -> Microbot.getClient().getBoostedSkillLevel(Skill.HITPOINTS) == 0, 15000);
+        sleepUntil(() -> !Rs2Pvp.isInWilderness(), 5000);
+    }
+
+
+    private void teleportToWilderness() {
+
+        // Enable protect item if needed
+        if (!Rs2Prayer.isPrayerActive(Rs2PrayerEnum.PROTECT_ITEM)) {
+            System.out.println("Enabling Protect Item");
+            Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_ITEM, true);
+            sleep(500, 800);
+        }
+
+        if (hasBurningAmulet()) {
+            walkTo(CHAOS_ALTAR_POINT);
+        }
+    }
+
+    private void offerBones() {
+        System.out.println("Offering bones at altar");
+
+        if (Rs2Inventory.contains(DRAGON_BONES) && isRunning()) {
+            Rs2Inventory.interact(DRAGON_BONES, "use");
+            Rs2Inventory.useItemOnObject(BIG_BONES, 411);
+            sleep(300, 500);
+
+            Rs2Inventory.waitForInventoryChanges(5000);
+
+            // Small random delay between offerings
+            sleep(200, 400);
+        }
+    }
+
+    private void handleBanking() {
+        if (!Rs2Bank.isOpen()) {
+            System.out.println("Opening bank");
+            Rs2Bank.walkToBankAndUseBank();
+        } else {
+            Rs2Bank.depositAll();
+            // If amulet not equipped or in inventory
+            if (!hasBurningAmulet()) {
+                System.out.println("Withdrawing burning amulet");
+                Rs2Bank.withdrawOne(BURNING_AMULET5);
+                Rs2Inventory.waitForInventoryChanges(2000);
+            }
+
+            // If no bones in inventory, withdraw 28
+            if (!Rs2Inventory.contains(DRAGON_BONES)) {
+                System.out.println("Withdrawing bones");
+                Rs2Bank.withdrawAll(DRAGON_BONES);
+                Rs2Inventory.waitForInventoryChanges(2000);
+            }
+
+        }
+    }
+
+    public boolean hasBurningAmulet() {
+        return Rs2Inventory.contains(ItemID.BURNING_AMULET1) ||
+                Rs2Inventory.contains(ItemID.BURNING_AMULET2) ||
+                Rs2Inventory.contains(ItemID.BURNING_AMULET3) ||
+                Rs2Inventory.contains(ItemID.BURNING_AMULET4) ||
+                Rs2Inventory.contains(BURNING_AMULET5);
+    }
+
+    private State determineState() {
+        boolean inWilderness = Rs2Pvp.isInWilderness();
+        boolean hasBones = Rs2Inventory.contains(DRAGON_BONES);
+        boolean atAltar = isAtChaosAltar();
+
+        if (!inWilderness && !hasBones) {
+            return State.BANK;
+        }
+        if (!inWilderness && hasBones) {
+            return State.TELEPORT_TO_WILDERNESS;
+        }
+        if (inWilderness && hasBones && !atAltar) {
+            return State.WALK_TO_ALTAR;
+        }
+        if (inWilderness && hasBones && atAltar) {
+            return State.OFFER_BONES;
+        }
+        if (inWilderness && !hasBones) {
+            return State.DIE_TO_NPC;
+        }
+
+        return State.UNKNOWN;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/State.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/State.java
@@ -1,0 +1,12 @@
+package net.runelite.client.plugins.microbot.bee.chaosaltar;
+
+public enum State {
+        UNKNOWN,
+        BANK,
+        TELEPORT_TO_WILDERNESS,
+        WALK_TO_ALTAR,
+        OFFER_BONES,
+        DIE_TO_NPC,
+        WALK_TO_BANK
+
+}


### PR DESCRIPTION
Requested by the community; a simple chaos altar plugin.
Make sure to have dragon bones and burning amulet in bank.
To be used exclusively with player monitor LiteMode and Autologin. 

Demo: https://youtu.be/1Vqz4162qz4