### PR TITLE
Wildy Killer & Wildy Safer updates

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
@@ -192,17 +192,19 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
 
         String name = currentTarget.getName();
 
-        for (Player p : Microbot.getClient().getPlayers()) {
-            if (p != null && p.getName() != null && p.getName().equals(name)) {
-                // Replace stale reference with a fresh one
-                currentTarget = new Rs2PlayerModel(p);
-                Microbot.log("Refreshed target reference for: " + name);
-                return;
-            }
-        }
+        // Use Rs2Player.getPlayers with a predicate to match the name
+        Optional<Rs2PlayerModel> updatedTarget = Rs2Player.getPlayers(
+                p -> p.getName() != null && p.getName().equals(name)
+        ).findFirst();
 
-        Microbot.log("Target " + name + " not found in current player list.");
+        if (updatedTarget.isPresent()) {
+            currentTarget = updatedTarget.get();
+            Microbot.log("Refreshed target reference for: " + name);
+        } else {
+            Microbot.log("Target " + name + " not found in current player list.");
+        }
     }
+
 
     @Subscribe
     public void onGameStateChanged(GameStateChanged event) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
@@ -185,6 +185,23 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
 
     }
 
+    public void updateTargetByName() {
+        if (currentTarget == null || currentTarget.getPlayer() == null) return;
+
+        String name = currentTarget.getName();
+
+        for (Player p : Microbot.getClient().getPlayers()) {
+            if (p != null && p.getName() != null && p.getName().equals(name)) {
+                // Replace stale reference with a fresh one
+                currentTarget = new Rs2PlayerModel(p);
+                Microbot.log("Refreshed target reference for: " + name);
+                return;
+            }
+        }
+
+        Microbot.log("Target " + name + " not found in current player list.");
+    }
+
     @Subscribe
     public void onVarbitChanged(VarbitChanged event) {
         if (config.wildy()) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static net.runelite.api.EquipmentInventorySlot.WEAPON;
@@ -58,6 +59,7 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
 
     @Inject
     private Client client;
+    private ScheduledFuture<?> mainScheduledFuture;
     @Inject
     private OverlayManager overlayManager;
     @Inject
@@ -200,6 +202,16 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
         }
 
         Microbot.log("Target " + name + " not found in current player list.");
+    }
+
+    @Subscribe
+    public void onGameStateChanged(GameStateChanged event) {
+        if (event.getGameState() == GameState.LOGGED_IN && config.wildySafer()) {
+            if (mainScheduledFuture == null || mainScheduledFuture.isCancelled() || mainScheduledFuture.isDone()) {
+                Microbot.log("GameState is LOGGED_IN and script was idle. Restarting run loop...");
+                wildySaferScript.run(config); // Or call your safe wrapper to resume the script
+            }
+        }
     }
 
     @Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
