### PR TITLE
Add Astral RC Script

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
@@ -65,6 +65,7 @@ public @interface PluginDescriptor
     String Gage = "<html>[<font color=#00008B>Gage</font>] ";
 	String Bradley = "<html>[<font color=#E32636>BR</font>] ";
 	String Frosty = "<html>[<font color=#00FFFF>\u2744</font>] ";
+	String Maxxin = "<html>[<font color='#8B0000'>MX</font>] ";
 
 
 
@@ -113,6 +114,6 @@ public @interface PluginDescriptor
 	boolean developerPlugin() default false;
 
 	boolean loadInSafeMode() default true;
-	
+
 	boolean priority() default false;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/MXUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/MXUtil.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.microbot.maxxin.util;
+package net.runelite.client.plugins.microbot.maxxin;
 
 import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/astralrc/AstralRunesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/astralrc/AstralRunesConfig.java
@@ -1,0 +1,22 @@
+package net.runelite.client.plugins.microbot.maxxin.astralrc;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigInformation;
+
+@ConfigGroup(AstralRunesConfig.configGroup)
+@ConfigInformation(
+        "Plugin to craft Astral runes. <br/>" +
+        "<b>REQUIRED ITEMS</b><br/>" +
+        "- Rune pouch w/ Law, Astrals, Cosmic runes <br/>" +
+        "- Dust staff equipped <br/>" +
+        "- Pure essence, Stamina potions, Lobsters in bank <br/>" +
+        "Make sure spell book is set to Lunar. <br/>" +
+        "Only supports Colossal pouch and will use NPC contact for repairs.<br/>" +
+        "Equipping a dust staff and and having a Rune pouch setup with Law, Astrals, and Cosmic runes is required. <br/>" +
+        "Runecraft cape should be supported. Only Law and Astrals are required in Rune pouch if using RC cape (or no Colossal pouch). <br/>" +
+        "The only food supported is Lobster, required to survive hits from mobs when banking. <br/>"
+)
+public interface AstralRunesConfig extends Config {
+    String configGroup = "astral-runes";
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/astralrc/AstralRunesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/astralrc/AstralRunesOverlay.java
@@ -1,0 +1,56 @@
+package net.runelite.client.plugins.microbot.maxxin.astralrc;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class AstralRunesOverlay extends OverlayPanel {
+    private final AstralRunesConfig config;
+
+    @Inject
+    AstralRunesOverlay(AstralRunesPlugin plugin, AstralRunesConfig config) {
+        super(plugin);
+        this.config = config;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        try {
+            panelComponent.setPreferredSize(new Dimension(200, 300));
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("Starter " + AstralRunesScript.version)
+                    .color(Color.GREEN)
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder().build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left(Microbot.status)
+                    .build());
+            if( getPlugin() instanceof AstralRunesPlugin ) {
+                var plugin = (AstralRunesPlugin) getPlugin();
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("Total Trips: " + AstralRunesScript.totalTrips)
+                        .build());
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("Total Runes: " + AstralRunesScript.runesForSession)
+                        .build());
+
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("State: " + plugin.getDebugText2())
+                        .build());
+            }
+
+        } catch (Exception ex) {
+            System.out.println(ex.getMessage());
+        }
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/astralrc/AstralRunesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/astralrc/AstralRunesPlugin.java
@@ -1,0 +1,81 @@
+package net.runelite.client.plugins.microbot.maxxin.astralrc;
+
+import com.google.inject.Provides;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+
+@PluginDescriptor(
+        name = PluginDescriptor.Maxxin + "Astral Runes",
+        description = "Astral Runes",
+        tags = {"astral", "rune"},
+        enabledByDefault = false
+)
+@Slf4j
+public class AstralRunesPlugin extends Plugin {
+    @Inject
+    private AstralRunesConfig config;
+
+    @Provides
+    AstralRunesConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(AstralRunesConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private AstralRunesOverlay astralRunesOverlay;
+
+    private AstralRunesScript astralRunesScript;
+
+    @Getter
+    @Setter
+    private String debugText1;
+    @Getter
+    @Setter
+    private String debugText2;
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(astralRunesOverlay);
+        }
+
+        astralRunesScript = new AstralRunesScript(this);
+        astralRunesScript.run(config);
+    }
+
+    protected void shutDown() {
+        astralRunesScript.shutdown();
+        overlayManager.remove(astralRunesOverlay);
+    }
+
+    @Subscribe
+    public void onChatMessage(ChatMessage event) {
+        if (event.getType() == ChatMessageType.GAMEMESSAGE && !Microbot.pauseAllScripts) {
+            if (event.getMessage().toLowerCase().contains("you don't have enough coins.")) {
+                Microbot.status = "[Shutting down] - Reason: Not enough coins.";
+                Microbot.showMessage(Microbot.status);
+                astralRunesScript.shutdown();
+            }
+        }
+    }
+
+    @Subscribe
+    public void onConfigChanged(ConfigChanged event) {
+        if (!event.getGroup().equals(AstralRunesConfig.configGroup)) return;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/astralrc/AstralRunesScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/astralrc/AstralRunesScript.java
@@ -6,7 +6,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
-import net.runelite.client.plugins.microbot.maxxin.util.MXUtil;
+import net.runelite.client.plugins.microbot.maxxin.MXUtil;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/astralrc/AstralRunesScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/astralrc/AstralRunesScript.java
@@ -1,0 +1,308 @@
+package net.runelite.client.plugins.microbot.maxxin.astralrc;
+
+import net.runelite.api.Quest;
+import net.runelite.api.QuestState;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.maxxin.util.MXUtil;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
+import net.runelite.client.plugins.microbot.util.magic.Rs2Spells;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.skillcalculator.skills.MagicAction;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class AstralRunesScript extends Script {
+    public static String version = "0.0.1";
+    private final AstralRunesPlugin plugin;
+
+    private final static List<Integer> LUNAR_ISLE_REGION_IDS = List.of(8509, 8508, 8253);
+    private static final WorldPoint SEAL_OF_PASSAGE_BANKER = new WorldPoint(2098, 3920, 0);
+    private static final WorldPoint DREAM_MENTOR_BANKER = new WorldPoint(2099, 3920, 0);
+    private final static WorldPoint LUNAR_ISLE_BANK_WORLD_POINT = new WorldPoint(2099, 3918, 0);
+    private final static WorldPoint LUNAR_ISLE_CRAFT_WORLD_POINT = new WorldPoint(2156, 3864, 0);
+
+    public final int runeItemId = ItemID.ASTRALRUNE;
+    public static int runesForSession = 0;
+    public static int totalTrips = 0;
+
+    private enum State {
+        BANKING,
+        CRAFTING,
+        REPAIRING;
+    }
+
+    private State state = State.BANKING;
+
+    public AstralRunesScript(final AstralRunesPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public boolean run(AstralRunesConfig config) {
+        Microbot.pauseAllScripts = false;
+        Microbot.enableAutoRunOn = false;
+        Rs2Antiban.resetAntibanSettings();
+        Rs2AntibanSettings.naturalMouse = true;
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) return;
+                if (Microbot.pauseAllScripts) return;
+                if (Rs2AntibanSettings.actionCooldownActive) return;
+
+                var regionId = Rs2Player.getWorldLocation().getRegionID();
+                if( !LUNAR_ISLE_REGION_IDS.contains(regionId) ) {
+                    plugin.setDebugText1("Region ID: " + regionId);
+                    Microbot.showMessage("Start bot in Lunar Isle");
+                    shutdown();
+                    return;
+                }
+
+                if(!Rs2Magic.isLunar()) {
+                    plugin.setDebugText1("Is Lunar Spellbook: " + Rs2Magic.isLunar());
+                    Microbot.showMessage("Set spellbook to Lunar Spellbook");
+                    shutdown();
+                    return;
+                }
+
+                var dreamMentorComplete = Rs2Player.getQuestState(Quest.DREAM_MENTOR) == QuestState.FINISHED;
+                if(!dreamMentorComplete && !(Rs2Inventory.hasItem(ItemID.LUNAR_SEAL_OF_PASSAGE) || Rs2Equipment.hasEquipped(ItemID.LUNAR_SEAL_OF_PASSAGE))) {
+                    plugin.setDebugText1("Has Seal of Passage: " + Rs2Inventory.hasItem(ItemID.LUNAR_SEAL_OF_PASSAGE));
+                    Microbot.showMessage("No Seal of Passage found equipped or in inventory");
+                    shutdown();
+                    return;
+                }
+
+                if( !Rs2Inventory.hasRunePouch() ) {
+                    Microbot.showMessage("No Rune pouch found");
+                    shutdown();
+                    return;
+                }
+
+                if( !Rs2Magic.canCast(MagicAction.MOONCLAN_TELEPORT) ) {
+                    Microbot.showMessage("Required runes not found, make sure Dust staff is equipped and Rune pouch contains Law and Astral runes.");
+                    shutdown();
+                    return;
+                }
+
+                if( !Rs2Magic.canCast(MagicAction.MOONCLAN_TELEPORT) && Rs2Inventory.contains(ItemID.RCU_POUCH_COLOSSAL) ) {
+                    Microbot.showMessage("Required runes not found, make sure Dust staff is equipped and Rune pouch contains Law, Astral, and Cosmic runes.");
+                    shutdown();
+                    return;
+                }
+
+                plugin.setDebugText2(state.toString());
+
+                var playerLoc = Rs2Player.getWorldLocation();
+
+                MXUtil.switchInventoryTabIfNeeded();
+                MXUtil.closeWorldMapIfNeeded();
+
+                var distToCraftPoint = playerLoc.distanceTo(LUNAR_ISLE_CRAFT_WORLD_POINT);
+
+                switch (state) {
+                    case REPAIRING:
+                        if( Rs2Inventory.hasDegradedPouch() ) {
+                            if( Rs2Bank.isOpen() ) {
+                                Rs2Bank.closeBank();
+                            }
+
+                            MXUtil.closeWorldMapIfNeeded();
+                            if( Rs2Magic.hasRequiredRunes(Rs2Spells.NPC_CONTACT) ) {
+                                Rs2Magic.repairPouchesWithLunar();
+                                Rs2Inventory.checkPouches();
+                            } else {
+                                Microbot.showMessage("No runes found for NPC Contact");
+                                shutdown();
+                                return;
+                            }
+                        } else {
+                            state = State.BANKING;
+                        }
+                        break;
+                    case BANKING:
+                        if( Rs2Inventory.hasDegradedPouch() ) {
+                            state = State.REPAIRING;
+                            return;
+                        }
+
+                        if( Rs2Inventory.allPouchesFull() && Rs2Inventory.getEmptySlots() < 1 && Rs2Inventory.hasItem(ItemID.BLANKRUNE_HIGH) ) {
+                            state = State.CRAFTING;
+                            return;
+                        }
+
+                        MXUtil.closeWorldMapIfNeeded();
+
+                        if( !Rs2Bank.isOpen() ) {
+                            if( playerLoc.distanceTo(LUNAR_ISLE_BANK_WORLD_POINT) > 20 ) {
+                                Rs2Magic.cast(MagicAction.MOONCLAN_TELEPORT);
+                                sleep(2200);
+                                Rs2Walker.walkFastCanvas(new WorldPoint(2107, 3915, 0));
+                            }
+
+                            MXUtil.switchInventoryTabIfNeeded();
+                            var bankTileLoc = !dreamMentorComplete ? SEAL_OF_PASSAGE_BANKER : DREAM_MENTOR_BANKER;
+                            var bankTile = Rs2GameObject.findGameObjectByLocation(bankTileLoc);
+                            Rs2Walker.walkFastCanvas(LUNAR_ISLE_BANK_WORLD_POINT);
+                            if( bankTile != null && !Rs2Bank.isOpen() ) {
+                                Rs2Bank.openBank(bankTile);
+                                if( Rs2Inventory.hasItem(runeItemId) ) {
+                                    updateRuneStates();
+                                    Rs2Bank.depositAll(runeItemId);
+                                }
+                            } else if( Rs2Player.distanceTo(bankTileLoc) > 2 ) {
+                                Rs2Walker.walkFastCanvas(bankTileLoc);
+                            } else if( bankTile == null ) {
+                                Rs2Bank.openBank();
+                            }
+                            return;
+                        }
+
+                        var hasEmptySlots = Rs2Inventory.getEmptySlots() > 0;
+                        if( hasEmptySlots && Rs2Inventory.hasItem(runeItemId) ) {
+                            Rs2Bank.depositAll(runeItemId);
+                        }
+
+                        if( Rs2Inventory.hasItem(ItemID.VIAL_EMPTY) ) {
+                            Rs2Bank.depositAll(ItemID.VIAL_EMPTY);
+                        }
+
+                        if( Rs2Inventory.hasItem(ItemID.LOBSTER) ) {
+                            Rs2Bank.depositAll(ItemID.LOBSTER);
+                        }
+
+                        if( !Rs2Bank.hasItem(ItemID.BLANKRUNE_HIGH) ) {
+                            Microbot.showMessage("No pure essence found in bank");
+                            shutdown();
+                            return;
+                        }
+
+                        boolean staminaPotNeeded = Rs2Bank.isOpen() && Microbot.getClient().getEnergy() < 6000 && !Rs2Player.hasStaminaBuffActive();
+                        boolean foodNeeded = Rs2Player.getHealthPercentage() < 70;
+
+                        if( staminaPotNeeded ) {
+                            if( !Rs2Bank.hasItem("Stamina Potion") ) {
+                                Microbot.showMessage("No Stamina Potions found in bank");
+                                shutdown();
+                                return;
+                            }
+                            Rs2Bank.withdrawOne("Stamina Potion", 1);
+                            Rs2Inventory.waitForInventoryChanges(600);
+                        }
+
+                        if( foodNeeded ) {
+                            if( !Rs2Bank.hasItem(ItemID.LOBSTER) ) {
+                                Microbot.showMessage("No lobsters found in bank");
+                                shutdown();
+                                return;
+                            }
+                            Rs2Bank.withdrawOne(ItemID.LOBSTER);
+                            Rs2Inventory.waitForInventoryChanges(400);
+                        }
+
+                        if( staminaPotNeeded ) {
+                            Rs2Inventory.interact("Stamina Potion", "Drink");
+                            Rs2Inventory.waitForInventoryChanges(400);
+                            sleep(600);
+                        }
+
+                        if( foodNeeded ) {
+                            Rs2Inventory.interact(ItemID.LOBSTER, "Eat");
+                            Rs2Inventory.waitForInventoryChanges(400);
+                            if( Rs2Inventory.hasItem(ItemID.LOBSTER) ) {
+                                Rs2Inventory.interact(ItemID.LOBSTER, "Eat");
+                                Rs2Inventory.waitForInventoryChanges(400);
+                            }
+                        }
+
+                        if( staminaPotNeeded ) {
+                            Rs2Bank.depositAll("Stamina Potion");
+                            Rs2Inventory.waitForInventoryChanges(600);
+                            if( Rs2Inventory.hasItem(ItemID.VIAL_EMPTY) ) {
+                                Rs2Bank.depositAll(ItemID.VIAL_EMPTY);
+                            }
+                            Rs2Bank.depositAll("Stamina Potion");
+                            Rs2Inventory.waitForInventoryChanges(600);
+                        }
+
+                        var colossalPouch = Rs2Inventory.get(ItemID.RCU_POUCH_COLOSSAL);
+                        if( hasEmptySlots && Rs2Bank.hasItem(ItemID.BLANKRUNE_HIGH) ) {
+                            Rs2Bank.withdrawAll(ItemID.BLANKRUNE_HIGH);
+                            sleep(600);
+                            if( Rs2Inventory.getRemainingCapacityInPouches() > 0 )
+                                Rs2Inventory.interact(colossalPouch, "Fill");
+                            Rs2Inventory.waitForInventoryChanges(200);
+                        }
+
+                        MXUtil.handlePouchOutOfSync(hasEmptySlots, colossalPouch);
+
+                        if( Rs2Inventory.allPouchesFull() && Rs2Inventory.getEmptySlots() < 1 ) {
+                            state = State.CRAFTING;
+                        }
+
+                        break;
+                    case CRAFTING:
+                        plugin.setDebugText1("distance to craft - " + distToCraftPoint);
+                        if( distToCraftPoint >= 3 && !Rs2Player.isMoving() ) {
+                            Rs2Walker.walkTo(LUNAR_ISLE_CRAFT_WORLD_POINT, 2);
+                            MXUtil.closeWorldMapIfNeeded();
+                            doAltarCraft();
+                        }
+
+                        doAltarCraft();
+
+                        if( Rs2Inventory.allPouchesEmpty() && !Rs2Inventory.hasItem(ItemID.BLANKRUNE_HIGH) ) {
+                            state = State.BANKING;
+                        }
+
+                        break;
+                    default:
+                        System.out.println("This shouldn't happen");
+                        state = State.BANKING;
+                        break;
+                }
+
+            } catch (Exception ex) {
+                System.out.println("Error: " + ex.getMessage());
+                ex.printStackTrace();
+            }
+        }, 0, 600, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    private static void doAltarCraft() {
+        var altarLoc = new WorldPoint(2158, 3864, 0);
+        var altarTile = Rs2GameObject.findGameObjectByLocation(altarLoc);
+        if( altarTile != null && Rs2Player.getWorldLocation().distanceTo(altarLoc) < 5) {
+            if( Rs2Inventory.hasItem(ItemID.BLANKRUNE_HIGH) ) {
+                Rs2GameObject.interact(altarTile);
+                Rs2Inventory.waitForInventoryChanges(800);
+            }
+            if( !Rs2Inventory.allPouchesEmpty() ) {
+                Rs2Inventory.interact(Rs2Inventory.get(ItemID.RCU_POUCH_COLOSSAL), "Empty");
+                Rs2Inventory.waitForInventoryChanges(800);
+            }
+        }
+    }
+
+    private void updateRuneStates() {
+        var runes = Rs2Inventory.get(this.runeItemId);
+        if( runes != null ) runesForSession += runes.getQuantity();
+        totalTrips++;
+    }
+
+    @Override
+    public void shutdown() {
+        Rs2Antiban.resetAntibanSettings();
+        super.shutdown();
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/util/MXUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/util/MXUtil.java
@@ -1,0 +1,49 @@
+package net.runelite.client.plugins.microbot.maxxin.util;
+
+import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+import net.runelite.client.plugins.microbot.util.tabs.Rs2Tab;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleep;
+import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
+
+public class MXUtil {
+    public static void switchInventoryTabIfNeeded() {
+        if( Rs2Tab.getCurrentTab() != InterfaceTab.INVENTORY ) {
+            Rs2Tab.switchToInventoryTab();
+            sleepUntil(() -> Rs2Tab.getCurrentTab() == InterfaceTab.INVENTORY);
+        }
+    }
+
+    public static void closeWorldMapIfNeeded() {
+        var worldMapOpen = Rs2Widget.findWidget("Game features") != null;
+        if( worldMapOpen ) {
+            var exitButton = Rs2Widget.findWidget(539, null);
+            if( exitButton != null ) {
+                Rs2Widget.clickWidget(exitButton);
+            }
+        }
+    }
+
+    public static void handlePouchOutOfSync(boolean hasEmptySlots, Rs2ItemModel colossalPouch) {
+        if( Rs2Bank.isOpen() && !hasEmptySlots && !Rs2Inventory.allPouchesFull() ) {
+            if( Rs2Inventory.anyPouchUnknown() ) {
+                Rs2Inventory.checkPouches();
+                Rs2Inventory.waitForInventoryChanges(200);
+            }
+            var emptySlots = Rs2Inventory.getEmptySlots();
+            Rs2Inventory.interact(colossalPouch, "Fill");
+            var nextEmptySlots = Rs2Inventory.getEmptySlots();
+            // Handle edge case where pouch goes out-of-sync
+            if( !Rs2Inventory.waitForInventoryChanges(400) || emptySlots == nextEmptySlots ) {
+                Rs2Bank.closeBank();
+                sleep(800);
+                Rs2Inventory.interact(colossalPouch, "Check");
+                sleep(800);
+            }
+        }
+    }
+}


### PR DESCRIPTION
PR to add Astral Rune crafting
- Crafts Astral Runes in Lunar Isle
- Supports Banking based on completion of Dream Mentor
- Supports Colossal Pouch and repairs using NPC contact
- Preventative measures in place to stop script if invalid region, inventory setup, quest, or equipment states detected
- Requirements outlined in Plugin Description alongside script messages