### PR TITLE
drop alch items that are not the current alch target in mage training…

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magetrainingarena/MageTrainingArenaScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magetrainingarena/MageTrainingArenaScript.java
@@ -518,6 +518,8 @@ public class MageTrainingArenaScript extends Script {
         if (item != null) {
             Rs2Magic.alch(item);
             return;
+        }else {
+            Rs2Inventory.dropAll(6897,6896,6895,6894,6893);
         }
 
         var timer = (AlchemyRoomTimer) Microbot.getInfoBoxManager().getInfoBoxes().stream()


### PR DESCRIPTION
… arena

this prevents the inventory from filling up with the other items. If no target item is found, the script now drops all of the 5 alch items from the inventory