### PR TITLE
improves efficiency in firemaking in woodcutter plugin when cannot burn log

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingPlugin.java
@@ -57,7 +57,6 @@ public class AutoWoodcuttingPlugin extends Plugin {
             if (event.getType() == ChatMessageType.GAMEMESSAGE) {
                 String message = event.getMessage().toLowerCase();
                 if (message.equals("you can't light a fire here.")){
-            Microbot.log("you cannot light a fire here message recieved");
             autoWoodcuttingScript.cannotLightFire = true;}
             }
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingPlugin.java
@@ -3,16 +3,12 @@ package net.runelite.client.plugins.microbot.woodcutting;
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
-import net.runelite.api.Client;
 import net.runelite.api.events.ChatMessage;
-import net.runelite.client.Notifier;
-import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.Microbot;
-import net.runelite.client.plugins.microbot.util.mouse.VirtualMouse;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
@@ -57,9 +53,12 @@ public class AutoWoodcuttingPlugin extends Plugin {
     }
 
     @Subscribe
-    public void onChatMessage(ChatMessage chatMessage) {
-        if (chatMessage.getType() == ChatMessageType.GAMEMESSAGE && chatMessage.getMessage().toLowerCase().contains("you can't light a fire here.")) {
-            autoWoodcuttingScript.cannotLightFire = true;
+    public void onChatMessage(ChatMessage event) {
+            if (event.getType() == ChatMessageType.GAMEMESSAGE) {
+                String message = event.getMessage().toLowerCase();
+                if (message.equals("you can't light a fire here.")){
+            Microbot.log("you cannot light a fire here message recieved");
+            autoWoodcuttingScript.cannotLightFire = true;}
+            }
         }
     }
-}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingScript.java
@@ -202,7 +202,9 @@ public class AutoWoodcuttingScript extends Script {
                 Rs2Inventory.useLast(config.TREE().getLogID());
             }, 300, 100);
         }
-        sleepUntil(() -> (!isFiremake() && Rs2Player.waitForXpDrop(Skill.FIREMAKING)) || cannotLightFire, 5000);
+        sleepUntil(() -> !isFiremake());
+        if (!isFiremake()) {sleepUntil(() -> cannotLightFire, 1500);}
+        if (!cannotLightFire && isFiremake()) {sleepUntil(() -> Rs2Player.waitForXpDrop(Skill.FIREMAKING, 40000), 40000);}
     }
 
     private WorldPoint fireSpot(int distance) {
@@ -231,6 +233,7 @@ public class AutoWoodcuttingScript extends Script {
     }
 
     private boolean isFiremake() {
+        if (cannotLightFire) return false;
         return Rs2Player.isAnimating(1800) && Rs2Player.getLastAnimationID() == AnimationID.FIREMAKING;
     }
     


### PR DESCRIPTION
I noticed that it would always hit the 5 second timeout when it received the "cannot light fire here" message and so I made these changes and noticed improvements in recovery.