### PR TITLE
Add House Thieving Script

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/HouseThievingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/HouseThievingConfig.java
@@ -1,0 +1,56 @@
+package net.runelite.client.plugins.microbot.maxxin.housethieving;
+
+import net.runelite.client.config.*;
+
+@ConfigGroup(HouseThievingConfig.configGroup)
+@ConfigInformation(
+        "Plugin to thief houses in Varlamore. <br/>" +
+        "Only requirement is completion of Children of the Sun quest to access Varlamore. <br/>"
+)
+public interface HouseThievingConfig extends Config {
+    String configGroup = "house-thieving";
+
+    String maxHouseKeys = "maxHouseKeys";
+    String minHouseKeys = "minHouseKeys";
+    String pickpocketWaitTime = "pickpocketWaitTime";
+
+    @ConfigSection(
+            name = "House Thieving Settings",
+            description = "Settings for house thieving in Varlamore",
+            position = 0
+    )
+    String generalSection = "general";
+
+    @ConfigItem(
+            keyName = maxHouseKeys,
+            name = "Max House Keys",
+            description = "Number of house keys to get before starting house thieving",
+            position = 1,
+            section = generalSection
+    )
+    default int maxHouseKeys() {
+        return 20;
+    }
+
+    @ConfigItem(
+            keyName = minHouseKeys,
+            name = "Minimum House Keys",
+            description = "Number of house keys to use before switching to pickpocketing",
+            position = 1,
+            section = generalSection
+    )
+    default int minHouseKeys() {
+        return 2;
+    }
+
+    @ConfigItem(
+            keyName = pickpocketWaitTime,
+            name = "Pickpocket Wait Time",
+            description = "How long to wait for wealthy citizen pickpocket event before world hopping",
+            position = 1,
+            section = generalSection
+    )
+    default int pickpocketWaitTime() {
+        return 90;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/HouseThievingConstants.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/HouseThievingConstants.java
@@ -1,0 +1,32 @@
+package net.runelite.client.plugins.microbot.maxxin.housethieving;
+
+import net.runelite.api.coords.WorldPoint;
+
+public class HouseThievingConstants {
+    public final static WorldPoint LAVINIA_HOUSE_CENTER = new WorldPoint(1670, 3091, 0);
+    public final static WorldPoint LAVINIA_LOCKED_DOOR_ENTRANCE = new WorldPoint(1668, 3095, 0);
+    public final static WorldPoint LAVINIA_LOCKED_DOOR_EGRESS = new WorldPoint(1668, 3094, 0);
+    public final static WorldPoint LAVINIA_WINDOW_ENTRANCE = new WorldPoint(1670, 3088, 0);
+    public final static WorldPoint LAVINIA_WINDOW_EGRESS = new WorldPoint(1670, 3087, 0);
+    public final static WorldPoint LAVINIA_INITIAL_THIEVING_CHEST = new WorldPoint(1666, 3093, 0);
+
+    public final static WorldPoint VICTOR_HOUSE_CENTER = new WorldPoint(1637, 3099, 0);
+    public final static WorldPoint VICTOR_LOCKED_DOOR_ENTRANCE = new WorldPoint(1636, 3104, 0);
+    public final static WorldPoint VICTOR_LOCKED_DOOR_EGRESS = new WorldPoint(1636, 3103, 0);
+    public final static WorldPoint VICTOR_WINDOW_ENTRANCE = new WorldPoint(1637, 3094, 0);
+    public final static WorldPoint VICTOR_WINDOW_EGRESS = new WorldPoint(1636, 3094, 0);
+    public final static WorldPoint VICTOR_INITIAL_THIEVING_CHEST = new WorldPoint(1635, 3099, 0);
+
+    public final static WorldPoint CAIUS_HOUSE_CENTER = new WorldPoint(1634, 3122, 0);
+    public final static WorldPoint CAIUS_LOCKED_DOOR_ENTRANCE = new WorldPoint(1630, 3121, 0);
+    public final static WorldPoint CAIUS_LOCKED_DOOR_EGRESS = new WorldPoint(1631, 3121, 0);
+    public final static WorldPoint CAIUS_WINDOW_ENTRANCE = new WorldPoint(1638, 3124, 0);
+    public final static WorldPoint CAIUS_WINDOW_EGRESS = new WorldPoint(1638, 3125, 0);
+    public final static WorldPoint CAIUS_INITIAL_THIEVING_CHEST = new WorldPoint(1635, 3124, 0);
+
+    public final static WorldPoint PICKPOCKET_LOCATION = new WorldPoint(1680, 3088, 0);
+    public final static WorldPoint BANKING_LOCATION = new WorldPoint(1648, 3117, 0);
+    public final static WorldPoint BANKING_TILE_LOCATION = new WorldPoint(1648, 3119, 0);
+
+    public final static int LOCKED_DOOR_ID = 51998;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/HouseThievingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/HouseThievingOverlay.java
@@ -1,0 +1,43 @@
+package net.runelite.client.plugins.microbot.maxxin.housethieving;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class HouseThievingOverlay extends OverlayPanel {
+    private final HouseThievingConfig config;
+
+    @Inject
+    HouseThievingOverlay(HouseThievingPlugin plugin, HouseThievingConfig config) {
+        super(plugin);
+        this.config = config;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        try {
+            panelComponent.setPreferredSize(new Dimension(200, 300));
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("Starter " + HouseThievingScript.version)
+                    .color(Color.GREEN)
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder().build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left(Microbot.status)
+                    .build());
+
+        } catch (Exception ex) {
+            System.out.println(ex.getMessage());
+        }
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/HouseThievingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/HouseThievingPlugin.java
@@ -1,0 +1,86 @@
+package net.runelite.client.plugins.microbot.maxxin.housethieving;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.OverheadTextChanged;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+
+@PluginDescriptor(
+        name = PluginDescriptor.Maxxin + "House Thieving",
+        description = "House Thieving",
+        tags = {"thieving", "house thieving"},
+        enabledByDefault = false
+)
+@Slf4j
+public class HouseThievingPlugin extends Plugin {
+    @Inject
+    private HouseThievingConfig config;
+
+    @Provides
+    HouseThievingConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(HouseThievingConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private HouseThievingOverlay houseThievingOverlay;
+
+    private HouseThievingScript houseThievingScript;
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(houseThievingOverlay);
+        }
+
+        houseThievingScript = new HouseThievingScript(this);
+        houseThievingScript.run(config);
+    }
+
+    protected void shutDown() {
+        houseThievingScript.shutdown();
+        overlayManager.remove(houseThievingOverlay);
+    }
+
+    @Subscribe
+    public void onChatMessage(ChatMessage event) {
+        if (event.getType() == ChatMessageType.GAMEMESSAGE && !Microbot.pauseAllScripts) {
+            if (event.getMessage().toLowerCase().contains("you don't have enough coins.")) {
+                Microbot.status = "[Shutting down] - Reason: Not enough coins.";
+                Microbot.showMessage(Microbot.status);
+                houseThievingScript.shutdown();
+            }
+        }
+    }
+
+    @Subscribe
+    public void onVarbitChanged(VarbitChanged event)
+    {
+//        System.out.println("varbit changed");
+//        System.out.println(event);
+    }
+
+    @Subscribe
+    public void onConfigChanged(ConfigChanged event) {
+        if (!event.getGroup().equals(HouseThievingConfig.configGroup)) return;
+    }
+
+    @Subscribe
+    public void onOverheadTextChanged(OverheadTextChanged event) {
+        /* ignore */
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/HouseThievingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/HouseThievingScript.java
@@ -1,0 +1,328 @@
+package net.runelite.client.plugins.microbot.maxxin.housethieving;
+
+import net.runelite.api.GameState;
+import net.runelite.api.Quest;
+import net.runelite.api.QuestState;
+import net.runelite.api.TileObject;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.math.Rs2Random;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.security.Login;
+import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import org.slf4j.event.Level;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static net.runelite.client.plugins.microbot.maxxin.housethieving.HouseThievingConstants.*;
+
+public class HouseThievingScript extends Script {
+    public static String version = "0.0.1";
+
+    private final HouseThievingPlugin plugin;
+
+    public HouseThievingScript(final HouseThievingPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    enum State {
+        PICKPOCKETING,
+        FINDING_HOUSE,
+        THIEVING_HOUSES,
+        BANKING
+    }
+    private State state = State.PICKPOCKETING;
+    private TileObject currentThievingObject = null;
+    private Long lastThievingSearch = null;
+    private ThievingHouse currentThievingHouse = null;
+
+    public boolean run(HouseThievingConfig config) {
+        Microbot.pauseAllScripts = false;
+        Microbot.enableAutoRunOn = false;
+        initialPlayerLocation = null;
+        Rs2Antiban.resetAntibanSettings();
+        Rs2AntibanSettings.naturalMouse = true;
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!super.run()) return;
+                if (!Microbot.isLoggedIn()) return;
+                if (Microbot.pauseAllScripts) return;
+                if (Rs2AntibanSettings.actionCooldownActive) return;
+
+                var childrenOfTheSunComplete = Rs2Player.getQuestState(Quest.CHILDREN_OF_THE_SUN) == QuestState.FINISHED;
+                if(!childrenOfTheSunComplete) {
+                    Microbot.showMessage("Children of the Sun quest is required to be complete to use this plugin.");
+                    shutdown();
+                    return;
+                }
+
+                if( state == null )
+                    state = State.PICKPOCKETING;
+
+                if( currentThievingHouse == null )
+                    currentThievingHouse = getThievingHouse();
+
+                var houseNpc = Rs2Npc.getNpc(currentThievingHouse.npcName);
+                switch (state) {
+                    case PICKPOCKETING:
+                        handlePickPocketing(config);
+                        break;
+                    case FINDING_HOUSE:
+                        handleFindingHouse(config);
+                        break;
+                    case THIEVING_HOUSES:
+                        handleThievingHouse(houseNpc);
+                        break;
+                    case BANKING:
+                        handleBanking();
+                        break;
+                }
+
+            } catch (Exception ex) {
+                Microbot.log("Error: " + ex.getMessage(), Level.ERROR);
+                ex.printStackTrace();
+            }
+        }, 0, 1000, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    private void handlePickPocketing(HouseThievingConfig config) {
+        if( Rs2Inventory.getEmptySlots() < 5 ) {
+            state = State.BANKING;
+            return;
+        }
+
+        if(Rs2Inventory.hasItem("House keys")) {
+            var houseKeys = Rs2Inventory.get("House keys");
+            if( houseKeys.getQuantity() >= config.maxHouseKeys() ) {
+                Microbot.log("Have enough house keys, thieving houses", Level.INFO);
+                state = State.FINDING_HOUSE;
+                return;
+            }
+        }
+
+        if( Rs2Player.getWorldLocation().distanceTo( PICKPOCKET_LOCATION ) > 3 ) {
+            Rs2Walker.walkTo(PICKPOCKET_LOCATION, 2);
+        }
+
+        if( Rs2Inventory.hasItem("Coin pouch") ) {
+            var coinPouches = Rs2Inventory.get("Coin pouch");
+            if( coinPouches.getQuantity() > 27 ) {
+                Rs2Inventory.interact(coinPouches, "Open-all");
+                Rs2Random.waitEx(800.0, 200.0);
+            }
+        }
+
+        var aureliaNpc = Rs2Npc.getNpc("Aurelia");
+        Rs2NpcModel wealthyCitizen = null;
+        if( aureliaNpc != null ) {
+            var aureliaAnim = aureliaNpc.getAnimation();
+            if( aureliaAnim == 866 || aureliaAnim == 860 ) {
+                var aureliaNpcs = Rs2Npc.getNpcs().filter(npc -> npc.getWorldLocation().distanceTo(aureliaNpc.getWorldLocation()) <= 1).collect(Collectors.toList());
+                for(var npc : aureliaNpcs) {
+                    var npcName = npc.getName();
+                    if( npcName != null && npcName.equalsIgnoreCase("Wealthy citizen") && npc.isInteracting() ) {
+                        Microbot.log("Found Wealthy citizen: " + npc.getWorldLocation(), Level.INFO);
+                        wealthyCitizen = npc;
+                    }
+                }
+            } else {
+                Microbot.log(String.format("Waiting %s seconds for Aurelia pickpocket", config.pickpocketWaitTime()), Level.INFO);
+                var waitForPickpocket = sleepUntil(() -> aureliaNpc.getAnimation() == 866 || aureliaNpc.getAnimation() == 860, config.pickpocketWaitTime() * 1000);
+                Microbot.log(String.format("Finished waiting %s seconds for Aurelia pickpocket", config.pickpocketWaitTime()), Level.INFO);
+                if( !waitForPickpocket ) {
+                    Microbot.log("World hopping to check for pickpocket", Level.INFO);
+                    boolean hoppedWorlds = Microbot.hopToWorld(Login.getRandomWorld(Rs2Player.isMember()));
+                    if( hoppedWorlds ) {
+                        sleepUntil(() -> Microbot.getClient().getGameState() == GameState.HOPPING);
+                        sleepUntil(() -> Microbot.getClient().getGameState() == GameState.LOGGED_IN);
+                    }
+                    return;
+                }
+            }
+        }
+
+        if( wealthyCitizen != null && !Rs2Player.isInteracting() ) {
+            Rs2Npc.interact(wealthyCitizen, "Pickpocket");
+            Rs2Random.waitEx(1000.0, 200.0);
+        }
+    }
+
+    private void handleFindingHouse(HouseThievingConfig config) {
+        if( Rs2Inventory.getEmptySlots() < 5 ) {
+            state = State.BANKING;
+            return;
+        }
+
+        if( Rs2Inventory.hasItem("House keys") ) {
+            var houseKeys = Rs2Inventory.get("House keys");
+            if( houseKeys != null && houseKeys.getQuantity() < config.minHouseKeys() ) {
+                state = State.PICKPOCKETING;
+                return;
+            }
+        }
+
+        var lockedDoorEntrance = currentThievingHouse.lockedDoorEntrance;
+        if( Rs2Player.getWorldLocation().distanceTo(lockedDoorEntrance) > 0 ) {
+            Rs2Walker.walkTo(lockedDoorEntrance);
+            Rs2Random.waitEx(800.0, 200.0);
+        }
+        var lockedDoorEgress = currentThievingHouse.lockedDoorEgress;
+        var lockedDoorTile = Rs2Tile.getTile(
+                currentThievingHouse.lockedDoorEgress.getX(),
+                currentThievingHouse.lockedDoorEgress.getY());
+        if( lockedDoorTile != null ) {
+            var wallObject = lockedDoorTile.getWallObject();
+            if( wallObject != null && wallObject.getId() == LOCKED_DOOR_ID ) {
+                Microbot.log("Current house can be thieved", Level.INFO);
+                Rs2GameObject.interact(wallObject);
+                Rs2Random.waitEx(3000.0, 100.0);
+                if( Rs2Player.getWorldLocation().distanceTo(lockedDoorEgress) < 1 ) {
+                    currentThievingObject = null;
+                    lastThievingSearch = null;
+                    state = State.THIEVING_HOUSES;
+                }
+            } else {
+                Microbot.log("Checking different house", Level.INFO);
+                setNextThievingHouse();
+            }
+        }
+    }
+
+    private void handleThievingHouse(Rs2NpcModel houseNpc) {
+        if( Rs2Inventory.getEmptySlots() < 5 ) {
+            state = State.BANKING;
+            return;
+        }
+
+        var windowEgress = currentThievingHouse.windowEgress;
+        var houseCenter = currentThievingHouse.houseCenter;
+        if( houseNpc != null ) {
+            var laviniaWorldLoc = houseNpc.getWorldLocation();
+            if( laviniaWorldLoc.distanceTo(houseCenter) < 9 ) {
+                Microbot.log("Owner in house or approaching currently", Level.INFO);
+                var windowTile = Rs2Tile.getTile(currentThievingHouse.windowEntrance.getX(), currentThievingHouse.windowEntrance.getY());
+                if( windowTile != null ) {
+                    var windowTileWallObject = windowTile.getWallObject();
+                    if( windowTileWallObject != null && !Rs2Player.isMoving() ) {
+                        Rs2GameObject.interact(windowTileWallObject, "Exit-window");
+                        Rs2Random.waitEx(5000.0, 200.0);
+                        if( Rs2Player.getWorldLocation().distanceTo(windowEgress) < 1 ) {
+                            currentThievingObject = null;
+                            lastThievingSearch = null;
+                            setNextThievingHouse();
+                            state = State.FINDING_HOUSE;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
+        var hintArrow = Microbot.getClient().getHintArrowPoint();
+        var elapsedTime = lastThievingSearch == null ? null : System.currentTimeMillis() - lastThievingSearch;
+        if( hintArrow == null ) {
+            if( currentThievingObject == null )
+                currentThievingObject = Rs2GameObject.findGameObjectByLocation(currentThievingHouse.initialThievingChest);
+
+            if( currentThievingObject != null && ( lastThievingSearch == null || (elapsedTime != null && elapsedTime > 50000) ) ) {
+                Rs2GameObject.interact(currentThievingObject, "Search");
+                lastThievingSearch = System.currentTimeMillis();
+                Rs2Random.waitEx(1000.0, 200.0);
+            }
+        } else {
+            currentThievingObject = Rs2GameObject.findGameObjectByLocation(hintArrow);
+            if( !Rs2Player.isInteracting() || lastThievingSearch == null || (elapsedTime != null && elapsedTime > 50000) ) {
+                Rs2GameObject.interact(currentThievingObject, "Search");
+                lastThievingSearch = System.currentTimeMillis();
+                Rs2Random.waitEx(1000.0, 200.0);
+            }
+        }
+    }
+
+    private void handleBanking() {
+        if( Rs2Inventory.getEmptySlots() > 6 ) {
+            state = State.PICKPOCKETING;
+            return;
+        }
+
+        if( Rs2Player.getWorldLocation().distanceTo( BANKING_LOCATION ) > 3 ) {
+            Rs2Walker.walkTo(BANKING_LOCATION, 2);
+        }
+
+        if( Rs2Player.distanceTo( BANKING_LOCATION ) <= 3 ) {
+            var bankingTile = Rs2GameObject.getGameObject(BANKING_TILE_LOCATION);
+            if( bankingTile != null )
+                Rs2Bank.openBank(bankingTile);
+            else
+                Rs2Bank.openBank();
+            sleepUntil(Rs2Bank::isOpen, 2);
+        }
+
+        if( Rs2Bank.isOpen() ) {
+            Rs2Bank.depositAllExcept("Coins", "Coin pouch", "House keys");
+            Rs2Inventory.waitForInventoryChanges(600);
+        }
+    }
+
+    private void setNextThievingHouse() {
+        if( currentThievingHouse == ThievingHouse.LAVINIA ) {
+            currentThievingHouse = ThievingHouse.VICTOR;
+            if( hasLockedDoor(ThievingHouse.CAIUS) )
+                currentThievingHouse = ThievingHouse.CAIUS;
+        }
+        else if( currentThievingHouse == ThievingHouse.VICTOR ) {
+            currentThievingHouse = ThievingHouse.CAIUS;
+            if( hasLockedDoor(ThievingHouse.LAVINIA) )
+                currentThievingHouse = ThievingHouse.LAVINIA;
+        }
+        else if( currentThievingHouse == ThievingHouse.CAIUS ) {
+            currentThievingHouse = ThievingHouse.LAVINIA;
+            if( hasLockedDoor(ThievingHouse.VICTOR) )
+                currentThievingHouse = ThievingHouse.VICTOR;
+        }
+    }
+
+    private static ThievingHouse getThievingHouse() {
+        ThievingHouse closestHouse = null;
+        for( var house : ThievingHouse.values() ) {
+            if( hasLockedDoor( house ) )
+                return house;
+            if( closestHouse == null )
+                closestHouse = house;
+            var houseDistance = Rs2Player.getWorldLocation().distanceTo(house.lockedDoorEntrance);
+            var shortestHouseDistance = Rs2Player.getWorldLocation().distanceTo(closestHouse.lockedDoorEntrance);
+            if( houseDistance < shortestHouseDistance ) {
+                closestHouse = house;
+            }
+        }
+        return closestHouse;
+    }
+
+    private static boolean hasLockedDoor(ThievingHouse thievingHouse) {
+        var lockedDoorTile = Rs2Tile.getTile(
+                thievingHouse.lockedDoorEgress.getX(),
+                thievingHouse.lockedDoorEgress.getY());
+        if( lockedDoorTile == null ) return false;
+        var wallObject = lockedDoorTile.getWallObject();
+        return wallObject != null && wallObject.getId() == LOCKED_DOOR_ID;
+    }
+
+    @Override
+    public void shutdown() {
+        Rs2Antiban.resetAntibanSettings();
+        super.shutdown();
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/ThievingHouse.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/maxxin/housethieving/ThievingHouse.java
@@ -1,0 +1,62 @@
+package net.runelite.client.plugins.microbot.maxxin.housethieving;
+
+import net.runelite.api.coords.WorldPoint;
+
+import static net.runelite.client.plugins.microbot.maxxin.housethieving.HouseThievingConstants.*;
+
+
+public enum ThievingHouse {
+    LAVINIA(
+            "Lavinia",
+            LAVINIA_HOUSE_CENTER,
+            LAVINIA_LOCKED_DOOR_ENTRANCE,
+            LAVINIA_LOCKED_DOOR_EGRESS,
+            LAVINIA_WINDOW_ENTRANCE,
+            LAVINIA_WINDOW_EGRESS,
+            LAVINIA_INITIAL_THIEVING_CHEST
+    ),
+    VICTOR(
+            "Victor",
+            VICTOR_HOUSE_CENTER,
+            VICTOR_LOCKED_DOOR_ENTRANCE,
+            VICTOR_LOCKED_DOOR_EGRESS,
+            VICTOR_WINDOW_ENTRANCE,
+            VICTOR_WINDOW_EGRESS,
+            VICTOR_INITIAL_THIEVING_CHEST
+    ),
+    CAIUS(
+            "Caius",
+            CAIUS_HOUSE_CENTER,
+            CAIUS_LOCKED_DOOR_ENTRANCE,
+            CAIUS_LOCKED_DOOR_EGRESS,
+            CAIUS_WINDOW_ENTRANCE,
+            CAIUS_WINDOW_EGRESS,
+            CAIUS_INITIAL_THIEVING_CHEST
+    );
+
+    final String npcName;
+    final WorldPoint houseCenter;
+    final WorldPoint lockedDoorEntrance;
+    final WorldPoint lockedDoorEgress;
+    final WorldPoint windowEntrance;
+    final WorldPoint windowEgress;
+    final WorldPoint initialThievingChest;
+
+    ThievingHouse(
+            final String npcName,
+            final WorldPoint houseCenter,
+            final WorldPoint lockedDoorEntrance,
+            final WorldPoint lockedDoorEgress,
+            final WorldPoint windowEntrance,
+            final WorldPoint windowEgress,
+            final WorldPoint initialThievingChest
+    ) {
+        this.npcName = npcName;
+        this.houseCenter = houseCenter;
+        this.lockedDoorEntrance = lockedDoorEntrance;
+        this.lockedDoorEgress = lockedDoorEgress;
+        this.windowEntrance = windowEntrance;
+        this.windowEgress = windowEgress;
+        this.initialThievingChest = initialThievingChest;
+    }
+}


### PR DESCRIPTION
PR to add House Thieving in Varlamore script

- Handles thieving houses in Varlamore
- Pickpockets NPCs for house keys
- Begins house thieving when configured number of house keys reached
- World hops for pickpocketing events
- Banks when inventory is full
- Setup to shutdown unless Children of the Sun quest requirement is met