### PR TITLE
Update Agility script to wait for xp drop OR New: damage taken

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
@@ -291,7 +291,8 @@ public class AgilityScript extends Script {
     }
 
     private boolean waitForAgilityObstabcleToFinish(final int agilityExp) {
-        sleepUntilOnClientThread(() -> agilityExp != Microbot.getClient().getSkillExperience(Skill.AGILITY), 15000);
+        double healthPlaceholder= Rs2Player.getHealthPercentage();
+        sleepUntilOnClientThread(() -> agilityExp != Microbot.getClient().getSkillExperience(Skill.AGILITY)||healthPlaceholder>Rs2Player.getHealthPercentage(), 15000);
 
 
         if (agilityExp != Microbot.getClient().getSkillExperience(Skill.AGILITY) || Microbot.getClient().getTopLevelWorldView().getPlane() == 0) {


### PR DESCRIPTION
if you fail an obstacle the script will sit there for 15 seconds since the sleepUntil condition is never reached. This change checks for current hp < intial hp and will exit sleepUntil if this condition is true.