### PR TITLE
Moss Killer Wildy Updates

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/EquipmentIdentifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/EquipmentIdentifier.java
@@ -1,0 +1,223 @@
+package net.runelite.client.plugins.microbot.bee;
+
+import net.runelite.client.plugins.microbot.util.player.Rs2PlayerModel;
+
+import static net.runelite.api.ItemID.*;
+import static net.runelite.api.ItemID.BLACK_PLATELEGS_G;
+import static net.runelite.api.gameval.ItemID.*;
+import static net.runelite.api.gameval.ItemID.ADAMANT_FULL_HELM;
+import static net.runelite.api.gameval.ItemID.ADAMANT_PLATEBODY;
+import static net.runelite.api.gameval.ItemID.ADAMANT_PLATEBODY_H1;
+import static net.runelite.api.gameval.ItemID.ADAMANT_PLATEBODY_H2;
+import static net.runelite.api.gameval.ItemID.ADAMANT_PLATEBODY_H3;
+import static net.runelite.api.gameval.ItemID.ADAMANT_PLATEBODY_H4;
+import static net.runelite.api.gameval.ItemID.ADAMANT_PLATEBODY_H5;
+import static net.runelite.api.gameval.ItemID.ADAMANT_PLATELEGS;
+import static net.runelite.api.gameval.ItemID.BLACK_FULL_HELM;
+import static net.runelite.api.gameval.ItemID.BLACK_PLATEBODY;
+import static net.runelite.api.gameval.ItemID.BLACK_PLATEBODY_H1;
+import static net.runelite.api.gameval.ItemID.BLACK_PLATEBODY_H2;
+import static net.runelite.api.gameval.ItemID.BLACK_PLATEBODY_H3;
+import static net.runelite.api.gameval.ItemID.BLACK_PLATEBODY_H4;
+import static net.runelite.api.gameval.ItemID.BLACK_PLATEBODY_H5;
+import static net.runelite.api.gameval.ItemID.BLACK_PLATELEGS;
+import static net.runelite.api.gameval.ItemID.MITHRIL_FULL_HELM;
+import static net.runelite.api.gameval.ItemID.MITHRIL_PLATEBODY;
+import static net.runelite.api.gameval.ItemID.MITHRIL_PLATELEGS;
+
+public class EquipmentIdentifier {
+
+    public static boolean isWearingRuneArmor (Rs2PlayerModel player){
+        int[] equipmentIds = player.getPlayerComposition().getEquipmentIds();
+        if (equipmentIds == null) {
+            return false;
+        }
+
+        // Initialize a counter for melee gear
+        int meleeGearCount = 0;
+
+        // Full helms (Rune, Gilded, God)
+        if (equipmentIds[0] == 3211 ||  // Rune full helm
+                equipmentIds[0] == 4667 ||  // Rune full helm (g)
+                equipmentIds[0] == 4675 ||  // Rune full helm (t)
+                equipmentIds[0] == 4705 ||  // Zamorak full helm
+                equipmentIds[0] == 4721 ||  // Guthix full helm
+                equipmentIds[0] == 4713 ||  // Saradomin full helm
+                equipmentIds[0] == 14534 ||  // Bandos full helm
+                equipmentIds[0] == 14524 ||  // Armadyl full helm
+                equipmentIds[0] == 14514 ||  // Ancients full helm
+                equipmentIds[0] == 12334 ||  // Rune helm (h1)
+                equipmentIds[0] == 12336 ||  // Rune helm (h2)
+                equipmentIds[0] == 12338 ||  // Rune helm (h3)
+                equipmentIds[0] == 12340 ||  // Rune helm (h4)
+                equipmentIds[0] == 12342 ||  // Rune helm (h5)
+                equipmentIds[0] == 5534 || // Gilded full helm
+                equipmentIds[0] == ADAMANT_FULL_HELM ||
+                equipmentIds[0] == ADAMANT_FULL_HELM_GOLD ||
+                equipmentIds[0] == ADAMANT_FULL_HELM_TRIM ||
+                equipmentIds[0] == ADAMANT_HELM_H1 ||
+                equipmentIds[0] == ADAMANT_HELM_H2 ||
+                equipmentIds[0] == ADAMANT_HELM_H3 ||
+                equipmentIds[0] == ADAMANT_HELM_H4 ||
+                equipmentIds[0] == ADAMANT_HELM_H5 ||
+                equipmentIds[0] == BLACK_HELM_H1 ||
+                equipmentIds[0] == BLACK_HELM_H2 ||
+                equipmentIds[0] == BLACK_HELM_H3 ||
+                equipmentIds[0] == BLACK_HELM_H4 ||
+                equipmentIds[0] == BLACK_HELM_H5 ||
+                equipmentIds[0] == MITHRIL_FULL_HELM ||
+                equipmentIds[0] == MITHRIL_FULL_HELM_T ||
+                equipmentIds[0] == MITHRIL_FULL_HELM_G ||
+                equipmentIds[0] == BLACK_FULL_HELM ||
+                equipmentIds[0] == BLACK_FULL_HELM_G ||
+                equipmentIds[0] == BLACK_FULL_HELM_T) {
+
+            meleeGearCount++;
+        }
+
+        // Bodies (Rune, Gilded, God, Chainbody)
+        if (equipmentIds[4] == 3175 ||  // Rune platebody
+                equipmentIds[4] == 4663 ||  // Rune platebody (g)
+                equipmentIds[4] == 4671 ||  // Rune platebody (t)
+                equipmentIds[4] == 4701 ||  // Zamorak platebody
+                equipmentIds[4] == 4717 ||  // Guthix platebody
+                equipmentIds[4] == 4709 ||  // Saradomin platebody
+                equipmentIds[4] == 14528 ||  // Bandos platebody
+                equipmentIds[4] == 14518 ||  // Armadyl platebody
+                equipmentIds[4] == 14508 ||  // Ancients platebody
+                equipmentIds[4] == 5529 ||  // Gilded platebody
+                equipmentIds[4] == 22197 ||
+                equipmentIds[4] == ADAMANT_PLATEBODY ||
+                equipmentIds[4] == ADAMANT_PLATEBODY_G ||
+                equipmentIds[4] == ADAMANT_PLATEBODY_T ||
+                equipmentIds[4] == ADAMANT_PLATEBODY_H1 ||
+                equipmentIds[4] == ADAMANT_PLATEBODY_H2 ||
+                equipmentIds[4] == ADAMANT_PLATEBODY_H3 ||
+                equipmentIds[4] == ADAMANT_PLATEBODY_H4 ||
+                equipmentIds[4] == ADAMANT_PLATEBODY_H5 ||
+                equipmentIds[4] == BLACK_PLATEBODY ||
+                equipmentIds[4] == BLACK_PLATEBODY_T ||
+                equipmentIds[4] == BLACK_PLATEBODY_G ||
+                equipmentIds[4] == BLACK_PLATEBODY_H1 ||
+                equipmentIds[4] == BLACK_PLATEBODY_H2 ||
+                equipmentIds[4] == BLACK_PLATEBODY_H3 ||
+                equipmentIds[4] == BLACK_PLATEBODY_H4 ||
+                equipmentIds[4] == BLACK_PLATEBODY_H5 ||
+                equipmentIds[4] == MITHRIL_PLATEBODY ||
+                equipmentIds[4] == MITHRIL_PLATEBODY_T ||
+                equipmentIds[4] == MITHRIL_PLATEBODY_G) {  // Gilded chainbody
+            meleeGearCount++;
+        }
+
+        // Legs/Skirts (Rune, Gilded, God)
+        if (equipmentIds[7] == 3127 ||  // Rune platelegs
+                equipmentIds[7] == 4665 ||  // Rune platelegs (g)
+                equipmentIds[7] == 4673 ||  // Rune platelegs (t)
+                equipmentIds[7] == 4703 ||  // Zamorak platelegs
+                equipmentIds[7] == 4719 ||  // Guthix platelegs
+                equipmentIds[7] == 4711 ||  // Saradomin platelegs
+                equipmentIds[7] == 14530 ||  // Bandos platelegs
+                equipmentIds[7] == 14520 ||  // Armadyl platelegs
+                equipmentIds[7] == 14510 ||  // Ancients platelegs
+                equipmentIds[7] == 5531 || // gilded platelegs
+                equipmentIds[7] == 5524 ||  // Rune plateskirt (g)
+                equipmentIds[7] == 5533 ||  // Gilded plateskirt
+                equipmentIds[7] == 5525 ||  // Trimmed plateskirt
+                equipmentIds[7] == 5526 ||  // Zamorak plateskirt
+                equipmentIds[7] == 5527 ||  // Saradomin plateskirt
+                equipmentIds[7] == 5528 ||  // Guthix plateskirt
+                equipmentIds[7] == 14532 ||  // Bandos plateskirt
+                equipmentIds[7] == 14522 ||  // Armadyl plateskirt
+                equipmentIds[7] == 14512 ||
+                equipmentIds[7] == ADAMANT_PLATELEGS ||
+                equipmentIds[7] == ADAMANT_PLATELEGS_G ||
+                equipmentIds[7] == ADAMANT_PLATELEGS_T ||
+                equipmentIds[7] == MITHRIL_PLATELEGS ||
+                equipmentIds[7] == MITHRIL_PLATELEGS_T ||
+                equipmentIds[7] == MITHRIL_PLATELEGS_G ||
+                equipmentIds[7] == BLACK_PLATELEGS ||
+                equipmentIds[7] == BLACK_PLATELEGS_T ||
+                equipmentIds[7] == BLACK_PLATELEGS_G) {  // Ancients plateskirt
+            meleeGearCount++;
+        }
+
+        // If the player is wearing at least 2 pieces of melee gear, classify them as wearing melee armor
+        return meleeGearCount >= 2;
+    }
+
+    public static boolean isWearingGreenDhide (Rs2PlayerModel player){
+        int[] equipmentIds = player.getPlayerComposition().getEquipmentIds();
+        if (equipmentIds == null) {
+            return false;
+        }
+
+        // Check against the correct Green D'hide armor IDs, including gilded and (g) variants
+        return equipmentIds[4] == 3183 ||  // Green d'hide body
+                equipmentIds[4] == 25312 ||  // Gilded d'hide body
+                equipmentIds[4] == 9418 ||  // Green d'hide body (g)
+                equipmentIds[7] == 3147 ||  // Green d'hide chaps
+                equipmentIds[7] == 25315 ||  // Gilded d'hide chaps
+                equipmentIds[7] == 9426;    // Green d'hide chaps (g)
+    }
+
+    public static boolean isWizard (Rs2PlayerModel player){
+        int[] equipmentIds = player.getPlayerComposition().getEquipmentIds();
+        if (equipmentIds == null) {
+            return false;
+        }
+
+        // Check if the player is wearing Rune armor or a shield
+        if (isWearingRuneArmor(player)) {
+            return false; // Not a wizard if wearing Rune armor
+        }
+
+        // Count the number of mage-related equipment pieces the player is wearing
+        int mageGearCount = 0;
+
+        // Headgear
+        if (equipmentIds[0] == 2627 ||  // Blue Wizard hat
+                equipmentIds[0] == 3065 ||  // Black wizard hat
+                equipmentIds[0] == 9442 ||  // Blue wizard hat (g)
+                equipmentIds[0] == 9444 ||  // Blue wizard hat (t)
+                equipmentIds[0] == 14502 ||  // Black wizard hat (g)
+                equipmentIds[0] == 14503) {  // Black wizard hat (t)
+            mageGearCount++;
+        }
+
+        // Weapons (staves)
+        if (equipmentIds[3] == 3435 ||  // Staff of fire
+                equipmentIds[3] == 3433 ||  // Staff of earth
+                equipmentIds[3] == 3429 ||  // Staff of air
+                equipmentIds[3] == 3431 ||  // Staff of water
+                equipmentIds[3] == 24418) { // Bryophyta staff
+            mageGearCount++;
+        }
+
+        // Shields (Mage shields or Sq shields)
+        if (equipmentIds[5] == 3233 ||  // Rune sq shield
+                equipmentIds[5] == 22200) {  // Gilded sq shield
+            mageGearCount++;
+        }
+
+        // Robes and skirts (including trimmed and gilded versions)
+        if (equipmentIds[4] == 3081 ||  // Zamorak robe bottom
+                equipmentIds[4] == 2626 ||  // Blue wizard robe
+                equipmentIds[4] == 2629 ||  // Zamorak robe top
+                equipmentIds[4] == 2875 ||  // Black robe
+                equipmentIds[4] == 9438 ||  // Blue wizard robe (g)
+                equipmentIds[4] == 9440 ||  // Blue wizard robe (t)
+                equipmentIds[4] == 14497 ||  // Black wizard robe (g)
+                equipmentIds[4] == 14499 ||  // Black wizard robe (t)
+                equipmentIds[7] == 3059 ||  // Blue skirt
+                equipmentIds[7] == 3063 ||  // Black skirt
+                equipmentIds[7] == 9434 ||  // Blue skirt (g)
+                equipmentIds[7] == 9436 ||  // Blue skirt (t)
+                equipmentIds[7] == 14493 ||  // Black skirt (g)
+                equipmentIds[7] == 14495) {  // Black skirt (t)
+            mageGearCount++;
+        }
+
+        // If the player is wearing at least 2 pieces of mage gear, classify them as a wizard
+        return mageGearCount >= 2;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -8,6 +8,7 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.bee.EquipmentIdentifier;
 import net.runelite.client.plugins.microbot.bee.MossKiller.Enums.CombatMode;
 import net.runelite.client.plugins.microbot.bee.MossKiller.Enums.MossKillerState;
 import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
@@ -803,7 +804,7 @@ public class WildyKillerScript extends Script {
                 && target.getOverheadIcon() == null
                 && !MossKillerPlugin.isPlayerSnared()) {
 
-            if (hasPlayerEquippedItem(target, RUNE_PLATEBODY) && Rs2Inventory.contains(DEATH_RUNE)) {
+            if (EquipmentIdentifier.isWearingRuneArmor(target) && Rs2Inventory.contains(DEATH_RUNE)) {
                 castWindBlast(target);
                 sleep(600);
             }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -2,6 +2,7 @@ package net.runelite.client.plugins.microbot.bee.MossKiller;
 
 import net.runelite.api.Client;
 import net.runelite.api.Player;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
@@ -98,6 +99,10 @@ public class WildySaferScript extends Script {
                 if (mossKillerPlugin.preparingForShutdown) {
                     MossKillerScript.prepareSoftStop();}
 
+                if (Rs2Inventory.contains(MOSSY_KEY)) {
+                    doBankingLogic();
+                }
+
                 //if you're at moss giants and your inventory is not prepared, prepare inventory
                 if (isInMossGiantArea() && !isInventoryPreparedMage()) {
                     if (config.attackStyle() == MAGIC) {doBankingLogic();}
@@ -168,9 +173,6 @@ public class WildySaferScript extends Script {
                 }
 
                 Rs2Player.eatAt(70);
-                if (Rs2Inventory.contains(MOSSY_KEY)) {
-                    doBankingLogic();
-                }
 
                 // if at the safe spot attack the moss giant and run to the safespot
                 if (isAtSafeSpot() && !Rs2Player.isInteracting() && desired2093Exists()) {
@@ -505,16 +507,6 @@ public class WildySaferScript extends Script {
             }
         }
 
-
-        if (config.attackStyle() == MAGIC && !Rs2Bank.isOpen()) {
-
-            Rs2Bank.walkToBank();
-            Rs2Bank.walkToBankAndUseBank();
-            sleep(1000);
-            return;
-        }
-
-
         if (config.attackStyle() == RANGE && !Rs2Bank.isOpen()) {
             Rs2Bank.walkToBank();
             Rs2Bank.walkToBankAndUseBank();
@@ -531,26 +523,28 @@ public class WildySaferScript extends Script {
         }
         }
         if (config.attackStyle() == MAGIC) {
-            Rs2Bank.walkToBank();
-            Rs2Bank.walkToBankAndUseBank();
-            sleepUntil(Rs2Bank::isOpen, 15000);
             if (!Rs2Bank.isOpen()) {
-                Rs2Bank.openBank();
-                System.out.println("called to open bank twice");
-                sleepUntil(Rs2Bank::isOpen);
-            }// Check if required consumables exist in the bank with the correct amounts
-            if (Rs2Bank.isOpen() && Rs2Bank.count(APPLE_PIE) < 16 ||
-                    Rs2Bank.count(MIND_RUNE) < 750 ||
-                    Rs2Bank.count(AIR_RUNE) < 1550 ||
-                    !Rs2Bank.hasItem(STAFF_OF_FIRE)) {
+                Rs2Bank.walkToBank();
+                Rs2Bank.walkToBankAndUseBank();
+                sleepUntil(Rs2Bank::isOpen, 15000);
+                if (!Rs2Bank.isOpen()) {
+                    Rs2Bank.openBank();
+                    System.out.println("called to open bank twice");
+                    sleepUntil(Rs2Bank::isOpen);
+                }// Check if required consumables exist in the bank with the correct amounts
+                if (Rs2Bank.isOpen() && Rs2Bank.count(APPLE_PIE) < 16 ||
+                        Rs2Bank.count(MIND_RUNE) < 750 ||
+                        Rs2Bank.count(AIR_RUNE) < 1550 ||
+                        !Rs2Bank.hasItem(STAFF_OF_FIRE)) {
 
-                Microbot.log("Missing required consumables in the bank. Shutting down script.");
-                shutdown(); // Stop script
-                return;
+                    Microbot.log("Missing required consumables in the bank. Shutting down script.");
+                    shutdown(); // Stop script
+                    return;
+                }
             }
         }
 
-        // Deposit all items
+        sleepUntil(Rs2Bank::isOpen);
         Rs2Bank.depositAll();
         sleep(600);
 
@@ -561,8 +555,6 @@ public class WildySaferScript extends Script {
             Rs2Bank.withdrawX(MIND_RUNE, 750);
             sleep(300);
             Rs2Bank.withdrawX(AIR_RUNE, 1550);
-            sleep(300);
-            Rs2Bank.withdrawX(LAW_RUNE, 6);
             sleep(300);
 
             // Check if equipped with necessary items
@@ -585,6 +577,7 @@ public class WildySaferScript extends Script {
                 OutfitHelper.equipOutfit(OutfitHelper.OutfitType.NAKED_MAGE);
                 Rs2Bank.withdrawAndEquip(STAFF_OF_FIRE);
                 Rs2Bank.withdrawAndEquip(capeId);
+                sleep(600,900);
             }
         }
 
@@ -616,18 +609,16 @@ public class WildySaferScript extends Script {
                 }
             }
 
-        Rs2Bank.withdrawX(MITHRIL_ARROW, config.mithrilArrowAmount());
-        sleep(400,800);
-        Rs2Inventory.equip(MITHRIL_ARROW);
-        sleep(300);
+            Rs2Bank.withdrawX(MITHRIL_ARROW, config.mithrilArrowAmount());
+            sleep(400,800);
+            Rs2Inventory.equip(MITHRIL_ARROW);
+            sleep(300);
 
         }
 
+        if (config.alchLoot() && Rs2Player.getRealSkillLevel(Skill.MAGIC) > 54) {Rs2Bank.withdrawX(NATURE_RUNE, 10);
+            if (config.attackStyle() == RANGE && Rs2Player.getRealSkillLevel(Skill.MAGIC) > 54) Rs2Bank.withdrawX(FIRE_RUNE,50);}
 
-        if (config.alchLoot()) {Rs2Bank.withdrawX(NATURE_RUNE, 10);
-            if (config.attackStyle() == RANGE) Rs2Bank.withdrawX(FIRE_RUNE,50);}
-
-    
         if (Microbot.getClient().getRealSkillLevel(WOODCUTTING) > 56 && Rs2Player.getWorldLocation().getY() < 3520) {
             Rs2Bank.withdrawOne("axe", false);
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -512,6 +512,7 @@ public class WildySaferScript extends Script {
             Rs2Bank.walkToBankAndUseBank();
             sleep(800,1900);
             if (Rs2Bank.openBank()){
+                if (Rs2Bank.isOpen()) {
                 sleep(2200,3200); if (Rs2Bank.count(APPLE_PIE) < 16 ||
                     Rs2Bank.count(MITHRIL_ARROW) < config.mithrilArrowAmount() ||
                     !Rs2Bank.hasItem(MAPLE_SHORTBOW)) {
@@ -521,6 +522,7 @@ public class WildySaferScript extends Script {
                 return;
             }
         }
+            }
         }
         if (config.attackStyle() == MAGIC) {
             if (!Rs2Bank.isOpen()) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -291,7 +291,7 @@ public class WildySaferScript extends Script {
     }
 
     private void playersCheck() {
-        if(!mossKillerScript.getNearbyPlayers(7).isEmpty()){
+        if(!mossKillerScript.getNearbyPlayers(14).isEmpty()){
 
             if(playerCounter > 15) {
                 sleep(10000, 15000);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarScript.java
@@ -54,7 +54,7 @@ public class ChaosAltarScript extends Script {
 
                 // Determine current state
                 currentState = determineState();
-                System.out.println("Current state: " + currentState);
+                Microbot.log("Current state: " + currentState);
 
                 // Execute state action
                 switch (currentState) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/chaosaltar/ChaosAltarScript.java
@@ -54,7 +54,7 @@ public class ChaosAltarScript extends Script {
 
                 // Determine current state
                 currentState = determineState();
-                Microbot.log("Current state: " + currentState);
+                System.out.println("Current state: " + currentState);
 
                 // Execute state action
                 switch (currentState) {


### PR DESCRIPTION
- Adds class 'equipment identifier' to rapidly determine equipment of an rs2playermodel if they are an archer, mage or rune armour wearer (comprehensive (f2p)).
- Uses equipment identifier class to determine if attacker is a meleer in Wildy Killer Script (_to do: add for determining a mager in order to use range against a mager instead of splashing wind blast (even if wind blast has higher max hit)_
- Organises banking better in wildy safer script + adds an extra banking check 
- Increases distance when locating players in order to hop (not player monitor related, just when competing with other players for moss giants) in Wildy Safer Script 