### PR TITLE
Stop quick action on retort if nearing end of process

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mixology/MixologyScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mixology/MixologyScript.java
@@ -271,7 +271,7 @@ public class MixologyScript extends Script {
                                 quickActionProcessPotion(nonFulfilledPotion);
                                 alembicQuickActionTicks = 0;
                             }
-                            if (nonFulfilledPotion.potionModifier().alchemyObject() == AlchemyObject.RETORT && config.useQuickActionOnRetort()) {
+                            if (nonFulfilledPotion.potionModifier().alchemyObject() == AlchemyObject.RETORT && config.useQuickActionOnRetort()&&Microbot.getVarbitValue(11327)<15&&Microbot.getVarbitValue(11327)!=0) {
                                 quickActionProcessPotion(nonFulfilledPotion);
                                 sleep(350, 400);
                             }


### PR DESCRIPTION
Looks at varbit for retort progress (11327), which goes from 0 to 18, and doesn't interact with the retort machine if the varbit value is 0 or below 15. This makes it stop clicking a tick or two before the progress is completed. Not clicking at 0 is because the progress varbit goes from 18 to 0 on the same tick as it finishes, which was also observed to make the script erroneously click.