### PR TITLE
Fix null error in Demonics script during target fetching

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/DemonicGorillaKiller/DemonicGorillaScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/DemonicGorillaKiller/DemonicGorillaScript.java
@@ -544,7 +544,7 @@ public class DemonicGorillaScript extends Script {
         }
         var interacting = Rs2Player.getInteracting();
         if (interacting != null) {
-            if (interacting.getName().equals("Demonic gorilla")) {
+            if (Objects.equals(interacting.getName(), "Demonic gorilla")) {
                 return (Rs2NpcModel) interacting;
             }
         }


### PR DESCRIPTION
Fix null error for interacting.getName() when target dies in the middle of target fetching