### PR TITLE
Clan Recruiter and Auto-Typer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/GEBotRecruiter/RecruiterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/GEBotRecruiter/RecruiterConfig.java
@@ -1,0 +1,54 @@
+package net.runelite.client.plugins.microbot.bee.GEBotRecruiter;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("recruiter")
+public interface RecruiterConfig extends Config {
+
+    @ConfigItem(
+            keyName = "instructionsGuide",
+            name = "Instructions",
+            description = "How to use the plugin",
+            position = 1
+    )
+    default String instructionsGuide() {
+        return  "Be in a clan and have equipped clan vexelium. Start the Plugin in crowded area (ge 301, ge 302). It will invite everyone systematically and send custom message (if you want). \n" +
+                "This plugin can also just send a custom message without clan invitation function.\n" +
+                "\n" +
+                "To be added: send Longer messages and/or messages/info/data from an http endpoint.";
+    }
+
+
+    @ConfigItem(
+            keyName = "recruit",
+            name = "Recruit clan",
+            description = "Enable or disable for clan recruiting."
+    )
+    default boolean recruit() {
+        return false; // Default to disabled
+    }
+
+    @ConfigItem(
+            keyName = "send message",
+            name = "Send message",
+            description = "Enable or disable recruitment message."
+    )
+    default boolean sendMessage() {
+        return false; // Default to disabled
+    }
+
+    @ConfigItem(
+            keyName = "customMessage",
+            name = "Custom Clan Invite Message",
+            description = "The message to be sent when inviting players to the clan (maximum 80 characters)",
+            position = 1
+    )
+
+    default String customMessage() {
+        String defaultMessage = "Hi, My Clan is recruiting! Please Accept Aid on in settings for an invite :)";
+        return defaultMessage.substring(0, 80);
+    }
+
+    }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/GEBotRecruiter/RecruiterOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/GEBotRecruiter/RecruiterOverlay.java
@@ -1,0 +1,42 @@
+package net.runelite.client.plugins.microbot.bee.GEBotRecruiter;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class RecruiterOverlay extends OverlayPanel {
+
+    @Inject
+    RecruiterOverlay(RecruiterPlugin plugin)
+    {
+        super(plugin);
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        try {
+            panelComponent.setPreferredSize(new Dimension(200, 300));
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("Recruiter 1.0.0")
+                    .color(Color.GREEN)
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder().build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left(Microbot.status)
+                    .build());
+
+
+        } catch(Exception ex) {
+            System.out.println(ex.getMessage());
+        }
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/GEBotRecruiter/RecruiterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/GEBotRecruiter/RecruiterPlugin.java
@@ -1,0 +1,72 @@
+package net.runelite.client.plugins.microbot.bee.GEBotRecruiter;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Bee + "Clan Recruiter",
+        description = "Recruits people at GE to your clan",
+        tags = {"recruit", "clan", "type", "keyboard", "typer","Auto-typer", "microbot"},
+        enabledByDefault = false
+)
+@Slf4j
+public class RecruiterPlugin extends Plugin {
+    @Inject
+    private RecruiterConfig config;
+
+    @Inject
+    private EventBus eventBus;
+
+    @Provides
+    RecruiterConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(RecruiterConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private RecruiterOverlay recruiterOverlay;
+
+    @Inject
+    private RecruiterScript recruiterScript;
+
+    @Override
+    protected void startUp() throws Exception {
+        if (overlayManager != null) {
+            overlayManager.add(recruiterOverlay);
+        }
+        recruiterScript.run(config);
+        eventBus.register(this);  // Register for events
+        log.info("Recruiter Plugin started!");
+    }
+
+    @Override
+    protected void shutDown() {
+        recruiterScript.shutdown();
+        overlayManager.remove(recruiterOverlay);
+        eventBus.unregister(this);  // Unregister events
+        log.info("Recruiter Plugin stopped!");
+    }
+
+    /**
+     * This method disables the "Walk here" option in the menu for all tiles.
+     */
+    @Subscribe
+    public void onMenuOptionClicked(MenuOptionClicked event) {
+        // Disable the "Walk here" option for all clicks
+        if (event.getMenuOption().equalsIgnoreCase("Walk here")) {
+            log.info("Disabling 'Walk here' option globally.");
+            event.consume();  // Consume the event to prevent the player from walking
+        }
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/GEBotRecruiter/RecruiterScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/GEBotRecruiter/RecruiterScript.java
@@ -1,0 +1,297 @@
+package net.runelite.client.plugins.microbot.bee.GEBotRecruiter;
+
+import net.runelite.api.Point;
+import net.runelite.api.*;
+import net.runelite.api.coords.WorldArea;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
+import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
+import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.player.Rs2PlayerModel;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
+import org.apache.commons.lang3.RandomUtils;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class RecruiterScript extends Script {
+
+    @Inject
+    private Client client;
+    private ScheduledFuture<?> mainScheduledFuture;
+    private Set<String> recruitedPlayers = new HashSet<>(); // Track players we've already interacted with
+
+    @Inject
+    public RecruiterScript(Client client) {
+        this.client = client;
+        this.recruitedPlayers = new HashSet<>();  // Initialize it properly here too
+    }
+
+    private Player localPlayer;
+    private final WorldArea GEarea = new WorldArea(3153, 3478, 24, 23, 0);
+
+    public boolean run(RecruiterConfig config) {
+
+        Microbot.enableAutoRunOn = false;
+        localPlayer = client.getLocalPlayer(); // Access localPlayer here, not in the constructor
+
+        if (recruitedPlayers == null) {
+            recruitedPlayers = new HashSet<>();
+        }
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                // If "recruit" is disabled in config, skip execution
+                if (!config.recruit() && !config.sendMessage()) {
+                    System.out.println("No options selected");
+                    return;
+                }
+
+                if (client == null) {
+                    System.out.println("Client is null! Ensure proper injection.");
+                    return;
+                }
+
+                if (!Microbot.isLoggedIn()) {
+                    System.out.println("Not logged in");
+                    return;
+                }
+                if (config.recruit()) {
+                    checkAndReturnToGeArea();
+
+                    // Fetch all players in the local area
+                    List<Rs2PlayerModel> localPlayers = Rs2Player.getPlayers(p -> true).collect(Collectors.toList());
+                    System.out.println("Found " + localPlayers.size() + " players.");
+                    // Calculate and print the statistics
+                    int recruitedCount = recruitedPlayers.size();
+                    int foundInRecruited = (int) localPlayers.stream().filter(p -> recruitedPlayers.contains(p.getName())).count();
+                    int difference = localPlayers.size() - foundInRecruited;
+
+                    System.out.println("Total recruited players in HashSet: " + recruitedCount);
+                    System.out.println("Players found in both local and recruited sets: " + foundInRecruited);
+                    System.out.println("Difference in count between found players and recruited HashSet: " + difference);
+
+                    // Loop through all the players and attempt to recruit them (one player at a time)
+                    for (Rs2PlayerModel player : localPlayers) {
+                        if (player == null || player.getName() == null || recruitedPlayers.contains(player.getName())) {
+                            continue; // Skip invalid, null, or already recruited players
+                        }
+
+                        System.out.println("Processing player: " + player.getName());
+
+
+                        Rs2Camera.turnTo(player);
+
+                        sleep(1000);
+
+                        // Simulate hovering over the player
+                        moveMouseToPlayer(player);
+
+                        // Find the "Recruit" action in the right-click menu
+                        MenuAction menuAction = findRecruitAction();
+
+                        // If the "Recruit" option is available, invoke it
+                        if (menuAction != null) {
+                            // Create a new menu entry for the "Recruit" action
+                            NewMenuEntry recruitMenuEntry = new NewMenuEntry(
+                                    "Recruit",                // The action name (Recruit)
+                                    player.getName(),          // The player's name
+                                    player.getId(),            // The player's identifier
+                                    MenuAction.of(menuAction.getId()),        // The MenuAction ID (PLAYER_FIFTH_OPTION for Recruit)
+                                    0,                         // param0 (set to 0 as seen in the menu entry data)
+                                    0,                         // param1 (set to 0 as seen in the menu entry data)
+                                    false                      // forceLeftClick (false, since it's not forced left-click)
+                            );
+
+                            // Set this menu entry as the target menu in Microbot
+                            Microbot.targetMenu = recruitMenuEntry;
+
+                            // Invoke the "Recruit" action programmatically
+                            Microbot.doInvoke(recruitMenuEntry, player.getCanvasTilePoly().getBounds());
+                            System.out.println("Invoked 'Recruit' on player: " + player.getName());
+
+                            System.out.println("the sleep before pressing 1");
+                            inviteToClanWithRetry(player.getName());
+
+                            // Add the player to the recruited list to avoid interacting with them again
+                            recruitedPlayers.add(player.getName());
+                        }
+
+                        final Random random = new Random();
+
+                        System.out.println("entering loop sleep");
+                        if (random.nextInt(5) == 0) {
+                            if (config.sendMessage()) {
+                                sleep(5000);
+                                sendMessage(config.customMessage());
+                                return;
+                            }
+                        }
+                        break; // Process only one player at a time, then wait for the next run
+                    }
+                }
+
+                if (config.sendMessage() && !config.recruit()){
+                    final Random random = new Random();
+
+                    System.out.println("entering loop sleep");
+                    if (random.nextInt(5) == 0) {
+                        if (config.sendMessage()) {
+                            sleep(5000);
+                            sendMessage(config.customMessage());
+                        }
+                    }
+                }
+
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }, 0, 1000, TimeUnit.MILLISECONDS); // Repeat every 2 seconds
+        return true;
+    }
+
+    private boolean isInGeArea() {
+        // Check if player is in the defined monk area
+        return GEarea.contains(localPlayer.getWorldLocation());
+    }
+
+    public void checkAndReturnToGeArea() {
+        // If player is outside the GE area, select a random point within it to walk back
+        if (!isInGeArea()) {
+            WorldPoint randomPoint = getRandomPointInGeArea();
+            Rs2Walker.walkTo(randomPoint);
+        }
+    }
+
+    private final Random random = new Random();
+
+    private WorldPoint getRandomPointInGeArea() {
+        int x = GEarea.getX() + random.nextInt(GEarea.getWidth());
+        int y = GEarea.getY() + random.nextInt(GEarea.getHeight());
+        return new WorldPoint(x, y, GEarea.getPlane());
+    }
+
+    public void sendMessage(String message) {
+
+            System.out.println("Sending message: " + message);
+
+            // Type the message in the chatbox
+            Rs2Keyboard.typeString(message);
+
+            // Press Enter to send the message
+            Rs2Keyboard.enter();
+
+            sleep(1000);
+        }
+
+    public void inviteToClanWithRetry(String playerName) {
+        for (int attempt = 0; attempt < 3; attempt++) {
+            sleep(600);
+
+            boolean clicked = inviteToClan(playerName); // Call method and check result
+            if (clicked) {
+                System.out.println("Successfully clicked 'Invite to join the clan' for " + playerName);
+                break; // Exit loop on success
+            } else {
+                sleep(1000, 1500);
+                System.out.println("Attempt " + (attempt + 1) + " failed to click 'Invite to join the clan' for " + playerName);
+            }
+        }
+    }
+
+
+    public boolean inviteToClan(String playerName) {
+        CompletableFuture<Boolean> resultFuture = new CompletableFuture<>();
+
+        Microbot.getClientThread().invoke(() -> {
+            System.out.println("Attempting to click 'Invite to join the clan' for player: " + playerName);
+
+            // Construct the full widget text with the player name included
+            String inviteText = "Invite " + playerName + " to join the clan.";
+
+            // Use Rs2Widget to find and click the widget with this text
+            boolean clicked = Rs2Widget.clickWidget(inviteText);
+
+            if (clicked) {
+                System.out.println("Successfully clicked 'Invite to join the clan' for " + playerName);
+            } else {
+                System.out.println("Failed to click 'Invite to join the clan' for " + playerName);
+            }
+
+            resultFuture.complete(clicked); // Complete the future with the result
+        });
+
+        try {
+            return resultFuture.get(); // Wait for and return the result
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Simulates hovering the mouse over the player to trigger menu population.
+     */
+    private void moveMouseToPlayer(Player player) {
+        if (player == null) {
+            return;
+        }
+
+        // Get the player's bounding box (canvas tile poly)
+        Shape playerBounds = player.getCanvasTilePoly();
+        if (playerBounds != null) {
+            Rectangle playerRectangle = playerBounds.getBounds();
+            Point randomPoint = getRandomPointInRectangle(playerRectangle); // Get a random point within the player's bounds
+
+            // Move the mouse to this point (hover)
+            if (randomPoint != null) {
+                System.out.println("Hovering over player: " + player.getName());
+                Microbot.getMouse().move(randomPoint.getX(), randomPoint.getY());
+                sleep(500); // Small delay to allow the menu to populate
+            }
+        }
+    }
+
+    /**
+     * Generates a random point within a rectangle for mouse hover.
+     */
+    private Point getRandomPointInRectangle(Rectangle rectangle) {
+        int x = rectangle.x + RandomUtils.nextInt(0, rectangle.width);
+        int y = rectangle.y + RandomUtils.nextInt(0, rectangle.height);
+        return new Point(x, y);
+    }
+
+    /**
+     * Attempts to find the "Recruit" action in the player's right-click menu.
+     * This returns the MenuAction corresponding to the "Recruit" option.
+     */
+    private MenuAction findRecruitAction() {
+        MenuEntry[] menuEntries = Microbot.getClient().getMenuEntries();
+        for (MenuEntry entry : menuEntries) {
+            if ("Recruit".equals(entry.getOption())) {
+                return entry.getType(); // Return the MenuAction if "Recruit" is found
+            }
+        }
+        return null; // Return null if the "Recruit" option is not found
+    }
+
+    @Override
+    public void shutdown() {
+        if (mainScheduledFuture != null && !mainScheduledFuture.isCancelled()) {
+            mainScheduledFuture.cancel(true);
+        }
+        System.out.println("Script shutdown");
+    }
+}


### PR DESCRIPTION
### Auto-Typer and Clan Recruitment Automator 

1. This plugin will invite players to your clan, if clan vexilium is equipped and you are in a clan. It will invite everyone systematically and send a custom message also (if you want it to).
2. Clan recruiter keeps track of players it has invited, so to not invite them again.
3. This plugin can also send a custom message without clan invitation for inviting people to a friends chat for example or for simple advertising/spamming.