@@ -150,8 +150,15 @@ public class MossKillerScript extends Script {
         Rs2Antiban.setActivityIntensity(LOW);
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                if (!Microbot.isLoggedIn()) return;
-                if (!super.run()) return;
+                if (!Microbot.isLoggedIn()) {
+                    Microbot.log("Not logged in, skipping tick.");
+                    return;}
+                if (!super.run()) {Microbot.log("super.run() returned false, skipping tick.");
+                    return;}
+                if (Microbot.getClient() == null || Microbot.getClient().getLocalPlayer() == null) {
+                    Microbot.log("Client or local player not ready. Skipping tick.");
+                    return;
+                }
                 long startTime = System.currentTimeMillis();
 
                 if(!isStarted){

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -765,34 +765,60 @@ public class WildyKillerScript extends Script {
         boolean useRange = mossKillerPlugin.useRange();
 
         if (!isInMulti()) {
-            if (Rs2Player.getRealSkillLevel(PRAYER) > 39) {
-                Rs2Prayer.toggle(PROTECT_RANGE, hasPlayerEquippedItem(target, MAPLE_SHORTBOW)
-                        || hasPlayerEquippedItem(target, WILLOW_SHORTBOW)
-                        || hasPlayerEquippedItem(target, OAK_SHORTBOW)
-                        || hasPlayerEquippedItem(target, MAPLE_LONGBOW)
-                        || hasPlayerEquippedItem(target, WILLOW_LONGBOW)
-                        || hasPlayerEquippedItem(target, LONGBOW)
-                        || hasPlayerEquippedItem(target, SHORTBOW)
-                        || hasPlayerEquippedItem(target, OAK_LONGBOW));
-            }
+            if (mossKillerPlugin.currentTarget != null) {
+                mossKillerPlugin.updateTargetByName();
+                boolean shouldProtectFromMagic =
+                        hasPlayerEquippedItem(mossKillerPlugin.currentTarget, STAFF_OF_FIRE)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, STAFF_OF_AIR)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, STAFF_OF_WATER)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, STAFF_OF_EARTH)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, BRYOPHYTAS_STAFF)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, BRYOPHYTAS_STAFF_UNCHARGED);
+                boolean shouldProtectFromRange =
+                        hasPlayerEquippedItem(mossKillerPlugin.currentTarget, MAPLE_SHORTBOW)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, WILLOW_SHORTBOW)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, OAK_SHORTBOW)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, MAPLE_LONGBOW)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, WILLOW_LONGBOW)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, LONGBOW)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, SHORTBOW)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, OAK_LONGBOW);
+                boolean shouldProtectFromMelee =
+                        hasPlayerEquippedItem(mossKillerPlugin.currentTarget, RUNE_SCIMITAR)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, RUNE_WARHAMMER)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, RUNE_2H_SWORD)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, RUNE_BATTLEAXE)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, RUNE_SWORD)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, BARRONITE_MACE)
+                                || hasPlayerEquippedItem(mossKillerPlugin.currentTarget, RUNE_MACE);
+                // 🏹 Protect from Range
+                if (shouldProtectFromRange && Rs2Player.getRealSkillLevel(PRAYER) > 39 && Rs2Player.getBoostedSkillLevel(PRAYER) > 0) {
 
-            if (Rs2Player.getRealSkillLevel(PRAYER) > 36) {
-                Rs2Prayer.toggle(PROTECT_MAGIC, hasPlayerEquippedItem(target, STAFF_OF_FIRE)
-                        || hasPlayerEquippedItem(target, STAFF_OF_AIR)
-                        || hasPlayerEquippedItem(target, STAFF_OF_WATER)
-                        || hasPlayerEquippedItem(target, STAFF_OF_EARTH)
-                        || hasPlayerEquippedItem(target, BRYOPHYTAS_STAFF)
-                        || hasPlayerEquippedItem(target, BRYOPHYTAS_STAFF_UNCHARGED));
-            }
 
-            if (Rs2Player.getRealSkillLevel(PRAYER) > 42) {
-                Rs2Prayer.toggle(PROTECT_MELEE, hasPlayerEquippedItem(target, RUNE_SCIMITAR)
-                        || hasPlayerEquippedItem(target, RUNE_WARHAMMER)
-                        || hasPlayerEquippedItem(target, RUNE_2H_SWORD)
-                        || hasPlayerEquippedItem(target, RUNE_BATTLEAXE)
-                        || hasPlayerEquippedItem(target, RUNE_SWORD)
-                        || hasPlayerEquippedItem(target, BARRONITE_MACE)
-                        || hasPlayerEquippedItem(target, RUNE_MACE));
+                    Microbot.log("Should Protect from Range: " + shouldProtectFromRange);
+                    if (Rs2Prayer.getActiveProtectionPrayer() == null){
+                        Rs2Prayer.toggle(PROTECT_RANGE);
+                    } else Rs2Prayer.swapOverHeadPrayer(PROTECT_RANGE);
+                }
+
+                // 🪄 Protect from Magic
+                if (shouldProtectFromMagic && Rs2Player.getRealSkillLevel(PRAYER) > 36 && Rs2Player.getBoostedSkillLevel(PRAYER) > 0) {
+
+
+                    Microbot.log("Should Protect from Magic: " + shouldProtectFromMagic);
+                    if (Rs2Prayer.getActiveProtectionPrayer() == null){
+                        Rs2Prayer.toggle(PROTECT_MAGIC);
+                    } else Rs2Prayer.swapOverHeadPrayer(PROTECT_MAGIC);
+                }
+
+                // ⚔️ Protect from Melee
+                if (shouldProtectFromMelee && Rs2Player.getRealSkillLevel(PRAYER) > 42 && Rs2Player.getBoostedSkillLevel(PRAYER) > 0) {
+
+                    Microbot.log("Should Protect from Melee: " + shouldProtectFromMelee);
+                    if (Rs2Prayer.getActiveProtectionPrayer() == null){
+                        Rs2Prayer.toggle(PROTECT_MELEE);
+                    } else Rs2Prayer.swapOverHeadPrayer(PROTECT_MELEE);
+                }
             }
         } else if (isInMulti()) {
             monitorAttacks();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -140,7 +140,10 @@ public class WildyKillerScript extends Script {
     }
 
     public boolean run(MossKillerConfig config) {
-        System.out.println("getting to run");
+        if (mainScheduledFuture != null && !mainScheduledFuture.isCancelled() && !mainScheduledFuture.isDone()) {
+            Microbot.log("Scheduled task already running.");
+            return false;
+        }
         WildyKillerScript.config = config;
         Microbot.enableAutoRunOn = false;
         Rs2Walker.disableTeleports = false;
@@ -163,8 +166,15 @@ public class WildyKillerScript extends Script {
 
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                if (!Microbot.isLoggedIn()) return;
-                if (!super.run()) return;
+                if (!Microbot.isLoggedIn()) {
+                    Microbot.log("Not logged in, skipping tick.");
+                    return;}
+                if (!super.run()) {Microbot.log("super.run() returned false, skipping tick.");
+                    return;}
+                if (Microbot.getClient() == null || Microbot.getClient().getLocalPlayer() == null) {
+                    Microbot.log("Client or local player not ready. Skipping tick.");
+                    return;
+                }
                 long startTime = System.currentTimeMillis();
 
                 Microbot.log("SoL " + state);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -1860,7 +1860,17 @@ public class WildyKillerScript extends Script {
                 Microbot.log("You're in the wilderness and I don't get the problem");
                 if (Rs2Equipment.isNaked()) {
                     state = MossKillerState.WALK_TO_BANK;
+                } else { Microbot.log("You've got equipment on, let's just reset inventory at ferox bank");
+                Rs2Bank.walkToBank(BankLocation.FEROX_ENCLAVE);
+                Rs2Bank.walkToBankAndUseBank(BankLocation.FEROX_ENCLAVE);
+                sleep(3000,6000);
+                if(!Rs2Bank.isOpen()) {
+                    Rs2Bank.openBank();
+                    sleep(2000,6000);
                 }
+                Rs2Bank.depositAll();
+                sleep(2000);
+            }
             }
             if (playerLocation.getY() < 3520) {
                 state = MossKillerState.WALK_TO_BANK;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -36,6 +36,7 @@ import static net.runelite.api.EquipmentInventorySlot.AMMO;
 import static net.runelite.api.EquipmentInventorySlot.WEAPON;
 import static net.runelite.api.ItemID.*;
 import static net.runelite.api.NpcID.MOSS_GIANT_2093;
+import static net.runelite.api.Skill.DEFENCE;
 import static net.runelite.client.plugins.microbot.bee.MossKiller.Enums.AttackStyle.MAGIC;
 import static net.runelite.client.plugins.microbot.bee.MossKiller.Enums.AttackStyle.RANGE;
 import static net.runelite.client.plugins.microbot.util.npc.Rs2Npc.getNpcs;
@@ -550,12 +551,14 @@ public class WildySaferScript extends Script {
         sleep(600);
 
         // Withdraw required consumables
-        Rs2Bank.withdrawX(APPLE_PIE, 16);
+        if (Rs2Player.getRealSkillLevel(DEFENCE) < 30) {Rs2Bank.withdrawX(APPLE_PIE, 16);} else {Rs2Bank.withdrawX(APPLE_PIE, 8);}
         sleep(300);
         if (config.attackStyle() == MAGIC) {
             Rs2Bank.withdrawX(MIND_RUNE, 750);
             sleep(300);
             Rs2Bank.withdrawX(AIR_RUNE, 1550);
+            sleep(300);
+            Rs2Bank.withdrawOne(LAW_RUNE);
             sleep(300);
 
             // Check if equipped with necessary items
@@ -614,6 +617,14 @@ public class WildySaferScript extends Script {
             sleep(400,800);
             Rs2Inventory.equip(MITHRIL_ARROW);
             sleep(300);
+            if (Rs2Player.getRealSkillLevel(Skill.MAGIC) > 24) {
+                Rs2Bank.withdrawOne(LAW_RUNE);
+                sleep(400,800);
+                Rs2Bank.withdrawX(AIR_RUNE,3);
+                sleep(400,800);
+                Rs2Bank.withdrawOne(FIRE_RUNE);
+                sleep(400,800);
+            }
 
         }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -120,7 +120,6 @@ public class WildySaferScript extends Script {
                     System.out.println("not in moss giant area but we are prepared");
                     if (config.attackStyle() == MAGIC && isEquippedWithRequiredItems() && isInventoryPreparedMage()) {walkTo(SAFESPOT);}
                     if (config.attackStyle() == RANGE && isEquippedWithRequiredItemsRange() && isInventoryPreparedArcher()) {walkTo(SAFESPOT);}
-                    return;
                     // if you're not at moss giants but don't have prepared inventory, prepare inventory
                 }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -7,6 +7,7 @@ import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.shortestpath.ShortestPathPlugin;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
@@ -40,9 +41,8 @@ import static net.runelite.api.Skill.DEFENCE;
 import static net.runelite.client.plugins.microbot.bee.MossKiller.Enums.AttackStyle.MAGIC;
 import static net.runelite.client.plugins.microbot.bee.MossKiller.Enums.AttackStyle.RANGE;
 import static net.runelite.client.plugins.microbot.util.npc.Rs2Npc.getNpcs;
-import static net.runelite.client.plugins.microbot.util.walker.Rs2Walker.walkFastCanvas;
-import static net.runelite.client.plugins.microbot.util.walker.Rs2Walker.walkTo;
 import static net.runelite.api.Skill.WOODCUTTING;
+import static net.runelite.client.plugins.microbot.util.walker.Rs2Walker.*;
 
 public class WildySaferScript extends Script {
     
@@ -303,7 +303,7 @@ public class WildySaferScript extends Script {
 
     private void playersCheck() {
         if(!mossKillerScript.getNearbyPlayers(14).isEmpty()){
-
+            if (ShortestPathPlugin.isStartPointSet()) {setTarget(null);}
             if(playerCounter > 15) {
                 sleep(10000, 15000);
                 int world = Login.getRandomWorld(false, null);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -84,14 +84,25 @@ public class WildySaferScript extends Script {
 
     public static boolean test = false;
     public boolean run(MossKillerConfig config) {
+        if (mainScheduledFuture != null && !mainScheduledFuture.isCancelled() && !mainScheduledFuture.isDone()) {
+            Microbot.log("Scheduled task already running.");
+            return false;
+        }
         Microbot.enableAutoRunOn = false;
         Rs2AntibanSettings.naturalMouse = true;
         Rs2AntibanSettings.simulateMistakes = true;
         Rs2Antiban.setActivityIntensity(ActivityIntensity.MODERATE);
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                if (!Microbot.isLoggedIn()) return;
-                if (!super.run()) return;
+                if (!Microbot.isLoggedIn()) {
+                    Microbot.log("Not logged in, skipping tick.");
+                    return;}
+                if (!super.run()) {Microbot.log("super.run() returned false, skipping tick.");
+                    return;}
+                if (Microbot.getClient() == null || Microbot.getClient().getLocalPlayer() == null) {
+                    Microbot.log("Client or local player not ready. Skipping tick.");
+                    return;
+                }
                 long startTime = System.currentTimeMillis();
 
                 if (mossKillerPlugin.startedFromScheduler) {prepareSchedulerStart();


### PR DESCRIPTION
- Utilises new Rs2Prayer switching logic by @slest1 in refactor of overhead prayer logic (Wildy Killer)
- Adds a refresh function to plugin class to avoid stale references to currentTarget for use of overheads (Wildy Killer)
- Takes out 8 food instead of 16 food if defence level is over 30 (Wildy Safer)
- Takes out Teleportation runes to reduce the 600 tile walk from Lumbridge (Wildy safer)
- Fixes inventory having unexpected composition while in ferox/wilderness (Wildy Killer)
- Removes a return statement which was getting the bot stuck if equipment wasn't perfect (Wildy Safer)