### PR TITLE
Added Broken bridge for Lighthouse traversing and some other options

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -1,4947 +1,4947 @@
 # Origin	Destination	menuOption menuTarget objectID	Skills	Item IDs	Currency	Quests	Varbits	Varplayers	isMembers	Duration	Display Info
-# Tutorial Island											
-3097 3107 0	3098 3107 0	Open;Door;9398								1	
-3098 3107 0	3097 3107 0	Open;Door;9398								1	
-3090 3092 0	3089 3092 0	Open;Gate;9470								1	
-3089 3092 0	3090 3092 0	Open;Gate;9470								1	
-3090 3091 0	3089 3091 0	Open;Gate;9708								1	
-3089 3091 0	3090 3091 0	Open;Gate;9708								1	
-3079 3084 0	3078 3084 0	Open;Door;9709								1	
-3078 3084 0	3079 3084 0	Open;Door;9709								1	
-3073 3090 0	3072 3090 0	Open;Door;9710								1	
-3072 3090 0	3073 3090 0	Open;Door;9710								1	
-3086 3126 0	3086 3125 0	Open;Door;9716								1	
-3086 3125 0	3086 3126 0	Open;Door;9716								1	
-3084 3125 0	3084 3124 1	Climb-up;Staircase;16671								1	
-3084 3124 1	3083 3123 0	Climb-down;Staircase;16673								1	
-3084 3124 0	3084 3124 1	Climb-up;Staircase;16671								1	
-3083 3123 0	3084 3124 1	Climb-up;Staircase;16671								1	
-3088 3120 0	3088 9520 0	Climb-down;Ladder;9726								2	
-3088 9520 0	3088 3120 0	Climb-up;Ladder;9725								2	
-3094 9503 0	3095 9503 0	Open;Gate;9717								1	
-3095 9503 0	3094 9503 0	Open;Gate;9717								1	
-3094 9502 0	3095 9502 0	Open;Gate;9718								1	
-3095 9502 0	3094 9502 0	Open;Gate;9718								1	
-3111 9519 0	3110 9519 0	Open;Gate;9720								1	
-3110 9519 0	3111 9519 0	Open;Gate;9720								1	
-3111 9518 0	3110 9518 0	Open;Gate;9719								1	
-3110 9518 0	3111 9518 0	Open;Gate;9719								1	
-3111 9525 0	3111 3125 0	Climb-up;Ladder;9727								2	
-3111 3125 0	3111 9525 0	Climb-down;Ladder;9728								2	
-3112 9526 0	3112 3126 0	Climb-up;Ladder;9727								2	
-3112 3126 0	3112 9526 0	Climb-down;Ladder;9728								2	
-3111 9527 0	3111 3127 0	Climb-up;Ladder;9727								2	
-3111 3127 0	3111 9527 0	Climb-down;Ladder;9728								2	
-3110 9526 0	3110 3126 0	Climb-up;Ladder;9727								2	
-3110 3126 0	3110 9526 0	Climb-down;Ladder;9728								2	
-3116 3125 0	3116 3125 1	Climb-up;Ladder;16683								2	
-3116 3125 1	3116 3125 0	Climb-down;Ladder;16679								2	
-3117 3126 0	3117 3126 1	Climb-up;Ladder;16683								2	
-3117 3126 1	3117 3126 0	Climb-down;Ladder;16679								2	
-3116 3127 0	3116 3127 1	Climb-up;Ladder;16683								2	
-3116 3127 1	3116 3127 0	Climb-down;Ladder;16679								2	
-3115 3126 0	3115 3126 1	Climb-up;Ladder;16683								2	
-3115 3126 1	3115 3126 0	Climb-down;Ladder;16679								2	
-3123 3127 0	3123 3127 1	Climb-up;Ladder;16683								2	
-3123 3127 1	3123 3127 0	Climb-down;Ladder;16679								2	
-3124 3128 0	3124 3128 1	Climb-up;Ladder;16683								2	
-3124 3128 1	3124 3128 0	Climb-down;Ladder;16679								2	
-3123 3129 0	3123 3129 1	Climb-up;Ladder;16683								2	
-3123 3129 1	3123 3129 0	Climb-down;Ladder;16679								2	
-3122 3128 0	3122 3128 1	Climb-up;Ladder;16683								2	
-3122 3128 1	3122 3128 0	Climb-down;Ladder;16679								2	
-3124 3124 0	3125 3124 0	Open;Door;9721								1	
-3125 3124 0	3124 3124 0	Open;Door;9721								1	
-3129 3124 0	3130 3124 0	Open;Door;9722								1	
-3130 3124 0	3129 3124 0	Open;Door;9722								1	
-3117 3107 0	3117 3107 1	Climb-up;Staircase;16671								1	
-3117 3107 1	3116 3106 0	Climb-down;Staircase;16673								1	
-3116 3106 0	3117 3107 1	Climb-up;Staircase;16671								1	
-3122 3103 0	3122 3102 0	Open;Door;9723								1	
-3122 3102 0	3122 3103 0	Open;Door;9723								1	
-3139 3079 0	3139 3079 1	Climb-up;Ladder;16683								2	
-3139 3079 1	3139 3079 0	Climb-down;Ladder;16679								2	
-3140 3078 0	3140 3078 1	Climb-up;Ladder;16683								2	
-3140 3078 1	3140 3078 0	Climb-down;Ladder;16679								2	
-3139 3077 0	3139 3077 1	Climb-up;Ladder;16683								2	
-3139 3077 1	3139 3077 0	Climb-down;Ladder;16679								2	
-3138 3078 0	3138 3078 1	Climb-up;Ladder;16683								2	
-3138 3078 1	3138 3078 0	Climb-down;Ladder;16679								2	
-											
-# Lumbridge											
-3205 3228 0	3206 3229 1	Climb-up;Staircase;56230								1	
-3206 3229 1	3205 3228 0	Climb-down;Staircase;16672								1	
-3206 3229 0	3206 3229 1	Climb-up;Staircase;56230								1	
-3205 3228 1	3205 3228 0	Climb-down;Staircase;16672								1	
-3206 3229 1	3206 3229 2	Climb-up;Staircase;16672								1	
-3206 3229 2	3205 3228 1	Climb-down;Staircase;56231								1	
-3205 3228 1	3206 3229 2	Climb-up;Staircase;16672								1	
-3205 3209 1	3206 3208 0	Climb-down;Staircase;16672								1	
-3206 3208 0	3205 3209 1	Climb-up;Staircase;56230								1	
-3206 3208 1	3206 3208 0	Climb-down;Staircase;16672								1	
-3205 3209 0	3205 3209 1	Climb-up;Staircase;56230								1	
-3205 3209 1	3205 3209 2	Climb-up;Staircase;16672								1	
-3205 3209 2	3206 3208 1	Climb-down;Staircase;56231								1	
-3206 3208 1	3205 3209 2	Climb-up;Staircase;16672								1	
-3210 3216 0	3210 9616 0	Climb-down;Trapdoor;14880									
-3210 9616 0	3210 3216 0	Climb-up;Ladder;17385								2	
-3209 9617 0	3209 3217 0	Climb-up;Ladder;17385								2	
-3209 9615 0	3209 3215 0	Climb-up;Ladder;17385								2	
-3208 9616 0	3208 3216 0	Climb-up;Ladder;17385								2	
-3213 3221 0	3212 3221 0	Open;Large door;12349								1	
-3212 3221 0	3213 3221 0	Open;Large door;12349								1	
-3213 3222 0	3212 3222 0	Open;Large door;12350								1	
-3212 3222 0	3213 3222 0	Open;Large door;12350								1	
-3207 3218 0	3207 3217 0	Open;Door;12348								1	
-3207 3217 0	3207 3218 0	Open;Door;12348								1	
-3228 3213 0	3228 3213 1	Climb-up;Ladder;16683								2	
-3228 3213 1	3228 3213 0	Climb-down;Ladder;16684								2	
-3229 3214 0	3229 3214 1	Climb-up;Ladder;16683								2	
-3229 3214 1	3229 3214 0	Climb-down;Ladder;16684								2	
-3230 3213 0	3230 3213 1	Climb-up;Ladder;16683								2	
-3230 3213 1	3230 3213 0	Climb-down;Ladder;16684								2	
-3229 3212 0	3229 3212 1	Climb-up;Ladder;16683								2	
-3229 3212 1	3229 3212 0	Climb-down;Ladder;16684								2	
-3229 3212 1	3229 3212 2	Climb-up;Ladder;16684								2	
-3228 3213 2	3228 3213 1	Climb-down;Ladder;16679								2	
-3228 3213 1	3228 3213 2	Climb-up;Ladder;16684								2	
-3229 3214 2	3229 3214 1	Climb-down;Ladder;16679								2	
-3229 3214 1	3229 3214 2	Climb-up;Ladder;16684								2	
-3230 3213 2	3230 3213 1	Climb-down;Ladder;16679								2	
-3230 3213 1	3230 3213 2	Climb-up;Ladder;16684								2	
-3229 3212 2	3229 3212 1	Climb-down;Ladder;16679								2	
-3229 3225 2	3229 3225 1	Climb-down;Ladder;16679								2	
-3229 3225 1	3229 3225 2	Climb-up;Ladder;16684								2	
-3228 3224 2	3228 3224 1	Climb-down;Ladder;16679								2	
-3228 3224 1	3228 3224 2	Climb-up;Ladder;16684								2	
-3229 3223 2	3229 3223 1	Climb-down;Ladder;16679								2	
-3229 3223 1	3229 3223 2	Climb-up;Ladder;16684								2	
-3230 3224 2	3230 3224 1	Climb-down;Ladder;16679								2	
-3230 3224 1	3230 3224 2	Climb-up;Ladder;16684								2	
-3230 3224 1	3230 3224 0	Climb-down;Ladder;16684								2	
-3230 3224 0	3230 3224 1	Climb-up;Ladder;16683								2	
-3229 3223 0	3229 3223 1	Climb-up;Ladder;16683								2	
-3228 3224 0	3228 3224 1	Climb-up;Ladder;16683								2	
-3228 3224 1	3228 3224 0	Climb-down;Ladder;16684								2	
-3229 3223 1	3229 3223 0	Climb-down;Ladder;16684								2	
-3229 3225 0	3229 3225 1	Climb-up;Ladder;16683								2	
-3229 3225 1	3229 3225 0	Climb-down;Ladder;16684								2	
-3211 3243 1	3211 3243 0	Climb-down;Ladder;16679								2	
-3211 3243 0	3211 3243 1	Climb-up;Ladder;16683								2	
-											
-# Farm between Lumbridge and Draynor											
-3197 3278 0	3197 3275 0	Climb-over;Stile;12982								6	
-3197 3275 0	3197 3278 0	Climb-over;Stile;12982								6	
-3198 3277 0	3197 3275 0	Climb-over;Stile;12982								6	
-3198 3276 0	3197 3278 0	Climb-over;Stile;12982								6	
-3196 3277 0	3197 3275 0	Climb-over;Stile;12982								6	
-3196 3276 0	3197 3278 0	Climb-over;Stile;12982								6	
-3164 3306 0	3164 3306 1	Climb-up;Ladder;12964								2	
-3164 3306 1	3164 3306 2	Climb-up;Ladder;12965								2	
-3164 3306 2	3164 3306 1	Climb-down;Ladder;12966								2	
-3165 3307 1	3165 3307 2	Climb-up;Ladder;12965								2	
-3165 3307 2	3165 3307 1	Climb-down;Ladder;12966								2	
-3165 3307 1	3165 3307 0	Climb-down;Ladder;12965								2	
-3165 3307 0	3165 3307 1	Climb-up;Ladder;12964								2	
-3164 3306 1	3164 3306 0	Climb-down;Ladder;12965								2	
-3140 3304 0	3140 3304 1	Climb-up;Ladder;16683								2	
-3140 3304 1	3140 3304 0	Climb-down;Ladder;16679								2	
-3141 3305 0	3141 3305 1	Climb-up;Ladder;16683								2	
-3141 3305 1	3141 3305 0	Climb-down;Ladder;16679								2	
-3140 3306 0	3140 3306 1	Climb-up;Ladder;16683								2	
-3140 3306 1	3140 3306 0	Climb-down;Ladder;16679								2	
-3139 3305 0	3139 3305 1	Climb-up;Ladder;16683								2	
-3139 3305 1	3139 3305 0	Climb-down;Ladder;16679								2	
-											
-# Draynor Village											
-3098 3267 0	3102 3266 1	Climb-up;Staircase;15645								1	
-3102 3266 1	3098 3266 0	Climb-down;Staircase;15648								1	
-3098 3266 0	3102 3266 1	Climb-up;Staircase;15645								1	
-3102 3267 1	3098 3266 0	Climb-down;Staircase;15648								1	
-3089 3251 0	3093 3251 1	Climb-up;Staircase;16670								1	
-3093 3251 1	3089 3251 0	Climb-down;Staircase;16669								1	
-											
-# Draynor Sewers											
-3085 9672 0	3085 3272 0	Climb-up;Ladder;17385								2	
-3084 9673 0	3084 3273 0	Climb-up;Ladder;17385								2	
-3083 9672 0	3083 3272 0	Climb-up;Ladder;17385								2	
-3084 9671 0	3084 3271 0	Climb-up;Ladder;17385								2	
-3085 3272 0	3085 9672 0	Climb-down;Trapdoor;6435								1	
-3084 3273 0	3084 9673 0	Climb-down;Trapdoor;6435								1	
-3083 3272 0	3083 9672 0	Climb-down;Trapdoor;6435								1	
-3084 3271 0	3084 9671 0	Climb-down;Trapdoor;6435								1	
-3118 3243 0	3118 9644 0	Climb-down;Trapdoor;6435								1	
-3117 3244 0	3118 9644 0	Climb-down;Trapdoor;6435								1	
-3119 3244 0	3118 9644 0	Climb-down;Trapdoor;6435								1	
-3118 3245 0	3118 9644 0	Climb-down;Trapdoor;6435								1	
-3119 9643 0	3118 3243 0	Climb-up;Ladder;6436								2	
-3118 9644 0	3118 3243 0	Climb-up;Ladder;6436								2	
-3117 9643 0	3118 3243 0	Climb-up;Ladder;6436								2	
-											
-# Draynor Manor											
-3115 3356 0	3077 9771 0	Walk-Down;Stairs;2616								1	
-3077 9771 0	3115 3356 0	Walk-Up;Stairs;2617								1	
-3116 3356 0	3077 9771 0	Walk-Down;Stairs;2616								1	
-3078 9771 0	3115 3356 0	Walk-Up;Stairs;2617								1	
-3076 9770 0	3115 3356 0	Walk-Up;Stairs;2617								1	
-3076 9769 0	3115 3356 0	Walk-Up;Stairs;2617								1	
-3076 9768 0	3115 3356 0	Walk-Up;Stairs;2617								1	
-3079 9770 0	3115 3356 0	Walk-Up;Stairs;2617								1	
-3079 9769 0	3115 3356 0	Walk-Up;Stairs;2617								1	
-3079 9768 0	3115 3356 0	Walk-Up;Stairs;2617								1	
-3123 3360 0	3123 3361 0	Open;Door;136								1	
-3123 3361 0	3123 3360 0	Open;Door;136								1	
-3109 3353 0	3109 3354 0	Open;Large door;135								3	
-3105 3364 2	3106 3363 1	Climb-down;Staircase;9584								1	
-3106 3363 1	3105 3364 2	Climb-up;Staircase;11511								1	
-3106 3362 1	3105 3364 2	Climb-up;Staircase;11511								1	
-3106 3362 2	3106 3361 2	Open;Door;22								1	
-3106 3361 2	3106 3362 2	Open;Door;22								1	
-3098 3359 0	3096 3359 0	Search;Bookcase;156								3	
-3092 3361 0	3117 9753 0	Climb-down;Ladder;133								2	
-3117 9753 0	3092 3361 0	Climb-up;Ladder;132								2	
-3098 3358 0	3096 3358 0	Search;Bookcase;155								3	
-3096 3357 0	3098 3358 0	Pull;Lever;160								6	
-3108 3353 0	3108 3354 0	Open;Large door;134								3	
-3097 3360 0	3096 3359 0	Search;Bookcase;156								3	
-3097 3357 0	3096 3358 0	Search;Bookcase;155								3	
-3108 3361 0	3108 3366 1	Climb-up;Staircase;11498								1	
-3108 3366 1	3108 3361 0	Climb-down;Staircase;11499								1	
-3109 3361 0	3109 3366 1	Climb-up;Staircase;11498								1	
-3109 3366 1	3109 3361 0	Climb-down;Staircase;11499								1	
-											
-# South Falador Farm											
-3045 3305 0	3042 3305 0	Climb-over;Stile;7527								6	
-3042 3305 0	3045 3305 0	Climb-over;Stile;7527								6	
-3043 3306 0	3045 3305 0	Climb-over;Stile;7527								6	
-3044 3306 0	3042 3305 0	Climb-over;Stile;7527								6	
-3043 3304 0	3045 3305 0	Climb-over;Stile;7527								6	
-3063 3281 0	3063 3284 0	Climb-over;Stile;7527								6	
-3064 3283 0	3063 3281 0	Climb-over;Stile;7527								6	
-3064 3282 0	3063 3284 0	Climb-over;Stile;7527								6	
-3063 3284 0	3063 3281 0	Climb-over;Stile;7527								6	
-3062 3282 0	3063 3284 0	Climb-over;Stile;7527								6	
-3062 3283 0	3063 3281 0	Climb-over;Stile;7527								6	
-											
-# Falador											
-3054 3382 0	3065 9951 0	Climb-down;Staircase;24249								1	
-3065 9951 0	3053 3382 0	Leave;Old passageway;31892									
-3053 3382 0	3065 9951 0	Climb-down;Staircase;24249								1	
-3065 9952 0	3053 3382 0	Leave;Old passageway;31892									
-3014 9952 0	3038 3382 0	Leave;Old passageway;31892									
-3038 3382 0	3014 9951 0	Climb-down;Staircase;24248								1	
-3014 9951 0	3038 3382 0	Leave;Old passageway;31892									
-3037 3382 0	3014 9951 0	Climb-down;Staircase;24248								1	
-3038 3382 0	3039 3383 1	Climb-up;Staircase;24248								1	
-3039 3383 1	3037 3382 0	Climb-down;Staircase;24252								1	
-3037 3382 0	3039 3383 1	Climb-up;Staircase;24248								1	
-3052 3383 1	3054 3382 0	Climb-down;Staircase;24254								1	
-3052 3373 1	3053 3374 2	Climb-up;Staircase;24251								1	
-3053 3374 2	3052 3372 1	Climb-down;Staircase;24255								1	
-3052 3372 1	3053 3374 2	Climb-up;Staircase;24251								1	
-3038 3374 2	3039 3372 1	Climb-down;Staircase;24253								1	
-3039 3372 1	3038 3374 2	Climb-up;Staircase;24250								1	
-3039 3373 1	3038 3374 2	Climb-up;Staircase;24250								1	
-3054 3382 0	3052 3383 1	Climb-up;Staircase;24249								1	
-3053 3382 0	3052 3383 1	Climb-up;Staircase;24249								1	
-3035 3364 1	3036 3363 0	Climb-down;Staircase;24076								1	
-3036 3363 0	3035 3364 1	Climb-up;Staircase;24075								1	
-3036 3362 0	3035 3364 1	Climb-up;Staircase;24075								1	
-3045 3362 0	3045 3366 1	Climb-up;Staircase;24079								1	
-3045 3366 1	3045 3362 0	Climb-down;Staircase;24080								1	
-3046 3362 0	3046 3366 1	Climb-up;Staircase;24079								1	
-3046 3366 1	3046 3362 0	Climb-down;Staircase;24080								1	
-3049 3354 1	3050 3353 0	Climb-down;Staircase;24076								1	
-3050 3353 0	3049 3354 1	Climb-up;Staircase;24075								1	
-3050 3352 0	3049 3354 1	Climb-up;Staircase;24075								1	
-3050 3356 1	3050 3354 2	Climb-up;Ladder;24082								2	
-3050 3354 2	3050 3356 1	Climb-down;Ladder;24084								2	
-3035 3345 1	3035 3345 0	Climb-down;Ladder;24085								2	
-3035 3345 0	3035 3345 1	Climb-up;Ladder;24082								2	
-3027 3354 0	3027 3352 1	Climb-up;Ladder;24082								2	
-3027 3352 1	3027 3354 0	Climb-down;Ladder;24084								2	
-3010 3338 0	3011 3337 1	Climb-up;Staircase;24072								1	
-3010 3339 0	3011 3337 1	Climb-up;Staircase;24072								1	
-3011 3337 1	3010 3338 0	Climb-down;Staircase;24074								1	
-3020 3333 0	3024 3333 1	Climb-up;Staircase;24077								1	
-3024 3333 1	3020 3333 0	Climb-down;Staircase;24078								1	
-3020 3332 0	3024 3332 1	Climb-up;Staircase;24077								1	
-3024 3332 1	3020 3332 0	Climb-down;Staircase;24078								1	
-3017 3344 0	3021 3344 1	Climb-up;Staircase;24077								1	
-3021 3344 1	3017 3344 0	Climb-down;Staircase;24078								1	
-3017 3343 0	3021 3343 1	Climb-up;Staircase;24077								1	
-3021 3343 1	3017 3343 0	Climb-down;Staircase;24078								1	
-2971 3369 0	2971 3373 1	Climb-up;Staircase;24079								1	
-2971 3373 1	2971 3369 0	Climb-down;Staircase;24080								1	
-2972 3369 0	2972 3373 1	Climb-up;Staircase;24079								1	
-2972 3373 1	2972 3369 0	Climb-down;Staircase;24080								1	
-2959 3368 0	2959 3372 1	Climb-up;Staircase;24079								1	
-2959 3372 1	2959 3368 0	Climb-down;Staircase;24080								1	
-2960 3368 0	2960 3372 1	Climb-up;Staircase;24079								1	
-2960 3372 1	2960 3368 0	Climb-down;Staircase;24080								1	
-2946 3379 0	2946 3377 1	Climb-up;Ladder;24082								2	
-2946 3377 1	2946 3379 0	Climb-down;Ladder;24084								2	
-2971 3347 0	2968 3348 1	Climb-up;Staircase;24067								1	
-2968 3348 1	2971 3347 0	Climb-down;Staircase;24068								1	
-2983 3350 1	2983 3350 0	Climb-down;Ladder;24071								2	
-2983 3350 0	2983 3350 1	Climb-up;Ladder;24070								2	
-2983 3353 1	2983 3353 2	Climb-up;Ladder;24070								2	
-2983 3353 2	2983 3353 1	Climb-down;Ladder;24071								2	
-2983 3350 2	2983 3350 3	Climb-up;Ladder;24070								2	
-2983 3350 3	2983 3350 2	Climb-down;Ladder;24071								2	
-2993 3341 1	2993 3341 0	Climb-down;Ladder;24071								2	
-2993 3341 0	2993 3341 1	Climb-up;Ladder;24070								2	
-2995 3341 1	2995 3341 2	Climb-up;Ladder;24070								2	
-2995 3341 2	2995 3341 1	Climb-down;Ladder;24071								2	
-2995 3341 2	2995 3341 3	Climb-up;Ladder;24070								2	
-2995 3341 3	2995 3341 2	Climb-down;Ladder;24071								2	
-2955 3337 0	2956 3338 1	Climb-up;Staircase;24072								1	
-2956 3338 1	2955 3337 0	Climb-down;Staircase;24074								1	
-2959 3339 2	2960 3340 1	Climb-down;Staircase;24074								1	
-2960 3340 1	2959 3339 2	Climb-up;Staircase;24072								1	
-2961 3340 1	2959 3339 2	Climb-up;Staircase;24072								1	
-2959 3338 3	2958 3337 2	Climb-down;Staircase;24074								1	
-2958 3337 2	2959 3338 3	Climb-up;Staircase;24072								1	
-2957 3337 2	2959 3338 3	Climb-up;Staircase;24072								1	
-2984 3340 2	2984 3336 1	Climb-down;Staircase;24078								1	
-2984 3336 1	2984 3340 2	Climb-up;Staircase;24077								1	
-2985 3340 2	2985 3336 1	Climb-down;Staircase;24078								1	
-2985 3336 1	2985 3340 2	Climb-up;Staircase;24077								1	
-2954 3390 0	2954 3388 1	Climb-up;Ladder;24083								2	
-2954 3388 1	2954 3390 0	Climb-down;Ladder;24084								2	
-2955 3390 1	2953 3390 2	Climb-up;Ladder;24082								2	
-2953 3390 2	2955 3390 1	Climb-down;Ladder;24084								2	
-2954 3388 2	2954 3390 3	Climb-up;Ladder;24082								2	
-2954 3390 3	2954 3388 2	Climb-down;Ladder;24084								2	
-2973 3386 0	2972 3385 1	Climb-up;Staircase;24075								1	
-2972 3385 1	2973 3386 0	Climb-down;Staircase;24076								1	
-2974 3386 0	2972 3385 1	Climb-up;Staircase;24075								1	
-1752 5137 0	2985 3316 0	Climb;Rope;12230								2	
-											
-# Makeover Mage											
-2916 3323 0	2916 3323 1	Climb-up;Ladder;9558								2	
-2916 3323 1	2916 3323 0	Climb-down;Ladder;9559								2	
-											
-# Dark Wizards' Tower											
-2909 3335 0	2908 3336 1	Climb-up;Staircase;11888								1	
-2908 3336 1	2909 3335 0	Climb-down;Staircase;11889								1	
-2909 3334 0	2908 3336 1	Climb-up;Staircase;11888								1	
-2908 3336 1	2908 3336 2	Climb-up;Staircase;11889								1	
-2908 3336 2	2908 3336 1	Climb-down;Staircase;11890								1	
-											
-# Killerwatt Plane											
-3110 3363 2	2677 5214 2	Enter;Interdimensional rift;11355				Ernest the Chicken				1	
-3111 3363 2	2677 5214 2	Enter;Interdimensional rift;11355				Ernest the Chicken				1	
-											
-# Ferox Enclave											
-3140 3637 0	3137 3637 1	Climb;Stairs;39643								1	
-3137 3637 1	3140 3637 0	Climb;Stairs;39650								1	
-3140 3636 0	3137 3636 1	Climb;Stairs;39643								1	
-3137 3636 1	3140 3636 0	Climb;Stairs;39650								1	
-3143 3637 0	3146 3637 1	Climb;Stairs;39643								1	
-3146 3637 1	3143 3637 0	Climb;Stairs;39650								1	
-3143 3636 0	3146 3636 1	Climb;Stairs;39643								1	
-3146 3636 1	3143 3636 0	Climb;Stairs;39650								1	
-3142 3634 1	3142 3637 2	Climb;Stairs;39643								1	
-3142 3637 2	3142 3634 1	Climb;Stairs;39650								1	
-3141 3634 1	3141 3637 2	Climb;Stairs;39643								1	
-3141 3637 2	3141 3634 1	Climb;Stairs;39650								1	
-3126 3639 0	3126 3639 1	Climb-up;Ladder;14745								2	
-3126 3639 1	3126 3639 0	Climb-down;Ladder;14746								2	
-3129 3639 1	3129 3639 2	Climb-up;Ladder;14745								2	
-3129 3639 2	3129 3639 1	Climb-down;Ladder;14746								2	
-3129 3633 2	3129 3633 1	Climb-down;Ladder;14746								2	
-3129 3633 1	3129 3633 2	Climb-up;Ladder;14745								2	
-3126 3633 1	3126 3633 0	Climb-down;Ladder;14746								2	
-3126 3633 0	3126 3633 1	Climb-up;Ladder;14745								2	
-3127 3625 2	3127 3625 1	Climb-down;Ladder;14746								2	
-3127 3625 1	3127 3625 2	Climb-up;Ladder;14745								2	
-3127 3618 1	3127 3618 2	Climb-up;Ladder;14745								2	
-3127 3618 2	3127 3618 1	Climb-down;Ladder;14746								2	
-3131 3622 1	3134 3622 0	Climb;Stairs;39650								1	
-3134 3622 0	3131 3622 1	Climb;Stairs;39643								1	
-3131 3621 1	3134 3621 0	Climb;Stairs;39650								1	
-3134 3621 0	3131 3621 1	Climb;Stairs;39643								1	
-3135 3622 0	3138 3622 1	Climb;Stairs;39643								1	
-3138 3622 1	3135 3622 0	Climb;Stairs;39650								1	
-3135 3621 0	3138 3621 1	Climb;Stairs;39643								1	
-3138 3621 1	3135 3621 0	Climb;Stairs;39650								1	
-3142 3618 1	3142 3618 2	Climb-up;Ladder;14745								2	
-3142 3618 2	3142 3618 1	Climb-down;Ladder;14746								2	
-3142 3625 1	3142 3625 2	Climb-up;Ladder;14745								2	
-3142 3625 2	3142 3625 1	Climb-down;Ladder;14746								2	
-3152 3644 0	3164 10043 0	Walk-down;Stairs;39647								1	
-3164 10044 0	3152 3644 0	Exit;Opening;39648								1	
-3152 3643 0	3164 10043 0	Walk-down;Stairs;39647								1	
-3164 10043 0	3152 3644 0	Exit;Opening;39648								1	
-3164 10042 0	3152 3644 0	Exit;Opening;39648								1	
-3154 3635 0	3155 3635 0	Pass-Through;Barrier;39653								6	
-3155 3635 0	3154 3635 0	Pass-Through;Barrier;39653								6	
-3154 3634 0	3155 3634 0	Pass-Through;Barrier;39652								6	
-3155 3634 0	3154 3634 0	Pass-Through;Barrier;39652								6	
-3135 3617 0	3135 3616 0	Pass-Through;Barrier;39653								6	
-3135 3616 0	3135 3617 0	Pass-Through;Barrier;39653								6	
-3134 3616 0	3134 3617 0	Pass-Through;Barrier;39652								6	
-3134 3617 0	3134 3616 0	Pass-Through;Barrier;39652								6	
-3123 3629 0	3122 3629 0	Pass-Through;Barrier;39652								6	
-3122 3629 0	3123 3629 0	Pass-Through;Barrier;39652								6	
-3123 3628 0	3122 3628 0	Pass-Through;Barrier;39653								6	
-3122 3628 0	3123 3628 0	Pass-Through;Barrier;39653								6	
-3135 3639 0	3135 3640 0	Pass-Through;Barrier;39652								6	
-3135 3640 0	3135 3639 0	Pass-Through;Barrier;39652								6	
-3134 3639 0	3134 3640 0	Pass-Through;Barrier;39653								6	
-3134 3640 0	3134 3639 0	Pass-Through;Barrier;39653								6	
-											
-# Clan Wars (Free-for-all)											
-3371 4810 0	3371 4810 1	Climb-up;Ladder;16683								2	
-3371 4810 1	3371 4810 0	Climb-down;Ladder;16679								2	
-3371 4808 1	3371 4808 0	Climb-down;Ladder;16679								2	
-3371 4808 0	3371 4808 1	Climb-up;Ladder;16683								2	
-3369 4826 1	3369 4826 0	Climb-down;Ladder;16679								2	
-3369 4826 0	3369 4826 1	Climb-up;Ladder;16683								2	
-3367 4826 1	3367 4826 0	Climb-down;Ladder;16679								2	
-3367 4826 0	3367 4826 1	Climb-up;Ladder;16683								2	
-											
-# Skavid Caves											
-2562 3024 0	2523 3070 0	Enter;Cave entrance;2805								10	
-2523 3070 0	2540 3055 0	Enter;Cave entrance;2806								10	
-2540 3054 0	2553 3055 0	Enter;Cave entrance;2807								10	
-2553 3054 0	2552 3034 0	Enter;Cave entrance;2808								10	
-2552 3034 0	2563 3024 0	Enter;Cave entrance;2809								10	
-2562 3023 0	2523 3070 0	Enter;Cave entrance;2805								10	
-2524 3070 0	2540 3055 0	Enter;Cave entrance;2806								10	
-2541 3054 0	2553 3055 0	Enter;Cave entrance;2807								10	
-2551 3053 0	2552 3034 0	Enter;Cave entrance;2808								10	
-2552 3035 0	2563 3024 0	Enter;Cave entrance;2809								10	
-2561 3021 0	2523 3070 0	Enter;Cave entrance;2805								10	
-2522 3070 0	2540 3055 0	Enter;Cave entrance;2806								10	
-2539 3054 0	2553 3055 0	Enter;Cave entrance;2807								10	
-2552 3054 0	2552 3034 0	Enter;Cave entrance;2808								10	
-2552 3033 0	2563 3024 0	Enter;Cave entrance;2809								10	
-2562 3025 0	2523 3070 0	Enter;Cave entrance;2805								10	
-2542 3054 0	2553 3055 0	Enter;Cave entrance;2807								10	
-2562 3022 0	2523 3070 0	Enter;Cave entrance;2805								10	
-2525 3070 0	2540 3055 0	Enter;Cave entrance;2806								10	
-2561 3026 0	2523 3070 0	Enter;Cave entrance;2805								10	
-2560 3026 0	2523 3070 0	Enter;Cave entrance;2805								10	
-2560 3021 0	2523 3070 0	Enter;Cave entrance;2805								10	
-											
-# Skavid Caves Island											
-2500 2988 0	2576 3029 0	Enter;Cave entrance;2811									
-2576 3029 0	2500 2988 0	Climb-down;Ladder;2812								2	
-2499 2988 0	2576 3029 0	Enter;Cave entrance;2811									
-2575 3028 0	2500 2988 0	Climb-down;Ladder;2812								2	
-2501 2989 0	2576 3029 0	Enter;Cave entrance;2811									
-2575 3030 0	2500 2988 0	Climb-down;Ladder;2812								2	
-2498 2989 0	2576 3029 0	Enter;Cave entrance;2811									
-2574 3029 0	2500 2988 0	Climb-down;Ladder;2812								2	
-											
-# Yanille											
-2537 3095 0	2537 3099 1	Climb-up;Staircase;15646								1	
-2537 3099 1	2537 3095 0	Climb-down;Staircase;15648								1	
-2538 3095 0	2538 3099 1	Climb-up;Staircase;15646								1	
-2538 3099 1	2537 3095 0	Climb-down;Staircase;15648								1	
-2538 3088 0	2538 3084 1	Climb-up;Staircase;15646								1	
-2538 3084 1	2537 3088 0	Climb-down;Staircase;15648								1	
-2537 3088 0	2537 3084 1	Climb-up;Staircase;15646								1	
-2537 3084 1	2537 3088 0	Climb-down;Staircase;15648								1	
-2555 3081 0	2555 3081 1	Climb-up;Ladder;16683								2	
-2555 3081 1	2555 3081 0	Climb-down;Ladder;16679								2	
-2556 3082 0	2556 3082 1	Climb-up;Ladder;16683								2	
-2556 3082 1	2556 3082 0	Climb-down;Ladder;16679								2	
-2557 3081 0	2557 3081 1	Climb-up;Ladder;16683								2	
-2557 3081 1	2557 3081 0	Climb-down;Ladder;16679								2	
-2556 3080 0	2556 3080 1	Climb-up;Ladder;16683								2	
-2556 3080 1	2556 3080 0	Climb-down;Ladder;16679								2	
-2606 3079 0	2601 9478 0	Climb-down;Staircase;16664								1	
-2602 9478 0	2606 3078 0	Climb-up;Staircase;16665								1	
-2606 3078 0	2601 9478 0	Climb-down;Staircase;16664								1	
-2602 9479 0	2606 3078 0	Climb-up;Staircase;16665								1	
-2597 3106 0	2597 3106 1	Climb-up;Ladder;16683								2	
-2597 3106 1	2597 3106 0	Climb-down;Ladder;16681								2	
-2598 3107 0	2598 3107 1	Climb-up;Ladder;16683								2	
-2598 3107 1	2598 3107 0	Climb-down;Ladder;16681								2	
-2597 3108 0	2597 3108 1	Climb-up;Ladder;16683								2	
-2597 3108 1	2597 3108 0	Climb-down;Ladder;16681								2	
-2596 3107 0	2596 3107 1	Climb-up;Ladder;16683								2	
-2596 3107 1	2596 3107 0	Climb-down;Ladder;16681								2	
-2594 9484 0	2594 3084 0	Climb-up;Ladder;17385	 								
-2594 9486 0	2594 3086 0	Climb-up;Ladder;17385	 								
-2594 3086 0	2594 9486 0	Climb-down;Ladder;17384	 								
-											
-# Hazelmere Island											
-2677 3088 1	2677 3088 0	Climb-down;Ladder;16679								2	
-2677 3088 0	2677 3088 1	Climb-up;Ladder;16683								2	
-2676 3087 1	2676 3087 0	Climb-down;Ladder;16679								2	
-2676 3087 0	2676 3087 1	Climb-up;Ladder;16683								2	
-2677 3086 1	2677 3086 0	Climb-down;Ladder;16679								2	
-2677 3086 0	2677 3086 1	Climb-up;Ladder;16683								2	
-2678 3087 1	2678 3087 0	Climb-down;Ladder;16679								2	
-2678 3087 0	2678 3087 1	Climb-up;Ladder;16683								2	
-											
-# Ardougne Monastery											
-2615 3209 0	2618 3208 1	Climb-up;Staircase;16671								1	
-2618 3208 1	2617 3207 0	Climb-down;Staircase;16673								1	
-2617 3207 0	2618 3208 1	Climb-up;Staircase;16671								1	
-2616 3207 0	2618 3208 1	Climb-up;Staircase;16671								1	
-2615 3208 0	2618 3208 1	Climb-up;Staircase;16671								1	
-2618 3208 0	2618 3208 1	Climb-up;Staircase;16671								1	
-2618 3209 0	2618 3208 1	Climb-up;Staircase;16671								1	
-2616 3210 0	2618 3208 1	Climb-up;Staircase;16671								1	
-2617 3210 0	2618 3208 1	Climb-up;Staircase;16671								1	
-2597 3209 0	2597 3208 1	Climb-up;Staircase;16671								1	
-2597 3208 1	2596 3207 0	Climb-down;Staircase;16673								1	
-2597 3208 0	2597 3208 1	Climb-up;Staircase;16671								1	
-2596 3207 0	2597 3208 1	Climb-up;Staircase;16671								1	
-2595 3207 0	2597 3208 1	Climb-up;Staircase;16671								1	
-2594 3208 0	2597 3208 1	Climb-up;Staircase;16671								1	
-2594 3209 0	2597 3208 1	Climb-up;Staircase;16671								1	
-2595 3210 0	2597 3208 1	Climb-up;Staircase;16671								1	
-2596 3210 0	2597 3208 1	Climb-up;Staircase;16671								1	
-2675 3300 0	2675 3300 1	Climb-up;Staircase;16671								1	
-# Ardougne Sewers											
-2587 3237 0	2570 9682 0	Enter;Cave entrance;2852									
-2570 9682 0	2587 3237 0	Climb-up;Stairs;2853									
-2586 3237 0	2570 9682 0	Enter;Cave entrance;2852									
-2571 9682 0	2587 3237 0	Climb-up;Stairs;2853									
-2589 3236 0	2570 9682 0	Enter;Cave entrance;2852									
-2588 3237 0	2570 9682 0	Enter;Cave entrance;2852									
-2569 9683 0	2587 3237 0	Climb-up;Stairs;2853									
-2584 3236 0	2570 9682 0	Enter;Cave entrance;2852									
-2569 9684 0	2587 3237 0	Climb-up;Stairs;2853									
-2584 3235 0	2570 9682 0	Enter;Cave entrance;2852									
-2569 9685 0	2587 3237 0	Climb-up;Stairs;2853									
-2584 3234 0	2570 9682 0	Enter;Cave entrance;2852									
-2589 3235 0	2570 9682 0	Enter;Cave entrance;2852									
-2589 3234 0	2570 9682 0	Enter;Cave entrance;2852									
-2588 3232 0	2570 9682 0	Enter;Cave entrance;2852									
-2587 3232 0	2570 9682 0	Enter;Cave entrance;2852									
-2586 3232 0	2570 9682 0	Enter;Cave entrance;2852									
-2585 3232 0	2570 9682 0	Enter;Cave entrance;2852									
-2584 3233 0	2570 9682 0	Enter;Cave entrance;2852									
-											
-# East Ardougne											
-2571 3298 0	2571 3294 1	Climb-up;Staircase;15645								1	
-2571 3294 1	2571 3298 0	Climb-down;Staircase;15648								1	
-2572 3298 0	2571 3294 1	Climb-up;Staircase;15645								1	
-2572 3294 1	2571 3298 0	Climb-down;Staircase;15648								1	
-2610 3307 0	2610 3307 1	Climb-up;Ladder;16683								2	
-2610 3307 1	2610 3307 2	Climb-up;Ladder;16684								2	
-2610 3307 2	2610 3307 3	Climb-up;Ladder;16684								2	
-2610 3307 3	2610 3307 2	Climb-down;Ladder;16679								2	
-2610 3307 2	2610 3307 1	Climb-down;Ladder;16684								2	
-2611 3306 0	2611 3306 1	Climb-up;Ladder;16683								2	
-2611 3306 1	2611 3306 2	Climb-up;Ladder;16684								2	
-2611 3306 2	2611 3306 3	Climb-up;Ladder;16684								2	
-2611 3306 3	2611 3306 2	Climb-down;Ladder;16679								2	
-2611 3306 2	2611 3306 1	Climb-down;Ladder;16684								2	
-2611 3306 1	2611 3306 0	Climb-down;Ladder;16684								2	
-2610 3307 1	2610 3307 0	Climb-down;Ladder;16684								2	
-2609 3306 0	2609 3306 1	Climb-up;Ladder;16683								2	
-2609 3306 1	2609 3306 2	Climb-up;Ladder;16684								2	
-2609 3306 2	2609 3306 1	Climb-down;Ladder;16684								2	
-2609 3306 1	2609 3306 0	Climb-down;Ladder;16684								2	
-2610 3305 0	2610 3305 1	Climb-up;Ladder;16683								2	
-2610 3305 1	2610 3305 0	Climb-down;Ladder;16684								2	
-2610 3305 1	2610 3305 2	Climb-up;Ladder;16684								2	
-2610 3305 2	2610 3305 3	Climb-up;Ladder;16684								2	
-2610 3305 3	2610 3305 2	Climb-down;Ladder;16679								2	
-2609 3306 2	2609 3306 3	Climb-up;Ladder;16684								2	
-2609 3306 3	2609 3306 2	Climb-down;Ladder;16679								2	
-2610 3305 2	2610 3305 1	Climb-down;Ladder;16684								2	
-2665 3321 1	2661 3321 0	Climb-down;Staircase;15648								1	
-2661 3321 0	2665 3321 1	Climb-up;Staircase;15645								1	
-2665 3322 1	2661 3321 0	Climb-down;Staircase;15648								1	
-2661 3322 0	2665 3321 1	Climb-up;Staircase;15645								1	
-2655 3321 0	2655 3321 1	Climb-up;Ladder;17026								2	
-2655 3321 1	2655 3321 0	Climb-down;Ladder;16685								2	
-2662 3294 0	2661 3291 1	Climb-up;Staircase;16668								1	
-2661 3291 1	2662 3294 0	Climb-down;Staircase;16667								1	
-2648 3301 1	2645 3302 0	Climb-down;Staircase;16667								1	
-2645 3302 0	2648 3301 1	Climb-up;Staircase;16668								1	
-2649 3312 1	2650 3311 0	Climb-down;Staircase;16673								1	
-2650 3311 0	2649 3312 1	Climb-up;Staircase;16671								1	
-2649 3312 0	2649 3312 1	Climb-up;Staircase;16671								1	
-2648 3312 0	2649 3312 1	Climb-up;Staircase;16671								1	
-2650 3310 0	2649 3312 1	Climb-up;Staircase;16671								1	
-2649 3296 1	2648 3293 0	Climb-down;Staircase;16667								1	
-2648 3293 0	2649 3296 1	Climb-up;Staircase;16668								1	
-2617 3324 0	2617 3324 1	Climb-up;Ladder;16683								2	
-2617 3324 1	2617 3324 0	Climb-down;Ladder;16679								2	
-2616 3323 0	2616 3323 1	Climb-up;Ladder;16683								2	
-2616 3323 1	2616 3323 0	Climb-down;Ladder;16679								2	
-2651 3286 0	2651 3286 1	Climb-up;Ladder;16683								2	
-2651 3286 1	2651 3286 0	Climb-down;Ladder;16679								2	
-2650 3287 0	2650 3287 1	Climb-up;Ladder;16683								2	
-2650 3287 1	2650 3287 0	Climb-down;Ladder;16679								2	
-2650 3285 0	2650 3285 1	Climb-up;Ladder;16683								2	
-2650 3285 1	2650 3285 0	Climb-down;Ladder;16679								2	
-2649 3287 1	2649 3287 2	Climb-up;Ladder;17026								2	
-2649 3287 2	2649 3287 1	Climb-down;Ladder;16685								2	
-2651 3281 0	2651 3281 1	Climb-up;Ladder;16683								2	
-2651 3281 1	2651 3281 0	Climb-down;Ladder;16679								2	
-2650 3280 0	2650 3280 1	Climb-up;Ladder;16683								2	
-2650 3280 1	2650 3280 0	Climb-down;Ladder;16679								2	
-2650 3282 0	2650 3282 1	Climb-up;Ladder;16683								2	
-2650 3282 1	2650 3282 0	Climb-down;Ladder;16679								2	
-2649 3282 1	2649 3282 2	Climb-up;Ladder;17026								2	
-2649 3282 2	2649 3282 1	Climb-down;Ladder;16685								2	
-2683 3271 0	2683 3268 1	Cross;Gangplank;2085								3	
-2683 3268 1	2683 3271 0	Cross;Gangplank;2086								3	
-2622 3291 0	2622 3291 1	Climb-up;Ladder;17026								2	
-2622 3291 1	2622 3291 0	Climb-down;Ladder;16685								2	
-2592 3339 0	2592 3338 0	Open;Door;2054								1	
-2592 3338 0	2592 3339 0	Open;Door;2054								1	
-2590 3334 0	2594 3334 1	Climb-up;Staircase;15645								1	
-2594 3334 1	2590 3334 0	Climb-down;Staircase;15648								1	
-2590 3335 0	2594 3334 1	Climb-up;Staircase;15645								1	
-2594 3335 1	2590 3334 0	Climb-down;Staircase;15648								1	
-2574 3332 0	2578 3332 1	Climb-up;Staircase;15649								1	
-2578 3332 1	2574 3332 0	Climb-down;Staircase;15650								1	
-2574 3331 0	2578 3331 1	Climb-up;Staircase;15649								1	
-2578 3331 1	2574 3331 0	Climb-down;Staircase;15650								1	
-2572 3324 0	2574 3325 1	Climb-up;Staircase;16671								1	
-2574 3325 1	2573 3324 0	Climb-down;Staircase;16673								1	
-2573 3324 0	2574 3325 1	Climb-up;Staircase;16671								1	
-2574 3325 0	2574 3325 1	Climb-up;Staircase;16671								1	
-2566 3321 1	2565 3322 0	Climb-down;Staircase;16673								1	
-2565 3322 0	2566 3321 1	Climb-up;Staircase;16671								1	
-2565 3323 0	2566 3321 1	Climb-up;Staircase;16671								1	
-2566 3321 0	2566 3321 1	Climb-up;Staircase;16671								1	
-2567 3321 0	2566 3321 1	Climb-up;Staircase;16671								1	
-2568 3322 0	2566 3321 1	Climb-up;Staircase;16671								1	
-2568 3323 0	2566 3321 1	Climb-up;Staircase;16671								1	
-2567 3324 0	2566 3321 1	Climb-up;Staircase;16671								1	
-2664 3333 0	2664 3333 1	Climb-up;Ladder;16683								2	
-2664 3333 1	2664 3333 0	Climb-down;Ladder;16679								2	
-2665 3334 0	2665 3334 1	Climb-up;Ladder;16683								2	
-2665 3334 1	2665 3334 0	Climb-down;Ladder;16679								2	
-2664 3335 0	2664 3335 1	Climb-up;Ladder;16683								2	
-2664 3335 1	2664 3335 0	Climb-down;Ladder;16679								2	
-2663 3334 0	2663 3334 1	Climb-up;Ladder;16683								2	
-2663 3334 1	2663 3334 0	Climb-down;Ladder;16679								2	
-2665 3291 0	2665 3291 1	Climb-up;Ladder;16683								2	
-2665 3291 1	2665 3291 0	Climb-down;Ladder;16679								2	
-2666 3290 0	2666 3290 1	Climb-up;Ladder;16683								2	
-2666 3290 1	2666 3290 0	Climb-down;Ladder;16679								2	
-2569 3271 0	2568 3267 1	Climb-up;Staircase;15645								1	
-2568 3267 1	2568 3271 0	Climb-down;Staircase;15648								1	
-2568 3271 0	2568 3267 1	Climb-up;Staircase;15645								1	
-2569 3267 1	2568 3271 0	Climb-down;Staircase;15648								1	
-2570 3268 0	2570 9668 0	Climb-down;Ladder;17384								2	
-2570 9668 0	2570 3268 0	Climb-up;Ladder;17385								2	
-2571 3267 0	2571 9667 0	Climb-down;Ladder;17384								2	
-2571 9667 0	2571 3267 0	Climb-up;Ladder;17385								2	
-2674 3299 0	2675 3300 1	Climb-up;Staircase;16671								1	
-2675 3300 1	2674 3299 0	Climb-down;Staircase;16673								1	
-2674 3304 0	2674 3303 0	Pick-lock;Door;11720								2	
-2674 3305 0	2674 3306 0	Pick-lock;Door;11719								2	
-2674 3303 0	2674 3304 0	Open;Door;11720								1	
-2674 3306 0	2674 3305 0	Open;Door;11719								1	
-											
-# Witchaven Dungeon											
-2697 3283 0	2696 9683 0	Climb-down;Old ruin entrance;18270								
-2696 9683 0	2697 3283 0	Climb-up;Exit;18354								
-											
-# West Ardougne											
-2559 3300 0	2556 3300 0	Open;Ardougne Wall Door;8739									
-2556 3300 0	2559 3300 0	Open;Ardougne Wall Door;8738									
-2559 3299 0	2556 3299 0	Open;Ardougne Wall Door;8738									
-2556 3299 0	2559 3299 0	Open;Ardougne Wall Door;8739									
-2542 3331 0	2541 3331 0	Squeeze-through;Fence;2068									
-2541 3331 0	2542 3331 0	Squeeze-through;Fence;2068									
-2531 3328 0	2531 3329 0	Open;Door;2537								1	
-2531 3329 0	2531 3328 0	Open;Door;2537								1	
-2528 3331 0	2527 3331 1	Walk-up;Stairs;2539									
-2527 3331 1	2527 3331 0	Walk-down;Stairs;2540									
-2527 3331 0	2527 3331 1	Walk-up;Stairs;2539									
-2530 3320 0	2529 3317 1	Climb-up;Staircase;16668								1	
-2529 3317 1	2530 3320 0	Climb-down;Staircase;16667								1	
-2527 3317 1	2527 3313 2	Climb-up;Staircase;15653								1	
-2527 3313 2	2527 3317 1	Climb-down;Staircase;15654								1	
-2528 3317 1	2527 3313 2	Climb-up;Staircase;15653								1	
-2528 3313 2	2527 3317 1	Climb-down;Staircase;15654								1	
-2524 3313 1	2523 3317 0	Climb-down;Staircase;15654								1	
-2523 3317 0	2523 3313 1	Climb-up;Staircase;15653								1	
-2523 3313 1	2523 3317 0	Climb-down;Staircase;15654								1	
-2524 3317 0	2523 3313 1	Climb-up;Staircase;15653								1	
-2530 3314 0	2529 3314 0	Open;Door;2528								1	
-2529 3314 0	2530 3314 0	Open;Door;2528								1	
-2526 3290 0	2527 3293 1	Climb-up;Staircase;16668								1	
-2527 3293 1	2526 3290 0	Climb-down;Staircase;16667								1	
-2530 3294 0	2531 3293 1	Climb-up;Staircase;16671								1	
-2531 3293 1	2530 3294 0	Climb-down;Staircase;16673								1	
-2530 3295 0	2531 3293 1	Climb-up;Staircase;16671								1	
-2531 3293 0	2531 3293 1	Climb-up;Staircase;16671								1	
-2532 3293 0	2531 3293 1	Climb-up;Staircase;16671								1	
-2533 3271 0	2533 3272 0	Open;Door;37321								1	
-2533 3272 0	2533 3271 0	Open;Door;37321								1	
-2536 3271 0	2537 9670 0	Walk-down;Spooky stairs;2522									
-2537 9670 0	2536 3271 0	Walk-up;Spooky stairs;2523									
-2537 3271 0	2537 9670 0	Walk-down;Spooky stairs;2522									
-2536 9670 0	2536 3271 0	Walk-up;Spooky stairs;2523									
-2539 9672 0	2540 9672 0	Open;Door;2526								1	
-2540 9672 0	2539 9672 0	Open;Door;2526								1	
-2540 3273 0	2540 3272 0	Open;Door;37321								1	
-2540 3272 0	2540 3273 0	Open;Door;37321								1	
-2458 3309 0	2458 3309 1	Climb-up;Ladder;16683								2	
-2458 3309 1	2458 3309 0	Climb-down;Ladder;16679								2	
-2459 3310 0	2459 3310 1	Climb-up;Ladder;16683								2	
-2459 3310 1	2459 3310 0	Climb-down;Ladder;16679								2	
-2457 3310 0	2457 3310 1	Climb-up;Ladder;16683								2	
-2457 3310 1	2457 3310 0	Climb-down;Ladder;16679								2	
-2458 3311 1	2458 3311 0	Climb-down;Ladder;16679								2	
-2458 3311 0	2458 3311 1	Climb-up;Ladder;16683								2	
-											
-# Clock tower											
-2571 3240 0	2571 3241 1	Climb-up;Staircase;16671								1	
-2571 3241 0	2571 3241 1	Climb-up;Staircase;16671								1	
-2571 3241 1	2572 3242 0	Climb-down;Staircase;16672								1	
-2572 3242 0	2571 3241 1	Climb-up;Staircase;16671								1	
-2572 3242 1	2572 3242 0	Climb-down;Staircase;16672								1	
-2573 3242 0	2571 3241 1	Climb-up;Staircase;16671								1	
-2572 3239 0	2571 3241 1	Climb-up;Staircase;16671								1	
-2573 3239 0	2571 3241 1	Climb-up;Staircase;16671								1	
-2571 3241 1	2571 3241 2	Climb-up;Staircase;16672								1	
-2571 3241 2	2572 3242 1	Climb-down;Staircase;16673								1	
-2572 3242 1	2571 3241 2	Climb-up;Staircase;16672								1	
-2566 3243 0	2566 9643 0	Climb-down;Ladder;17384								2	
-2566 9643 0	2566 3243 0	Climb-up;Ladder;17385								2	
-2565 3242 0	2565 9642 0	Climb-down;Ladder;17384								2	
-2565 9642 0	2565 3242 0	Climb-up;Ladder;17385								2	
-2566 3241 0	2566 9641 0	Climb-down;Ladder;17384								2	
-2566 9641 0	2566 3241 0	Climb-up;Ladder;17385								2	
-2567 3242 0	2567 9642 0	Climb-down;Ladder;17384								2	
-2567 9642 0	2567 3242 0	Climb-up;Ladder;17385								2	
-2569 9628 0	2569 3228 0	Climb-up;Ladder;17385								2	
-2569 3228 0	2569 9628 0	Climb-down;Ladder;17384								2	
-2568 9627 0	2568 3227 0	Climb-up;Ladder;17385								2	
-2568 3227 0	2568 9627 0	Climb-down;Ladder;17384								2	
-2569 9626 0	2569 3226 0	Climb-up;Ladder;17385								2	
-2569 3226 0	2569 9626 0	Climb-down;Ladder;17384								2	
-2570 9627 0	2570 3227 0	Climb-up;Ladder;17385								2	
-2570 3227 0	2570 9627 0	Climb-down;Ladder;17384								2	
-2571 3227 0	2571 9627 0	Climb-down;Ladder;17384								2	
-2571 9627 0	2571 3227 0	Climb-up;Ladder;17385								2	
-2572 3228 0	2572 9628 0	Climb-down;Ladder;17384								2	
-2572 9628 0	2572 3228 0	Climb-up;Ladder;17385								2	
-2573 3227 0	2573 9627 0	Climb-down;Ladder;17384								2	
-2573 9627 0	2573 3227 0	Climb-up;Ladder;17385								2	
-2572 3226 0	2572 9626 0	Climb-down;Ladder;17384								2	
-2572 9626 0	2572 3226 0	Climb-up;Ladder;17385								2	
-2567 3227 0	2567 9627 0	Climb-down;Ladder;17384								2	
-2567 9627 0	2567 3227 0	Climb-up;Ladder;17385								2	
-2566 3226 0	2566 9626 0	Climb-down;Ladder;17384								2	
-2566 9626 0	2566 3226 0	Climb-up;Ladder;17385								2	
-2565 3227 0	2565 9627 0	Climb-down;Ladder;17384								2	
-2565 9627 0	2565 3227 0	Climb-up;Ladder;17385								2	
-2566 3228 0	2566 9628 0	Climb-down;Ladder;17384								2	
-2566 9628 0	2566 3228 0	Climb-up;Ladder;17385								2	
-2566 3230 0	2566 9630 0	Climb-down;Ladder;17384								2	
-2566 9630 0	2566 3230 0	Climb-up;Ladder;17385								2	
-2567 3231 0	2567 9631 0	Climb-down;Ladder;17384								2	
-2567 9631 0	2567 3231 0	Climb-up;Ladder;17385								2	
-2566 3232 0	2566 9632 0	Climb-down;Ladder;17384								2	
-2566 9632 0	2566 3232 0	Climb-up;Ladder;17385								2	
-2565 3231 0	2565 9631 0	Climb-down;Ladder;17384								2	
-2565 9631 0	2565 3231 0	Climb-up;Ladder;17385								2	
-2568 3231 0	2568 9631 0	Climb-down;Ladder;17384								2	
-2568 9631 0	2568 3231 0	Climb-up;Ladder;17385								2	
-2569 3232 0	2569 9632 0	Climb-down;Ladder;17384								2	
-2569 9632 0	2569 3232 0	Climb-up;Ladder;17385								2	
-2570 3231 0	2570 9631 0	Climb-down;Ladder;17384								2	
-2570 9631 0	2570 3231 0	Climb-up;Ladder;17385								2	
-2569 3230 0	2569 9630 0	Climb-down;Ladder;17384								2	
-2569 9630 0	2569 3230 0	Climb-up;Ladder;17385								2	
-2621 3262 0	2621 9662 0	Climb-down;Ladder;17384								2	
-2621 9662 0	2621 3262 0	Climb-up;Ladder;17385								2	
-2622 3261 0	2622 9661 0	Climb-down;Ladder;17384								2	
-2622 9661 0	2622 3261 0	Climb-up;Ladder;17385								2	
-2621 3260 0	2621 9660 0	Climb-down;Ladder;17384								2	
-2621 9660 0	2621 3260 0	Climb-up;Ladder;17385								2	
-2620 3261 0	2620 9661 0	Climb-down;Ladder;17384								2	
-2620 9661 0	2620 3261 0	Climb-up;Ladder;17385								2	
-2576 9631 0	2575 9631 0	Push;Wall;1597									
-2575 9631 0	2576 9631 0	Push;Wall;1597									
-2573 9631 0	2573 3231 0	Climb-up;Ladder;17385								2	
-2571 9631 0	2571 3231 0	Climb-up;Ladder;17385								2	
-2572 9632 0	2572 3232 0	Climb-up;Ladder;17385								2	
-2572 9630 0	2572 3230 0	Climb-up;Ladder;17385								2	
-2561 9621 0	2561 3221 0	Climb-up;Ladder;17385								2	
-2561 3221 0	2561 9621 0	Climb-down;Ladder;16680								2	
-2562 9622 0	2562 3222 0	Climb-up;Ladder;17385								2	
-2562 3222 0	2561 9621 0	Climb-down;Ladder;16680								2	
-2561 3223 0	2561 9621 0	Climb-down;Ladder;16680								2	
-2560 3222 0	2561 9621 0	Climb-down;Ladder;16680								2	
-											
-# Edgeville											
-3097 3511 0	3097 3511 1	Climb-up;Ladder;16683									
-3097 3511 1	3097 3511 0	Climb-down;Ladder;16679									
-3096 3512 0	3096 3512 1	Climb-up;Ladder;16683									
-3096 3512 1	3096 3512 0	Climb-down;Ladder;16679									
-3095 3511 0	3095 3511 1	Climb-up;Ladder;16683									
-3095 3511 1	3095 3511 0	Climb-down;Ladder;16679									
-3096 3510 0	3096 3510 1	Climb-up;Ladder;16683									
-3096 3510 1	3096 3510 0	Climb-down;Ladder;16679									
-3083 3512 0	3083 3512 1	Climb-up;Ladder;16683									
-3083 3512 1	3083 3512 0	Climb-down;Ladder;16679									
-3082 3513 0	3082 3513 1	Climb-up;Ladder;16683									
-3082 3513 1	3082 3513 0	Climb-down;Ladder;16679									
-3096 3468 0	3096 9867 0	Climb-down;Trapdoor;1581								1	
-3096 9867 0	3096 3468 0	Climb-up;Ladder;17385								1	
-3097 9868 0	3096 3468 0	Climb-up;Ladder;17385								1	
-3089 9971 0	3089 3571 0	Climb-up;Ladder;17385								1	
-3089 3571 0	3089 9971 0	Climb-down;Ladder;16680								1	
-3094 9895 0	3093 9895 0	Push;Odd looking wall;1736									
-3093 9895 0	3094 9895 0	Push;Odd looking wall;1736									
-3094 9896 0	3093 9896 0	Push;Odd looking wall;1734									
-3093 9896 0	3094 9896 0	Push;Odd looking wall;1734									
-3132 9917 0	3132 9918 0	Open;Gate;1728								1	
-3132 9918 0	3132 9917 0	Open;Gate;1728								1	
-3131 9917 0	3131 9918 0	Open;Gate;1727								1	
-3131 9918 0	3131 9917 0	Open;Gate;1727								1	
-3122 3488 0	3122 3487 0	Open;Door;102									
-3122 3487 0	3122 3488 0	Open;Door;102									
-3115 3449 0	3115 3450 0	Open;Door;1804		983						2	
-3115 3450 0	3115 3449 0	Open;Door;1804		983						2	
-3115 3452 0	3115 9852 0	Climb-down;Ladder;17384								2	
-3115 9852 0	3115 3452 0	Climb-up;Ladder;17385								2	
-											
-# Varrock											
-3212 3472 0	3212 3476 1	Climb-up;Staircase;11807									
-3212 3476 1	3212 3472 0	Climb-down;Staircase;11799									
-3213 3472 0	3213 3476 1	Climb-up;Staircase;11807									
-3213 3476 1	3213 3472 0	Climb-down;Staircase;11799									
-3203 3496 0	3204 3497 1	Climb-up;Staircase;11790									
-3204 3497 1	3203 3496 0	Climb-down;Staircase;11792									
-3204 3497 1	3204 3497 2	Climb-up;Staircase;11792									
-3204 3497 2	3203 3496 1	Climb-down;Staircase;11793									
-3204 3497 2	3204 3497 3	Climb-up;Ladder;11801									
-3204 3497 3	3204 3497 2	Climb-down;Ladder;11802									
-3220 3496 1	3219 3495 0	Climb-down;Staircase;11793									
-3219 3495 0	3220 3496 1	Climb-up;Staircase;11789									
-3218 3495 0	3220 3496 1	Climb-up;Staircase;11789									
-3222 3491 0	3222 3490 0	Open;Door;32464									
-3222 3490 0	3222 3491 0	Open;Door;32464									
-3222 3479 0	3222 3478 0	Open;Door;32464									
-3222 3478 0	3222 3479 0	Open;Door;32464									
-3223 3472 1	3223 3472 2	Climb-up;Ladder;11801									
-3223 3472 2	3223 3472 1	Climb-down;Ladder;11802									
-3223 3472 3	3222 3471 2	Climb-down;Staircase;11793									
-3222 3471 2	3223 3472 3	Climb-up;Staircase;11790									
-3221 3471 2	3223 3472 3	Climb-up;Staircase;11790									
-3238 3490 0	3242 3490 1	Climb-up;Staircase;11797									
-3242 3490 1	3238 3490 0	Climb-down;Staircase;11799									
-3238 3489 0	3242 3489 1	Climb-up;Staircase;11797									
-3242 3489 1	3238 3489 0	Climb-down;Staircase;11799									
-3257 3487 0	3258 3486 1	Climb-up;Staircase;11790									
-3258 3486 1	3257 3487 0	Climb-down;Staircase;11792									
-3257 3488 0	3258 3486 1	Climb-up;Staircase;11790									
-3258 3486 1	3258 3486 2	Climb-up;Staircase;11792									
-3258 3486 2	3257 3487 1	Climb-down;Staircase;11792									
-3258 3486 2	3258 3486 3	Climb-up;Staircase;11792									
-3258 3486 3	3257 3487 2	Climb-down;Staircase;11793									
-3239 3447 1	3238 3446 0	Climb-down;Staircase;11793									
-3238 3446 0	3239 3447 1	Climb-up;Staircase;11789									
-3237 3446 0	3239 3447 1	Climb-up;Staircase;11789									
-3257 3454 0	1759 4958 0	Walk-down;Stairs;24428									
-1759 4958 0	3258 3452 0	Walk-up;Stairs;24427									
-3258 3453 0	1759 4958 0	Walk-down;Stairs;24428									
-1758 4958 0	3258 3452 0	Walk-up;Stairs;24427									
-3258 3452 0	1759 4958 0	Walk-down;Stairs;24428									
-1760 4958 0	3258 3452 0	Walk-up;Stairs;24427									
-3258 3451 0	1759 4958 0	Walk-down;Stairs;24428									
-3257 3450 0	1759 4958 0	Walk-down;Stairs;24428									
-1761 4965 0	1631 4957 0	Walk-down;Stairs;24428									
-1631 4957 0	1761 4964 0	Walk-up;Stairs;24427									
-1761 4964 0	1631 4957 0	Walk-down;Stairs;24428									
-1630 4957 0	1761 4964 0	Walk-up;Stairs;24427									
-1761 4963 0	1631 4957 0	Walk-down;Stairs;24428									
-1632 4957 0	1761 4964 0	Walk-up;Stairs;24427									
-3266 3451 0	3266 3455 1	Climb-up;Staircase;11798									
-3266 3455 1	3266 3451 0	Climb-down;Staircase;11799									
-3267 3451 0	3267 3455 1	Climb-up;Staircase;11798									
-3267 3455 1	3267 3451 0	Climb-down;Staircase;11799									
-3254 3442 1	3254 3446 2	Climb-up;Staircase;11797									
-3254 3446 2	3254 3442 1	Climb-down;Staircase;11799									
-3253 3442 1	3253 3446 2	Climb-up;Staircase;11797									
-3253 3446 2	3253 3442 1	Climb-down;Staircase;11799									
-3257 3421 1	3256 3420 0	Climb-down;Staircase;11793									
-3256 3420 0	3257 3421 1	Climb-up;Staircase;11789									
-3255 3420 0	3257 3421 1	Climb-up;Staircase;11789									
-3257 3422 1	3256 3420 0	Climb-down;Staircase;11793									
-3234 3424 0	3234 3424 1	Climb-up;Ladder;11794									
-3234 3424 1	3234 3424 0	Climb-down;Ladder;11795									
-3230 3394 1	3226 3394 0	Climb-down;Staircase;11799									
-3226 3394 0	3230 3394 1	Climb-up;Staircase;11796									
-3230 3393 1	3226 3393 0	Climb-down;Staircase;11799									
-3226 3393 0	3230 3393 1	Climb-up;Staircase;11796									
-3231 9800 0	3231 3400 0	Climb-up;Ladder;11804									
-3231 3400 0	3231 9800 0	Climb-down;Ladder;11803									
-3230 9801 0	3230 3401 0	Climb-up;Ladder;11804									
-3230 3401 0	3230 9801 0	Climb-down;Ladder;11803									
-3231 9802 0	3231 3402 0	Climb-up;Ladder;11804									
-3231 3402 0	3231 9802 0	Climb-down;Ladder;11803									
-3232 9801 0	3232 3401 0	Climb-up;Ladder;11804									
-3232 3401 0	3232 9801 0	Climb-down;Ladder;11803									
-3230 3386 0	3230 3382 1	Climb-up;Staircase;11797									
-3230 3382 1	3230 3386 0	Climb-down;Staircase;11799									
-3231 3386 0	3231 3382 1	Climb-up;Staircase;11797									
-3231 3382 1	3231 3386 0	Climb-down;Staircase;11799									
-3222 3387 1	3222 3387 0	Climb-down;Ladder;11802									
-3222 3387 0	3222 3387 1	Climb-up;Ladder;11794									
-3186 3434 0	3190 9834 0	Climb-down;Staircase;11800									
-3190 9834 0	3186 3434 0	Climb-up;Staircase;11805									
-3186 3433 0	3190 9833 0	Climb-down;Staircase;11800									
-3190 9833 0	3186 3433 0	Climb-up;Staircase;11805									
-3185 3447 0	3185 3447 1	Climb-up;Ladder;11794									
-3185 3447 1	3185 3447 0	Climb-down;Ladder;11795									
-3159 3436 0	3155 3436 1	Climb-up;Staircase;11797									
-3155 3436 1	3159 3436 0	Climb-down;Staircase;11799									
-3159 3435 0	3155 3435 1	Climb-up;Staircase;11797									
-3155 3435 1	3159 3435 0	Climb-down;Staircase;11799									
-3186 3414 0	3186 3414 1	Climb-up;Ladder;11794									
-3186 3414 1	3186 3414 0	Climb-down;Ladder;11795									
-3205 3396 0	3205 3396 1	Climb-up;Ladder;11794									
-3205 3396 1	3205 3396 0	Climb-down;Ladder;11795									
-3203 3389 1	3205 3389 0	Climb-down;Ladder;11802									
-3203 3389 0	3203 3389 1	Climb-up;Ladder;11801									
-3243 3383 0	3243 9783 0	Climb-down;Ladder;11803									
-3243 9783 0	3244 3382 0	Climb-up;Ladder;2405									
-3244 3382 0	3244 9782 0	Climb-down;Ladder;11803									
-3244 9782 0	3244 3382 0	Climb-up;Ladder;2405									
-3245 9783 0	3244 3382 0	Climb-up;Ladder;2405									
-3244 9784 0	3244 3382 0	Climb-up;Ladder;2405									
-3262 3402 0	3262 3402 1	Climb-up;Ladder;11794									
-3262 3402 1	3262 3402 0	Climb-down;Ladder;11795									
-3263 3406 0	3264 3406 0	Open;Gate;2051									
-3264 3406 0	3263 3406 0	Open;Gate;2051									
-3263 3405 0	3264 3405 0	Open;Gate;2050									
-3264 3405 0	3263 3405 0	Open;Gate;2050									
-3283 3397 1	3283 3397 0	Climb-down;Ladder;11802									
-3283 3397 0	3283 3397 1	Climb-up;Ladder;11801									
-3202 3435 1	3202 3435 0	Climb-down;Ladder;11795									
-3202 3435 0	3202 3435 1	Climb-up;Ladder;11794									
-3246 3409 0	3246 3409 1	Climb-up;Ladder;11794									
-3246 3409 1	3246 3409 0	Climb-down;Ladder;11795									
-3202 3417 1	3202 3417 0	Climb-down;Ladder;11795									
-3202 3417 0	3202 3417 1	Climb-up;Ladder;11794									
-3214 3411 0	3214 3411 1	Climb-up;Ladder;11794									
-3214 3411 1	3214 3411 0	Climb-down;Ladder;11795									
-3179 3401 0	3179 3401 1	Climb-up;Ladder;11801									
-3179 3401 1	3179 3401 0	Climb-down;Ladder;11802									
-3175 3421 0	3175 3421 1	Climb-up;Ladder;11801									
-3175 3421 1	3175 3421 0	Climb-down;Ladder;11802									
-3267 3379 0	3269 3379 1	Climb-up;Ladder;11794									
-3267 3379 1	3267 3379 0	Climb-down;Ladder;11795									
-3237 9858 0	3236 3458 0	Climb-up;Ladder;11806									
-3236 3458 0	3237 9858 0	Open;Manhole;881								2	
-3236 3458 0	3237 9858 0	Climb-down;Manhole;882								2	
-3210 9899 0	3210 9898 0	Slash;Web;733								8	
-3210 9898 0	3210 9899 0	Slash;Web;733								8	
-3143 3443 0	3143 3444 0	Open;Door;24958	32 Cooking							2	
-3143 3444 0	3143 3443 0	Open;Door;24958	32 Cooking							2	
-3143 3452 0	3144 3452 0	Open;Door;10045									
-3144 3452 0	3143 3452 0	Open;Door;10045									
-3144 3449 0	3144 3449 1	Climb-up;Staircase;2608								2	
-3144 3449 1	3144 3449 0	Climb-down;Staircase;2609								2	
-3144 3449 1	3144 3446 2	Climb-up;Staircase;2609								2	
-3144 3446 2	3144 3449 1	Climb-down;Staircase;2610								2	
-											
-# Stronghold of Security											
-3081 3421 0	1859 5243 0	Climb-down;Entrance;20790									
-1859 5243 0	3081 3421 0	Climb-up;Ladder;20784									
-1860 5244 0	3081 3421 0	Climb-up;Ladder;20784									
-1858 5244 0	3081 3421 0	Climb-up;Ladder;20784									
-1913 5225 0	3081 3421 0	Climb-up;Ladder;20784									
-1914 5226 0	3081 3421 0	Climb-up;Ladder;20784									
-1912 5226 0	3081 3421 0	Climb-up;Ladder;20784									
-1913 5227 0	3081 3421 0	Climb-up;Ladder;20784									
-3081 3421 0	1859 5243 0	Climb-down;Entrance;20790									
-1859 5243 0	3081 3421 0	Climb-up;Ladder;20784									
-1860 5244 0	3081 3421 0	Climb-up;Ladder;20784									
-1858 5244 0	3081 3421 0	Climb-up;Ladder;20784									
-1913 5225 0	3081 3421 0	Climb-up;Ladder;20784									
-1914 5226 0	3081 3421 0	Climb-up;Ladder;20784									
-1912 5226 0	3081 3421 0	Climb-up;Ladder;20784									
-1913 5227 0	3081 3421 0	Climb-up;Ladder;20784									
-1902 5223 0	2042 5245 0	Climb-down;Ladder;20785									
-1903 5222 0	2042 5245 0	Climb-down;Ladder;20785									
-1902 5221 0	2042 5245 0	Climb-down;Ladder;20785									
-2042 5245 0	1859 5243 0	Climb-up;Ladder;19003									
-2026 5219 0	2123 5252 0	Climb-down;Ladder;19004									
-2025 5218 0	2123 5252 0	Climb-down;Ladder;19004									
-2122 5251 0	2042 5245 0	Climb-up;Dripping vine;23705									
-2026 5217 0	2123 5252 0	Climb-down;Ladder;19004									
-2150 5279 0	2123 5252 0	Push;Odd looking wall;1734									
-2147 5284 0	2358 5215 0	Climb-down;Dripping vine;23706									
-2358 5215 0	2123 5252 0	Climb-up;Boney ladder;23921									
-2148 5283 0	2358 5215 0	Climb-down;Dripping vine;23706									
-2357 5216 0	2123 5252 0	Climb-up;Boney ladder;23921									
-2149 5284 0	2358 5215 0	Climb-down;Dripping vine;23706									
-2026 5217 0	2123 5252 0	Climb-down;Ladder;19004									
-2150 5279 0	2123 5252 0	Climb-up;Goo covered vine;23703									
-2147 5284 0	2358 5215 0	Climb-down;Dripping vine;23706									
-2358 5215 0	2123 5252 0	Climb-up;Boney ladder;23921									
-2148 5283 0	2358 5215 0	Climb-down;Dripping vine;23706									
-2357 5216 0	2123 5252 0	Climb-up;Boney ladder;23921									
-2149 5284 0	2358 5215 0	Climb-down;Dripping vine;23706									
-2349 5215 0	3081 3421 0	Climb-up;Bone Chain;23732									
-2027 5218 0	2123 5252 0	Climb-down;Ladder;19004									
-2350 5214 0	3081 3421 0	Climb-up;Bone Chain;23732									
-2150 5277 0	2123 5252 0	Climb-up;Goo covered vine;23703									
-2151 5278 0	2123 5252 0	Climb-up;Goo covered vine;23703									
-2351 5215 0	3081 3421 0	Climb-up;Bone Chain;23732									
-2350 5216 0	3081 3421 0	Climb-up;Bone Chain;23732									
-											
-# Barbarian Village											
-3096 3432 0	3096 3432 1	Climb-up;Ladder;17026									
-3096 3432 1	3096 3432 0	Climb-down;Ladder;16685									
-3097 3432 1	3097 3432 2	Climb-up;Ladder;17026									
-3097 3432 2	3097 3432 1	Climb-down;Ladder;16685									
-											
-# Al Kharid											
-3267 3228 0	3268 3228 0	Pay-toll(10gp);Gate;44599								1	
-3268 3228 0	3267 3228 0	Pay-toll(10gp);Gate;44599								1	
-3267 3227 0	3268 3227 0	Pay-toll(10gp);Gate;44598								1	
-3268 3227 0	3267 3227 0	Pay-toll(10gp);Gate;44598								1	
-3298 3124 0	3297 3124 0	Open;Prison door;2692									
-3297 3124 0	3298 3124 0	Open;Prison door;2692									
-3303 3117 0	3304 3115 0	Go-through;Shantay pass;4031		1854						2	
-3304 3117 0	3304 3115 0	Go-through;Shantay pass;4031		1854						2	
-3304 3115 0	3304 3117 0	Go-through;Shantay pass;4031								2	
-3303 3115 0	3304 3117 0	Go-through;Shantay pass;4031								2	
-3193 2843 0	3196 2843 0	Go-through;Shantay pass;41326		1854						3	
-3193 2842 0	3196 2842 0	Go-through;Shantay pass;41326		1854						3	
-3196 2843 0	3193 2843 0	Go-through;Shantay pass;41326								3	
-3196 2842 0	3193 2842 0	Go-through;Shantay pass;41326								3	
-3167 2819 0	3167 2816 0	Go-through;Shantay pass;41326		1854						3	
-3168 2819 0	3168 2816 0	Go-through;Shantay pass;41326		1854						3	
-3167 2816 0	3167 2819 0	Go-through;Shantay pass;41326								3	
-3168 2816 0	3168 2819 0	Go-through;Shantay pass;41326								3	
-3322 3138 0	3322 3138 1	Climb-up;Ladder;21781									
-3322 3138 1	3322 3138 0	Climb-down;Ladder;21782									
-3312 3184 0	3314 3185 1	Climb-up;Staircase;16671									
-3314 3185 1	3313 3184 0	Climb-down;Staircase;16673									
-3313 3184 0	3314 3185 1	Climb-up;Staircase;16671									
-3314 3185 0	3314 3185 1	Climb-up;Staircase;16671									
-3314 3186 0	3314 3185 1	Climb-up;Staircase;16671									
-3285 3165 0	3285 3165 1	Climb-up;Ladder;16683									
-3285 3165 1	3285 3165 0	Climb-down;Ladder;16679									
-3284 3166 0	3284 3166 1	Climb-up;Ladder;16683									
-3284 3166 1	3284 3166 0	Climb-down;Ladder;16679									
-3283 3165 0	3283 3165 1	Climb-up;Ladder;16683									
-3283 3165 1	3283 3165 0	Climb-down;Ladder;16679									
-3284 3164 0	3284 3164 1	Climb-up;Ladder;16683									
-3284 3164 1	3284 3164 0	Climb-down;Ladder;16679									
-3287 3192 0	3287 3192 1	Climb-up;Ladder;16683									
-3287 3192 1	3287 3192 0	Climb-down;Ladder;16684									
-3286 3191 0	3286 3191 1	Climb-up;Ladder;16683									
-3286 3191 1	3286 3191 0	Climb-down;Ladder;16684									
-3286 3191 1	3286 3191 2	Climb-up;Ladder;16684									
-3286 3191 2	3286 3191 1	Climb-down;Ladder;16679									
-3287 3192 1	3287 3192 2	Climb-up;Ladder;16684									
-											
-# Citharede Abbey											
-3420 3185 0	3420 3185 1	Climb-up;Ladder;10493								2	
-3420 3185 1	3420 3185 0	Climb-down;Ladder;10494								2	
-											
-# Mage Trainining Arena											
-3363 3300 0	3363 3298 0	Enter;Doorway;10721									
-3363 3298 0	3363 3300 0	Enter;Doorway;10721									
-3363 3300 0	3363 3298 0	Enter;Doorway;10721									
-3363 3298 0	3363 3300 0	Enter;Doorway;10721									
-3360 3306 0	3357 3307 1	Climb-up;Stairs;10775									
-3357 3307 1	3360 3306 0	Climb-down;Stairs;10776									
-3358 3307 1	3360 3306 0	Climb-down;Stairs;10776									
-3360 3307 0	3357 3307 1	Climb-up;Stairs;10775									
-3359 3307 1	3360 3306 0	Climb-down;Stairs;10776									
-3366 3306 0	3369 3307 1	Climb-up;Stairs;10771									
-3369 3307 1	3366 3306 0	Climb-down;Stairs;10773									
-3366 3307 0	3369 3307 1	Climb-up;Stairs;10771									
-3368 3307 1	3366 3306 0	Climb-down;Stairs;10773									
-3367 3307 1	3366 3306 0	Climb-down;Stairs;10773									
-											
-# HAM Hideout											
-3165 3252 0	3149 9652 0	Climb-down;Trapdoor;5492									
-3166 3251 0	3149 9652 0	Climb-down;Trapdoor;5492									
-3149 9652 0	3165 3251 0	Climb-up;Ladder;5493									
-3150 9653 0	3165 3251 0	Climb-up;Ladder;5493									
-3148 9653 0	3165 3251 0	Climb-up;Ladder;5493									
-											
-# Port Sarim											
-3055 3245 0	3055 3242 1	Cross;Gangplank;34671								3	
-3055 3242 1	3055 3245 0	Cross;Gangplank;34672								3	
-3048 3234 0	3048 3231 1	Cross;Gangplank;2412								3	
-3048 3231 1	3048 3234 0	Cross;Gangplank;2413								3	
-3047 3231 1	3045 3231 2	Climb-up;Ship's ladder;245									
-3045 3231 2	3047 3231 1	Climb-down;Ship's ladder;246									
-3045 3227 2	3047 3227 1	Climb-down;Ship's ladder;246									
-3047 3227 1	3045 3227 2	Climb-up;Ship's ladder;245									
-3029 3217 0	3032 3217 1	Cross;Gangplank;2083								3	
-3032 3217 1	3029 3217 0	Cross;Gangplank;2084								3	
-3035 3214 0	3035 3214 1	Climb-up;Ship's ladder;272									
-3035 3214 1	3035 3214 0	Climb-down;Ship's ladder;273									
-3035 3218 0	3035 3218 1	Climb-up;Ship's ladder;272									
-3035 3218 1	3035 3218 0	Climb-down;Ship's ladder;273									
-3035 3222 0	3035 3222 1	Climb-up;Ship's ladder;272									
-3035 3222 1	3035 3222 0	Climb-down;Ship's ladder;273									
-3036 3223 1	3036 3225 2	Climb-up;Ship's ladder;245									
-3036 3225 2	3036 3223 1	Climb-down;Ship's ladder;246									
-3032 3225 2	3032 3223 1	Climb-down;Ship's ladder;246									
-3032 3223 1	3032 3225 2	Climb-up;Ship's ladder;245									
-3041 3202 0	3041 3199 1	Cross;Gangplank;14304								3	
-3041 3199 1	3041 3202 0	Cross;Gangplank;14305								3	
-3038 3192 0	3038 3189 1	Cross;Gangplank;17404									
-3038 3189 1	3038 3192 0	Cross;Gangplank;17405									
-											
-#pest control											
-2662 2677 1	2659 2676 0	Cross;Gangplank;14307								3	
-3013 3204 0	3013 3204 1	Climb-up;Ladder;16683									
-3013 3204 1	3013 3204 0	Climb-down;Ladder;16679									
-3014 3203 0	3014 3203 1	Climb-up;Ladder;16683									
-3014 3203 1	3014 3203 0	Climb-down;Ladder;16679									
-3012 3203 0	3012 3203 1	Climb-up;Ladder;16683									
-3012 3203 1	3012 3203 0	Climb-down;Ladder;16679									
-3011 3184 0	3011 3184 1	Climb-up;Ladder;9558									
-3011 3184 1	3011 3184 0	Climb-down;Ladder;9559									
-3012 3235 0	3012 3235 1	Climb-up;Ladder;16683									
-3012 3235 1	3012 3235 0	Climb-down;Ladder;16679									
-3011 3234 0	3011 3234 1	Climb-up;Ladder;16683									
-3011 3234 1	3011 3234 0	Climb-down;Ladder;16679									
-3010 3235 0	3010 3235 1	Climb-up;Ladder;16683									
-3010 3235 1	3010 3235 0	Climb-down;Ladder;16679									
-3011 3236 0	3011 3236 1	Climb-up;Ladder;16683									
-3011 3236 1	3011 3236 0	Climb-down;Ladder;16679									
-3016 3246 0	3015 3246 0	Open;Door;59									
-3015 3246 0	3016 3246 0	Open;Door;59									
-3013 3245 0	3013 3245 1	Climb-up;Ladder;60									
-3013 3245 1	3013 3245 0	Climb-down;Ladder;16679									
-3014 3244 0	3013 3245 1	Climb-up;Ladder;60									
-3012 3244 1	3012 3244 0	Climb-down;Ladder;16679									
-3012 3244 0	3013 3245 1	Climb-up;Ladder;60									
-3014 3244 1	3014 3244 0	Climb-down;Ladder;16679									
-3025 3261 1	3024 3260 0	Climb-down;Staircase;9584									
-3024 3260 0	3025 3261 1	Climb-up;Staircase;9582									
-3023 3260 0	3025 3261 1	Climb-up;Staircase;9582									
-3026 3247 1	3025 3248 0	Climb-down;Staircase;9584									
-3025 3248 0	3026 3247 1	Climb-up;Staircase;9582									
-3025 3249 0	3026 3247 1	Climb-up;Staircase;9582									
-3018 3231 0	2962 9650 0	Climb-down;Manhole;10321									
-2962 9650 0	3018 3233 0	Climb-up;Ladder;10309									
-											
-# Wizard Tower											
-3105 3162 0	3104 9576 0	Climb-down;Ladder;2147									
-3104 9576 0	3105 3162 0	Climb-up;Ladder;2148									
-3104 3163 0	3104 9576 0	Climb-down;Ladder;2147									
-3103 9577 0	3105 3162 0	Climb-up;Ladder;2148									
-3104 3161 0	3104 9576 0	Climb-down;Ladder;2147									
-3103 9575 0	3105 3162 0	Climb-up;Ladder;2148									
-3103 3162 0	3104 9576 0	Climb-down;Ladder;2147									
-3105 3160 0	3104 3161 1	Climb-up;Staircase;12536									
-3104 3161 1	3104 3161 0	Climb-down;Staircase;12537									
-3105 3159 0	3104 3161 1	Climb-up;Staircase;12536									
-3103 3161 1	3104 3161 0	Climb-down;Staircase;12537									
-3104 3161 1	3104 3161 2	Climb-up;Staircase;12537									
-3104 3161 2	3104 3161 1	Climb-down;Staircase;12538									
-3107 3162 0	3107 3162 0	Open;Door;23972									
-# Taverley Dungeon											
-2884 3398 0	2884 9798 0	Climb-down;Ladder;16680									
-2884 9798 0	2884 3398 0	Climb-up;Ladder;17385									
-2885 3397 0	2885 9797 0	Climb-down;Ladder;16680									
-2885 9797 0	2885 3397 0	Climb-up;Ladder;17385									
-2884 3396 0	2884 9796 0	Climb-down;Ladder;16680									
-2884 9796 0	2884 3396 0	Climb-up;Ladder;17385									
-2883 3397 0	2883 9797 0	Climb-down;Ladder;16680									
-2883 9797 0	2883 3397 0	Climb-up;Ladder;17385									
-2888 9831 0	2889 9831 0	Open;Prison door;2143									
-2888 9830 0	2889 9830 0	Open;Prison door;2144									
-2889 9830 0	2888 9830 0	Open;Prison door;2144									
-2889 9831 0	2888 9831 0	Open;Prison door;2143									
-2842 3423 0	2842 9823 0	Climb-down;Ladder;17384									
-2842 9823 0	2842 3423 0	Climb-up;Ladder;17385									
-2843 3424 0	2843 9824 0	Climb-down;Ladder;17384									
-2843 9824 0	2843 3424 0	Climb-up;Ladder;17385									
-2842 3425 0	2842 9825 0	Climb-down;Ladder;17384									
-2842 9825 0	2842 3425 0	Climb-up;Ladder;17385									
-2841 3424 0	2841 9824 0	Climb-down;Ladder;17384									
-2841 9824 0	2841 3424 0	Climb-up;Ladder;17385									
-1310 1237 0	2873 9848 0	Crawl;Cave;26566									
-2873 9848 0	1310 1237 0	Crawl;Cave;26568									
-1311 1237 0	2873 9848 0	Crawl;Cave;26565									
-2873 9847 0	1310 1237 0	Crawl;Cave;26569									
-1309 1237 0	2873 9848 0	Crawl;Cave;26564									
-2873 9846 0	1310 1237 0	Crawl;Cave;26567									
-1292 1253 0	1240 1226 0	Turn;Iron Winch;23104									
-1291 1253 0	1240 1226 0	Turn;Iron Winch;23104									
-1240 1226 0	1291 1253 0	Exit;Portcullis;21772									
-1309 1269 0	1304 1290 0	Turn;Iron Winch;23104									
-1304 1290 0	1309 1269 0	Exit;Portcullis;21772									
-1368 1226 0	1328 1253 0	Exit;Portcullis;21772									
-1328 1253 0	1368 1226 0	Turn;Iron Winch;23104									
-1329 1253 0	1368 1226 0	Turn;Iron Winch;23104									
-2903 9813 1	2906 9813 0	Climb;Steps;30190									
-2906 9813 0	2903 9813 1	Climb;Steps;30189									
-2883 9825 0	2880 9825 1	Climb;Steps;30189									
-2880 9825 1	2883 9825 0	Climb;Steps;30190									
-2924 9803 0	2923 9803 0	Open;Gate;2623		1590							
-2923 9803 0	2924 9803 0	Open;Gate;2623									
-											
-# Taverley											
-2914 3450 0	2914 3450 1	Climb-up;Ladder;16683									
-2914 3450 1	2914 3450 0	Climb-down;Ladder;16679									
-2915 3451 0	2915 3451 1	Climb-up;Ladder;16683									
-2915 3451 1	2915 3451 0	Climb-down;Ladder;16679									
-2915 3449 0	2915 3449 1	Climb-up;Ladder;16683									
-2915 3449 1	2915 3449 0	Climb-down;Ladder;16679									
-2916 3450 0	2916 3450 1	Climb-up;Ladder;16683									
-2914 3441 0	2914 3441 1	Climb-up;Ladder;17026									
-2914 3441 1	2914 3441 0	Climb-down;Ladder;16685									
-2918 3439 0	2916 3438 0	Climb-over;Stile;993									
-2916 3438 0	2919 3438 0	Climb-over;Stile;993									
-2919 3438 0	2916 3438 0	Climb-over;Stile;993									
-2917 3437 0	2919 3438 0	Climb-over;Stile;993									
-2918 3437 0	2916 3438 0	Climb-over;Stile;993									
-2917 3439 0	2919 3438 0	Climb-over;Stile;993									
-2898 3427 0	2898 3427 1	Climb-up;Staircase;16671									
-2898 3427 1	2897 3428 0	Climb-down;Staircase;16673									
-2897 3428 0	2898 3427 1	Climb-up;Staircase;16671									
-2897 3429 0	2898 3427 1	Climb-up;Staircase;16671									
-2898 3430 0	2898 3427 1	Climb-up;Staircase;16671									
-2899 3430 0	2898 3427 1	Climb-up;Staircase;16671									
-2899 3427 0	2898 3427 1	Climb-up;Staircase;16671									
-2900 3428 0	2898 3427 1	Climb-up;Staircase;16671									
-2900 3429 0	2898 3427 1	Climb-up;Staircase;16671									
-2900 3473 0	2901 3473 0	Open;Door;2861									
-2901 3473 0	2900 3473 0	Open;Door;2861									
-2906 3468 0	2906 3472 1	Walk-up;Staircase;24672									
-2906 3472 1	2906 3468 0	Walk-down;Staircase;24673									
-2907 3468 0	2906 3472 1	Walk-up;Staircase;24672									
-2907 3472 1	2906 3468 0	Walk-down;Staircase;24673									
-2906 3476 0	2906 9876 0	Climb-down;Ladder;24718									
-2906 9876 0	2906 3476 0	Climb-up;Ladder;24717									
-2907 3475 0	2906 9876 0	Climb-down;Ladder;24718									
-2907 9875 0	2906 3476 0	Climb-up;Ladder;24717									
-2898 3469 0	2901 9867 0	Enter;Manhole;24842									
-2901 9867 0	2899 3469 0	Climb-up;Staircase;24687									
-2899 3469 0	2901 9867 0	Enter;Manhole;24842									
-2899 3470 0	2901 9867 0	Enter;Manhole;24842									
-2899 3468 0	2901 9867 0	Enter;Manhole;24842									
-2877 3482 0	2876 9878 0	Climb-down;Stairs;57				Fishing Contest					
-2876 9879 0	2877 3482 0	Climb-up;Stairs;56				Fishing Contest					
-2876 3482 0	2876 9878 0	Climb-down;Stairs;57				Fishing Contest					
-2877 9879 0	2877 3482 0	Climb-up;Stairs;56				Fishing Contest					
-2821 9882 0	2820 3486 0	Climb-up;Stairs;54				Fishing Contest					
-2820 3486 0	2820 9882 0	Climb-down;Stairs;55				Fishing Contest					
-2820 9882 0	2820 3486 0	Climb-up;Stairs;54				Fishing Contest					
-2821 3486 0	2820 9882 0	Climb-down;Stairs;55				Fishing Contest					
-											
-# Catherby											
-2792 3414 0	2792 3417 1	Cross;Gangplank;17394								3	
-2792 3417 1	2792 3414 0	Cross;Gangplank;17395								3	
-2813 3450 0	2813 3450 1	Climb-up;Ladder;16683									
-2813 3450 1	2813 3450 0	Climb-down;Ladder;16679									
-2812 3451 0	2812 3451 1	Climb-up;Ladder;16683									
-2812 3451 1	2812 3451 0	Climb-down;Ladder;16679									
-											
-# Seers Village and Camelot Castle											
-2758 3482 0	2758 3483 0	Open;Gate;26082									
-2758 3483 0	2758 3482 0	Open;Gate;26082									
-2757 3482 0	2757 3483 0	Open;Gate;26081									
-2757 3483 0	2757 3482 0	Open;Gate;26081									
-2751 3508 0	2751 3513 1	Climb-up;Staircase;26106									
-2751 3513 1	2751 3508 0	Climb-down;Staircase;25604									
-2750 3508 0	2750 3513 1	Climb-up;Staircase;26106									
-2750 3513 1	2750 3508 0	Climb-down;Staircase;25604									
-2768 3493 0	2768 3493 1	Climb-up;Ladder;26107									
-2768 3493 1	2768 3493 0	Climb-down;Ladder;25606									
-2769 3492 0	2769 3492 1	Climb-up;Ladder;26107									
-2769 3492 1	2769 3492 0	Climb-down;Ladder;25606									
-2770 3493 0	2770 3493 1	Climb-up;Ladder;26107									
-2770 3493 1	2770 3493 0	Climb-down;Ladder;25606									
-2769 3494 0	2769 3494 1	Climb-up;Ladder;26107									
-2769 3494 1	2769 3494 0	Climb-down;Ladder;25606									
-2748 3493 0	2748 3493 1	Climb-up;Ladder;26107									
-2748 3493 1	2748 3493 0	Climb-down;Ladder;25606									
-2747 3494 0	2747 3494 1	Climb-up;Ladder;26107									
-2747 3494 1	2747 3494 0	Climb-down;Ladder;25606									
-2747 3492 0	2747 3492 1	Climb-up;Ladder;26107									
-2747 3492 1	2747 3492 0	Climb-down;Ladder;25606									
-2746 3493 0	2746 3493 1	Climb-up;Ladder;26107									
-2746 3493 1	2746 3493 0	Climb-down;Ladder;25606									
-2728 3490 0	2728 3490 1	Climb-up;Ladder;25938									
-2728 3490 1	2728 3490 0	Climb-down;Ladder;25939									
-2729 3491 0	2729 3491 1	Climb-up;Ladder;25938									
-2729 3491 1	2729 3491 0	Climb-down;Ladder;25939									
-2728 3492 0	2728 3492 1	Climb-up;Ladder;25938									
-2728 3492 1	2728 3492 0	Climb-down;Ladder;25939									
-2727 3491 0	2727 3491 1	Climb-up;Ladder;25938									
-2727 3491 1	2727 3491 0	Climb-down;Ladder;25939									
-2715 3471 0	2715 3471 1	Climb-up;Ladder;25938									
-2715 3471 1	2715 3471 0	Climb-down;Ladder;25939									
-2714 3470 0	2714 3470 1	Climb-up;Ladder;25938									
-2714 3470 1	2714 3470 0	Climb-down;Ladder;25939									
-2699 3475 0	2699 3475 1	Climb-up;Ladder;25941									
-2699 3475 1	2699 3475 0	Climb-down;Ladder;25940									
-2697 3496 0	2698 3495 1	Climb-up;Staircase;25935									
-2698 3495 1	2697 3496 0	Climb-down;Staircase;25801									
-2697 3497 0	2698 3495 1	Climb-up;Staircase;25935									
-2698 3498 0	2698 3495 1	Climb-up;Staircase;25935									
-2699 3498 0	2698 3495 1	Climb-up;Staircase;25935									
-2698 3495 0	2698 3495 1	Climb-up;Staircase;25935									
-2700 3497 0	2698 3495 1	Climb-up;Staircase;25935									
-2699 3495 0	2698 3495 1	Climb-up;Staircase;25935									
-2700 3496 0	2698 3495 1	Climb-up;Staircase;25935									
-2807 3453 0	2807 3453 1	Climb-up;Ladder;16683									
-2807 3453 1	2807 3453 0	Climb-down;Ladder;16679									
-2808 3454 1	2808 3453 0	Climb-down;Ladder;16679									
-2767 3492 1	2767 3492 2	Climb-up;Ladder;26107									
-2767 3492 2	2767 3492 1	Climb-down;Ladder;25606									
-2766 3491 1	2766 3491 2	Climb-up;Ladder;26107									
-2766 3491 2	2766 3491 1	Climb-down;Ladder;25606									
-2768 3491 1	2768 3491 2	Climb-up;Ladder;26107									
-2768 3491 2	2768 3491 1	Climb-down;Ladder;25606									
-2767 3490 1	2767 3490 2	Climb-up;Ladder;26107									
-2767 3490 2	2767 3490 1	Climb-down;Ladder;25606									
-2749 3492 1	2749 3492 2	Climb-up;Ladder;26107									
-2749 3492 2	2749 3492 1	Climb-down;Ladder;25606									
-2748 3491 1	2748 3491 2	Climb-up;Ladder;26107									
-2748 3491 2	2748 3491 1	Climb-down;Ladder;25606									
-2749 3490 1	2749 3490 2	Climb-up;Ladder;26107									
-2749 3490 2	2749 3490 1	Climb-down;Ladder;25606									
-2750 3491 1	2750 3491 2	Climb-up;Ladder;26107									
-2750 3491 2	2750 3491 1	Climb-down;Ladder;25606									
-											
-# Dwarf Cannon Quest area											
-2569 3441 0	2569 3441 1	Climb-up;Ladder;16683									
-2569 3441 1	2569 3441 0	Climb-down;Ladder;16679									
-2570 3442 0	2570 3442 1	Climb-up;Ladder;16683									
-2570 3442 1	2570 3442 0	Climb-down;Ladder;16679									
-2571 3441 0	2571 3441 1	Climb-up;Ladder;16683									
-2571 3441 1	2571 3441 0	Climb-down;Ladder;16679									
-2570 3440 0	2570 3440 1	Climb-up;Ladder;16683									
-2570 3440 1	2570 3440 0	Climb-down;Ladder;16679									
-2570 3442 1	2569 3443 2	Climb-up;Ladder;11									
-2569 3443 2	2569 3443 1	Climb-down;Ladder;16679									
-2569 3443 1	2569 3443 2	Climb-up;Ladder;11									
-2570 3444 2	2570 3444 1	Climb-down;Ladder;16679									
-2570 3444 1	2569 3443 2	Climb-up;Ladder;11									
-2570 3442 2	2570 3442 1	Climb-down;Ladder;16679									
-2571 3443 1	2569 3443 2	Climb-up;Ladder;11									
-2571 3443 2	2571 3443 1	Climb-down;Ladder;16679									
-2568 3455 0	2568 3456 0	Open;Gate;15605									
-2568 3456 0	2568 3455 0	Open;Gate;15605									
-2567 3455 0	2567 3456 0	Open;Gate;15604									
-2567 3456 0	2567 3455 0	Open;Gate;15604									
-2555 3475 0	2554 3475 0	Open;Gate;15604									
-2554 3475 0	2555 3475 0	Open;Gate;15604									
-2555 3474 0	2554 3474 0	Open;Gate;15605									
-2554 3474 0	2555 3474 0	Open;Gate;15605									
-											
-# Tourist Information Center											
-2518 3431 0	2518 3431 1	Climb-up;Staircase;16671									
-2518 3431 1	2519 3430 0	Climb-down;Staircase;16673									
-2519 3430 0	2518 3431 1	Climb-up;Staircase;16671									
-2519 3429 0	2518 3431 1	Climb-up;Staircase;16671									
-2518 3428 0	2518 3431 1	Climb-up;Staircase;16671									
-2517 3428 0	2518 3431 1	Climb-up;Staircase;16671									
-2517 3431 0	2518 3431 1	Climb-up;Staircase;16671									
-2516 3430 0	2518 3431 1	Climb-up;Staircase;16671									
-2516 3429 0	2518 3431 1	Climb-up;Staircase;16671									
-2517 3426 1	2516 3423 0	Climb-down;Staircase;16667									
-2516 3423 0	2517 3426 1	Climb-up;Staircase;16668									
-											
-# Waterfall Island and Dungeon											
-2512 3476 0	2527 3413 0	Swim;River;10283									
-2510 3494 0	2512 3481 0	Board;Log raft;1987									
-2511 3477 0	2527 3413 0	Swim;River;10283									
-2510 3493 0	2512 3481 0	Board;Log raft;1987									
-2511 3463 0	2527 3413 0	Get in;Barrel;2022									
-2512 3466 0	2527 3413 0	Climb;Dead Tree;2020									
-2512 3476 0	2527 3413 0	Swim to;Rock;1996									
-2511 3463 0	2575 9861 0	Open;Door;2010		295		Waterfall Quest					
-2575 9861 0	2511 3463 0	Open;Door;2000									
-2568 9893 0	2568 9894 0	Open;Door;2002									
-2568 9894 0	2568 9893 0	Open;Door;2002									
-2566 9901 0	2604 9901 0	Open;Door;2002									
-2604 9901 0	2566 9901 0	Open;Door;2002									
-											
-# Glarial's Tomb											
-2557 9844 0	2557 3444 0	Climb-up;Ladder;17387								2	
-											
-# Tree Gnome Village Dungeon (during Waterfall quest)											
-2533 3156 0	2533 9556 0	Climb-down;Ladder;5250									
-2534 3155 0	2534 9555 0	Climb-down;Ladder;5250									
-2532 3155 0	2532 9555 0	Climb-down;Ladder;5250									
-2533 9556 0	2533 3156 0	Climb-up;Ladder;17387									
-											
-# Tree Gnome Village Dungeon (after Waterfall quest)											
-2533 3156 0	2597 4436 0	Climb-down;Ladder;5250				Waterfall Quest					
-2532 3155 0	2596 4435 0	Climb-down;Ladder;5250				Waterfall Quest					
-2534 3155 0	2598 4435 0	Climb-down;Ladder;5250				Waterfall Quest					
-2597 4436 0	2533 3156 0	Climb-up;Ladder;5251				Waterfall Quest					
-2596 4435 0	2533 3156 0	Climb-up;Ladder;5251				Waterfall Quest					
-2598 4435 0	2533 3156 0	Climb-up;Ladder;5251				Waterfall Quest					
-2597 4434 0	2533 3156 0	Climb-up;Ladder;5251				Waterfall Quest					
-											
-# Lithkren											
-3555 4002 0	3549 10448 0	Climb-down;Staircase;32080									
-3549 10448 0	3555 4002 0	Climb-up;Staircase;32112									
-3554 4002 0	3549 10448 0	Climb-down;Staircase;32080									
-3550 10448 0	3555 4002 0	Climb-up;Staircase;32112									
-3549 10468 0	3549 10473 0	Climb;Staircase;32113									
-3549 10473 0	3549 10468 0	Climb;Staircase;32113									
-3550 10468 0	3550 10473 0	Climb;Staircase;32113									
-3550 10473 0	3550 10468 0	Climb;Staircase;32113									
-3551 10481 0	1568 5061 0	Enter;Broken Grandiose Doors;32117									
-1570 5061 0	3549 10481 0	Climb-up;Goo covered vine;23703									
-3550 10481 0	1568 5061 0	Enter;Broken Grandiose Doors;32117									
-1569 5061 0	3549 10481 0	Enter;Broken Grandiose Doors;32132									
-3549 10481 0	1568 5061 0	Enter;Broken Grandiose Doors;32117									
-1568 5061 0	3549 10481 0	Enter;Broken Grandiose Doors;32132									
-1567 5061 0	3549 10481 0	Enter;Broken Grandiose Doors;32132									
-1566 5061 0	3549 10481 0	Enter;Broken Grandiose Doors;32132									
-1565 5061 0	3549 10481 0	Enter;Broken Grandiose Doors;32132									
-1573 5077 0	1575 5077 0	Pass;Barrier;32153									
-1575 5077 0	1573 5077 0	Pass;Barrier;32153									
-1573 5076 0	1575 5076 0	Pass;Barrier;32153									
-1575 5076 0	1573 5076 0	Pass;Barrier;32153									
-1573 5075 0	1575 5075 0	Pass;Barrier;32153									
-1575 5075 0	1573 5075 0	Pass;Barrier;32153									
-1573 5074 0	1575 5074 0	Pass;Barrier;32153									
-1575 5074 0	1573 5074 0	Pass;Barrier;32153									
-1573 5073 0	1575 5073 0	Pass;Barrier;32153									
-1575 5073 0	1573 5073 0	Pass;Barrier;32153									
-1573 5072 0	1575 5072 0	Pass;Barrier;32153									
-1575 5072 0	1573 5072 0	Pass;Barrier;32153									
-1584 5089 0	1584 5087 0	Pass;Barrier;32153									
-1584 5087 0	1584 5089 0	Pass;Barrier;32153									
-1585 5089 0	1585 5087 0	Pass;Barrier;32153									
-1585 5087 0	1585 5089 0	Pass;Barrier;32153									
-1586 5089 0	1586 5087 0	Pass;Barrier;32153									
-1586 5087 0	1586 5089 0	Pass;Barrier;32153									
-1587 5089 0	1587 5087 0	Pass;Barrier;32153									
-1587 5087 0	1587 5089 0	Pass;Barrier;32153									
-1588 5089 0	1588 5087 0	Pass;Barrier;32153									
-1588 5087 0	1588 5089 0	Pass;Barrier;32153									
-1589 5089 0	1589 5087 0	Pass;Barrier;32153									
-1589 5087 0	1589 5089 0	Pass;Barrier;32153									
-1546 5089 0	1546 5087 0	Pass;Barrier;32153									
-1546 5087 0	1546 5089 0	Pass;Barrier;32153									
-1547 5089 0	1547 5087 0	Pass;Barrier;32153									
-1547 5087 0	1547 5089 0	Pass;Barrier;32153									
-1548 5089 0	1548 5087 0	Pass;Barrier;32153									
-1548 5087 0	1548 5089 0	Pass;Barrier;32153									
-1549 5089 0	1549 5087 0	Pass;Barrier;32153									
-1549 5087 0	1549 5089 0	Pass;Barrier;32153									
-1550 5089 0	1550 5087 0	Pass;Barrier;32153									
-1550 5087 0	1550 5089 0	Pass;Barrier;32153									
-1551 5089 0	1551 5087 0	Pass;Barrier;32153									
-1551 5087 0	1551 5089 0	Pass;Barrier;32153									
-1560 5072 0	1562 5072 0	Pass;Barrier;32153									
-1562 5072 0	1560 5072 0	Pass;Barrier;32153									
-1560 5073 0	1562 5073 0	Pass;Barrier;32153									
-1562 5073 0	1560 5073 0	Pass;Barrier;32153									
-1560 5074 0	1562 5074 0	Pass;Barrier;32153									
-1562 5074 0	1560 5074 0	Pass;Barrier;32153									
-1560 5075 0	1562 5075 0	Pass;Barrier;32153									
-1562 5075 0	1560 5075 0	Pass;Barrier;32153									
-1560 5076 0	1562 5076 0	Pass;Barrier;32153									
-1562 5076 0	1560 5076 0	Pass;Barrier;32153									
-1560 5077 0	1562 5077 0	Pass;Barrier;32153									
-1562 5077 0	1560 5077 0	Pass;Barrier;32153									
-3554 4000 0	3554 4000 1	Climb-up;Ladder;32083									
-3554 4000 1	3554 4000 0	Climb-down;Trapdoor;32084									
-3555 4000 0	3554 4000 1	Climb-up;Ladder;32083									
-3555 4000 1	3554 4000 0	Climb-down;Trapdoor;32084									
-3556 4003 1	3561 4004 0	Climb-down;Stairs;32082									
-3561 4004 0	3556 4004 1	Climb-up;Stairs;32081									
-3556 4004 1	3561 4004 0	Climb-down;Stairs;32082									
-3561 4005 0	3556 4004 1	Climb-up;Stairs;32081									
-3556 4005 1	3561 4004 0	Climb-down;Stairs;32082									
-3561 4003 0	3556 4004 1	Climb-up;Stairs;32081									
-											
-# Fossil Island											
-3595 10291 0	3680 3854 0	Climb-up;Exit;30844									
-3680 3854 0	3595 10291 0	Enter;Broken Grandiose Doors;32132									
-3596 10291 0	3680 3854 0	Climb-up;Exit;30844									
-3603 10291 0	3607 10290 0	Climb;Stairs;31485									
-3607 10290 0	3603 10290 0	Climb;Stairs;31485									
-3603 10290 0	3607 10290 0	Climb;Stairs;31485									
-3607 10291 0	3603 10290 0	Climb;Stairs;31485									
-3606 10292 0	3603 10290 0	Climb;Stairs;31485									
-3605 10292 0	3603 10290 0	Climb;Stairs;31485									
-3606 10289 0	3603 10290 0	Climb;Stairs;31485									
-3605 10289 0	3603 10290 0	Climb;Stairs;31485									
-3680 3855 0	3595 10291 0	Climb Down;Trap Door;30842									
-3680 3853 0	3595 10291 0	Climb Down;Trap Door;30842									
-3666 3810 0	3685 3756 0	Jump on;Rubber cap mushroom;30606									
-3666 3809 0	3685 3756 0	Jump on;Rubber cap mushroom;30606									
-3663 3808 0	3685 3756 0	Jump on;Rubber cap mushroom;30606									
-3664 3808 0	3685 3756 0	Jump on;Rubber cap mushroom;30606									
-3665 3808 0	3685 3756 0	Jump on;Rubber cap mushroom;30606									
-3768 3868 1	3768 3868 0	Climb-down;Trapdoor;30725									
-3768 3868 0	3768 3868 1	Climb-up;Ladder;30727									
-3767 3868 1	3768 3868 0	Climb-down;Trapdoor;30725									
-3767 3868 0	3768 3868 1	Climb-up;Ladder;30727									
-3766 3867 1	3768 3868 0	Climb-down;Trapdoor;30725									
-3769 3867 0	3768 3868 1	Climb-up;Ladder;30727									
-3766 3867 0	3768 3868 1	Climb-up;Ladder;30727									
-3766 3866 0	3768 3868 1	Climb-up;Ladder;30727									
-3767 3865 0	3768 3868 1	Climb-up;Ladder;30727									
-3757 3870 1	3753 3869 0	Descend;Stairs;30682									
-3753 3869 0	3757 3869 1	Climb;Stairs;30681									
-3757 3869 1	3753 3869 0	Descend;Stairs;30682									
-3753 3870 0	3757 3869 1	Climb;Stairs;30681									
-3757 3868 1	3753 3869 0	Descend;Stairs;30682									
-3753 3868 0	3757 3869 1	Climb;Stairs;30681									
-3746 3832 0	3745 3831 1	Climb Up;Ladder;30940									
-3745 3831 1	3747 3831 0	Climb Down;Ladder;30941									
-3747 3831 0	3745 3831 1	Climb Up;Ladder;30940									
-3746 3830 0	3745 3831 1	Climb Up;Ladder;30940									
-3730 3831 1	3728 3831 0	Climb Down;Ladder;30939									
-3728 3831 0	3730 3831 1	Climb Up;Ladder;30938									
-3729 3830 0	3730 3831 1	Climb Up;Ladder;30938									
-3729 3832 0	3730 3831 1	Climb Up;Ladder;30938									
-											
-# Musa Point											
-2956 3146 0	2956 3143 1	Cross;Gangplank;2081								3	
-2956 3143 1	2956 3146 0	Cross;Gangplank;2082								3	
-2960 3141 0	2960 3141 1	Climb-up;Ship's ladder;272									
-2960 3141 1	2960 3141 0	Climb-down;Ship's ladder;273									
-2956 3141 0	2956 3141 1	Climb-up;Ship's ladder;272									
-2956 3141 1	2956 3141 0	Climb-down;Ship's ladder;273									
-2952 3141 0	2952 3141 1	Climb-up;Ship's ladder;272									
-2952 3141 1	2952 3141 0	Climb-down;Ship's ladder;273									
-2962 3139 1	2964 3139 2	Climb-up;Ship's ladder;245									
-2964 3139 2	2962 3139 1	Climb-down;Ship's ladder;246									
-2962 3143 1	2964 3143 2	Climb-up;Ship's ladder;245									
-2964 3143 2	2962 3143 1	Climb-down;Ship's ladder;246									
-2954 3158 0	2957 3158 1	Cross;Gangplank;17398								3	
-2957 3158 1	2954 3158 0	Cross;Gangplank;17399								3	
-											
-# Brimhaven											
-2763 3238 1	2760 3238 0	Cross;Gangplank;17401								3	
-2760 3238 0	2763 3238 1	Cross;Gangplank;17400								3	
-2772 3234 0	2775 3234 1	Cross;Gangplank;2087								3	
-2775 3234 1	2772 3234 0	Cross;Gangplank;2088								3	
-2776 3235 0	2776 3235 1	Climb-up;Ship's ladder;9744									
-2776 3235 1	2776 3235 0	Climb-down;Ship's ladder;9745									
-2777 3234 1	2776 3235 0	Climb-down;Ship's ladder;9745									
-2775 3234 1	2776 3235 0	Climb-down;Ship's ladder;9745									
-2808 3162 0	2808 3162 1	Climb-up;Ladder;16683								3	
-2808 3162 1	2808 3162 0	Climb-down;Ladder;16679								3	
-2744 3153 0	2713 9564 0	Pay;Dungeon entrance;20877			875 Coins						
-2713 9564 0	2744 3153 0	Leave;Exit;20878									
-2691 9564 0	2689 9564 0	Chop-down;Vines;21731		1351;1349;1361;1353;1355;1357;1359							
-2689 9564 0	2691 9564 0	Chop-down;Vines;21731		1351;1349;1361;1353;1355;1357;1359							
-2683 9568 0	2683 9570 0	Chop-down;Vines;21732		1351;1349;1361;1353;1355;1357;1359							
-2683 9570 0	2683 9568 0	Chop-down;Vines;21732		1351;1349;1361;1353;1355;1357;1359							
-2649 9591 0	2643 9595 2	Walk-up;Stairs;21722									
-2650 9591 0	2643 9595 2	Walk-up;Stairs;21722									
-2643 9595 2	2649 9591 0	Walk-down;Stairs;21724									
-2647 9557 0	2649 9562 0	Jump-from;Stepping Stone;21739								3	
-2649 9562 0	2647 9557 0	Jump-from;Stepping Stone;21738								3	
-2636 9517 0	2636 9510 2	Walk-up;Stairs;21725									
-2637 9517 0	2636 9510 2	Walk-up;Stairs;21725									
-2636 9510 2	2636 9517 0	Walk-down;Stairs;21726									
-2682 9506 0	2687 9506 0	Walk-across;Log balance;20882								3	
-2687 9506 0	2682 9506 0	Walk-across;Log balance;20884								3	
-2698 9500 0	2698 9492 0	Squeeze-through;Pipe;21727									
-2698 9492 0	2698 9500 0	Squeeze-through;Pipe;21727									
-2697 9436 0	2684 9436 0	Enter;Crevice;30198									
-2684 9436 0	2697 9436 0	Enter;Crevice;30198									
-											
-# Karamja Volcano											
-2855 3169 0	2855 9569 0	Climb-down;Rocks;11441									
-2855 9569 0	2856 3167 0	Climb;Climbing rope;18969									
-2856 3167 0	2856 9567 0	Climb-down;Rocks;11441									
-2856 9568 0	2856 3167 0	Climb;Climbing rope;18969									
-2855 3168 0	2855 9568 0	Climb-down;Rocks;11441									
-2856 9570 0	2856 3167 0	Climb;Climbing rope;18969									
-2857 3167 0	2857 9567 0	Climb-down;Rocks;11441									
-2857 9569 0	2856 3167 0	Climb;Climbing rope;18969									
-2858 3168 0	2858 9568 0	Climb-down;Rocks;11441									
-2858 3169 0	2858 9569 0	Climb-down;Rocks;11441									
-2857 3170 0	2857 9570 0	Climb-down;Rocks;11441									
-2856 3170 0	2856 9570 0	Climb-down;Rocks;11441									
-2862 9573 0	2480 5175 0	Enter;Cave entrance;11835									
-2480 5175 0	2862 9572 0	Enter;Cave exit;11836									
-2862 9572 0	2480 5175 0	Enter;Cave entrance;11835									
-2481 5175 0	2862 9572 0	Enter;Cave exit;11836									
-2862 9571 0	2480 5175 0	Enter;Cave entrance;11835									
-2479 5175 0	2862 9572 0	Enter;Cave exit;11836									
-2863 9574 0	2480 5175 0	Enter;Cave entrance;11835									
-2863 9570 0	2480 5175 0	Enter;Cave entrance;11835									
-2864 9570 0	2480 5175 0	Enter;Cave entrance;11835									
-2865 9571 0	2480 5175 0	Enter;Cave entrance;11835									
-2865 9572 0	2480 5175 0	Enter;Cave entrance;11835									
-											
-# Island West of Brimhaven											
-2709 3209 0	2704 3209 0	Swing-on;Ropeswing;23568									
-2705 3205 0	2709 3205 0	Swing-on;Ropeswing;23569									
-											
-# Port Piscarillius											
-1824 3694 1	1824 3691 0	Cross;Gangplank;27778								3	
-1824 3691 0	1824 3694 1	Cross;Gangplank;27777								3	
-											
-# Tree Gnome Village											
-2515 3160 0	2515 3161 0	Squeeze-through;Loose Railing;2186									
-2515 3161 0	2515 3160 0	Squeeze-through;Loose Railing;2186									
-2516 3166 1	2516 3166 0	Climb-down;Ladder;16679									
-2516 3166 0	2516 3166 1	Climb-up;Ladder;17026									
-2515 3165 1	2515 3165 0	Climb-down;Ladder;16679									
-2517 3165 1	2517 3165 0	Climb-down;Ladder;16679									
-2521 3163 1	2521 3163 0	Climb-down;Ladder;16685									
-2521 3163 0	2521 3163 1	Climb-up;Ladder;17026									
-2526 3162 0	2526 3162 1	Climb-up;Ladder;17026									
-2525 3163 1	2525 3163 0	Climb-down;Ladder;16679									
-2526 3162 1	2526 3162 0	Climb-down;Ladder;16679									
-2525 3161 1	2525 3161 0	Climb-down;Ladder;16679									
-2526 3172 1	2526 3172 0	Climb-down;Ladder;16679									
-2526 3172 0	2526 3172 1	Climb-up;Ladder;17026									
-2525 3171 1	2525 3171 0	Climb-down;Ladder;16679									
+# Tutorial Island
+3097 3107 0	3098 3107 0	Open;Door;9398								1
+3098 3107 0	3097 3107 0	Open;Door;9398								1
+3090 3092 0	3089 3092 0	Open;Gate;9470								1
+3089 3092 0	3090 3092 0	Open;Gate;9470								1
+3090 3091 0	3089 3091 0	Open;Gate;9708								1
+3089 3091 0	3090 3091 0	Open;Gate;9708								1
+3079 3084 0	3078 3084 0	Open;Door;9709								1
+3078 3084 0	3079 3084 0	Open;Door;9709								1
+3073 3090 0	3072 3090 0	Open;Door;9710								1
+3072 3090 0	3073 3090 0	Open;Door;9710								1
+3086 3126 0	3086 3125 0	Open;Door;9716								1
+3086 3125 0	3086 3126 0	Open;Door;9716								1
+3084 3125 0	3084 3124 1	Climb-up;Staircase;16671								1
+3084 3124 1	3083 3123 0	Climb-down;Staircase;16673								1
+3084 3124 0	3084 3124 1	Climb-up;Staircase;16671								1
+3083 3123 0	3084 3124 1	Climb-up;Staircase;16671								1
+3088 3120 0	3088 9520 0	Climb-down;Ladder;9726								2
+3088 9520 0	3088 3120 0	Climb-up;Ladder;9725								2
+3094 9503 0	3095 9503 0	Open;Gate;9717								1
+3095 9503 0	3094 9503 0	Open;Gate;9717								1
+3094 9502 0	3095 9502 0	Open;Gate;9718								1
+3095 9502 0	3094 9502 0	Open;Gate;9718								1
+3111 9519 0	3110 9519 0	Open;Gate;9720								1
+3110 9519 0	3111 9519 0	Open;Gate;9720								1
+3111 9518 0	3110 9518 0	Open;Gate;9719								1
+3110 9518 0	3111 9518 0	Open;Gate;9719								1
+3111 9525 0	3111 3125 0	Climb-up;Ladder;9727								2
+3111 3125 0	3111 9525 0	Climb-down;Ladder;9728								2
+3112 9526 0	3112 3126 0	Climb-up;Ladder;9727								2
+3112 3126 0	3112 9526 0	Climb-down;Ladder;9728								2
+3111 9527 0	3111 3127 0	Climb-up;Ladder;9727								2
+3111 3127 0	3111 9527 0	Climb-down;Ladder;9728								2
+3110 9526 0	3110 3126 0	Climb-up;Ladder;9727								2
+3110 3126 0	3110 9526 0	Climb-down;Ladder;9728								2
+3116 3125 0	3116 3125 1	Climb-up;Ladder;16683								2
+3116 3125 1	3116 3125 0	Climb-down;Ladder;16679								2
+3117 3126 0	3117 3126 1	Climb-up;Ladder;16683								2
+3117 3126 1	3117 3126 0	Climb-down;Ladder;16679								2
+3116 3127 0	3116 3127 1	Climb-up;Ladder;16683								2
+3116 3127 1	3116 3127 0	Climb-down;Ladder;16679								2
+3115 3126 0	3115 3126 1	Climb-up;Ladder;16683								2
+3115 3126 1	3115 3126 0	Climb-down;Ladder;16679								2
+3123 3127 0	3123 3127 1	Climb-up;Ladder;16683								2
+3123 3127 1	3123 3127 0	Climb-down;Ladder;16679								2
+3124 3128 0	3124 3128 1	Climb-up;Ladder;16683								2
+3124 3128 1	3124 3128 0	Climb-down;Ladder;16679								2
+3123 3129 0	3123 3129 1	Climb-up;Ladder;16683								2
+3123 3129 1	3123 3129 0	Climb-down;Ladder;16679								2
+3122 3128 0	3122 3128 1	Climb-up;Ladder;16683								2
+3122 3128 1	3122 3128 0	Climb-down;Ladder;16679								2
+3124 3124 0	3125 3124 0	Open;Door;9721								1
+3125 3124 0	3124 3124 0	Open;Door;9721								1
+3129 3124 0	3130 3124 0	Open;Door;9722								1
+3130 3124 0	3129 3124 0	Open;Door;9722								1
+3117 3107 0	3117 3107 1	Climb-up;Staircase;16671								1
+3117 3107 1	3116 3106 0	Climb-down;Staircase;16673								1
+3116 3106 0	3117 3107 1	Climb-up;Staircase;16671								1
+3122 3103 0	3122 3102 0	Open;Door;9723								1
+3122 3102 0	3122 3103 0	Open;Door;9723								1
+3139 3079 0	3139 3079 1	Climb-up;Ladder;16683								2
+3139 3079 1	3139 3079 0	Climb-down;Ladder;16679								2
+3140 3078 0	3140 3078 1	Climb-up;Ladder;16683								2
+3140 3078 1	3140 3078 0	Climb-down;Ladder;16679								2
+3139 3077 0	3139 3077 1	Climb-up;Ladder;16683								2
+3139 3077 1	3139 3077 0	Climb-down;Ladder;16679								2
+3138 3078 0	3138 3078 1	Climb-up;Ladder;16683								2
+3138 3078 1	3138 3078 0	Climb-down;Ladder;16679								2
+
+# Lumbridge
+3205 3228 0	3206 3229 1	Climb-up;Staircase;56230								1
+3206 3229 1	3205 3228 0	Climb-down;Staircase;16672								1
+3206 3229 0	3206 3229 1	Climb-up;Staircase;56230								1
+3205 3228 1	3205 3228 0	Climb-down;Staircase;16672								1
+3206 3229 1	3206 3229 2	Climb-up;Staircase;16672								1
+3206 3229 2	3205 3228 1	Climb-down;Staircase;56231								1
+3205 3228 1	3206 3229 2	Climb-up;Staircase;16672								1
+3205 3209 1	3206 3208 0	Climb-down;Staircase;16672								1
+3206 3208 0	3205 3209 1	Climb-up;Staircase;56230								1
+3206 3208 1	3206 3208 0	Climb-down;Staircase;16672								1
+3205 3209 0	3205 3209 1	Climb-up;Staircase;56230								1
+3205 3209 1	3205 3209 2	Climb-up;Staircase;16672								1
+3205 3209 2	3206 3208 1	Climb-down;Staircase;56231								1
+3206 3208 1	3205 3209 2	Climb-up;Staircase;16672								1
+3210 3216 0	3210 9616 0	Climb-down;Trapdoor;14880
+3210 9616 0	3210 3216 0	Climb-up;Ladder;17385								2
+3209 9617 0	3209 3217 0	Climb-up;Ladder;17385								2
+3209 9615 0	3209 3215 0	Climb-up;Ladder;17385								2
+3208 9616 0	3208 3216 0	Climb-up;Ladder;17385								2
+3213 3221 0	3212 3221 0	Open;Large door;12349								1
+3212 3221 0	3213 3221 0	Open;Large door;12349								1
+3213 3222 0	3212 3222 0	Open;Large door;12350								1
+3212 3222 0	3213 3222 0	Open;Large door;12350								1
+3207 3218 0	3207 3217 0	Open;Door;12348								1
+3207 3217 0	3207 3218 0	Open;Door;12348								1
+3228 3213 0	3228 3213 1	Climb-up;Ladder;16683								2
+3228 3213 1	3228 3213 0	Climb-down;Ladder;16684								2
+3229 3214 0	3229 3214 1	Climb-up;Ladder;16683								2
+3229 3214 1	3229 3214 0	Climb-down;Ladder;16684								2
+3230 3213 0	3230 3213 1	Climb-up;Ladder;16683								2
+3230 3213 1	3230 3213 0	Climb-down;Ladder;16684								2
+3229 3212 0	3229 3212 1	Climb-up;Ladder;16683								2
+3229 3212 1	3229 3212 0	Climb-down;Ladder;16684								2
+3229 3212 1	3229 3212 2	Climb-up;Ladder;16684								2
+3228 3213 2	3228 3213 1	Climb-down;Ladder;16679								2
+3228 3213 1	3228 3213 2	Climb-up;Ladder;16684								2
+3229 3214 2	3229 3214 1	Climb-down;Ladder;16679								2
+3229 3214 1	3229 3214 2	Climb-up;Ladder;16684								2
+3230 3213 2	3230 3213 1	Climb-down;Ladder;16679								2
+3230 3213 1	3230 3213 2	Climb-up;Ladder;16684								2
+3229 3212 2	3229 3212 1	Climb-down;Ladder;16679								2
+3229 3225 2	3229 3225 1	Climb-down;Ladder;16679								2
+3229 3225 1	3229 3225 2	Climb-up;Ladder;16684								2
+3228 3224 2	3228 3224 1	Climb-down;Ladder;16679								2
+3228 3224 1	3228 3224 2	Climb-up;Ladder;16684								2
+3229 3223 2	3229 3223 1	Climb-down;Ladder;16679								2
+3229 3223 1	3229 3223 2	Climb-up;Ladder;16684								2
+3230 3224 2	3230 3224 1	Climb-down;Ladder;16679								2
+3230 3224 1	3230 3224 2	Climb-up;Ladder;16684								2
+3230 3224 1	3230 3224 0	Climb-down;Ladder;16684								2
+3230 3224 0	3230 3224 1	Climb-up;Ladder;16683								2
+3229 3223 0	3229 3223 1	Climb-up;Ladder;16683								2
+3228 3224 0	3228 3224 1	Climb-up;Ladder;16683								2
+3228 3224 1	3228 3224 0	Climb-down;Ladder;16684								2
+3229 3223 1	3229 3223 0	Climb-down;Ladder;16684								2
+3229 3225 0	3229 3225 1	Climb-up;Ladder;16683								2
+3229 3225 1	3229 3225 0	Climb-down;Ladder;16684								2
+3211 3243 1	3211 3243 0	Climb-down;Ladder;16679								2
+3211 3243 0	3211 3243 1	Climb-up;Ladder;16683								2
+
+# Farm between Lumbridge and Draynor
+3197 3278 0	3197 3275 0	Climb-over;Stile;12982								6
+3197 3275 0	3197 3278 0	Climb-over;Stile;12982								6
+3198 3277 0	3197 3275 0	Climb-over;Stile;12982								6
+3198 3276 0	3197 3278 0	Climb-over;Stile;12982								6
+3196 3277 0	3197 3275 0	Climb-over;Stile;12982								6
+3196 3276 0	3197 3278 0	Climb-over;Stile;12982								6
+3164 3306 0	3164 3306 1	Climb-up;Ladder;12964								2
+3164 3306 1	3164 3306 2	Climb-up;Ladder;12965								2
+3164 3306 2	3164 3306 1	Climb-down;Ladder;12966								2
+3165 3307 1	3165 3307 2	Climb-up;Ladder;12965								2
+3165 3307 2	3165 3307 1	Climb-down;Ladder;12966								2
+3165 3307 1	3165 3307 0	Climb-down;Ladder;12965								2
+3165 3307 0	3165 3307 1	Climb-up;Ladder;12964								2
+3164 3306 1	3164 3306 0	Climb-down;Ladder;12965								2
+3140 3304 0	3140 3304 1	Climb-up;Ladder;16683								2
+3140 3304 1	3140 3304 0	Climb-down;Ladder;16679								2
+3141 3305 0	3141 3305 1	Climb-up;Ladder;16683								2
+3141 3305 1	3141 3305 0	Climb-down;Ladder;16679								2
+3140 3306 0	3140 3306 1	Climb-up;Ladder;16683								2
+3140 3306 1	3140 3306 0	Climb-down;Ladder;16679								2
+3139 3305 0	3139 3305 1	Climb-up;Ladder;16683								2
+3139 3305 1	3139 3305 0	Climb-down;Ladder;16679								2
+
+# Draynor Village
+3098 3267 0	3102 3266 1	Climb-up;Staircase;15645								1
+3102 3266 1	3098 3266 0	Climb-down;Staircase;15648								1
+3098 3266 0	3102 3266 1	Climb-up;Staircase;15645								1
+3102 3267 1	3098 3266 0	Climb-down;Staircase;15648								1
+3089 3251 0	3093 3251 1	Climb-up;Staircase;16670								1
+3093 3251 1	3089 3251 0	Climb-down;Staircase;16669								1
+
+# Draynor Sewers
+3085 9672 0	3085 3272 0	Climb-up;Ladder;17385								2
+3084 9673 0	3084 3273 0	Climb-up;Ladder;17385								2
+3083 9672 0	3083 3272 0	Climb-up;Ladder;17385								2
+3084 9671 0	3084 3271 0	Climb-up;Ladder;17385								2
+3085 3272 0	3085 9672 0	Climb-down;Trapdoor;6435								1
+3084 3273 0	3084 9673 0	Climb-down;Trapdoor;6435								1
+3083 3272 0	3083 9672 0	Climb-down;Trapdoor;6435								1
+3084 3271 0	3084 9671 0	Climb-down;Trapdoor;6435								1
+3118 3243 0	3118 9644 0	Climb-down;Trapdoor;6435								1
+3117 3244 0	3118 9644 0	Climb-down;Trapdoor;6435								1
+3119 3244 0	3118 9644 0	Climb-down;Trapdoor;6435								1
+3118 3245 0	3118 9644 0	Climb-down;Trapdoor;6435								1
+3119 9643 0	3118 3243 0	Climb-up;Ladder;6436								2
+3118 9644 0	3118 3243 0	Climb-up;Ladder;6436								2
+3117 9643 0	3118 3243 0	Climb-up;Ladder;6436								2
+
+# Draynor Manor
+3115 3356 0	3077 9771 0	Walk-Down;Stairs;2616								1
+3077 9771 0	3115 3356 0	Walk-Up;Stairs;2617								1
+3116 3356 0	3077 9771 0	Walk-Down;Stairs;2616								1
+3078 9771 0	3115 3356 0	Walk-Up;Stairs;2617								1
+3076 9770 0	3115 3356 0	Walk-Up;Stairs;2617								1
+3076 9769 0	3115 3356 0	Walk-Up;Stairs;2617								1
+3076 9768 0	3115 3356 0	Walk-Up;Stairs;2617								1
+3079 9770 0	3115 3356 0	Walk-Up;Stairs;2617								1
+3079 9769 0	3115 3356 0	Walk-Up;Stairs;2617								1
+3079 9768 0	3115 3356 0	Walk-Up;Stairs;2617								1
+3123 3360 0	3123 3361 0	Open;Door;136								1
+3123 3361 0	3123 3360 0	Open;Door;136								1
+3109 3353 0	3109 3354 0	Open;Large door;135								3
+3105 3364 2	3106 3363 1	Climb-down;Staircase;9584								1
+3106 3363 1	3105 3364 2	Climb-up;Staircase;11511								1
+3106 3362 1	3105 3364 2	Climb-up;Staircase;11511								1
+3106 3362 2	3106 3361 2	Open;Door;22								1
+3106 3361 2	3106 3362 2	Open;Door;22								1
+3098 3359 0	3096 3359 0	Search;Bookcase;156								3
+3092 3361 0	3117 9753 0	Climb-down;Ladder;133								2
+3117 9753 0	3092 3361 0	Climb-up;Ladder;132								2
+3098 3358 0	3096 3358 0	Search;Bookcase;155								3
+3096 3357 0	3098 3358 0	Pull;Lever;160								6
+3108 3353 0	3108 3354 0	Open;Large door;134								3
+3097 3360 0	3096 3359 0	Search;Bookcase;156								3
+3097 3357 0	3096 3358 0	Search;Bookcase;155								3
+3108 3361 0	3108 3366 1	Climb-up;Staircase;11498								1
+3108 3366 1	3108 3361 0	Climb-down;Staircase;11499								1
+3109 3361 0	3109 3366 1	Climb-up;Staircase;11498								1
+3109 3366 1	3109 3361 0	Climb-down;Staircase;11499								1
+
+# South Falador Farm
+3045 3305 0	3042 3305 0	Climb-over;Stile;7527								6
+3042 3305 0	3045 3305 0	Climb-over;Stile;7527								6
+3043 3306 0	3045 3305 0	Climb-over;Stile;7527								6
+3044 3306 0	3042 3305 0	Climb-over;Stile;7527								6
+3043 3304 0	3045 3305 0	Climb-over;Stile;7527								6
+3063 3281 0	3063 3284 0	Climb-over;Stile;7527								6
+3064 3283 0	3063 3281 0	Climb-over;Stile;7527								6
+3064 3282 0	3063 3284 0	Climb-over;Stile;7527								6
+3063 3284 0	3063 3281 0	Climb-over;Stile;7527								6
+3062 3282 0	3063 3284 0	Climb-over;Stile;7527								6
+3062 3283 0	3063 3281 0	Climb-over;Stile;7527								6
+
+# Falador
+3054 3382 0	3065 9951 0	Climb-down;Staircase;24249								1
+3065 9951 0	3053 3382 0	Leave;Old passageway;31892
+3053 3382 0	3065 9951 0	Climb-down;Staircase;24249								1
+3065 9952 0	3053 3382 0	Leave;Old passageway;31892
+3014 9952 0	3038 3382 0	Leave;Old passageway;31892
+3038 3382 0	3014 9951 0	Climb-down;Staircase;24248								1
+3014 9951 0	3038 3382 0	Leave;Old passageway;31892
+3037 3382 0	3014 9951 0	Climb-down;Staircase;24248								1
+3038 3382 0	3039 3383 1	Climb-up;Staircase;24248								1
+3039 3383 1	3037 3382 0	Climb-down;Staircase;24252								1
+3037 3382 0	3039 3383 1	Climb-up;Staircase;24248								1
+3052 3383 1	3054 3382 0	Climb-down;Staircase;24254								1
+3052 3373 1	3053 3374 2	Climb-up;Staircase;24251								1
+3053 3374 2	3052 3372 1	Climb-down;Staircase;24255								1
+3052 3372 1	3053 3374 2	Climb-up;Staircase;24251								1
+3038 3374 2	3039 3372 1	Climb-down;Staircase;24253								1
+3039 3372 1	3038 3374 2	Climb-up;Staircase;24250								1
+3039 3373 1	3038 3374 2	Climb-up;Staircase;24250								1
+3054 3382 0	3052 3383 1	Climb-up;Staircase;24249								1
+3053 3382 0	3052 3383 1	Climb-up;Staircase;24249								1
+3035 3364 1	3036 3363 0	Climb-down;Staircase;24076								1
+3036 3363 0	3035 3364 1	Climb-up;Staircase;24075								1
+3036 3362 0	3035 3364 1	Climb-up;Staircase;24075								1
+3045 3362 0	3045 3366 1	Climb-up;Staircase;24079								1
+3045 3366 1	3045 3362 0	Climb-down;Staircase;24080								1
+3046 3362 0	3046 3366 1	Climb-up;Staircase;24079								1
+3046 3366 1	3046 3362 0	Climb-down;Staircase;24080								1
+3049 3354 1	3050 3353 0	Climb-down;Staircase;24076								1
+3050 3353 0	3049 3354 1	Climb-up;Staircase;24075								1
+3050 3352 0	3049 3354 1	Climb-up;Staircase;24075								1
+3050 3356 1	3050 3354 2	Climb-up;Ladder;24082								2
+3050 3354 2	3050 3356 1	Climb-down;Ladder;24084								2
+3035 3345 1	3035 3345 0	Climb-down;Ladder;24085								2
+3035 3345 0	3035 3345 1	Climb-up;Ladder;24082								2
+3027 3354 0	3027 3352 1	Climb-up;Ladder;24082								2
+3027 3352 1	3027 3354 0	Climb-down;Ladder;24084								2
+3010 3338 0	3011 3337 1	Climb-up;Staircase;24072								1
+3010 3339 0	3011 3337 1	Climb-up;Staircase;24072								1
+3011 3337 1	3010 3338 0	Climb-down;Staircase;24074								1
+3020 3333 0	3024 3333 1	Climb-up;Staircase;24077								1
+3024 3333 1	3020 3333 0	Climb-down;Staircase;24078								1
+3020 3332 0	3024 3332 1	Climb-up;Staircase;24077								1
+3024 3332 1	3020 3332 0	Climb-down;Staircase;24078								1
+3017 3344 0	3021 3344 1	Climb-up;Staircase;24077								1
+3021 3344 1	3017 3344 0	Climb-down;Staircase;24078								1
+3017 3343 0	3021 3343 1	Climb-up;Staircase;24077								1
+3021 3343 1	3017 3343 0	Climb-down;Staircase;24078								1
+2971 3369 0	2971 3373 1	Climb-up;Staircase;24079								1
+2971 3373 1	2971 3369 0	Climb-down;Staircase;24080								1
+2972 3369 0	2972 3373 1	Climb-up;Staircase;24079								1
+2972 3373 1	2972 3369 0	Climb-down;Staircase;24080								1
+2959 3368 0	2959 3372 1	Climb-up;Staircase;24079								1
+2959 3372 1	2959 3368 0	Climb-down;Staircase;24080								1
+2960 3368 0	2960 3372 1	Climb-up;Staircase;24079								1
+2960 3372 1	2960 3368 0	Climb-down;Staircase;24080								1
+2946 3379 0	2946 3377 1	Climb-up;Ladder;24082								2
+2946 3377 1	2946 3379 0	Climb-down;Ladder;24084								2
+2971 3347 0	2968 3348 1	Climb-up;Staircase;24067								1
+2968 3348 1	2971 3347 0	Climb-down;Staircase;24068								1
+2983 3350 1	2983 3350 0	Climb-down;Ladder;24071								2
+2983 3350 0	2983 3350 1	Climb-up;Ladder;24070								2
+2983 3353 1	2983 3353 2	Climb-up;Ladder;24070								2
+2983 3353 2	2983 3353 1	Climb-down;Ladder;24071								2
+2983 3350 2	2983 3350 3	Climb-up;Ladder;24070								2
+2983 3350 3	2983 3350 2	Climb-down;Ladder;24071								2
+2993 3341 1	2993 3341 0	Climb-down;Ladder;24071								2
+2993 3341 0	2993 3341 1	Climb-up;Ladder;24070								2
+2995 3341 1	2995 3341 2	Climb-up;Ladder;24070								2
+2995 3341 2	2995 3341 1	Climb-down;Ladder;24071								2
+2995 3341 2	2995 3341 3	Climb-up;Ladder;24070								2
+2995 3341 3	2995 3341 2	Climb-down;Ladder;24071								2
+2955 3337 0	2956 3338 1	Climb-up;Staircase;24072								1
+2956 3338 1	2955 3337 0	Climb-down;Staircase;24074								1
+2959 3339 2	2960 3340 1	Climb-down;Staircase;24074								1
+2960 3340 1	2959 3339 2	Climb-up;Staircase;24072								1
+2961 3340 1	2959 3339 2	Climb-up;Staircase;24072								1
+2959 3338 3	2958 3337 2	Climb-down;Staircase;24074								1
+2958 3337 2	2959 3338 3	Climb-up;Staircase;24072								1
+2957 3337 2	2959 3338 3	Climb-up;Staircase;24072								1
+2984 3340 2	2984 3336 1	Climb-down;Staircase;24078								1
+2984 3336 1	2984 3340 2	Climb-up;Staircase;24077								1
+2985 3340 2	2985 3336 1	Climb-down;Staircase;24078								1
+2985 3336 1	2985 3340 2	Climb-up;Staircase;24077								1
+2954 3390 0	2954 3388 1	Climb-up;Ladder;24083								2
+2954 3388 1	2954 3390 0	Climb-down;Ladder;24084								2
+2955 3390 1	2953 3390 2	Climb-up;Ladder;24082								2
+2953 3390 2	2955 3390 1	Climb-down;Ladder;24084								2
+2954 3388 2	2954 3390 3	Climb-up;Ladder;24082								2
+2954 3390 3	2954 3388 2	Climb-down;Ladder;24084								2
+2973 3386 0	2972 3385 1	Climb-up;Staircase;24075								1
+2972 3385 1	2973 3386 0	Climb-down;Staircase;24076								1
+2974 3386 0	2972 3385 1	Climb-up;Staircase;24075								1
+1752 5137 0	2985 3316 0	Climb;Rope;12230								2
+
+# Makeover Mage
+2916 3323 0	2916 3323 1	Climb-up;Ladder;9558								2
+2916 3323 1	2916 3323 0	Climb-down;Ladder;9559								2
+
+# Dark Wizards' Tower
+2909 3335 0	2908 3336 1	Climb-up;Staircase;11888								1
+2908 3336 1	2909 3335 0	Climb-down;Staircase;11889								1
+2909 3334 0	2908 3336 1	Climb-up;Staircase;11888								1
+2908 3336 1	2908 3336 2	Climb-up;Staircase;11889								1
+2908 3336 2	2908 3336 1	Climb-down;Staircase;11890								1
+
+# Killerwatt Plane
+3110 3363 2	2677 5214 2	Enter;Interdimensional rift;11355				Ernest the Chicken				1
+3111 3363 2	2677 5214 2	Enter;Interdimensional rift;11355				Ernest the Chicken				1
+
+# Ferox Enclave
+3140 3637 0	3137 3637 1	Climb;Stairs;39643								1
+3137 3637 1	3140 3637 0	Climb;Stairs;39650								1
+3140 3636 0	3137 3636 1	Climb;Stairs;39643								1
+3137 3636 1	3140 3636 0	Climb;Stairs;39650								1
+3143 3637 0	3146 3637 1	Climb;Stairs;39643								1
+3146 3637 1	3143 3637 0	Climb;Stairs;39650								1
+3143 3636 0	3146 3636 1	Climb;Stairs;39643								1
+3146 3636 1	3143 3636 0	Climb;Stairs;39650								1
+3142 3634 1	3142 3637 2	Climb;Stairs;39643								1
+3142 3637 2	3142 3634 1	Climb;Stairs;39650								1
+3141 3634 1	3141 3637 2	Climb;Stairs;39643								1
+3141 3637 2	3141 3634 1	Climb;Stairs;39650								1
+3126 3639 0	3126 3639 1	Climb-up;Ladder;14745								2
+3126 3639 1	3126 3639 0	Climb-down;Ladder;14746								2
+3129 3639 1	3129 3639 2	Climb-up;Ladder;14745								2
+3129 3639 2	3129 3639 1	Climb-down;Ladder;14746								2
+3129 3633 2	3129 3633 1	Climb-down;Ladder;14746								2
+3129 3633 1	3129 3633 2	Climb-up;Ladder;14745								2
+3126 3633 1	3126 3633 0	Climb-down;Ladder;14746								2
+3126 3633 0	3126 3633 1	Climb-up;Ladder;14745								2
+3127 3625 2	3127 3625 1	Climb-down;Ladder;14746								2
+3127 3625 1	3127 3625 2	Climb-up;Ladder;14745								2
+3127 3618 1	3127 3618 2	Climb-up;Ladder;14745								2
+3127 3618 2	3127 3618 1	Climb-down;Ladder;14746								2
+3131 3622 1	3134 3622 0	Climb;Stairs;39650								1
+3134 3622 0	3131 3622 1	Climb;Stairs;39643								1
+3131 3621 1	3134 3621 0	Climb;Stairs;39650								1
+3134 3621 0	3131 3621 1	Climb;Stairs;39643								1
+3135 3622 0	3138 3622 1	Climb;Stairs;39643								1
+3138 3622 1	3135 3622 0	Climb;Stairs;39650								1
+3135 3621 0	3138 3621 1	Climb;Stairs;39643								1
+3138 3621 1	3135 3621 0	Climb;Stairs;39650								1
+3142 3618 1	3142 3618 2	Climb-up;Ladder;14745								2
+3142 3618 2	3142 3618 1	Climb-down;Ladder;14746								2
+3142 3625 1	3142 3625 2	Climb-up;Ladder;14745								2
+3142 3625 2	3142 3625 1	Climb-down;Ladder;14746								2
+3152 3644 0	3164 10043 0	Walk-down;Stairs;39647								1
+3164 10044 0	3152 3644 0	Exit;Opening;39648								1
+3152 3643 0	3164 10043 0	Walk-down;Stairs;39647								1
+3164 10043 0	3152 3644 0	Exit;Opening;39648								1
+3164 10042 0	3152 3644 0	Exit;Opening;39648								1
+3154 3635 0	3155 3635 0	Pass-Through;Barrier;39653								6
+3155 3635 0	3154 3635 0	Pass-Through;Barrier;39653								6
+3154 3634 0	3155 3634 0	Pass-Through;Barrier;39652								6
+3155 3634 0	3154 3634 0	Pass-Through;Barrier;39652								6
+3135 3617 0	3135 3616 0	Pass-Through;Barrier;39653								6
+3135 3616 0	3135 3617 0	Pass-Through;Barrier;39653								6
+3134 3616 0	3134 3617 0	Pass-Through;Barrier;39652								6
+3134 3617 0	3134 3616 0	Pass-Through;Barrier;39652								6
+3123 3629 0	3122 3629 0	Pass-Through;Barrier;39652								6
+3122 3629 0	3123 3629 0	Pass-Through;Barrier;39652								6
+3123 3628 0	3122 3628 0	Pass-Through;Barrier;39653								6
+3122 3628 0	3123 3628 0	Pass-Through;Barrier;39653								6
+3135 3639 0	3135 3640 0	Pass-Through;Barrier;39652								6
+3135 3640 0	3135 3639 0	Pass-Through;Barrier;39652								6
+3134 3639 0	3134 3640 0	Pass-Through;Barrier;39653								6
+3134 3640 0	3134 3639 0	Pass-Through;Barrier;39653								6
+
+# Clan Wars (Free-for-all)
+3371 4810 0	3371 4810 1	Climb-up;Ladder;16683								2
+3371 4810 1	3371 4810 0	Climb-down;Ladder;16679								2
+3371 4808 1	3371 4808 0	Climb-down;Ladder;16679								2
+3371 4808 0	3371 4808 1	Climb-up;Ladder;16683								2
+3369 4826 1	3369 4826 0	Climb-down;Ladder;16679								2
+3369 4826 0	3369 4826 1	Climb-up;Ladder;16683								2
+3367 4826 1	3367 4826 0	Climb-down;Ladder;16679								2
+3367 4826 0	3367 4826 1	Climb-up;Ladder;16683								2
+
+# Skavid Caves
+2562 3024 0	2523 3070 0	Enter;Cave entrance;2805								10
+2523 3070 0	2540 3055 0	Enter;Cave entrance;2806								10
+2540 3054 0	2553 3055 0	Enter;Cave entrance;2807								10
+2553 3054 0	2552 3034 0	Enter;Cave entrance;2808								10
+2552 3034 0	2563 3024 0	Enter;Cave entrance;2809								10
+2562 3023 0	2523 3070 0	Enter;Cave entrance;2805								10
+2524 3070 0	2540 3055 0	Enter;Cave entrance;2806								10
+2541 3054 0	2553 3055 0	Enter;Cave entrance;2807								10
+2551 3053 0	2552 3034 0	Enter;Cave entrance;2808								10
+2552 3035 0	2563 3024 0	Enter;Cave entrance;2809								10
+2561 3021 0	2523 3070 0	Enter;Cave entrance;2805								10
+2522 3070 0	2540 3055 0	Enter;Cave entrance;2806								10
+2539 3054 0	2553 3055 0	Enter;Cave entrance;2807								10
+2552 3054 0	2552 3034 0	Enter;Cave entrance;2808								10
+2552 3033 0	2563 3024 0	Enter;Cave entrance;2809								10
+2562 3025 0	2523 3070 0	Enter;Cave entrance;2805								10
+2542 3054 0	2553 3055 0	Enter;Cave entrance;2807								10
+2562 3022 0	2523 3070 0	Enter;Cave entrance;2805								10
+2525 3070 0	2540 3055 0	Enter;Cave entrance;2806								10
+2561 3026 0	2523 3070 0	Enter;Cave entrance;2805								10
+2560 3026 0	2523 3070 0	Enter;Cave entrance;2805								10
+2560 3021 0	2523 3070 0	Enter;Cave entrance;2805								10
+
+# Skavid Caves Island
+2500 2988 0	2576 3029 0	Enter;Cave entrance;2811
+2576 3029 0	2500 2988 0	Climb-down;Ladder;2812								2
+2499 2988 0	2576 3029 0	Enter;Cave entrance;2811
+2575 3028 0	2500 2988 0	Climb-down;Ladder;2812								2
+2501 2989 0	2576 3029 0	Enter;Cave entrance;2811
+2575 3030 0	2500 2988 0	Climb-down;Ladder;2812								2
+2498 2989 0	2576 3029 0	Enter;Cave entrance;2811
+2574 3029 0	2500 2988 0	Climb-down;Ladder;2812								2
+
+# Yanille
+2537 3095 0	2537 3099 1	Climb-up;Staircase;15646								1
+2537 3099 1	2537 3095 0	Climb-down;Staircase;15648								1
+2538 3095 0	2538 3099 1	Climb-up;Staircase;15646								1
+2538 3099 1	2537 3095 0	Climb-down;Staircase;15648								1
+2538 3088 0	2538 3084 1	Climb-up;Staircase;15646								1
+2538 3084 1	2537 3088 0	Climb-down;Staircase;15648								1
+2537 3088 0	2537 3084 1	Climb-up;Staircase;15646								1
+2537 3084 1	2537 3088 0	Climb-down;Staircase;15648								1
+2555 3081 0	2555 3081 1	Climb-up;Ladder;16683								2
+2555 3081 1	2555 3081 0	Climb-down;Ladder;16679								2
+2556 3082 0	2556 3082 1	Climb-up;Ladder;16683								2
+2556 3082 1	2556 3082 0	Climb-down;Ladder;16679								2
+2557 3081 0	2557 3081 1	Climb-up;Ladder;16683								2
+2557 3081 1	2557 3081 0	Climb-down;Ladder;16679								2
+2556 3080 0	2556 3080 1	Climb-up;Ladder;16683								2
+2556 3080 1	2556 3080 0	Climb-down;Ladder;16679								2
+2606 3079 0	2601 9478 0	Climb-down;Staircase;16664								1
+2602 9478 0	2606 3078 0	Climb-up;Staircase;16665								1
+2606 3078 0	2601 9478 0	Climb-down;Staircase;16664								1
+2602 9479 0	2606 3078 0	Climb-up;Staircase;16665								1
+2597 3106 0	2597 3106 1	Climb-up;Ladder;16683								2
+2597 3106 1	2597 3106 0	Climb-down;Ladder;16681								2
+2598 3107 0	2598 3107 1	Climb-up;Ladder;16683								2
+2598 3107 1	2598 3107 0	Climb-down;Ladder;16681								2
+2597 3108 0	2597 3108 1	Climb-up;Ladder;16683								2
+2597 3108 1	2597 3108 0	Climb-down;Ladder;16681								2
+2596 3107 0	2596 3107 1	Climb-up;Ladder;16683								2
+2596 3107 1	2596 3107 0	Climb-down;Ladder;16681								2
+2594 9484 0	2594 3084 0	Climb-up;Ladder;17385
+2594 9486 0	2594 3086 0	Climb-up;Ladder;17385
+2594 3086 0	2594 9486 0	Climb-down;Ladder;17384
+
+# Hazelmere Island
+2677 3088 1	2677 3088 0	Climb-down;Ladder;16679								2
+2677 3088 0	2677 3088 1	Climb-up;Ladder;16683								2
+2676 3087 1	2676 3087 0	Climb-down;Ladder;16679								2
+2676 3087 0	2676 3087 1	Climb-up;Ladder;16683								2
+2677 3086 1	2677 3086 0	Climb-down;Ladder;16679								2
+2677 3086 0	2677 3086 1	Climb-up;Ladder;16683								2
+2678 3087 1	2678 3087 0	Climb-down;Ladder;16679								2
+2678 3087 0	2678 3087 1	Climb-up;Ladder;16683								2
+
+# Ardougne Monastery
+2615 3209 0	2618 3208 1	Climb-up;Staircase;16671								1
+2618 3208 1	2617 3207 0	Climb-down;Staircase;16673								1
+2617 3207 0	2618 3208 1	Climb-up;Staircase;16671								1
+2616 3207 0	2618 3208 1	Climb-up;Staircase;16671								1
+2615 3208 0	2618 3208 1	Climb-up;Staircase;16671								1
+2618 3208 0	2618 3208 1	Climb-up;Staircase;16671								1
+2618 3209 0	2618 3208 1	Climb-up;Staircase;16671								1
+2616 3210 0	2618 3208 1	Climb-up;Staircase;16671								1
+2617 3210 0	2618 3208 1	Climb-up;Staircase;16671								1
+2597 3209 0	2597 3208 1	Climb-up;Staircase;16671								1
+2597 3208 1	2596 3207 0	Climb-down;Staircase;16673								1
+2597 3208 0	2597 3208 1	Climb-up;Staircase;16671								1
+2596 3207 0	2597 3208 1	Climb-up;Staircase;16671								1
+2595 3207 0	2597 3208 1	Climb-up;Staircase;16671								1
+2594 3208 0	2597 3208 1	Climb-up;Staircase;16671								1
+2594 3209 0	2597 3208 1	Climb-up;Staircase;16671								1
+2595 3210 0	2597 3208 1	Climb-up;Staircase;16671								1
+2596 3210 0	2597 3208 1	Climb-up;Staircase;16671								1
+2675 3300 0	2675 3300 1	Climb-up;Staircase;16671								1
+# Ardougne Sewers
+2587 3237 0	2570 9682 0	Enter;Cave entrance;2852
+2570 9682 0	2587 3237 0	Climb-up;Stairs;2853
+2586 3237 0	2570 9682 0	Enter;Cave entrance;2852
+2571 9682 0	2587 3237 0	Climb-up;Stairs;2853
+2589 3236 0	2570 9682 0	Enter;Cave entrance;2852
+2588 3237 0	2570 9682 0	Enter;Cave entrance;2852
+2569 9683 0	2587 3237 0	Climb-up;Stairs;2853
+2584 3236 0	2570 9682 0	Enter;Cave entrance;2852
+2569 9684 0	2587 3237 0	Climb-up;Stairs;2853
+2584 3235 0	2570 9682 0	Enter;Cave entrance;2852
+2569 9685 0	2587 3237 0	Climb-up;Stairs;2853
+2584 3234 0	2570 9682 0	Enter;Cave entrance;2852
+2589 3235 0	2570 9682 0	Enter;Cave entrance;2852
+2589 3234 0	2570 9682 0	Enter;Cave entrance;2852
+2588 3232 0	2570 9682 0	Enter;Cave entrance;2852
+2587 3232 0	2570 9682 0	Enter;Cave entrance;2852
+2586 3232 0	2570 9682 0	Enter;Cave entrance;2852
+2585 3232 0	2570 9682 0	Enter;Cave entrance;2852
+2584 3233 0	2570 9682 0	Enter;Cave entrance;2852
+
+# East Ardougne
+2571 3298 0	2571 3294 1	Climb-up;Staircase;15645								1
+2571 3294 1	2571 3298 0	Climb-down;Staircase;15648								1
+2572 3298 0	2571 3294 1	Climb-up;Staircase;15645								1
+2572 3294 1	2571 3298 0	Climb-down;Staircase;15648								1
+2610 3307 0	2610 3307 1	Climb-up;Ladder;16683								2
+2610 3307 1	2610 3307 2	Climb-up;Ladder;16684								2
+2610 3307 2	2610 3307 3	Climb-up;Ladder;16684								2
+2610 3307 3	2610 3307 2	Climb-down;Ladder;16679								2
+2610 3307 2	2610 3307 1	Climb-down;Ladder;16684								2
+2611 3306 0	2611 3306 1	Climb-up;Ladder;16683								2
+2611 3306 1	2611 3306 2	Climb-up;Ladder;16684								2
+2611 3306 2	2611 3306 3	Climb-up;Ladder;16684								2
+2611 3306 3	2611 3306 2	Climb-down;Ladder;16679								2
+2611 3306 2	2611 3306 1	Climb-down;Ladder;16684								2
+2611 3306 1	2611 3306 0	Climb-down;Ladder;16684								2
+2610 3307 1	2610 3307 0	Climb-down;Ladder;16684								2
+2609 3306 0	2609 3306 1	Climb-up;Ladder;16683								2
+2609 3306 1	2609 3306 2	Climb-up;Ladder;16684								2
+2609 3306 2	2609 3306 1	Climb-down;Ladder;16684								2
+2609 3306 1	2609 3306 0	Climb-down;Ladder;16684								2
+2610 3305 0	2610 3305 1	Climb-up;Ladder;16683								2
+2610 3305 1	2610 3305 0	Climb-down;Ladder;16684								2
+2610 3305 1	2610 3305 2	Climb-up;Ladder;16684								2
+2610 3305 2	2610 3305 3	Climb-up;Ladder;16684								2
+2610 3305 3	2610 3305 2	Climb-down;Ladder;16679								2
+2609 3306 2	2609 3306 3	Climb-up;Ladder;16684								2
+2609 3306 3	2609 3306 2	Climb-down;Ladder;16679								2
+2610 3305 2	2610 3305 1	Climb-down;Ladder;16684								2
+2665 3321 1	2661 3321 0	Climb-down;Staircase;15648								1
+2661 3321 0	2665 3321 1	Climb-up;Staircase;15645								1
+2665 3322 1	2661 3321 0	Climb-down;Staircase;15648								1
+2661 3322 0	2665 3321 1	Climb-up;Staircase;15645								1
+2655 3321 0	2655 3321 1	Climb-up;Ladder;17026								2
+2655 3321 1	2655 3321 0	Climb-down;Ladder;16685								2
+2662 3294 0	2661 3291 1	Climb-up;Staircase;16668								1
+2661 3291 1	2662 3294 0	Climb-down;Staircase;16667								1
+2648 3301 1	2645 3302 0	Climb-down;Staircase;16667								1
+2645 3302 0	2648 3301 1	Climb-up;Staircase;16668								1
+2649 3312 1	2650 3311 0	Climb-down;Staircase;16673								1
+2650 3311 0	2649 3312 1	Climb-up;Staircase;16671								1
+2649 3312 0	2649 3312 1	Climb-up;Staircase;16671								1
+2648 3312 0	2649 3312 1	Climb-up;Staircase;16671								1
+2650 3310 0	2649 3312 1	Climb-up;Staircase;16671								1
+2649 3296 1	2648 3293 0	Climb-down;Staircase;16667								1
+2648 3293 0	2649 3296 1	Climb-up;Staircase;16668								1
+2617 3324 0	2617 3324 1	Climb-up;Ladder;16683								2
+2617 3324 1	2617 3324 0	Climb-down;Ladder;16679								2
+2616 3323 0	2616 3323 1	Climb-up;Ladder;16683								2
+2616 3323 1	2616 3323 0	Climb-down;Ladder;16679								2
+2651 3286 0	2651 3286 1	Climb-up;Ladder;16683								2
+2651 3286 1	2651 3286 0	Climb-down;Ladder;16679								2
+2650 3287 0	2650 3287 1	Climb-up;Ladder;16683								2
+2650 3287 1	2650 3287 0	Climb-down;Ladder;16679								2
+2650 3285 0	2650 3285 1	Climb-up;Ladder;16683								2
+2650 3285 1	2650 3285 0	Climb-down;Ladder;16679								2
+2649 3287 1	2649 3287 2	Climb-up;Ladder;17026								2
+2649 3287 2	2649 3287 1	Climb-down;Ladder;16685								2
+2651 3281 0	2651 3281 1	Climb-up;Ladder;16683								2
+2651 3281 1	2651 3281 0	Climb-down;Ladder;16679								2
+2650 3280 0	2650 3280 1	Climb-up;Ladder;16683								2
+2650 3280 1	2650 3280 0	Climb-down;Ladder;16679								2
+2650 3282 0	2650 3282 1	Climb-up;Ladder;16683								2
+2650 3282 1	2650 3282 0	Climb-down;Ladder;16679								2
+2649 3282 1	2649 3282 2	Climb-up;Ladder;17026								2
+2649 3282 2	2649 3282 1	Climb-down;Ladder;16685								2
+2683 3271 0	2683 3268 1	Cross;Gangplank;2085								3
+2683 3268 1	2683 3271 0	Cross;Gangplank;2086								3
+2622 3291 0	2622 3291 1	Climb-up;Ladder;17026								2
+2622 3291 1	2622 3291 0	Climb-down;Ladder;16685								2
+2592 3339 0	2592 3338 0	Open;Door;2054								1
+2592 3338 0	2592 3339 0	Open;Door;2054								1
+2590 3334 0	2594 3334 1	Climb-up;Staircase;15645								1
+2594 3334 1	2590 3334 0	Climb-down;Staircase;15648								1
+2590 3335 0	2594 3334 1	Climb-up;Staircase;15645								1
+2594 3335 1	2590 3334 0	Climb-down;Staircase;15648								1
+2574 3332 0	2578 3332 1	Climb-up;Staircase;15649								1
+2578 3332 1	2574 3332 0	Climb-down;Staircase;15650								1
+2574 3331 0	2578 3331 1	Climb-up;Staircase;15649								1
+2578 3331 1	2574 3331 0	Climb-down;Staircase;15650								1
+2572 3324 0	2574 3325 1	Climb-up;Staircase;16671								1
+2574 3325 1	2573 3324 0	Climb-down;Staircase;16673								1
+2573 3324 0	2574 3325 1	Climb-up;Staircase;16671								1
+2574 3325 0	2574 3325 1	Climb-up;Staircase;16671								1
+2566 3321 1	2565 3322 0	Climb-down;Staircase;16673								1
+2565 3322 0	2566 3321 1	Climb-up;Staircase;16671								1
+2565 3323 0	2566 3321 1	Climb-up;Staircase;16671								1
+2566 3321 0	2566 3321 1	Climb-up;Staircase;16671								1
+2567 3321 0	2566 3321 1	Climb-up;Staircase;16671								1
+2568 3322 0	2566 3321 1	Climb-up;Staircase;16671								1
+2568 3323 0	2566 3321 1	Climb-up;Staircase;16671								1
+2567 3324 0	2566 3321 1	Climb-up;Staircase;16671								1
+2664 3333 0	2664 3333 1	Climb-up;Ladder;16683								2
+2664 3333 1	2664 3333 0	Climb-down;Ladder;16679								2
+2665 3334 0	2665 3334 1	Climb-up;Ladder;16683								2
+2665 3334 1	2665 3334 0	Climb-down;Ladder;16679								2
+2664 3335 0	2664 3335 1	Climb-up;Ladder;16683								2
+2664 3335 1	2664 3335 0	Climb-down;Ladder;16679								2
+2663 3334 0	2663 3334 1	Climb-up;Ladder;16683								2
+2663 3334 1	2663 3334 0	Climb-down;Ladder;16679								2
+2665 3291 0	2665 3291 1	Climb-up;Ladder;16683								2
+2665 3291 1	2665 3291 0	Climb-down;Ladder;16679								2
+2666 3290 0	2666 3290 1	Climb-up;Ladder;16683								2
+2666 3290 1	2666 3290 0	Climb-down;Ladder;16679								2
+2569 3271 0	2568 3267 1	Climb-up;Staircase;15645								1
+2568 3267 1	2568 3271 0	Climb-down;Staircase;15648								1
+2568 3271 0	2568 3267 1	Climb-up;Staircase;15645								1
+2569 3267 1	2568 3271 0	Climb-down;Staircase;15648								1
+2570 3268 0	2570 9668 0	Climb-down;Ladder;17384								2
+2570 9668 0	2570 3268 0	Climb-up;Ladder;17385								2
+2571 3267 0	2571 9667 0	Climb-down;Ladder;17384								2
+2571 9667 0	2571 3267 0	Climb-up;Ladder;17385								2
+2674 3299 0	2675 3300 1	Climb-up;Staircase;16671								1
+2675 3300 1	2674 3299 0	Climb-down;Staircase;16673								1
+2674 3304 0	2674 3303 0	Pick-lock;Door;11720								2
+2674 3305 0	2674 3306 0	Pick-lock;Door;11719								2
+2674 3303 0	2674 3304 0	Open;Door;11720								1
+2674 3306 0	2674 3305 0	Open;Door;11719								1
+
+# Witchaven Dungeon
+2697 3283 0	2696 9683 0	Climb-down;Old ruin entrance;18270
+2696 9683 0	2697 3283 0	Climb-up;Exit;18354
+
+# West Ardougne
+2559 3300 0	2556 3300 0	Open;Ardougne Wall Door;8739
+2556 3300 0	2559 3300 0	Open;Ardougne Wall Door;8738
+2559 3299 0	2556 3299 0	Open;Ardougne Wall Door;8738
+2556 3299 0	2559 3299 0	Open;Ardougne Wall Door;8739
+2542 3331 0	2541 3331 0	Squeeze-through;Fence;2068
+2541 3331 0	2542 3331 0	Squeeze-through;Fence;2068
+2531 3328 0	2531 3329 0	Open;Door;2537								1
+2531 3329 0	2531 3328 0	Open;Door;2537								1
+2528 3331 0	2527 3331 1	Walk-up;Stairs;2539
+2527 3331 1	2527 3331 0	Walk-down;Stairs;2540
+2527 3331 0	2527 3331 1	Walk-up;Stairs;2539
+2530 3320 0	2529 3317 1	Climb-up;Staircase;16668								1
+2529 3317 1	2530 3320 0	Climb-down;Staircase;16667								1
+2527 3317 1	2527 3313 2	Climb-up;Staircase;15653								1
+2527 3313 2	2527 3317 1	Climb-down;Staircase;15654								1
+2528 3317 1	2527 3313 2	Climb-up;Staircase;15653								1
+2528 3313 2	2527 3317 1	Climb-down;Staircase;15654								1
+2524 3313 1	2523 3317 0	Climb-down;Staircase;15654								1
+2523 3317 0	2523 3313 1	Climb-up;Staircase;15653								1
+2523 3313 1	2523 3317 0	Climb-down;Staircase;15654								1
+2524 3317 0	2523 3313 1	Climb-up;Staircase;15653								1
+2530 3314 0	2529 3314 0	Open;Door;2528								1
+2529 3314 0	2530 3314 0	Open;Door;2528								1
+2526 3290 0	2527 3293 1	Climb-up;Staircase;16668								1
+2527 3293 1	2526 3290 0	Climb-down;Staircase;16667								1
+2530 3294 0	2531 3293 1	Climb-up;Staircase;16671								1
+2531 3293 1	2530 3294 0	Climb-down;Staircase;16673								1
+2530 3295 0	2531 3293 1	Climb-up;Staircase;16671								1
+2531 3293 0	2531 3293 1	Climb-up;Staircase;16671								1
+2532 3293 0	2531 3293 1	Climb-up;Staircase;16671								1
+2533 3271 0	2533 3272 0	Open;Door;37321								1
+2533 3272 0	2533 3271 0	Open;Door;37321								1
+2536 3271 0	2537 9670 0	Walk-down;Spooky stairs;2522
+2537 9670 0	2536 3271 0	Walk-up;Spooky stairs;2523
+2537 3271 0	2537 9670 0	Walk-down;Spooky stairs;2522
+2536 9670 0	2536 3271 0	Walk-up;Spooky stairs;2523
+2539 9672 0	2540 9672 0	Open;Door;2526								1
+2540 9672 0	2539 9672 0	Open;Door;2526								1
+2540 3273 0	2540 3272 0	Open;Door;37321								1
+2540 3272 0	2540 3273 0	Open;Door;37321								1
+2458 3309 0	2458 3309 1	Climb-up;Ladder;16683								2
+2458 3309 1	2458 3309 0	Climb-down;Ladder;16679								2
+2459 3310 0	2459 3310 1	Climb-up;Ladder;16683								2
+2459 3310 1	2459 3310 0	Climb-down;Ladder;16679								2
+2457 3310 0	2457 3310 1	Climb-up;Ladder;16683								2
+2457 3310 1	2457 3310 0	Climb-down;Ladder;16679								2
+2458 3311 1	2458 3311 0	Climb-down;Ladder;16679								2
+2458 3311 0	2458 3311 1	Climb-up;Ladder;16683								2
+
+# Clock tower
+2571 3240 0	2571 3241 1	Climb-up;Staircase;16671								1
+2571 3241 0	2571 3241 1	Climb-up;Staircase;16671								1
+2571 3241 1	2572 3242 0	Climb-down;Staircase;16672								1
+2572 3242 0	2571 3241 1	Climb-up;Staircase;16671								1
+2572 3242 1	2572 3242 0	Climb-down;Staircase;16672								1
+2573 3242 0	2571 3241 1	Climb-up;Staircase;16671								1
+2572 3239 0	2571 3241 1	Climb-up;Staircase;16671								1
+2573 3239 0	2571 3241 1	Climb-up;Staircase;16671								1
+2571 3241 1	2571 3241 2	Climb-up;Staircase;16672								1
+2571 3241 2	2572 3242 1	Climb-down;Staircase;16673								1
+2572 3242 1	2571 3241 2	Climb-up;Staircase;16672								1
+2566 3243 0	2566 9643 0	Climb-down;Ladder;17384								2
+2566 9643 0	2566 3243 0	Climb-up;Ladder;17385								2
+2565 3242 0	2565 9642 0	Climb-down;Ladder;17384								2
+2565 9642 0	2565 3242 0	Climb-up;Ladder;17385								2
+2566 3241 0	2566 9641 0	Climb-down;Ladder;17384								2
+2566 9641 0	2566 3241 0	Climb-up;Ladder;17385								2
+2567 3242 0	2567 9642 0	Climb-down;Ladder;17384								2
+2567 9642 0	2567 3242 0	Climb-up;Ladder;17385								2
+2569 9628 0	2569 3228 0	Climb-up;Ladder;17385								2
+2569 3228 0	2569 9628 0	Climb-down;Ladder;17384								2
+2568 9627 0	2568 3227 0	Climb-up;Ladder;17385								2
+2568 3227 0	2568 9627 0	Climb-down;Ladder;17384								2
+2569 9626 0	2569 3226 0	Climb-up;Ladder;17385								2
+2569 3226 0	2569 9626 0	Climb-down;Ladder;17384								2
+2570 9627 0	2570 3227 0	Climb-up;Ladder;17385								2
+2570 3227 0	2570 9627 0	Climb-down;Ladder;17384								2
+2571 3227 0	2571 9627 0	Climb-down;Ladder;17384								2
+2571 9627 0	2571 3227 0	Climb-up;Ladder;17385								2
+2572 3228 0	2572 9628 0	Climb-down;Ladder;17384								2
+2572 9628 0	2572 3228 0	Climb-up;Ladder;17385								2
+2573 3227 0	2573 9627 0	Climb-down;Ladder;17384								2
+2573 9627 0	2573 3227 0	Climb-up;Ladder;17385								2
+2572 3226 0	2572 9626 0	Climb-down;Ladder;17384								2
+2572 9626 0	2572 3226 0	Climb-up;Ladder;17385								2
+2567 3227 0	2567 9627 0	Climb-down;Ladder;17384								2
+2567 9627 0	2567 3227 0	Climb-up;Ladder;17385								2
+2566 3226 0	2566 9626 0	Climb-down;Ladder;17384								2
+2566 9626 0	2566 3226 0	Climb-up;Ladder;17385								2
+2565 3227 0	2565 9627 0	Climb-down;Ladder;17384								2
+2565 9627 0	2565 3227 0	Climb-up;Ladder;17385								2
+2566 3228 0	2566 9628 0	Climb-down;Ladder;17384								2
+2566 9628 0	2566 3228 0	Climb-up;Ladder;17385								2
+2566 3230 0	2566 9630 0	Climb-down;Ladder;17384								2
+2566 9630 0	2566 3230 0	Climb-up;Ladder;17385								2
+2567 3231 0	2567 9631 0	Climb-down;Ladder;17384								2
+2567 9631 0	2567 3231 0	Climb-up;Ladder;17385								2
+2566 3232 0	2566 9632 0	Climb-down;Ladder;17384								2
+2566 9632 0	2566 3232 0	Climb-up;Ladder;17385								2
+2565 3231 0	2565 9631 0	Climb-down;Ladder;17384								2
+2565 9631 0	2565 3231 0	Climb-up;Ladder;17385								2
+2568 3231 0	2568 9631 0	Climb-down;Ladder;17384								2
+2568 9631 0	2568 3231 0	Climb-up;Ladder;17385								2
+2569 3232 0	2569 9632 0	Climb-down;Ladder;17384								2
+2569 9632 0	2569 3232 0	Climb-up;Ladder;17385								2
+2570 3231 0	2570 9631 0	Climb-down;Ladder;17384								2
+2570 9631 0	2570 3231 0	Climb-up;Ladder;17385								2
+2569 3230 0	2569 9630 0	Climb-down;Ladder;17384								2
+2569 9630 0	2569 3230 0	Climb-up;Ladder;17385								2
+2621 3262 0	2621 9662 0	Climb-down;Ladder;17384								2
+2621 9662 0	2621 3262 0	Climb-up;Ladder;17385								2
+2622 3261 0	2622 9661 0	Climb-down;Ladder;17384								2
+2622 9661 0	2622 3261 0	Climb-up;Ladder;17385								2
+2621 3260 0	2621 9660 0	Climb-down;Ladder;17384								2
+2621 9660 0	2621 3260 0	Climb-up;Ladder;17385								2
+2620 3261 0	2620 9661 0	Climb-down;Ladder;17384								2
+2620 9661 0	2620 3261 0	Climb-up;Ladder;17385								2
+2576 9631 0	2575 9631 0	Push;Wall;1597
+2575 9631 0	2576 9631 0	Push;Wall;1597
+2573 9631 0	2573 3231 0	Climb-up;Ladder;17385								2
+2571 9631 0	2571 3231 0	Climb-up;Ladder;17385								2
+2572 9632 0	2572 3232 0	Climb-up;Ladder;17385								2
+2572 9630 0	2572 3230 0	Climb-up;Ladder;17385								2
+2561 9621 0	2561 3221 0	Climb-up;Ladder;17385								2
+2561 3221 0	2561 9621 0	Climb-down;Ladder;16680								2
+2562 9622 0	2562 3222 0	Climb-up;Ladder;17385								2
+2562 3222 0	2561 9621 0	Climb-down;Ladder;16680								2
+2561 3223 0	2561 9621 0	Climb-down;Ladder;16680								2
+2560 3222 0	2561 9621 0	Climb-down;Ladder;16680								2
+
+# Edgeville
+3097 3511 0	3097 3511 1	Climb-up;Ladder;16683
+3097 3511 1	3097 3511 0	Climb-down;Ladder;16679
+3096 3512 0	3096 3512 1	Climb-up;Ladder;16683
+3096 3512 1	3096 3512 0	Climb-down;Ladder;16679
+3095 3511 0	3095 3511 1	Climb-up;Ladder;16683
+3095 3511 1	3095 3511 0	Climb-down;Ladder;16679
+3096 3510 0	3096 3510 1	Climb-up;Ladder;16683
+3096 3510 1	3096 3510 0	Climb-down;Ladder;16679
+3083 3512 0	3083 3512 1	Climb-up;Ladder;16683
+3083 3512 1	3083 3512 0	Climb-down;Ladder;16679
+3082 3513 0	3082 3513 1	Climb-up;Ladder;16683
+3082 3513 1	3082 3513 0	Climb-down;Ladder;16679
+3096 3468 0	3096 9867 0	Climb-down;Trapdoor;1581								1
+3096 9867 0	3096 3468 0	Climb-up;Ladder;17385								1
+3097 9868 0	3096 3468 0	Climb-up;Ladder;17385								1
+3089 9971 0	3089 3571 0	Climb-up;Ladder;17385								1
+3089 3571 0	3089 9971 0	Climb-down;Ladder;16680								1
+3094 9895 0	3093 9895 0	Push;Odd looking wall;1736
+3093 9895 0	3094 9895 0	Push;Odd looking wall;1736
+3094 9896 0	3093 9896 0	Push;Odd looking wall;1734
+3093 9896 0	3094 9896 0	Push;Odd looking wall;1734
+3132 9917 0	3132 9918 0	Open;Gate;1728								1
+3132 9918 0	3132 9917 0	Open;Gate;1728								1
+3131 9917 0	3131 9918 0	Open;Gate;1727								1
+3131 9918 0	3131 9917 0	Open;Gate;1727								1
+3122 3488 0	3122 3487 0	Open;Door;102
+3122 3487 0	3122 3488 0	Open;Door;102
+3115 3449 0	3115 3450 0	Open;Door;1804		983						2
+3115 3450 0	3115 3449 0	Open;Door;1804		983						2
+3115 3452 0	3115 9852 0	Climb-down;Ladder;17384								2
+3115 9852 0	3115 3452 0	Climb-up;Ladder;17385								2
+
+# Varrock
+3212 3472 0	3212 3476 1	Climb-up;Staircase;11807
+3212 3476 1	3212 3472 0	Climb-down;Staircase;11799
+3213 3472 0	3213 3476 1	Climb-up;Staircase;11807
+3213 3476 1	3213 3472 0	Climb-down;Staircase;11799
+3203 3496 0	3204 3497 1	Climb-up;Staircase;11790
+3204 3497 1	3203 3496 0	Climb-down;Staircase;11792
+3204 3497 1	3204 3497 2	Climb-up;Staircase;11792
+3204 3497 2	3203 3496 1	Climb-down;Staircase;11793
+3204 3497 2	3204 3497 3	Climb-up;Ladder;11801
+3204 3497 3	3204 3497 2	Climb-down;Ladder;11802
+3220 3496 1	3219 3495 0	Climb-down;Staircase;11793
+3219 3495 0	3220 3496 1	Climb-up;Staircase;11789
+3218 3495 0	3220 3496 1	Climb-up;Staircase;11789
+3222 3491 0	3222 3490 0	Open;Door;32464
+3222 3490 0	3222 3491 0	Open;Door;32464
+3222 3479 0	3222 3478 0	Open;Door;32464
+3222 3478 0	3222 3479 0	Open;Door;32464
+3223 3472 1	3223 3472 2	Climb-up;Ladder;11801
+3223 3472 2	3223 3472 1	Climb-down;Ladder;11802
+3223 3472 3	3222 3471 2	Climb-down;Staircase;11793
+3222 3471 2	3223 3472 3	Climb-up;Staircase;11790
+3221 3471 2	3223 3472 3	Climb-up;Staircase;11790
+3238 3490 0	3242 3490 1	Climb-up;Staircase;11797
+3242 3490 1	3238 3490 0	Climb-down;Staircase;11799
+3238 3489 0	3242 3489 1	Climb-up;Staircase;11797
+3242 3489 1	3238 3489 0	Climb-down;Staircase;11799
+3257 3487 0	3258 3486 1	Climb-up;Staircase;11790
+3258 3486 1	3257 3487 0	Climb-down;Staircase;11792
+3257 3488 0	3258 3486 1	Climb-up;Staircase;11790
+3258 3486 1	3258 3486 2	Climb-up;Staircase;11792
+3258 3486 2	3257 3487 1	Climb-down;Staircase;11792
+3258 3486 2	3258 3486 3	Climb-up;Staircase;11792
+3258 3486 3	3257 3487 2	Climb-down;Staircase;11793
+3239 3447 1	3238 3446 0	Climb-down;Staircase;11793
+3238 3446 0	3239 3447 1	Climb-up;Staircase;11789
+3237 3446 0	3239 3447 1	Climb-up;Staircase;11789
+3257 3454 0	1759 4958 0	Walk-down;Stairs;24428
+1759 4958 0	3258 3452 0	Walk-up;Stairs;24427
+3258 3453 0	1759 4958 0	Walk-down;Stairs;24428
+1758 4958 0	3258 3452 0	Walk-up;Stairs;24427
+3258 3452 0	1759 4958 0	Walk-down;Stairs;24428
+1760 4958 0	3258 3452 0	Walk-up;Stairs;24427
+3258 3451 0	1759 4958 0	Walk-down;Stairs;24428
+3257 3450 0	1759 4958 0	Walk-down;Stairs;24428
+1761 4965 0	1631 4957 0	Walk-down;Stairs;24428
+1631 4957 0	1761 4964 0	Walk-up;Stairs;24427
+1761 4964 0	1631 4957 0	Walk-down;Stairs;24428
+1630 4957 0	1761 4964 0	Walk-up;Stairs;24427
+1761 4963 0	1631 4957 0	Walk-down;Stairs;24428
+1632 4957 0	1761 4964 0	Walk-up;Stairs;24427
+3266 3451 0	3266 3455 1	Climb-up;Staircase;11798
+3266 3455 1	3266 3451 0	Climb-down;Staircase;11799
+3267 3451 0	3267 3455 1	Climb-up;Staircase;11798
+3267 3455 1	3267 3451 0	Climb-down;Staircase;11799
+3254 3442 1	3254 3446 2	Climb-up;Staircase;11797
+3254 3446 2	3254 3442 1	Climb-down;Staircase;11799
+3253 3442 1	3253 3446 2	Climb-up;Staircase;11797
+3253 3446 2	3253 3442 1	Climb-down;Staircase;11799
+3257 3421 1	3256 3420 0	Climb-down;Staircase;11793
+3256 3420 0	3257 3421 1	Climb-up;Staircase;11789
+3255 3420 0	3257 3421 1	Climb-up;Staircase;11789
+3257 3422 1	3256 3420 0	Climb-down;Staircase;11793
+3234 3424 0	3234 3424 1	Climb-up;Ladder;11794
+3234 3424 1	3234 3424 0	Climb-down;Ladder;11795
+3230 3394 1	3226 3394 0	Climb-down;Staircase;11799
+3226 3394 0	3230 3394 1	Climb-up;Staircase;11796
+3230 3393 1	3226 3393 0	Climb-down;Staircase;11799
+3226 3393 0	3230 3393 1	Climb-up;Staircase;11796
+3231 9800 0	3231 3400 0	Climb-up;Ladder;11804
+3231 3400 0	3231 9800 0	Climb-down;Ladder;11803
+3230 9801 0	3230 3401 0	Climb-up;Ladder;11804
+3230 3401 0	3230 9801 0	Climb-down;Ladder;11803
+3231 9802 0	3231 3402 0	Climb-up;Ladder;11804
+3231 3402 0	3231 9802 0	Climb-down;Ladder;11803
+3232 9801 0	3232 3401 0	Climb-up;Ladder;11804
+3232 3401 0	3232 9801 0	Climb-down;Ladder;11803
+3230 3386 0	3230 3382 1	Climb-up;Staircase;11797
+3230 3382 1	3230 3386 0	Climb-down;Staircase;11799
+3231 3386 0	3231 3382 1	Climb-up;Staircase;11797
+3231 3382 1	3231 3386 0	Climb-down;Staircase;11799
+3222 3387 1	3222 3387 0	Climb-down;Ladder;11802
+3222 3387 0	3222 3387 1	Climb-up;Ladder;11794
+3186 3434 0	3190 9834 0	Climb-down;Staircase;11800
+3190 9834 0	3186 3434 0	Climb-up;Staircase;11805
+3186 3433 0	3190 9833 0	Climb-down;Staircase;11800
+3190 9833 0	3186 3433 0	Climb-up;Staircase;11805
+3185 3447 0	3185 3447 1	Climb-up;Ladder;11794
+3185 3447 1	3185 3447 0	Climb-down;Ladder;11795
+3159 3436 0	3155 3436 1	Climb-up;Staircase;11797
+3155 3436 1	3159 3436 0	Climb-down;Staircase;11799
+3159 3435 0	3155 3435 1	Climb-up;Staircase;11797
+3155 3435 1	3159 3435 0	Climb-down;Staircase;11799
+3186 3414 0	3186 3414 1	Climb-up;Ladder;11794
+3186 3414 1	3186 3414 0	Climb-down;Ladder;11795
+3205 3396 0	3205 3396 1	Climb-up;Ladder;11794
+3205 3396 1	3205 3396 0	Climb-down;Ladder;11795
+3203 3389 1	3205 3389 0	Climb-down;Ladder;11802
+3203 3389 0	3203 3389 1	Climb-up;Ladder;11801
+3243 3383 0	3243 9783 0	Climb-down;Ladder;11803
+3243 9783 0	3244 3382 0	Climb-up;Ladder;2405
+3244 3382 0	3244 9782 0	Climb-down;Ladder;11803
+3244 9782 0	3244 3382 0	Climb-up;Ladder;2405
+3245 9783 0	3244 3382 0	Climb-up;Ladder;2405
+3244 9784 0	3244 3382 0	Climb-up;Ladder;2405
+3262 3402 0	3262 3402 1	Climb-up;Ladder;11794
+3262 3402 1	3262 3402 0	Climb-down;Ladder;11795
+3263 3406 0	3264 3406 0	Open;Gate;2051
+3264 3406 0	3263 3406 0	Open;Gate;2051
+3263 3405 0	3264 3405 0	Open;Gate;2050
+3264 3405 0	3263 3405 0	Open;Gate;2050
+3283 3397 1	3283 3397 0	Climb-down;Ladder;11802
+3283 3397 0	3283 3397 1	Climb-up;Ladder;11801
+3202 3435 1	3202 3435 0	Climb-down;Ladder;11795
+3202 3435 0	3202 3435 1	Climb-up;Ladder;11794
+3246 3409 0	3246 3409 1	Climb-up;Ladder;11794
+3246 3409 1	3246 3409 0	Climb-down;Ladder;11795
+3202 3417 1	3202 3417 0	Climb-down;Ladder;11795
+3202 3417 0	3202 3417 1	Climb-up;Ladder;11794
+3214 3411 0	3214 3411 1	Climb-up;Ladder;11794
+3214 3411 1	3214 3411 0	Climb-down;Ladder;11795
+3179 3401 0	3179 3401 1	Climb-up;Ladder;11801
+3179 3401 1	3179 3401 0	Climb-down;Ladder;11802
+3175 3421 0	3175 3421 1	Climb-up;Ladder;11801
+3175 3421 1	3175 3421 0	Climb-down;Ladder;11802
+3267 3379 0	3269 3379 1	Climb-up;Ladder;11794
+3267 3379 1	3267 3379 0	Climb-down;Ladder;11795
+3237 9858 0	3236 3458 0	Climb-up;Ladder;11806
+3236 3458 0	3237 9858 0	Open;Manhole;881								2
+3236 3458 0	3237 9858 0	Climb-down;Manhole;882								2
+3210 9899 0	3210 9898 0	Slash;Web;733								8
+3210 9898 0	3210 9899 0	Slash;Web;733								8
+3143 3443 0	3143 3444 0	Open;Door;24958	32 Cooking							2
+3143 3444 0	3143 3443 0	Open;Door;24958	32 Cooking							2
+3143 3452 0	3144 3452 0	Open;Door;10045
+3144 3452 0	3143 3452 0	Open;Door;10045
+3144 3449 0	3144 3449 1	Climb-up;Staircase;2608								2
+3144 3449 1	3144 3449 0	Climb-down;Staircase;2609								2
+3144 3449 1	3144 3446 2	Climb-up;Staircase;2609								2
+3144 3446 2	3144 3449 1	Climb-down;Staircase;2610								2
+
+# Stronghold of Security
+3081 3421 0	1859 5243 0	Climb-down;Entrance;20790
+1859 5243 0	3081 3421 0	Climb-up;Ladder;20784
+1860 5244 0	3081 3421 0	Climb-up;Ladder;20784
+1858 5244 0	3081 3421 0	Climb-up;Ladder;20784
+1913 5225 0	3081 3421 0	Climb-up;Ladder;20784
+1914 5226 0	3081 3421 0	Climb-up;Ladder;20784
+1912 5226 0	3081 3421 0	Climb-up;Ladder;20784
+1913 5227 0	3081 3421 0	Climb-up;Ladder;20784
+3081 3421 0	1859 5243 0	Climb-down;Entrance;20790
+1859 5243 0	3081 3421 0	Climb-up;Ladder;20784
+1860 5244 0	3081 3421 0	Climb-up;Ladder;20784
+1858 5244 0	3081 3421 0	Climb-up;Ladder;20784
+1913 5225 0	3081 3421 0	Climb-up;Ladder;20784
+1914 5226 0	3081 3421 0	Climb-up;Ladder;20784
+1912 5226 0	3081 3421 0	Climb-up;Ladder;20784
+1913 5227 0	3081 3421 0	Climb-up;Ladder;20784
+1902 5223 0	2042 5245 0	Climb-down;Ladder;20785
+1903 5222 0	2042 5245 0	Climb-down;Ladder;20785
+1902 5221 0	2042 5245 0	Climb-down;Ladder;20785
+2042 5245 0	1859 5243 0	Climb-up;Ladder;19003
+2026 5219 0	2123 5252 0	Climb-down;Ladder;19004
+2025 5218 0	2123 5252 0	Climb-down;Ladder;19004
+2122 5251 0	2042 5245 0	Climb-up;Dripping vine;23705
+2026 5217 0	2123 5252 0	Climb-down;Ladder;19004
+2150 5279 0	2123 5252 0	Push;Odd looking wall;1734
+2147 5284 0	2358 5215 0	Climb-down;Dripping vine;23706
+2358 5215 0	2123 5252 0	Climb-up;Boney ladder;23921
+2148 5283 0	2358 5215 0	Climb-down;Dripping vine;23706
+2357 5216 0	2123 5252 0	Climb-up;Boney ladder;23921
+2149 5284 0	2358 5215 0	Climb-down;Dripping vine;23706
+2026 5217 0	2123 5252 0	Climb-down;Ladder;19004
+2150 5279 0	2123 5252 0	Climb-up;Goo covered vine;23703
+2147 5284 0	2358 5215 0	Climb-down;Dripping vine;23706
+2358 5215 0	2123 5252 0	Climb-up;Boney ladder;23921
+2148 5283 0	2358 5215 0	Climb-down;Dripping vine;23706
+2357 5216 0	2123 5252 0	Climb-up;Boney ladder;23921
+2149 5284 0	2358 5215 0	Climb-down;Dripping vine;23706
+2349 5215 0	3081 3421 0	Climb-up;Bone Chain;23732
+2027 5218 0	2123 5252 0	Climb-down;Ladder;19004
+2350 5214 0	3081 3421 0	Climb-up;Bone Chain;23732
+2150 5277 0	2123 5252 0	Climb-up;Goo covered vine;23703
+2151 5278 0	2123 5252 0	Climb-up;Goo covered vine;23703
+2351 5215 0	3081 3421 0	Climb-up;Bone Chain;23732
+2350 5216 0	3081 3421 0	Climb-up;Bone Chain;23732
+
+# Barbarian Village
+3096 3432 0	3096 3432 1	Climb-up;Ladder;17026
+3096 3432 1	3096 3432 0	Climb-down;Ladder;16685
+3097 3432 1	3097 3432 2	Climb-up;Ladder;17026
+3097 3432 2	3097 3432 1	Climb-down;Ladder;16685
+
+# Al Kharid
+3267 3228 0	3268 3228 0	Pay-toll(10gp);Gate;44599								1
+3268 3228 0	3267 3228 0	Pay-toll(10gp);Gate;44599								1
+3267 3227 0	3268 3227 0	Pay-toll(10gp);Gate;44598								1
+3268 3227 0	3267 3227 0	Pay-toll(10gp);Gate;44598								1
+3298 3124 0	3297 3124 0	Open;Prison door;2692
+3297 3124 0	3298 3124 0	Open;Prison door;2692
+3303 3117 0	3304 3115 0	Go-through;Shantay pass;4031		1854						2
+3304 3117 0	3304 3115 0	Go-through;Shantay pass;4031		1854						2
+3304 3115 0	3304 3117 0	Go-through;Shantay pass;4031								2
+3303 3115 0	3304 3117 0	Go-through;Shantay pass;4031								2
+3193 2843 0	3196 2843 0	Go-through;Shantay pass;41326		1854						3
+3193 2842 0	3196 2842 0	Go-through;Shantay pass;41326		1854						3
+3196 2843 0	3193 2843 0	Go-through;Shantay pass;41326								3
+3196 2842 0	3193 2842 0	Go-through;Shantay pass;41326								3
+3167 2819 0	3167 2816 0	Go-through;Shantay pass;41326		1854						3
+3168 2819 0	3168 2816 0	Go-through;Shantay pass;41326		1854						3
+3167 2816 0	3167 2819 0	Go-through;Shantay pass;41326								3
+3168 2816 0	3168 2819 0	Go-through;Shantay pass;41326								3
+3322 3138 0	3322 3138 1	Climb-up;Ladder;21781
+3322 3138 1	3322 3138 0	Climb-down;Ladder;21782
+3312 3184 0	3314 3185 1	Climb-up;Staircase;16671
+3314 3185 1	3313 3184 0	Climb-down;Staircase;16673
+3313 3184 0	3314 3185 1	Climb-up;Staircase;16671
+3314 3185 0	3314 3185 1	Climb-up;Staircase;16671
+3314 3186 0	3314 3185 1	Climb-up;Staircase;16671
+3285 3165 0	3285 3165 1	Climb-up;Ladder;16683
+3285 3165 1	3285 3165 0	Climb-down;Ladder;16679
+3284 3166 0	3284 3166 1	Climb-up;Ladder;16683
+3284 3166 1	3284 3166 0	Climb-down;Ladder;16679
+3283 3165 0	3283 3165 1	Climb-up;Ladder;16683
+3283 3165 1	3283 3165 0	Climb-down;Ladder;16679
+3284 3164 0	3284 3164 1	Climb-up;Ladder;16683
+3284 3164 1	3284 3164 0	Climb-down;Ladder;16679
+3287 3192 0	3287 3192 1	Climb-up;Ladder;16683
+3287 3192 1	3287 3192 0	Climb-down;Ladder;16684
+3286 3191 0	3286 3191 1	Climb-up;Ladder;16683
+3286 3191 1	3286 3191 0	Climb-down;Ladder;16684
+3286 3191 1	3286 3191 2	Climb-up;Ladder;16684
+3286 3191 2	3286 3191 1	Climb-down;Ladder;16679
+3287 3192 1	3287 3192 2	Climb-up;Ladder;16684
+
+# Citharede Abbey
+3420 3185 0	3420 3185 1	Climb-up;Ladder;10493								2
+3420 3185 1	3420 3185 0	Climb-down;Ladder;10494								2
+
+# Mage Trainining Arena
+3363 3300 0	3363 3298 0	Enter;Doorway;10721
+3363 3298 0	3363 3300 0	Enter;Doorway;10721
+3363 3300 0	3363 3298 0	Enter;Doorway;10721
+3363 3298 0	3363 3300 0	Enter;Doorway;10721
+3360 3306 0	3357 3307 1	Climb-up;Stairs;10775
+3357 3307 1	3360 3306 0	Climb-down;Stairs;10776
+3358 3307 1	3360 3306 0	Climb-down;Stairs;10776
+3360 3307 0	3357 3307 1	Climb-up;Stairs;10775
+3359 3307 1	3360 3306 0	Climb-down;Stairs;10776
+3366 3306 0	3369 3307 1	Climb-up;Stairs;10771
+3369 3307 1	3366 3306 0	Climb-down;Stairs;10773
+3366 3307 0	3369 3307 1	Climb-up;Stairs;10771
+3368 3307 1	3366 3306 0	Climb-down;Stairs;10773
+3367 3307 1	3366 3306 0	Climb-down;Stairs;10773
+
+# HAM Hideout
+3165 3252 0	3149 9652 0	Climb-down;Trapdoor;5492
+3166 3251 0	3149 9652 0	Climb-down;Trapdoor;5492
+3149 9652 0	3165 3251 0	Climb-up;Ladder;5493
+3150 9653 0	3165 3251 0	Climb-up;Ladder;5493
+3148 9653 0	3165 3251 0	Climb-up;Ladder;5493
+
+# Port Sarim
+3055 3245 0	3055 3242 1	Cross;Gangplank;34671								3
+3055 3242 1	3055 3245 0	Cross;Gangplank;34672								3
+3048 3234 0	3048 3231 1	Cross;Gangplank;2412								3
+3048 3231 1	3048 3234 0	Cross;Gangplank;2413								3
+3047 3231 1	3045 3231 2	Climb-up;Ship's ladder;245
+3045 3231 2	3047 3231 1	Climb-down;Ship's ladder;246
+3045 3227 2	3047 3227 1	Climb-down;Ship's ladder;246
+3047 3227 1	3045 3227 2	Climb-up;Ship's ladder;245
+3029 3217 0	3032 3217 1	Cross;Gangplank;2083								3
+3032 3217 1	3029 3217 0	Cross;Gangplank;2084								3
+3035 3214 0	3035 3214 1	Climb-up;Ship's ladder;272
+3035 3214 1	3035 3214 0	Climb-down;Ship's ladder;273
+3035 3218 0	3035 3218 1	Climb-up;Ship's ladder;272
+3035 3218 1	3035 3218 0	Climb-down;Ship's ladder;273
+3035 3222 0	3035 3222 1	Climb-up;Ship's ladder;272
+3035 3222 1	3035 3222 0	Climb-down;Ship's ladder;273
+3036 3223 1	3036 3225 2	Climb-up;Ship's ladder;245
+3036 3225 2	3036 3223 1	Climb-down;Ship's ladder;246
+3032 3225 2	3032 3223 1	Climb-down;Ship's ladder;246
+3032 3223 1	3032 3225 2	Climb-up;Ship's ladder;245
+3041 3202 0	3041 3199 1	Cross;Gangplank;14304								3
+3041 3199 1	3041 3202 0	Cross;Gangplank;14305								3
+3038 3192 0	3038 3189 1	Cross;Gangplank;17404
+3038 3189 1	3038 3192 0	Cross;Gangplank;17405
+
+#pest control
+2662 2677 1	2659 2676 0	Cross;Gangplank;14307								3
+3013 3204 0	3013 3204 1	Climb-up;Ladder;16683
+3013 3204 1	3013 3204 0	Climb-down;Ladder;16679
+3014 3203 0	3014 3203 1	Climb-up;Ladder;16683
+3014 3203 1	3014 3203 0	Climb-down;Ladder;16679
+3012 3203 0	3012 3203 1	Climb-up;Ladder;16683
+3012 3203 1	3012 3203 0	Climb-down;Ladder;16679
+3011 3184 0	3011 3184 1	Climb-up;Ladder;9558
+3011 3184 1	3011 3184 0	Climb-down;Ladder;9559
+3012 3235 0	3012 3235 1	Climb-up;Ladder;16683
+3012 3235 1	3012 3235 0	Climb-down;Ladder;16679
+3011 3234 0	3011 3234 1	Climb-up;Ladder;16683
+3011 3234 1	3011 3234 0	Climb-down;Ladder;16679
+3010 3235 0	3010 3235 1	Climb-up;Ladder;16683
+3010 3235 1	3010 3235 0	Climb-down;Ladder;16679
+3011 3236 0	3011 3236 1	Climb-up;Ladder;16683
+3011 3236 1	3011 3236 0	Climb-down;Ladder;16679
+3016 3246 0	3015 3246 0	Open;Door;59
+3015 3246 0	3016 3246 0	Open;Door;59
+3013 3245 0	3013 3245 1	Climb-up;Ladder;60
+3013 3245 1	3013 3245 0	Climb-down;Ladder;16679
+3014 3244 0	3013 3245 1	Climb-up;Ladder;60
+3012 3244 1	3012 3244 0	Climb-down;Ladder;16679
+3012 3244 0	3013 3245 1	Climb-up;Ladder;60
+3014 3244 1	3014 3244 0	Climb-down;Ladder;16679
+3025 3261 1	3024 3260 0	Climb-down;Staircase;9584
+3024 3260 0	3025 3261 1	Climb-up;Staircase;9582
+3023 3260 0	3025 3261 1	Climb-up;Staircase;9582
+3026 3247 1	3025 3248 0	Climb-down;Staircase;9584
+3025 3248 0	3026 3247 1	Climb-up;Staircase;9582
+3025 3249 0	3026 3247 1	Climb-up;Staircase;9582
+3018 3231 0	2962 9650 0	Climb-down;Manhole;10321
+2962 9650 0	3018 3233 0	Climb-up;Ladder;10309
+
+# Wizard Tower
+3105 3162 0	3104 9576 0	Climb-down;Ladder;2147
+3104 9576 0	3105 3162 0	Climb-up;Ladder;2148
+3104 3163 0	3104 9576 0	Climb-down;Ladder;2147
+3103 9577 0	3105 3162 0	Climb-up;Ladder;2148
+3104 3161 0	3104 9576 0	Climb-down;Ladder;2147
+3103 9575 0	3105 3162 0	Climb-up;Ladder;2148
+3103 3162 0	3104 9576 0	Climb-down;Ladder;2147
+3105 3160 0	3104 3161 1	Climb-up;Staircase;12536
+3104 3161 1	3104 3161 0	Climb-down;Staircase;12537
+3105 3159 0	3104 3161 1	Climb-up;Staircase;12536
+3103 3161 1	3104 3161 0	Climb-down;Staircase;12537
+3104 3161 1	3104 3161 2	Climb-up;Staircase;12537
+3104 3161 2	3104 3161 1	Climb-down;Staircase;12538
+3107 3162 0	3107 3162 0	Open;Door;23972
+# Taverley Dungeon
+2884 3398 0	2884 9798 0	Climb-down;Ladder;16680
+2884 9798 0	2884 3398 0	Climb-up;Ladder;17385
+2885 3397 0	2885 9797 0	Climb-down;Ladder;16680
+2885 9797 0	2885 3397 0	Climb-up;Ladder;17385
+2884 3396 0	2884 9796 0	Climb-down;Ladder;16680
+2884 9796 0	2884 3396 0	Climb-up;Ladder;17385
+2883 3397 0	2883 9797 0	Climb-down;Ladder;16680
+2883 9797 0	2883 3397 0	Climb-up;Ladder;17385
+2888 9831 0	2889 9831 0	Open;Prison door;2143
+2888 9830 0	2889 9830 0	Open;Prison door;2144
+2889 9830 0	2888 9830 0	Open;Prison door;2144
+2889 9831 0	2888 9831 0	Open;Prison door;2143
+2842 3423 0	2842 9823 0	Climb-down;Ladder;17384
+2842 9823 0	2842 3423 0	Climb-up;Ladder;17385
+2843 3424 0	2843 9824 0	Climb-down;Ladder;17384
+2843 9824 0	2843 3424 0	Climb-up;Ladder;17385
+2842 3425 0	2842 9825 0	Climb-down;Ladder;17384
+2842 9825 0	2842 3425 0	Climb-up;Ladder;17385
+2841 3424 0	2841 9824 0	Climb-down;Ladder;17384
+2841 9824 0	2841 3424 0	Climb-up;Ladder;17385
+1310 1237 0	2873 9848 0	Crawl;Cave;26566
+2873 9848 0	1310 1237 0	Crawl;Cave;26568
+1311 1237 0	2873 9848 0	Crawl;Cave;26565
+2873 9847 0	1310 1237 0	Crawl;Cave;26569
+1309 1237 0	2873 9848 0	Crawl;Cave;26564
+2873 9846 0	1310 1237 0	Crawl;Cave;26567
+1292 1253 0	1240 1226 0	Turn;Iron Winch;23104
+1291 1253 0	1240 1226 0	Turn;Iron Winch;23104
+1240 1226 0	1291 1253 0	Exit;Portcullis;21772
+1309 1269 0	1304 1290 0	Turn;Iron Winch;23104
+1304 1290 0	1309 1269 0	Exit;Portcullis;21772
+1368 1226 0	1328 1253 0	Exit;Portcullis;21772
+1328 1253 0	1368 1226 0	Turn;Iron Winch;23104
+1329 1253 0	1368 1226 0	Turn;Iron Winch;23104
+2903 9813 1	2906 9813 0	Climb;Steps;30190
+2906 9813 0	2903 9813 1	Climb;Steps;30189
+2883 9825 0	2880 9825 1	Climb;Steps;30189
+2880 9825 1	2883 9825 0	Climb;Steps;30190
+2924 9803 0	2923 9803 0	Open;Gate;2623		1590
+2923 9803 0	2924 9803 0	Open;Gate;2623
+
+# Taverley
+2914 3450 0	2914 3450 1	Climb-up;Ladder;16683
+2914 3450 1	2914 3450 0	Climb-down;Ladder;16679
+2915 3451 0	2915 3451 1	Climb-up;Ladder;16683
+2915 3451 1	2915 3451 0	Climb-down;Ladder;16679
+2915 3449 0	2915 3449 1	Climb-up;Ladder;16683
+2915 3449 1	2915 3449 0	Climb-down;Ladder;16679
+2916 3450 0	2916 3450 1	Climb-up;Ladder;16683
+2914 3441 0	2914 3441 1	Climb-up;Ladder;17026
+2914 3441 1	2914 3441 0	Climb-down;Ladder;16685
+2918 3439 0	2916 3438 0	Climb-over;Stile;993
+2916 3438 0	2919 3438 0	Climb-over;Stile;993
+2919 3438 0	2916 3438 0	Climb-over;Stile;993
+2917 3437 0	2919 3438 0	Climb-over;Stile;993
+2918 3437 0	2916 3438 0	Climb-over;Stile;993
+2917 3439 0	2919 3438 0	Climb-over;Stile;993
+2898 3427 0	2898 3427 1	Climb-up;Staircase;16671
+2898 3427 1	2897 3428 0	Climb-down;Staircase;16673
+2897 3428 0	2898 3427 1	Climb-up;Staircase;16671
+2897 3429 0	2898 3427 1	Climb-up;Staircase;16671
+2898 3430 0	2898 3427 1	Climb-up;Staircase;16671
+2899 3430 0	2898 3427 1	Climb-up;Staircase;16671
+2899 3427 0	2898 3427 1	Climb-up;Staircase;16671
+2900 3428 0	2898 3427 1	Climb-up;Staircase;16671
+2900 3429 0	2898 3427 1	Climb-up;Staircase;16671
+2900 3473 0	2901 3473 0	Open;Door;2861
+2901 3473 0	2900 3473 0	Open;Door;2861
+2906 3468 0	2906 3472 1	Walk-up;Staircase;24672
+2906 3472 1	2906 3468 0	Walk-down;Staircase;24673
+2907 3468 0	2906 3472 1	Walk-up;Staircase;24672
+2907 3472 1	2906 3468 0	Walk-down;Staircase;24673
+2906 3476 0	2906 9876 0	Climb-down;Ladder;24718
+2906 9876 0	2906 3476 0	Climb-up;Ladder;24717
+2907 3475 0	2906 9876 0	Climb-down;Ladder;24718
+2907 9875 0	2906 3476 0	Climb-up;Ladder;24717
+2898 3469 0	2901 9867 0	Enter;Manhole;24842
+2901 9867 0	2899 3469 0	Climb-up;Staircase;24687
+2899 3469 0	2901 9867 0	Enter;Manhole;24842
+2899 3470 0	2901 9867 0	Enter;Manhole;24842
+2899 3468 0	2901 9867 0	Enter;Manhole;24842
+2877 3482 0	2876 9878 0	Climb-down;Stairs;57				Fishing Contest
+2876 9879 0	2877 3482 0	Climb-up;Stairs;56				Fishing Contest
+2876 3482 0	2876 9878 0	Climb-down;Stairs;57				Fishing Contest
+2877 9879 0	2877 3482 0	Climb-up;Stairs;56				Fishing Contest
+2821 9882 0	2820 3486 0	Climb-up;Stairs;54				Fishing Contest
+2820 3486 0	2820 9882 0	Climb-down;Stairs;55				Fishing Contest
+2820 9882 0	2820 3486 0	Climb-up;Stairs;54				Fishing Contest
+2821 3486 0	2820 9882 0	Climb-down;Stairs;55				Fishing Contest
+
+# Catherby
+2792 3414 0	2792 3417 1	Cross;Gangplank;17394								3
+2792 3417 1	2792 3414 0	Cross;Gangplank;17395								3
+2813 3450 0	2813 3450 1	Climb-up;Ladder;16683
+2813 3450 1	2813 3450 0	Climb-down;Ladder;16679
+2812 3451 0	2812 3451 1	Climb-up;Ladder;16683
+2812 3451 1	2812 3451 0	Climb-down;Ladder;16679
+
+# Seers Village and Camelot Castle
+2758 3482 0	2758 3483 0	Open;Gate;26082
+2758 3483 0	2758 3482 0	Open;Gate;26082
+2757 3482 0	2757 3483 0	Open;Gate;26081
+2757 3483 0	2757 3482 0	Open;Gate;26081
+2751 3508 0	2751 3513 1	Climb-up;Staircase;26106
+2751 3513 1	2751 3508 0	Climb-down;Staircase;25604
+2750 3508 0	2750 3513 1	Climb-up;Staircase;26106
+2750 3513 1	2750 3508 0	Climb-down;Staircase;25604
+2768 3493 0	2768 3493 1	Climb-up;Ladder;26107
+2768 3493 1	2768 3493 0	Climb-down;Ladder;25606
+2769 3492 0	2769 3492 1	Climb-up;Ladder;26107
+2769 3492 1	2769 3492 0	Climb-down;Ladder;25606
+2770 3493 0	2770 3493 1	Climb-up;Ladder;26107
+2770 3493 1	2770 3493 0	Climb-down;Ladder;25606
+2769 3494 0	2769 3494 1	Climb-up;Ladder;26107
+2769 3494 1	2769 3494 0	Climb-down;Ladder;25606
+2748 3493 0	2748 3493 1	Climb-up;Ladder;26107
+2748 3493 1	2748 3493 0	Climb-down;Ladder;25606
+2747 3494 0	2747 3494 1	Climb-up;Ladder;26107
+2747 3494 1	2747 3494 0	Climb-down;Ladder;25606
+2747 3492 0	2747 3492 1	Climb-up;Ladder;26107
+2747 3492 1	2747 3492 0	Climb-down;Ladder;25606
+2746 3493 0	2746 3493 1	Climb-up;Ladder;26107
+2746 3493 1	2746 3493 0	Climb-down;Ladder;25606
+2728 3490 0	2728 3490 1	Climb-up;Ladder;25938
+2728 3490 1	2728 3490 0	Climb-down;Ladder;25939
+2729 3491 0	2729 3491 1	Climb-up;Ladder;25938
+2729 3491 1	2729 3491 0	Climb-down;Ladder;25939
+2728 3492 0	2728 3492 1	Climb-up;Ladder;25938
+2728 3492 1	2728 3492 0	Climb-down;Ladder;25939
+2727 3491 0	2727 3491 1	Climb-up;Ladder;25938
+2727 3491 1	2727 3491 0	Climb-down;Ladder;25939
+2715 3471 0	2715 3471 1	Climb-up;Ladder;25938
+2715 3471 1	2715 3471 0	Climb-down;Ladder;25939
+2714 3470 0	2714 3470 1	Climb-up;Ladder;25938
+2714 3470 1	2714 3470 0	Climb-down;Ladder;25939
+2699 3475 0	2699 3475 1	Climb-up;Ladder;25941
+2699 3475 1	2699 3475 0	Climb-down;Ladder;25940
+2697 3496 0	2698 3495 1	Climb-up;Staircase;25935
+2698 3495 1	2697 3496 0	Climb-down;Staircase;25801
+2697 3497 0	2698 3495 1	Climb-up;Staircase;25935
+2698 3498 0	2698 3495 1	Climb-up;Staircase;25935
+2699 3498 0	2698 3495 1	Climb-up;Staircase;25935
+2698 3495 0	2698 3495 1	Climb-up;Staircase;25935
+2700 3497 0	2698 3495 1	Climb-up;Staircase;25935
+2699 3495 0	2698 3495 1	Climb-up;Staircase;25935
+2700 3496 0	2698 3495 1	Climb-up;Staircase;25935
+2807 3453 0	2807 3453 1	Climb-up;Ladder;16683
+2807 3453 1	2807 3453 0	Climb-down;Ladder;16679
+2808 3454 1	2808 3453 0	Climb-down;Ladder;16679
+2767 3492 1	2767 3492 2	Climb-up;Ladder;26107
+2767 3492 2	2767 3492 1	Climb-down;Ladder;25606
+2766 3491 1	2766 3491 2	Climb-up;Ladder;26107
+2766 3491 2	2766 3491 1	Climb-down;Ladder;25606
+2768 3491 1	2768 3491 2	Climb-up;Ladder;26107
+2768 3491 2	2768 3491 1	Climb-down;Ladder;25606
+2767 3490 1	2767 3490 2	Climb-up;Ladder;26107
+2767 3490 2	2767 3490 1	Climb-down;Ladder;25606
+2749 3492 1	2749 3492 2	Climb-up;Ladder;26107
+2749 3492 2	2749 3492 1	Climb-down;Ladder;25606
+2748 3491 1	2748 3491 2	Climb-up;Ladder;26107
+2748 3491 2	2748 3491 1	Climb-down;Ladder;25606
+2749 3490 1	2749 3490 2	Climb-up;Ladder;26107
+2749 3490 2	2749 3490 1	Climb-down;Ladder;25606
+2750 3491 1	2750 3491 2	Climb-up;Ladder;26107
+2750 3491 2	2750 3491 1	Climb-down;Ladder;25606
+
+# Dwarf Cannon Quest area
+2569 3441 0	2569 3441 1	Climb-up;Ladder;16683
+2569 3441 1	2569 3441 0	Climb-down;Ladder;16679
+2570 3442 0	2570 3442 1	Climb-up;Ladder;16683
+2570 3442 1	2570 3442 0	Climb-down;Ladder;16679
+2571 3441 0	2571 3441 1	Climb-up;Ladder;16683
+2571 3441 1	2571 3441 0	Climb-down;Ladder;16679
+2570 3440 0	2570 3440 1	Climb-up;Ladder;16683
+2570 3440 1	2570 3440 0	Climb-down;Ladder;16679
+2570 3442 1	2569 3443 2	Climb-up;Ladder;11
+2569 3443 2	2569 3443 1	Climb-down;Ladder;16679
+2569 3443 1	2569 3443 2	Climb-up;Ladder;11
+2570 3444 2	2570 3444 1	Climb-down;Ladder;16679
+2570 3444 1	2569 3443 2	Climb-up;Ladder;11
+2570 3442 2	2570 3442 1	Climb-down;Ladder;16679
+2571 3443 1	2569 3443 2	Climb-up;Ladder;11
+2571 3443 2	2571 3443 1	Climb-down;Ladder;16679
+2568 3455 0	2568 3456 0	Open;Gate;15605
+2568 3456 0	2568 3455 0	Open;Gate;15605
+2567 3455 0	2567 3456 0	Open;Gate;15604
+2567 3456 0	2567 3455 0	Open;Gate;15604
+2555 3475 0	2554 3475 0	Open;Gate;15604
+2554 3475 0	2555 3475 0	Open;Gate;15604
+2555 3474 0	2554 3474 0	Open;Gate;15605
+2554 3474 0	2555 3474 0	Open;Gate;15605
+
+# Tourist Information Center
+2518 3431 0	2518 3431 1	Climb-up;Staircase;16671
+2518 3431 1	2519 3430 0	Climb-down;Staircase;16673
+2519 3430 0	2518 3431 1	Climb-up;Staircase;16671
+2519 3429 0	2518 3431 1	Climb-up;Staircase;16671
+2518 3428 0	2518 3431 1	Climb-up;Staircase;16671
+2517 3428 0	2518 3431 1	Climb-up;Staircase;16671
+2517 3431 0	2518 3431 1	Climb-up;Staircase;16671
+2516 3430 0	2518 3431 1	Climb-up;Staircase;16671
+2516 3429 0	2518 3431 1	Climb-up;Staircase;16671
+2517 3426 1	2516 3423 0	Climb-down;Staircase;16667
+2516 3423 0	2517 3426 1	Climb-up;Staircase;16668
+
+# Waterfall Island and Dungeon
+2512 3476 0	2527 3413 0	Swim;River;10283
+2510 3494 0	2512 3481 0	Board;Log raft;1987
+2511 3477 0	2527 3413 0	Swim;River;10283
+2510 3493 0	2512 3481 0	Board;Log raft;1987
+2511 3463 0	2527 3413 0	Get in;Barrel;2022
+2512 3466 0	2527 3413 0	Climb;Dead Tree;2020
+2512 3476 0	2527 3413 0	Swim to;Rock;1996
+2511 3463 0	2575 9861 0	Open;Door;2010		295		Waterfall Quest
+2575 9861 0	2511 3463 0	Open;Door;2000
+2568 9893 0	2568 9894 0	Open;Door;2002
+2568 9894 0	2568 9893 0	Open;Door;2002
+2566 9901 0	2604 9901 0	Open;Door;2002
+2604 9901 0	2566 9901 0	Open;Door;2002
+
+# Glarial's Tomb
+2557 9844 0	2557 3444 0	Climb-up;Ladder;17387								2
+
+# Tree Gnome Village Dungeon (during Waterfall quest)
+2533 3156 0	2533 9556 0	Climb-down;Ladder;5250
+2534 3155 0	2534 9555 0	Climb-down;Ladder;5250
+2532 3155 0	2532 9555 0	Climb-down;Ladder;5250
+2533 9556 0	2533 3156 0	Climb-up;Ladder;17387
+
+# Tree Gnome Village Dungeon (after Waterfall quest)
+2533 3156 0	2597 4436 0	Climb-down;Ladder;5250				Waterfall Quest
+2532 3155 0	2596 4435 0	Climb-down;Ladder;5250				Waterfall Quest
+2534 3155 0	2598 4435 0	Climb-down;Ladder;5250				Waterfall Quest
+2597 4436 0	2533 3156 0	Climb-up;Ladder;5251				Waterfall Quest
+2596 4435 0	2533 3156 0	Climb-up;Ladder;5251				Waterfall Quest
+2598 4435 0	2533 3156 0	Climb-up;Ladder;5251				Waterfall Quest
+2597 4434 0	2533 3156 0	Climb-up;Ladder;5251				Waterfall Quest
+
+# Lithkren
+3555 4002 0	3549 10448 0	Climb-down;Staircase;32080
+3549 10448 0	3555 4002 0	Climb-up;Staircase;32112
+3554 4002 0	3549 10448 0	Climb-down;Staircase;32080
+3550 10448 0	3555 4002 0	Climb-up;Staircase;32112
+3549 10468 0	3549 10473 0	Climb;Staircase;32113
+3549 10473 0	3549 10468 0	Climb;Staircase;32113
+3550 10468 0	3550 10473 0	Climb;Staircase;32113
+3550 10473 0	3550 10468 0	Climb;Staircase;32113
+3551 10481 0	1568 5061 0	Enter;Broken Grandiose Doors;32117
+1570 5061 0	3549 10481 0	Climb-up;Goo covered vine;23703
+3550 10481 0	1568 5061 0	Enter;Broken Grandiose Doors;32117
+1569 5061 0	3549 10481 0	Enter;Broken Grandiose Doors;32132
+3549 10481 0	1568 5061 0	Enter;Broken Grandiose Doors;32117
+1568 5061 0	3549 10481 0	Enter;Broken Grandiose Doors;32132
+1567 5061 0	3549 10481 0	Enter;Broken Grandiose Doors;32132
+1566 5061 0	3549 10481 0	Enter;Broken Grandiose Doors;32132
+1565 5061 0	3549 10481 0	Enter;Broken Grandiose Doors;32132
+1573 5077 0	1575 5077 0	Pass;Barrier;32153
+1575 5077 0	1573 5077 0	Pass;Barrier;32153
+1573 5076 0	1575 5076 0	Pass;Barrier;32153
+1575 5076 0	1573 5076 0	Pass;Barrier;32153
+1573 5075 0	1575 5075 0	Pass;Barrier;32153
+1575 5075 0	1573 5075 0	Pass;Barrier;32153
+1573 5074 0	1575 5074 0	Pass;Barrier;32153
+1575 5074 0	1573 5074 0	Pass;Barrier;32153
+1573 5073 0	1575 5073 0	Pass;Barrier;32153
+1575 5073 0	1573 5073 0	Pass;Barrier;32153
+1573 5072 0	1575 5072 0	Pass;Barrier;32153
+1575 5072 0	1573 5072 0	Pass;Barrier;32153
+1584 5089 0	1584 5087 0	Pass;Barrier;32153
+1584 5087 0	1584 5089 0	Pass;Barrier;32153
+1585 5089 0	1585 5087 0	Pass;Barrier;32153
+1585 5087 0	1585 5089 0	Pass;Barrier;32153
+1586 5089 0	1586 5087 0	Pass;Barrier;32153
+1586 5087 0	1586 5089 0	Pass;Barrier;32153
+1587 5089 0	1587 5087 0	Pass;Barrier;32153
+1587 5087 0	1587 5089 0	Pass;Barrier;32153
+1588 5089 0	1588 5087 0	Pass;Barrier;32153
+1588 5087 0	1588 5089 0	Pass;Barrier;32153
+1589 5089 0	1589 5087 0	Pass;Barrier;32153
+1589 5087 0	1589 5089 0	Pass;Barrier;32153
+1546 5089 0	1546 5087 0	Pass;Barrier;32153
+1546 5087 0	1546 5089 0	Pass;Barrier;32153
+1547 5089 0	1547 5087 0	Pass;Barrier;32153
+1547 5087 0	1547 5089 0	Pass;Barrier;32153
+1548 5089 0	1548 5087 0	Pass;Barrier;32153
+1548 5087 0	1548 5089 0	Pass;Barrier;32153
+1549 5089 0	1549 5087 0	Pass;Barrier;32153
+1549 5087 0	1549 5089 0	Pass;Barrier;32153
+1550 5089 0	1550 5087 0	Pass;Barrier;32153
+1550 5087 0	1550 5089 0	Pass;Barrier;32153
+1551 5089 0	1551 5087 0	Pass;Barrier;32153
+1551 5087 0	1551 5089 0	Pass;Barrier;32153
+1560 5072 0	1562 5072 0	Pass;Barrier;32153
+1562 5072 0	1560 5072 0	Pass;Barrier;32153
+1560 5073 0	1562 5073 0	Pass;Barrier;32153
+1562 5073 0	1560 5073 0	Pass;Barrier;32153
+1560 5074 0	1562 5074 0	Pass;Barrier;32153
+1562 5074 0	1560 5074 0	Pass;Barrier;32153
+1560 5075 0	1562 5075 0	Pass;Barrier;32153
+1562 5075 0	1560 5075 0	Pass;Barrier;32153
+1560 5076 0	1562 5076 0	Pass;Barrier;32153
+1562 5076 0	1560 5076 0	Pass;Barrier;32153
+1560 5077 0	1562 5077 0	Pass;Barrier;32153
+1562 5077 0	1560 5077 0	Pass;Barrier;32153
+3554 4000 0	3554 4000 1	Climb-up;Ladder;32083
+3554 4000 1	3554 4000 0	Climb-down;Trapdoor;32084
+3555 4000 0	3554 4000 1	Climb-up;Ladder;32083
+3555 4000 1	3554 4000 0	Climb-down;Trapdoor;32084
+3556 4003 1	3561 4004 0	Climb-down;Stairs;32082
+3561 4004 0	3556 4004 1	Climb-up;Stairs;32081
+3556 4004 1	3561 4004 0	Climb-down;Stairs;32082
+3561 4005 0	3556 4004 1	Climb-up;Stairs;32081
+3556 4005 1	3561 4004 0	Climb-down;Stairs;32082
+3561 4003 0	3556 4004 1	Climb-up;Stairs;32081
+
+# Fossil Island
+3595 10291 0	3680 3854 0	Climb-up;Exit;30844
+3680 3854 0	3595 10291 0	Enter;Broken Grandiose Doors;32132
+3596 10291 0	3680 3854 0	Climb-up;Exit;30844
+3603 10291 0	3607 10290 0	Climb;Stairs;31485
+3607 10290 0	3603 10290 0	Climb;Stairs;31485
+3603 10290 0	3607 10290 0	Climb;Stairs;31485
+3607 10291 0	3603 10290 0	Climb;Stairs;31485
+3606 10292 0	3603 10290 0	Climb;Stairs;31485
+3605 10292 0	3603 10290 0	Climb;Stairs;31485
+3606 10289 0	3603 10290 0	Climb;Stairs;31485
+3605 10289 0	3603 10290 0	Climb;Stairs;31485
+3680 3855 0	3595 10291 0	Climb Down;Trap Door;30842
+3680 3853 0	3595 10291 0	Climb Down;Trap Door;30842
+3666 3810 0	3685 3756 0	Jump on;Rubber cap mushroom;30606
+3666 3809 0	3685 3756 0	Jump on;Rubber cap mushroom;30606
+3663 3808 0	3685 3756 0	Jump on;Rubber cap mushroom;30606
+3664 3808 0	3685 3756 0	Jump on;Rubber cap mushroom;30606
+3665 3808 0	3685 3756 0	Jump on;Rubber cap mushroom;30606
+3768 3868 1	3768 3868 0	Climb-down;Trapdoor;30725
+3768 3868 0	3768 3868 1	Climb-up;Ladder;30727
+3767 3868 1	3768 3868 0	Climb-down;Trapdoor;30725
+3767 3868 0	3768 3868 1	Climb-up;Ladder;30727
+3766 3867 1	3768 3868 0	Climb-down;Trapdoor;30725
+3769 3867 0	3768 3868 1	Climb-up;Ladder;30727
+3766 3867 0	3768 3868 1	Climb-up;Ladder;30727
+3766 3866 0	3768 3868 1	Climb-up;Ladder;30727
+3767 3865 0	3768 3868 1	Climb-up;Ladder;30727
+3757 3870 1	3753 3869 0	Descend;Stairs;30682
+3753 3869 0	3757 3869 1	Climb;Stairs;30681
+3757 3869 1	3753 3869 0	Descend;Stairs;30682
+3753 3870 0	3757 3869 1	Climb;Stairs;30681
+3757 3868 1	3753 3869 0	Descend;Stairs;30682
+3753 3868 0	3757 3869 1	Climb;Stairs;30681
+3746 3832 0	3745 3831 1	Climb Up;Ladder;30940
+3745 3831 1	3747 3831 0	Climb Down;Ladder;30941
+3747 3831 0	3745 3831 1	Climb Up;Ladder;30940
+3746 3830 0	3745 3831 1	Climb Up;Ladder;30940
+3730 3831 1	3728 3831 0	Climb Down;Ladder;30939
+3728 3831 0	3730 3831 1	Climb Up;Ladder;30938
+3729 3830 0	3730 3831 1	Climb Up;Ladder;30938
+3729 3832 0	3730 3831 1	Climb Up;Ladder;30938
+
+# Musa Point
+2956 3146 0	2956 3143 1	Cross;Gangplank;2081								3
+2956 3143 1	2956 3146 0	Cross;Gangplank;2082								3
+2960 3141 0	2960 3141 1	Climb-up;Ship's ladder;272
+2960 3141 1	2960 3141 0	Climb-down;Ship's ladder;273
+2956 3141 0	2956 3141 1	Climb-up;Ship's ladder;272
+2956 3141 1	2956 3141 0	Climb-down;Ship's ladder;273
+2952 3141 0	2952 3141 1	Climb-up;Ship's ladder;272
+2952 3141 1	2952 3141 0	Climb-down;Ship's ladder;273
+2962 3139 1	2964 3139 2	Climb-up;Ship's ladder;245
+2964 3139 2	2962 3139 1	Climb-down;Ship's ladder;246
+2962 3143 1	2964 3143 2	Climb-up;Ship's ladder;245
+2964 3143 2	2962 3143 1	Climb-down;Ship's ladder;246
+2954 3158 0	2957 3158 1	Cross;Gangplank;17398								3
+2957 3158 1	2954 3158 0	Cross;Gangplank;17399								3
+
+# Brimhaven
+2763 3238 1	2760 3238 0	Cross;Gangplank;17401								3
+2760 3238 0	2763 3238 1	Cross;Gangplank;17400								3
+2772 3234 0	2775 3234 1	Cross;Gangplank;2087								3
+2775 3234 1	2772 3234 0	Cross;Gangplank;2088								3
+2776 3235 0	2776 3235 1	Climb-up;Ship's ladder;9744
+2776 3235 1	2776 3235 0	Climb-down;Ship's ladder;9745
+2777 3234 1	2776 3235 0	Climb-down;Ship's ladder;9745
+2775 3234 1	2776 3235 0	Climb-down;Ship's ladder;9745
+2808 3162 0	2808 3162 1	Climb-up;Ladder;16683								3
+2808 3162 1	2808 3162 0	Climb-down;Ladder;16679								3
+2744 3153 0	2713 9564 0	Pay;Dungeon entrance;20877			875 Coins
+2713 9564 0	2744 3153 0	Leave;Exit;20878
+2691 9564 0	2689 9564 0	Chop-down;Vines;21731		1351;1349;1361;1353;1355;1357;1359
+2689 9564 0	2691 9564 0	Chop-down;Vines;21731		1351;1349;1361;1353;1355;1357;1359
+2683 9568 0	2683 9570 0	Chop-down;Vines;21732		1351;1349;1361;1353;1355;1357;1359
+2683 9570 0	2683 9568 0	Chop-down;Vines;21732		1351;1349;1361;1353;1355;1357;1359
+2649 9591 0	2643 9595 2	Walk-up;Stairs;21722
+2650 9591 0	2643 9595 2	Walk-up;Stairs;21722
+2643 9595 2	2649 9591 0	Walk-down;Stairs;21724
+2647 9557 0	2649 9562 0	Jump-from;Stepping Stone;21739								3
+2649 9562 0	2647 9557 0	Jump-from;Stepping Stone;21738								3
+2636 9517 0	2636 9510 2	Walk-up;Stairs;21725
+2637 9517 0	2636 9510 2	Walk-up;Stairs;21725
+2636 9510 2	2636 9517 0	Walk-down;Stairs;21726
+2682 9506 0	2687 9506 0	Walk-across;Log balance;20882								3
+2687 9506 0	2682 9506 0	Walk-across;Log balance;20884								3
+2698 9500 0	2698 9492 0	Squeeze-through;Pipe;21727
+2698 9492 0	2698 9500 0	Squeeze-through;Pipe;21727
+2697 9436 0	2684 9436 0	Enter;Crevice;30198
+2684 9436 0	2697 9436 0	Enter;Crevice;30198
+
+# Karamja Volcano
+2855 3169 0	2855 9569 0	Climb-down;Rocks;11441
+2855 9569 0	2856 3167 0	Climb;Climbing rope;18969
+2856 3167 0	2856 9567 0	Climb-down;Rocks;11441
+2856 9568 0	2856 3167 0	Climb;Climbing rope;18969
+2855 3168 0	2855 9568 0	Climb-down;Rocks;11441
+2856 9570 0	2856 3167 0	Climb;Climbing rope;18969
+2857 3167 0	2857 9567 0	Climb-down;Rocks;11441
+2857 9569 0	2856 3167 0	Climb;Climbing rope;18969
+2858 3168 0	2858 9568 0	Climb-down;Rocks;11441
+2858 3169 0	2858 9569 0	Climb-down;Rocks;11441
+2857 3170 0	2857 9570 0	Climb-down;Rocks;11441
+2856 3170 0	2856 9570 0	Climb-down;Rocks;11441
+2862 9573 0	2480 5175 0	Enter;Cave entrance;11835
+2480 5175 0	2862 9572 0	Enter;Cave exit;11836
+2862 9572 0	2480 5175 0	Enter;Cave entrance;11835
+2481 5175 0	2862 9572 0	Enter;Cave exit;11836
+2862 9571 0	2480 5175 0	Enter;Cave entrance;11835
+2479 5175 0	2862 9572 0	Enter;Cave exit;11836
+2863 9574 0	2480 5175 0	Enter;Cave entrance;11835
+2863 9570 0	2480 5175 0	Enter;Cave entrance;11835
+2864 9570 0	2480 5175 0	Enter;Cave entrance;11835
+2865 9571 0	2480 5175 0	Enter;Cave entrance;11835
+2865 9572 0	2480 5175 0	Enter;Cave entrance;11835
+
+# Island West of Brimhaven
+2709 3209 0	2704 3209 0	Swing-on;Ropeswing;23568
+2705 3205 0	2709 3205 0	Swing-on;Ropeswing;23569
+
+# Port Piscarillius
+1824 3694 1	1824 3691 0	Cross;Gangplank;27778								3
+1824 3691 0	1824 3694 1	Cross;Gangplank;27777								3
+
+# Tree Gnome Village
+2515 3160 0	2515 3161 0	Squeeze-through;Loose Railing;2186
+2515 3161 0	2515 3160 0	Squeeze-through;Loose Railing;2186
+2516 3166 1	2516 3166 0	Climb-down;Ladder;16679
+2516 3166 0	2516 3166 1	Climb-up;Ladder;17026
+2515 3165 1	2515 3165 0	Climb-down;Ladder;16679
+2517 3165 1	2517 3165 0	Climb-down;Ladder;16679
+2521 3163 1	2521 3163 0	Climb-down;Ladder;16685
+2521 3163 0	2521 3163 1	Climb-up;Ladder;17026
+2526 3162 0	2526 3162 1	Climb-up;Ladder;17026
+2525 3163 1	2525 3163 0	Climb-down;Ladder;16679
+2526 3162 1	2526 3162 0	Climb-down;Ladder;16679
+2525 3161 1	2525 3161 0	Climb-down;Ladder;16679
+2526 3172 1	2526 3172 0	Climb-down;Ladder;16679
+2526 3172 0	2526 3172 1	Climb-up;Ladder;17026
+2525 3171 1	2525 3171 0	Climb-down;Ladder;16679
 
 # Combat Training Camp
 2522 3375 0	2523 3375 0	Squeeze-through;Loose Railing;19171
 2523 3375 0	2522 3375 0	Squeeze-through;Loose Railing;19171
 
-# Tree Gnome Stronghold											
-2449 3463 0	2449 3463 1	Climb-up;Ladder;16683									
-2449 3463 1	2449 3463 0	Climb-down;Ladder;16679									
-2443 3462 0	2443 3462 1	Climb-up;Ladder;16683									
-2443 3462 1	2443 3462 0	Climb-down;Ladder;16679									
-2444 3463 0	2444 3463 1	Climb-up;Ladder;16683									
-2444 3463 1	2444 3463 0	Climb-down;Ladder;16679									
-2443 3464 0	2443 3464 1	Climb-up;Ladder;16683									
-2443 3464 1	2443 3464 0	Climb-down;Ladder;16679									
-2442 3463 0	2442 3463 1	Climb-up;Ladder;16683									
-2442 3463 1	2442 3463 0	Climb-down;Ladder;16679									
-2438 3464 0	2438 3464 1	Climb-up;Ladder;16683									
-2438 3464 1	2438 3464 0	Climb-down;Ladder;16679									
-2437 3465 0	2437 3465 1	Climb-up;Ladder;16683									
-2437 3465 1	2437 3465 0	Climb-down;Ladder;16679									
-2436 3464 1	2436 3464 0	Climb-down;Ladder;16679									
-2436 3464 0	2436 3464 1	Climb-up;Ladder;16683									
-2437 3463 1	2437 3463 0	Climb-down;Ladder;16679									
-2437 3463 0	2437 3463 1	Climb-up;Ladder;16683									
-2423 3441 0	2423 3441 1	Climb-up;Ladder;16683									
-2423 3441 1	2423 3441 0	Climb-down;Ladder;16679									
-2424 3442 0	2424 3442 1	Climb-up;Ladder;16683									
-2424 3442 1	2424 3442 0	Climb-down;Ladder;16679									
-2423 3443 0	2423 3443 1	Climb-up;Ladder;16683									
-2423 3443 1	2423 3443 0	Climb-down;Ladder;16679									
-2422 3442 0	2422 3442 1	Climb-up;Ladder;16683									
-2422 3442 1	2422 3442 0	Climb-down;Ladder;16679									
-2422 3422 1	2422 3422 2	Climb-up;Ladder;16683									
-2422 3422 2	2422 3422 1	Climb-down;Ladder;16679									
-2423 3423 1	2423 3423 2	Climb-up;Ladder;16683									
-2423 3423 2	2423 3423 1	Climb-down;Ladder;16679									
-2424 3422 1	2424 3422 2	Climb-up;Ladder;16683									
-2424 3422 2	2424 3422 1	Climb-down;Ladder;16679									
-2416 3444 0	2415 3446 1	Climb-up;Staircase;16675									
-2415 3446 1	2416 3447 0	Climb-down;Staircase;16677									
-2416 3447 0	2415 3446 1	Climb-up;Staircase;16675									
-2417 3447 0	2415 3446 1	Climb-up;Staircase;16675									
-2418 3446 0	2415 3446 1	Climb-up;Staircase;16675									
-2418 3445 0	2415 3446 1	Climb-up;Staircase;16675									
-2417 3444 0	2415 3446 1	Climb-up;Staircase;16675									
-2415 3445 0	2415 3446 1	Climb-up;Staircase;16675									
-2403 3450 0	2400 3450 1	Climb-up;Staircase;16675									
-2400 3450 1	2401 3451 0	Climb-down;Staircase;16677									
-2401 3451 0	2400 3450 1	Climb-up;Staircase;16675									
-2402 3451 0	2400 3450 1	Climb-up;Staircase;16675									
-2400 3450 0	2400 3450 1	Climb-up;Staircase;16675									
-2403 3449 0	2400 3450 1	Climb-up;Staircase;16675									
-2402 3448 0	2400 3450 1	Climb-up;Staircase;16675									
-2401 3448 0	2400 3450 1	Climb-up;Staircase;16675									
-2408 3436 0	2408 3436 1	Climb-up;Ladder;16683									
-2408 3436 1	2408 3436 0	Climb-down;Ladder;16679									
-2409 3435 0	2409 3435 1	Climb-up;Ladder;16683									
-2409 3435 1	2409 3435 0	Climb-down;Ladder;16679									
-2408 3434 0	2408 3434 1	Climb-up;Ladder;16683									
-2408 3434 1	2408 3434 0	Climb-down;Ladder;16679									
-2407 3435 0	2407 3435 1	Climb-up;Ladder;16683									
-2407 3435 1	2407 3435 0	Climb-down;Ladder;16679									
-2418 3416 1	2417 3417 0	Climb-down;Staircase;16677									
-2417 3417 0	2418 3416 1	Climb-up;Staircase;16675									
-2417 3418 0	2418 3416 1	Climb-up;Staircase;16675									
-2418 3419 0	2418 3416 1	Climb-up;Staircase;16675									
-2419 3419 0	2418 3416 1	Climb-up;Staircase;16675									
-2418 3416 0	2418 3416 1	Climb-up;Staircase;16675									
-2420 3417 0	2418 3416 1	Climb-up;Staircase;16675									
-2420 3418 0	2418 3416 1	Climb-up;Staircase;16675									
-2443 3415 0	2445 3416 1	Climb-up;Staircase;16675									
-2445 3416 1	2446 3415 0	Climb-down;Staircase;16677									
-2446 3415 0	2445 3416 1	Climb-up;Staircase;16675								10	
-2446 3414 0	2445 3416 1	Climb-up;Staircase;16675								10	
-2445 3413 0	2445 3416 1	Climb-up;Staircase;16675								10	
-2444 3413 0	2445 3416 1	Climb-up;Staircase;16675								10	
-2443 3414 0	2445 3416 1	Climb-up;Staircase;16675								10	
-2445 3416 0	2445 3416 1	Climb-up;Staircase;16675								10	
-2444 3416 0	2445 3416 1	Climb-up;Staircase;16675								10	
-2445 3433 1	2444 3434 0	Climb-down;Staircase;16677								10	
-2444 3434 0	2445 3433 1	Climb-up;Staircase;16675								10	
-2444 3435 0	2445 3433 1	Climb-up;Staircase;16675								10	
-2445 3436 0	2445 3433 1	Climb-up;Staircase;16675								10	
-2446 3436 0	2445 3433 1	Climb-up;Staircase;16675								10	
-2447 3435 0	2445 3433 1	Climb-up;Staircase;16675								10	
-2447 3434 0	2445 3433 1	Climb-up;Staircase;16675								10	
-2445 3433 0	2445 3433 1	Climb-up;Staircase;16675								10	
-2446 3433 0	2445 3433 1	Climb-up;Staircase;16675								10	
-2442 3405 0	2440 3403 1	Climb-up;Staircase;16675								10	
-2440 3403 1	2439 3404 0	Climb-down;Staircase;16677									
-2439 3404 0	2440 3403 1	Climb-up;Staircase;16675								10	
-2439 3405 0	2440 3403 1	Climb-up;Staircase;16675								10	
-2440 3406 0	2440 3403 1	Climb-up;Staircase;16675								10	
-2441 3406 0	2440 3403 1	Climb-up;Staircase;16675								10	
-2440 3403 0	2440 3403 1	Climb-up;Staircase;16675								10	
-2442 3404 0	2440 3403 1	Climb-up;Staircase;16675								10	
-2461 3415 0	2460 3417 1	Climb-up;Staircase;16675								10	
-2460 3417 1	2461 3418 0	Climb-down;Staircase;16677									
-2461 3418 0	2460 3417 1	Climb-up;Staircase;16675								10	
-2462 3418 0	2460 3417 1	Climb-up;Staircase;16675								10	
-2463 3417 0	2460 3417 1	Climb-up;Staircase;16675								10	
-2463 3416 0	2460 3417 1	Climb-up;Staircase;16675								10	
-2462 3415 0	2460 3417 1	Climb-up;Staircase;16675								10	
-2460 3417 0	2460 3417 1	Climb-up;Staircase;16675								10	
-2460 3416 0	2460 3417 1	Climb-up;Staircase;16675								10	
-2457 3417 1	2456 3416 0	Climb-down;Staircase;16677									
-2456 3416 0	2457 3417 1	Climb-up;Staircase;16675								10	
-2455 3416 0	2457 3417 1	Climb-up;Staircase;16675								10	
-2457 3418 0	2457 3417 1	Climb-up;Staircase;16675								10	
-2457 3417 0	2457 3417 1	Climb-up;Staircase;16675								10	
-2456 3419 0	2457 3417 1	Climb-up;Staircase;16675								10	
-2455 3419 0	2457 3417 1	Climb-up;Staircase;16675								10	
-2477 3400 0	2475 3399 1	Climb-up;Staircase;16675								10	
-2475 3399 1	2474 3400 0	Climb-down;Staircase;16677									
-2474 3400 0	2475 3399 1	Climb-up;Staircase;16675								10	
-2474 3401 0	2475 3399 1	Climb-up;Staircase;16675								10	
-2475 3402 0	2475 3399 1	Climb-up;Staircase;16675								10	
-2475 3399 0	2475 3399 1	Climb-up;Staircase;16675								10	
-2477 3401 0	2475 3399 1	Climb-up;Staircase;16675								10	
-2476 3402 0	2475 3399 1	Climb-up;Staircase;16675								10	
-2378 3490 0	2378 3489 1	Climb-up;Staircase;16675								10	
-2378 3489 1	2377 3488 0	Climb-down;Staircase;16677									
-2377 3488 0	2378 3489 1	Climb-up;Staircase;16675								10	
-2378 3489 0	2378 3489 1	Climb-up;Staircase;16675								10	
-2377 3491 0	2378 3489 1	Climb-up;Staircase;16675								10	
-2376 3491 0	2378 3489 1	Climb-up;Staircase;16675								10	
-2375 3490 0	2378 3489 1	Climb-up;Staircase;16675								10	
-2375 3489 0	2378 3489 1	Climb-up;Staircase;16675								10	
-2384 3505 0	2384 3505 1	Climb-up;Staircase;16675								10	
-2384 3505 1	2383 3506 0	Climb-down;Staircase;16677									
-2383 3506 0	2384 3505 1	Climb-up;Staircase;16675								10	
-2383 3507 0	2384 3505 1	Climb-up;Staircase;16675								10	
-2384 3508 0	2384 3505 1	Climb-up;Staircase;16675								10	
-2385 3508 0	2384 3505 1	Climb-up;Staircase;16675								10	
-2386 3507 0	2384 3505 1	Climb-up;Staircase;16675								10	
-2386 3506 0	2384 3505 1	Climb-up;Staircase;16675								10	
-2385 3505 0	2384 3505 1	Climb-up;Staircase;16675								10	
-2388 3513 0	2388 3513 1	Climb-up;Staircase;16675								10	
-2388 3513 1	2389 3514 0	Climb-down;Staircase;16677									
-2389 3514 0	2388 3513 1	Climb-up;Staircase;16675								10	
-2390 3514 0	2388 3513 1	Climb-up;Staircase;16675								10	
-2391 3512 0	2388 3513 1	Climb-up;Staircase;16675								10	
-2390 3511 0	2388 3513 1	Climb-up;Staircase;16675								10	
-2389 3511 0	2388 3513 1	Climb-up;Staircase;16675								10	
-2388 3512 0	2388 3513 1	Climb-up;Staircase;16675								10	
-2397 3512 0	2397 3513 1	Climb-up;Staircase;16675								10	
-2397 3513 1	2398 3514 0	Climb-down;Staircase;16677									
-2398 3514 0	2397 3513 1	Climb-up;Staircase;16675								10	
-2399 3514 0	2397 3513 1	Climb-up;Staircase;16675								10	
-2397 3513 0	2397 3513 1	Climb-up;Staircase;16675								10	
-2398 3511 0	2397 3513 1	Climb-up;Staircase;16675								10	
-2399 3511 0	2397 3513 1	Climb-up;Staircase;16675								10	
-2400 3512 0	2397 3513 1	Climb-up;Staircase;16675								10	
-2414 3490 0	2412 3489 1	Climb-up;Staircase;16675								10	
-2413 3490 0	2412 3489 1	Climb-up;Staircase;16675								10	
-2412 3489 1	2413 3490 0	Climb-down;Staircase;16677									
-2412 3489 0	2412 3489 1	Climb-up;Staircase;16675								10	
-2412 3488 0	2412 3489 1	Climb-up;Staircase;16675								10	
-2413 3487 0	2412 3489 1	Climb-up;Staircase;16675								10	
-2414 3487 0	2412 3489 1	Climb-up;Staircase;16675								10	
-2415 3489 0	2412 3489 1	Climb-up;Staircase;16675								10	
-2415 3488 0	2412 3489 1	Climb-up;Staircase;16675								10	
-2416 3491 0	2418 3492 1	Climb-up;Staircase;16675								10	
-2418 3492 1	2419 3491 0	Climb-down;Staircase;16677								10	
-2419 3491 0	2418 3492 1	Climb-up;Staircase;16675								10	
-2419 3490 0	2418 3492 1	Climb-up;Staircase;16675								10	
-2417 3492 0	2418 3492 1	Climb-up;Staircase;16675								10	
-2417 3489 0	2418 3492 1	Climb-up;Staircase;16675								10	
-2416 3490 0	2418 3492 1	Climb-up;Staircase;16675								10	
-2422 3472 0	2421 3473 1	Climb-up;Staircase;16675								10	
-2421 3473 1	2422 3472 0	Climb-down;Staircase;16677									
-2422 3471 0	2421 3473 1	Climb-up;Staircase;16675								10	
-2421 3470 0	2421 3473 1	Climb-up;Staircase;16675								10	
-2421 3473 0	2421 3473 1	Climb-up;Staircase;16675								10	
-2420 3473 0	2421 3473 1	Climb-up;Staircase;16675								10	
-2419 3472 0	2421 3473 1	Climb-up;Staircase;16675								10	
-2419 3471 0	2421 3473 1	Climb-up;Staircase;16675								10	
-2420 3470 0	2421 3473 1	Climb-up;Staircase;16675								10	
-2395 3473 0	2396 3476 1	Climb-up;Staircase;16675								10	
-2396 3476 1	2397 3475 0	Climb-down;Staircase;16677									
-2397 3475 0	2396 3476 1	Climb-up;Staircase;16675								10	
-2397 3474 0	2396 3476 1	Climb-up;Staircase;16675								10	
-2396 3473 0	2396 3476 1	Climb-up;Staircase;16675								10	
-2396 3476 0	2396 3476 1	Climb-up;Staircase;16675								10	
-2395 3476 0	2396 3476 1	Climb-up;Staircase;16675								10	
-2394 3475 0	2396 3476 1	Climb-up;Staircase;16675								10	
-2394 3474 0	2396 3476 1	Climb-up;Staircase;16675								10	
-2396 3503 0	2396 3500 1	Climb-up;Staircase;16675								10	
-2396 3500 1	2395 3501 0	Climb-down;Staircase;16677									
-2395 3501 0	2396 3500 1	Climb-up;Staircase;16675								10	
-2395 3502 0	2396 3500 1	Climb-up;Staircase;16675								10	
-2397 3500 0	2396 3500 1	Climb-up;Staircase;16675								10	
-2397 3503 0	2396 3500 1	Climb-up;Staircase;16675								10	
-2398 3502 0	2396 3500 1	Climb-up;Staircase;16675								10	
-2398 3501 0	2396 3500 1	Climb-up;Staircase;16675								10	
-2477 3463 0	2477 3463 1	Climb-up;Ladder;16683									
-2477 3463 1	2477 3463 0	Climb-down;Ladder;16679									
-2476 3464 0	2476 3464 1	Climb-up;Ladder;16683									
-2476 3464 1	2476 3464 0	Climb-down;Ladder;16679									
-2475 3463 0	2475 3463 1	Climb-up;Ladder;16683									
-2475 3463 1	2475 3463 0	Climb-down;Ladder;16679									
-2476 3462 0	2476 3462 1	Climb-up;Ladder;16683									
-2476 3462 1	2476 3462 0	Climb-down;Ladder;16679									
-2481 3409 0	2479 3407 1	Climb-up;Staircase;16675									
-2479 3407 1	2478 3408 0	Climb-down;Staircase;16677									
-2478 3408 0	2479 3407 1	Climb-up;Staircase;16675								10	
-2478 3409 0	2479 3407 1	Climb-up;Staircase;16675								10	
-2479 3410 0	2479 3407 1	Climb-up;Staircase;16675								10	
-2480 3410 0	2479 3407 1	Climb-up;Staircase;16675								10	
-2479 3407 0	2479 3407 1	Climb-up;Staircase;16675								10	
-2480 3407 0	2479 3407 1	Climb-up;Staircase;16675								10	
-2481 3408 0	2479 3407 1	Climb-up;Staircase;16675								10	
-2487 3407 0	2489 3409 1	Climb-up;Staircase;16675								10	
-2489 3409 1	2490 3408 0	Climb-down;Staircase;16677									
-2490 3408 0	2489 3409 1	Climb-up;Staircase;16675								10	
-2490 3407 0	2489 3409 1	Climb-up;Staircase;16675								10	
-2489 3406 0	2489 3409 1	Climb-up;Staircase;16675								10	
-2488 3406 0	2489 3409 1	Climb-up;Staircase;16675								10	
-2488 3409 0	2489 3409 1	Climb-up;Staircase;16675								10	
-2486 3401 0	2485 3401 1	Climb-up;Staircase;16675								10	
-2485 3401 1	2484 3402 0	Climb-down;Staircase;16677									
-2484 3402 0	2485 3401 1	Climb-up;Staircase;16675								10	
-2484 3403 0	2485 3401 1	Climb-up;Staircase;16675								10	
-2485 3404 0	2485 3401 1	Climb-up;Staircase;16675								10	
-2485 3401 0	2485 3401 1	Climb-up;Staircase;16675								10	
-2487 3402 0	2485 3401 1	Climb-up;Staircase;16675								10	
-2487 3403 0	2485 3401 1	Climb-up;Staircase;16675								10	
-2486 3404 0	2485 3401 1	Climb-up;Staircase;16675								10	
-2461 3385 0	2461 3382 0	Open;Gate;190									
-2461 3382 0	2461 3385 0	Open;Gate;190									
-2462 3385 0	2461 3382 0	Open;Gate;190									
-2460 3382 0	2461 3385 0	Open;Gate;190									
-2460 3385 0	2461 3382 0	Open;Gate;190									
-2462 3382 0	2461 3385 0	Open;Gate;190									
-2465 3491 0	2465 3493 0	Open;Tree Door;1967								10	
-2465 3493 0	2465 3491 0	Open;Tree Door;1967								10	
-2466 3491 0	2466 3493 0	Open;Tree Door;1968								10	
-2466 3493 0	2466 3491 0	Open;Tree Door;1968								10	
-2467 3493 0	2466 3491 0	Open;Tree Door;1968								10	
-2467 3491 0	2466 3493 0	Open;Tree Door;1968								10	
-2464 3493 0	2465 3491 0	Open;Tree Door;1967								10	
-2464 3491 0	2465 3493 0	Open;Tree Door;1967								10	
-2466 3494 0	2466 3494 1	Climb-up;Ladder;4458									
+# Tree Gnome Stronghold
+2449 3463 0	2449 3463 1	Climb-up;Ladder;16683
+2449 3463 1	2449 3463 0	Climb-down;Ladder;16679
+2443 3462 0	2443 3462 1	Climb-up;Ladder;16683
+2443 3462 1	2443 3462 0	Climb-down;Ladder;16679
+2444 3463 0	2444 3463 1	Climb-up;Ladder;16683
+2444 3463 1	2444 3463 0	Climb-down;Ladder;16679
+2443 3464 0	2443 3464 1	Climb-up;Ladder;16683
+2443 3464 1	2443 3464 0	Climb-down;Ladder;16679
+2442 3463 0	2442 3463 1	Climb-up;Ladder;16683
+2442 3463 1	2442 3463 0	Climb-down;Ladder;16679
+2438 3464 0	2438 3464 1	Climb-up;Ladder;16683
+2438 3464 1	2438 3464 0	Climb-down;Ladder;16679
+2437 3465 0	2437 3465 1	Climb-up;Ladder;16683
+2437 3465 1	2437 3465 0	Climb-down;Ladder;16679
+2436 3464 1	2436 3464 0	Climb-down;Ladder;16679
+2436 3464 0	2436 3464 1	Climb-up;Ladder;16683
+2437 3463 1	2437 3463 0	Climb-down;Ladder;16679
+2437 3463 0	2437 3463 1	Climb-up;Ladder;16683
+2423 3441 0	2423 3441 1	Climb-up;Ladder;16683
+2423 3441 1	2423 3441 0	Climb-down;Ladder;16679
+2424 3442 0	2424 3442 1	Climb-up;Ladder;16683
+2424 3442 1	2424 3442 0	Climb-down;Ladder;16679
+2423 3443 0	2423 3443 1	Climb-up;Ladder;16683
+2423 3443 1	2423 3443 0	Climb-down;Ladder;16679
+2422 3442 0	2422 3442 1	Climb-up;Ladder;16683
+2422 3442 1	2422 3442 0	Climb-down;Ladder;16679
+2422 3422 1	2422 3422 2	Climb-up;Ladder;16683
+2422 3422 2	2422 3422 1	Climb-down;Ladder;16679
+2423 3423 1	2423 3423 2	Climb-up;Ladder;16683
+2423 3423 2	2423 3423 1	Climb-down;Ladder;16679
+2424 3422 1	2424 3422 2	Climb-up;Ladder;16683
+2424 3422 2	2424 3422 1	Climb-down;Ladder;16679
+2416 3444 0	2415 3446 1	Climb-up;Staircase;16675
+2415 3446 1	2416 3447 0	Climb-down;Staircase;16677
+2416 3447 0	2415 3446 1	Climb-up;Staircase;16675
+2417 3447 0	2415 3446 1	Climb-up;Staircase;16675
+2418 3446 0	2415 3446 1	Climb-up;Staircase;16675
+2418 3445 0	2415 3446 1	Climb-up;Staircase;16675
+2417 3444 0	2415 3446 1	Climb-up;Staircase;16675
+2415 3445 0	2415 3446 1	Climb-up;Staircase;16675
+2403 3450 0	2400 3450 1	Climb-up;Staircase;16675
+2400 3450 1	2401 3451 0	Climb-down;Staircase;16677
+2401 3451 0	2400 3450 1	Climb-up;Staircase;16675
+2402 3451 0	2400 3450 1	Climb-up;Staircase;16675
+2400 3450 0	2400 3450 1	Climb-up;Staircase;16675
+2403 3449 0	2400 3450 1	Climb-up;Staircase;16675
+2402 3448 0	2400 3450 1	Climb-up;Staircase;16675
+2401 3448 0	2400 3450 1	Climb-up;Staircase;16675
+2408 3436 0	2408 3436 1	Climb-up;Ladder;16683
+2408 3436 1	2408 3436 0	Climb-down;Ladder;16679
+2409 3435 0	2409 3435 1	Climb-up;Ladder;16683
+2409 3435 1	2409 3435 0	Climb-down;Ladder;16679
+2408 3434 0	2408 3434 1	Climb-up;Ladder;16683
+2408 3434 1	2408 3434 0	Climb-down;Ladder;16679
+2407 3435 0	2407 3435 1	Climb-up;Ladder;16683
+2407 3435 1	2407 3435 0	Climb-down;Ladder;16679
+2418 3416 1	2417 3417 0	Climb-down;Staircase;16677
+2417 3417 0	2418 3416 1	Climb-up;Staircase;16675
+2417 3418 0	2418 3416 1	Climb-up;Staircase;16675
+2418 3419 0	2418 3416 1	Climb-up;Staircase;16675
+2419 3419 0	2418 3416 1	Climb-up;Staircase;16675
+2418 3416 0	2418 3416 1	Climb-up;Staircase;16675
+2420 3417 0	2418 3416 1	Climb-up;Staircase;16675
+2420 3418 0	2418 3416 1	Climb-up;Staircase;16675
+2443 3415 0	2445 3416 1	Climb-up;Staircase;16675
+2445 3416 1	2446 3415 0	Climb-down;Staircase;16677
+2446 3415 0	2445 3416 1	Climb-up;Staircase;16675								10
+2446 3414 0	2445 3416 1	Climb-up;Staircase;16675								10
+2445 3413 0	2445 3416 1	Climb-up;Staircase;16675								10
+2444 3413 0	2445 3416 1	Climb-up;Staircase;16675								10
+2443 3414 0	2445 3416 1	Climb-up;Staircase;16675								10
+2445 3416 0	2445 3416 1	Climb-up;Staircase;16675								10
+2444 3416 0	2445 3416 1	Climb-up;Staircase;16675								10
+2445 3433 1	2444 3434 0	Climb-down;Staircase;16677								10
+2444 3434 0	2445 3433 1	Climb-up;Staircase;16675								10
+2444 3435 0	2445 3433 1	Climb-up;Staircase;16675								10
+2445 3436 0	2445 3433 1	Climb-up;Staircase;16675								10
+2446 3436 0	2445 3433 1	Climb-up;Staircase;16675								10
+2447 3435 0	2445 3433 1	Climb-up;Staircase;16675								10
+2447 3434 0	2445 3433 1	Climb-up;Staircase;16675								10
+2445 3433 0	2445 3433 1	Climb-up;Staircase;16675								10
+2446 3433 0	2445 3433 1	Climb-up;Staircase;16675								10
+2442 3405 0	2440 3403 1	Climb-up;Staircase;16675								10
+2440 3403 1	2439 3404 0	Climb-down;Staircase;16677
+2439 3404 0	2440 3403 1	Climb-up;Staircase;16675								10
+2439 3405 0	2440 3403 1	Climb-up;Staircase;16675								10
+2440 3406 0	2440 3403 1	Climb-up;Staircase;16675								10
+2441 3406 0	2440 3403 1	Climb-up;Staircase;16675								10
+2440 3403 0	2440 3403 1	Climb-up;Staircase;16675								10
+2442 3404 0	2440 3403 1	Climb-up;Staircase;16675								10
+2461 3415 0	2460 3417 1	Climb-up;Staircase;16675								10
+2460 3417 1	2461 3418 0	Climb-down;Staircase;16677
+2461 3418 0	2460 3417 1	Climb-up;Staircase;16675								10
+2462 3418 0	2460 3417 1	Climb-up;Staircase;16675								10
+2463 3417 0	2460 3417 1	Climb-up;Staircase;16675								10
+2463 3416 0	2460 3417 1	Climb-up;Staircase;16675								10
+2462 3415 0	2460 3417 1	Climb-up;Staircase;16675								10
+2460 3417 0	2460 3417 1	Climb-up;Staircase;16675								10
+2460 3416 0	2460 3417 1	Climb-up;Staircase;16675								10
+2457 3417 1	2456 3416 0	Climb-down;Staircase;16677
+2456 3416 0	2457 3417 1	Climb-up;Staircase;16675								10
+2455 3416 0	2457 3417 1	Climb-up;Staircase;16675								10
+2457 3418 0	2457 3417 1	Climb-up;Staircase;16675								10
+2457 3417 0	2457 3417 1	Climb-up;Staircase;16675								10
+2456 3419 0	2457 3417 1	Climb-up;Staircase;16675								10
+2455 3419 0	2457 3417 1	Climb-up;Staircase;16675								10
+2477 3400 0	2475 3399 1	Climb-up;Staircase;16675								10
+2475 3399 1	2474 3400 0	Climb-down;Staircase;16677
+2474 3400 0	2475 3399 1	Climb-up;Staircase;16675								10
+2474 3401 0	2475 3399 1	Climb-up;Staircase;16675								10
+2475 3402 0	2475 3399 1	Climb-up;Staircase;16675								10
+2475 3399 0	2475 3399 1	Climb-up;Staircase;16675								10
+2477 3401 0	2475 3399 1	Climb-up;Staircase;16675								10
+2476 3402 0	2475 3399 1	Climb-up;Staircase;16675								10
+2378 3490 0	2378 3489 1	Climb-up;Staircase;16675								10
+2378 3489 1	2377 3488 0	Climb-down;Staircase;16677
+2377 3488 0	2378 3489 1	Climb-up;Staircase;16675								10
+2378 3489 0	2378 3489 1	Climb-up;Staircase;16675								10
+2377 3491 0	2378 3489 1	Climb-up;Staircase;16675								10
+2376 3491 0	2378 3489 1	Climb-up;Staircase;16675								10
+2375 3490 0	2378 3489 1	Climb-up;Staircase;16675								10
+2375 3489 0	2378 3489 1	Climb-up;Staircase;16675								10
+2384 3505 0	2384 3505 1	Climb-up;Staircase;16675								10
+2384 3505 1	2383 3506 0	Climb-down;Staircase;16677
+2383 3506 0	2384 3505 1	Climb-up;Staircase;16675								10
+2383 3507 0	2384 3505 1	Climb-up;Staircase;16675								10
+2384 3508 0	2384 3505 1	Climb-up;Staircase;16675								10
+2385 3508 0	2384 3505 1	Climb-up;Staircase;16675								10
+2386 3507 0	2384 3505 1	Climb-up;Staircase;16675								10
+2386 3506 0	2384 3505 1	Climb-up;Staircase;16675								10
+2385 3505 0	2384 3505 1	Climb-up;Staircase;16675								10
+2388 3513 0	2388 3513 1	Climb-up;Staircase;16675								10
+2388 3513 1	2389 3514 0	Climb-down;Staircase;16677
+2389 3514 0	2388 3513 1	Climb-up;Staircase;16675								10
+2390 3514 0	2388 3513 1	Climb-up;Staircase;16675								10
+2391 3512 0	2388 3513 1	Climb-up;Staircase;16675								10
+2390 3511 0	2388 3513 1	Climb-up;Staircase;16675								10
+2389 3511 0	2388 3513 1	Climb-up;Staircase;16675								10
+2388 3512 0	2388 3513 1	Climb-up;Staircase;16675								10
+2397 3512 0	2397 3513 1	Climb-up;Staircase;16675								10
+2397 3513 1	2398 3514 0	Climb-down;Staircase;16677
+2398 3514 0	2397 3513 1	Climb-up;Staircase;16675								10
+2399 3514 0	2397 3513 1	Climb-up;Staircase;16675								10
+2397 3513 0	2397 3513 1	Climb-up;Staircase;16675								10
+2398 3511 0	2397 3513 1	Climb-up;Staircase;16675								10
+2399 3511 0	2397 3513 1	Climb-up;Staircase;16675								10
+2400 3512 0	2397 3513 1	Climb-up;Staircase;16675								10
+2414 3490 0	2412 3489 1	Climb-up;Staircase;16675								10
+2413 3490 0	2412 3489 1	Climb-up;Staircase;16675								10
+2412 3489 1	2413 3490 0	Climb-down;Staircase;16677
+2412 3489 0	2412 3489 1	Climb-up;Staircase;16675								10
+2412 3488 0	2412 3489 1	Climb-up;Staircase;16675								10
+2413 3487 0	2412 3489 1	Climb-up;Staircase;16675								10
+2414 3487 0	2412 3489 1	Climb-up;Staircase;16675								10
+2415 3489 0	2412 3489 1	Climb-up;Staircase;16675								10
+2415 3488 0	2412 3489 1	Climb-up;Staircase;16675								10
+2416 3491 0	2418 3492 1	Climb-up;Staircase;16675								10
+2418 3492 1	2419 3491 0	Climb-down;Staircase;16677								10
+2419 3491 0	2418 3492 1	Climb-up;Staircase;16675								10
+2419 3490 0	2418 3492 1	Climb-up;Staircase;16675								10
+2417 3492 0	2418 3492 1	Climb-up;Staircase;16675								10
+2417 3489 0	2418 3492 1	Climb-up;Staircase;16675								10
+2416 3490 0	2418 3492 1	Climb-up;Staircase;16675								10
+2422 3472 0	2421 3473 1	Climb-up;Staircase;16675								10
+2421 3473 1	2422 3472 0	Climb-down;Staircase;16677
+2422 3471 0	2421 3473 1	Climb-up;Staircase;16675								10
+2421 3470 0	2421 3473 1	Climb-up;Staircase;16675								10
+2421 3473 0	2421 3473 1	Climb-up;Staircase;16675								10
+2420 3473 0	2421 3473 1	Climb-up;Staircase;16675								10
+2419 3472 0	2421 3473 1	Climb-up;Staircase;16675								10
+2419 3471 0	2421 3473 1	Climb-up;Staircase;16675								10
+2420 3470 0	2421 3473 1	Climb-up;Staircase;16675								10
+2395 3473 0	2396 3476 1	Climb-up;Staircase;16675								10
+2396 3476 1	2397 3475 0	Climb-down;Staircase;16677
+2397 3475 0	2396 3476 1	Climb-up;Staircase;16675								10
+2397 3474 0	2396 3476 1	Climb-up;Staircase;16675								10
+2396 3473 0	2396 3476 1	Climb-up;Staircase;16675								10
+2396 3476 0	2396 3476 1	Climb-up;Staircase;16675								10
+2395 3476 0	2396 3476 1	Climb-up;Staircase;16675								10
+2394 3475 0	2396 3476 1	Climb-up;Staircase;16675								10
+2394 3474 0	2396 3476 1	Climb-up;Staircase;16675								10
+2396 3503 0	2396 3500 1	Climb-up;Staircase;16675								10
+2396 3500 1	2395 3501 0	Climb-down;Staircase;16677
+2395 3501 0	2396 3500 1	Climb-up;Staircase;16675								10
+2395 3502 0	2396 3500 1	Climb-up;Staircase;16675								10
+2397 3500 0	2396 3500 1	Climb-up;Staircase;16675								10
+2397 3503 0	2396 3500 1	Climb-up;Staircase;16675								10
+2398 3502 0	2396 3500 1	Climb-up;Staircase;16675								10
+2398 3501 0	2396 3500 1	Climb-up;Staircase;16675								10
+2477 3463 0	2477 3463 1	Climb-up;Ladder;16683
+2477 3463 1	2477 3463 0	Climb-down;Ladder;16679
+2476 3464 0	2476 3464 1	Climb-up;Ladder;16683
+2476 3464 1	2476 3464 0	Climb-down;Ladder;16679
+2475 3463 0	2475 3463 1	Climb-up;Ladder;16683
+2475 3463 1	2475 3463 0	Climb-down;Ladder;16679
+2476 3462 0	2476 3462 1	Climb-up;Ladder;16683
+2476 3462 1	2476 3462 0	Climb-down;Ladder;16679
+2481 3409 0	2479 3407 1	Climb-up;Staircase;16675
+2479 3407 1	2478 3408 0	Climb-down;Staircase;16677
+2478 3408 0	2479 3407 1	Climb-up;Staircase;16675								10
+2478 3409 0	2479 3407 1	Climb-up;Staircase;16675								10
+2479 3410 0	2479 3407 1	Climb-up;Staircase;16675								10
+2480 3410 0	2479 3407 1	Climb-up;Staircase;16675								10
+2479 3407 0	2479 3407 1	Climb-up;Staircase;16675								10
+2480 3407 0	2479 3407 1	Climb-up;Staircase;16675								10
+2481 3408 0	2479 3407 1	Climb-up;Staircase;16675								10
+2487 3407 0	2489 3409 1	Climb-up;Staircase;16675								10
+2489 3409 1	2490 3408 0	Climb-down;Staircase;16677
+2490 3408 0	2489 3409 1	Climb-up;Staircase;16675								10
+2490 3407 0	2489 3409 1	Climb-up;Staircase;16675								10
+2489 3406 0	2489 3409 1	Climb-up;Staircase;16675								10
+2488 3406 0	2489 3409 1	Climb-up;Staircase;16675								10
+2488 3409 0	2489 3409 1	Climb-up;Staircase;16675								10
+2486 3401 0	2485 3401 1	Climb-up;Staircase;16675								10
+2485 3401 1	2484 3402 0	Climb-down;Staircase;16677
+2484 3402 0	2485 3401 1	Climb-up;Staircase;16675								10
+2484 3403 0	2485 3401 1	Climb-up;Staircase;16675								10
+2485 3404 0	2485 3401 1	Climb-up;Staircase;16675								10
+2485 3401 0	2485 3401 1	Climb-up;Staircase;16675								10
+2487 3402 0	2485 3401 1	Climb-up;Staircase;16675								10
+2487 3403 0	2485 3401 1	Climb-up;Staircase;16675								10
+2486 3404 0	2485 3401 1	Climb-up;Staircase;16675								10
+2461 3385 0	2461 3382 0	Open;Gate;190
+2461 3382 0	2461 3385 0	Open;Gate;190
+2462 3385 0	2461 3382 0	Open;Gate;190
+2460 3382 0	2461 3385 0	Open;Gate;190
+2460 3385 0	2461 3382 0	Open;Gate;190
+2462 3382 0	2461 3385 0	Open;Gate;190
+2465 3491 0	2465 3493 0	Open;Tree Door;1967								10
+2465 3493 0	2465 3491 0	Open;Tree Door;1967								10
+2466 3491 0	2466 3493 0	Open;Tree Door;1968								10
+2466 3493 0	2466 3491 0	Open;Tree Door;1968								10
+2467 3493 0	2466 3491 0	Open;Tree Door;1968								10
+2467 3491 0	2466 3493 0	Open;Tree Door;1968								10
+2464 3493 0	2465 3491 0	Open;Tree Door;1967								10
+2464 3491 0	2465 3493 0	Open;Tree Door;1967								10
+2466 3494 0	2466 3494 1	Climb-up;Ladder;4458
 2466 3494 1	2466 3494 0	Climb-down;Ladder;56233
-2465 3495 0	2465 3495 1	Climb-up;Ladder;4458									
+2465 3495 0	2465 3495 1	Climb-up;Ladder;4458
 2465 3495 1	2465 3495 0	Climb-down;Ladder;56233
-2466 3496 0	2466 3496 1	Climb-up;Ladder;4458									
+2466 3496 0	2466 3496 1	Climb-up;Ladder;4458
 2466 3496 1	2466 3496 0	Climb-down;Ladder;56233
-2467 3495 0	2467 3495 1	Climb-up;Ladder;4458									
+2467 3495 0	2467 3495 1	Climb-up;Ladder;4458
 2467 3495 1	2467 3495 0	Climb-down;Ladder;56233
 2467 3495 1	2467 3495 2	Climb-up;Ladder;56233
-2467 3495 2	2467 3495 3	Climb-up;Ladder;56232									
-2467 3495 3	2467 3495 2	Climb-down;Ladder;56229									
-2467 3495 2	2467 3495 1	Climb-down;Ladder;56232									
+2467 3495 2	2467 3495 3	Climb-up;Ladder;56232
+2467 3495 3	2467 3495 2	Climb-down;Ladder;56229
+2467 3495 2	2467 3495 1	Climb-down;Ladder;56232
 2466 3496 1	2466 3496 2	Climb-up;Ladder;56233
-2466 3496 2	2466 3496 1	Climb-down;Ladder;56232									
+2466 3496 2	2466 3496 1	Climb-down;Ladder;56232
 2465 3495 1	2465 3495 2	Climb-up;Ladder;56233
-2465 3495 2	2465 3495 1	Climb-down;Ladder;56232									
+2465 3495 2	2465 3495 1	Climb-down;Ladder;56232
 2466 3494 1	2466 3494 2	Climb-up;Ladder;56233
-2466 3494 2	2466 3494 1	Climb-down;Ladder;56232									
-2466 3494 2	2466 3494 3	Climb-up;Ladder;56232									
-2466 3494 3	2466 3494 2	Climb-down;Ladder;56229									
-2465 3495 2	2465 3495 3	Climb-up;Ladder;56232									
-2465 3495 3	2465 3495 2	Climb-down;Ladder;56229									
-2466 3496 2	2466 3496 3	Climb-up;Ladder;56232									
-2466 3496 3	2466 3496 2	Climb-down;Ladder;56229									
-2464 3497 0	2464 9897 0	Open;Trapdoor;2446									
-2464 9897 0	2464 3497 0	Climb-up;Ladder;17385									
-2467 9903 0	2467 9905 0	Push;Roots;2451									
-2467 9905 0	2467 9903 0	Push;Roots;2451									
-2468 9903 0	2468 9905 0	Push;Roots;2451									
-2468 9905 0	2468 9903 0	Push;Roots;2451									
-2430 3424 0	2429 9824 0	Enter;Cave;26709									
-2429 9824 0	2430 3424 0	Use;Tunnel;27257									
-2429 9825 0	2430 3424 0	Use;Tunnel;27258									
-2435 9807 0	2429 9807 0	Enter;Tunnel;30174									
-2435 9806 0	2429 9806 0	Enter;Tunnel;30174									
-2402 3420 0	2409 9812 0	Enter;Cave entrance;17209									
-2409 9812 0	2402 3419 0	Exit;Tunnel;17223									
-2402 3419 0	2409 9812 0	Enter;Cave entrance;17209									
-2402 3418 0	2409 9812 0	Enter;Cave entrance;17209									
-2403 3421 0	2409 9812 0	Enter;Cave entrance;17209									
-2408 9812 0	2402 3419 0	Exit;Tunnel;17222									
-2403 3417 0	2409 9812 0	Enter;Cave entrance;17209									
-2405 3420 0	2409 9812 0	Enter;Cave entrance;17209									
-2405 3419 0	2409 9812 0	Enter;Cave entrance;17209									
-2405 3418 0	2409 9812 0	Enter;Cave entrance;17209									
-2435 3519 0	1987 5568 0	Pass-through;Opening;28807									
-1987 5568 0	2435 3519 0	Pass-through;Opening;28807									
-											
-# Tolna's Rift											
-3309 3452 0	3297 9824 0	Enter;Rift;13968									
-3297 9824 0	3312 3450 0	Climb-up;Rope;13999									
-3298 9823 0	3312 3450 0	Climb-up;Rope;13999									
-3296 9823 0	3312 3450 0	Climb-up;Rope;13999									
-3297 9822 0	3312 3450 0	Climb-up;Rope;13999									
-2484 3463 1	2486 3465 2	Climb-up;Tree;2447									
-2485 3465 2	2484 3463 1	Climb-down;Tree;28800									
-											
-# Land's End											
-1504 3396 1	1504 3399 0	Cross;Gangplank;29724								3	
-1504 3399 0	1504 3396 1	Cross;Gangplank;29723								3	
-1512 3416 0	1512 3416 1	Climb-up;Ladder;18324									
-1512 3416 1	1512 3416 0	Climb-down;Ladder;18325									
-1493 3403 1	1496 3403 0	Cross;Gangplank;50066									
-1496 3403 0	1493 3403 1	Cross;Gangplank;50065									
-											
-# Shayzien											
-1483 3549 0	1483 9951 3	Enter;Crypt Entrance;32403									
-1483 9951 3	1483 3549 0	Climb-up;Ladder;32401									
-1561 3596 0	1561 3592 1	Climb;Stairs;27201									
-1561 3592 1	1561 3596 0	Climb;Stairs;27202									
-1562 3596 0	1562 3592 1	Climb;Stairs;27201									
-1562 3592 1	1562 3596 0	Climb;Stairs;27202									
-1579 3590 0	1579 3586 1	Climb;Stairs;27201									
-1579 3586 1	1579 3590 0	Climb;Stairs;27202									
-1580 3590 0	1580 3586 1	Climb;Stairs;27201									
-1580 3586 1	1580 3590 0	Climb;Stairs;27202									
-1420 3589 0	1432 9913 0	Enter;Cave;42248									
-1420 3588 0	1432 9913 0	Enter;Cave;42248									
-1432 9913 0	1420 3588 0	Exit;Cave;42247									
-1509 3593 0	1509 3593 1	Climb-up;Ladder;42207	 								
-1509 3593 1	1509 3593 0	Climb-down;Ladder;42208	 								
-1511 3592 1	1507 3592 2	Climb;Stairs;27199									
-1507 3592 2	1511 3592 1	Climb;Stairs;27200									
-											
-# Meyerditch											
-3649 3220 0	3631 3219 0	Enter;Door;32660				Darkness of Hallowvale					
-3631 3219 0	3649 3219 0	Enter;Door;32659				Darkness of Hallowvale					
-3649 3219 0	3631 3219 0	Enter;Door;32660				Darkness of Hallowvale					
-3631 3220 0	3649 3219 0	Enter;Door;32659				Darkness of Hallowvale					
-3649 3218 0	3631 3219 0	Enter;Door;32660				Darkness of Hallowvale					
-3631 3218 0	3649 3219 0	Enter;Door;32659				Darkness of Hallowvale					
-3632 3205 0	3632 3202 1	Climb-up;Stairs up;17976									
-3632 3202 1	3632 3205 0	Climb-down;Stairs down;17978									
-3604 3202 0	3602 3202 1	Climb-up;Ladder;17974									
-3602 3202 1	3604 3202 0	Climb-down;Ladder;17975									
-3588 3180 0	3592 3180 0	Climb-over;Wall rubble;18037									
-3592 3180 0	3588 3180 0	Climb-over;Wall rubble;18038									
-3589 3179 0	3592 3180 0	Climb-over;Wall rubble;18037									
-3590 3173 1	3588 3173 0	Climb-down;Floor;18122									
-3588 3173 0	3590 3173 1	Climb-up;Floor;18124									
-3589 3174 1	3588 3173 0	Climb-down;Floor;18122									
-3589 3174 0	3590 3173 1	Climb-up;Floor;18124									
-3589 3173 1	3588 3173 0	Climb-down;Floor;18122									
-3588 3173 1	3588 3173 0	Climb-down;Floor;18122									
-3589 3173 0	3590 3173 1	Climb-up;Floor;18124									
-3588 3211 0	3588 3209 1	Climb-up;Ladder;18000									
-3588 3209 1	3588 3211 0	Climb-down;Ladder;17999									
-3589 3214 0	3589 3215 0	Open;Barricade;18054									
-3589 3215 0	3589 3214 0	Open;Barricade;18054									
-3592 3230 0	3594 3230 1	Climb-up;Ladder;18000									
-3594 3230 1	3592 3230 0	Climb-down;Ladder;17999									
-3588 3250 1	3588 3252 2	Climb-up;Ladder;18002									
-3588 3252 2	3588 3250 1	Climb-down;Ladder;18001									
-3588 3258 2	3588 3260 1	Climb-down;Ladder;18001									
-3588 3260 1	3588 3258 2	Climb-up;Ladder;18002									
-3595 3310 1	3595 3312 0	Climb-up;Wall;39173									
-3595 3312 0	3595 3310 1	Climb-down;Wall;39172									
-3601 3163 1	3605 3163 1	Climb-down;Rock;17960									
-3605 3163 1	3601 3163 1	Climb-up;Rock;17959									
-3605 3161 1	3605 3163 1	Jump-onto;Rock;17958									
-3595 3203 0	3595 3205 1	Climb-up;Ladder;17974									
-3595 3205 1	3595 3203 0	Climb-down;Ladder;17975									
-3598 3203 1	3598 3201 1	Jump-to;Floorboards;18070									
-3598 3201 1	3598 3203 1	Jump-to;Floorboards;18071									
-3599 3200 1	3601 3200 1	Jump-to;Floorboards;18072									
-3601 3200 1	3599 3200 1	Jump-to;Floorboards;18073									
-3605 3203 1	3605 3206 1	Walk-across;Floor;18129									
-3605 3206 1	3605 3203 1	Walk-across;Floor;18130									
-3606 3207 1	3606 3208 1	Crawl-under;Wall;18078									
-3606 3208 1	3606 3207 1	Crawl-under;Wall;18078									
-3604 3214 1	3601 3214 1	Walk-across;Floor;18132									
-3601 3214 1	3604 3214 1	Walk-across;Floor;18133									
-3601 3216 1	3601 3214 0	Climb-down;Ladder;17975									
-3601 3214 0	3601 3216 1	Climb-up;Ladder;17974									
-3598 3215 0	3598 3220 0	Climb-into;Trapdoor tunnel;18083									
-3598 3220 0	3598 3215 0	Climb-into;Tunnel;18085									
-3597 3219 0	3598 3215 0	Climb-into;Tunnel;18085									
-3594 3223 0	3595 3223 1	Climb-up;Shelf;18086									
-3595 3223 1	3594 3223 0	Climb-down;Shelf;18087									
-3596 3223 1	3597 3223 1	Crawl-under;Wall;18088									
-3597 3223 1	3596 3223 1	Crawl-under;Wall;18088									
-3598 3222 1	3601 3222 1	Jump-to;Floorboards;18089									
-3601 3222 1	3598 3222 1	Jump-to;Floorboards;18090									
-3603 3223 1	3603 3221 0	Climb-down;Ladder;17975									
-3603 3221 0	3603 3223 1	Climb-up;Ladder;17974									
-3608 3221 0	3609 3221 0	Open;Door;18091									
-3609 3221 0	3608 3221 0	Open;Door;18091									
-3619 3219 0	3617 3219 1	Climb-up;Ladder;17974									
-3617 3219 1	3619 3219 0	Climb-down;Ladder;17975									
-3615 3218 1	3615 3216 1	Jump-to;Floorboards;18093									
-3615 3216 1	3615 3218 1	Jump-to;Floorboards;18094									
-3615 3210 1	3614 3210 2	Climb-up;Shelf;18095									
-3614 3210 2	3615 3210 1	Climb-down;Shelf;18096									
-3610 3211 2	3610 3209 3	Climb-up;Ladder;17974									
-3610 3209 3	3610 3211 2	Climb-down;Ladder;17975									
-3613 3208 3	3613 3205 3	Jump-to;Floorboards;18097									
-3613 3205 3	3613 3208 3	Jump-to;Floorboards;18098									
-3613 3203 3	3611 3203 2	Climb-down;Ladder;17975									
-3611 3203 2	3613 3203 3	Climb-up;Ladder;17974									
-3612 3201 2	3610 3201 1	Climb-down;Ladder;17975									
-3610 3201 1	3612 3201 2	Climb-up;Ladder;17974									
-3611 3199 1	3611 3201 0	Climb-down;Ladder;17975									
-3611 3201 0	3611 3199 1	Climb-up;Ladder;17974									
-3616 3202 2	3622 3202 2	Walk-across;Washing line;18099									
-3622 3202 2	3616 3202 2	Walk-across;Washing line;18100									
-3625 3202 2	3625 3204 1	Climb-down;Ladder;17975									
-3625 3204 1	3625 3202 2	Climb-up;Ladder;17974									
-3623 3207 1	3623 3210 1	Walk-across;Floor;18135									
-3623 3210 1	3623 3207 1	Walk-across;Floor;18136									
-3623 3217 1	3623 3218 2	Climb-up;Shelf;18105									
-3623 3218 2	3623 3217 1	Climb-down;Shelf;18106									
-3623 3218 0	3621 3218 1	Climb-up;Ladder;17974									
-3621 3218 1	3623 3218 0	Climb-down;Ladder;17975									
-3625 3223 0	3625 3224 0	Open;Door;18057									
-3625 3224 0	3625 3223 0	Open;Door;18057									
-3625 3221 2	3626 3221 1	Climb-down;Shelf;18107									
-3626 3221 1	3625 3221 2	Climb-up;Shelf;18108									
-3623 3223 1	3623 3226 1	Jump-to;Floorboards;18109									
-3623 3226 1	3623 3223 1	Jump-to;Floorboards;18110									
-3622 3230 1	3622 3232 1	Jump-to;Floorboards;18111									
-3622 3232 1	3622 3230 1	Jump-to;Floorboards;18112									
-3624 3240 1	3626 3240 1	Jump-to;Floorboards;18113									
-3626 3240 1	3624 3240 1	Jump-to;Floorboards;18114									
-3631 3239 2	3629 3239 1	Climb-down;Ladder;17975									
-3629 3239 1	3631 3239 2	Climb-up;Ladder;17974									
-3628 3240 1	3630 3240 0	Climb-down;Ladder;18116									
-3630 3240 0	3628 3240 1	Climb-up;Ladder;17974									
-3625 3251 0	3627 3251 1	Climb-up;Ladder;17974									
-3627 3251 1	3625 3251 0	Climb-down;Ladder;17975									
-3632 3258 0	3630 3258 1	Climb-up;Ladder;17974									
-3630 3258 1	3632 3258 0	Climb-down;Ladder;17975									
-3633 3256 1	3636 3256 1	Jump-to;Floorboards;18117									
-3636 3256 1	3633 3256 1	Jump-to;Floorboards;18118									
-3639 3255 1	3639 3258 0	Climb-down;Stairs down;17978									
-3639 3258 0	3639 3255 1	Climb-up;Stairs up;17976									
-3640 3253 0	3640 3252 0	Push;Wall;17980									
-3640 3252 0	3640 3253 0	Push;Wall;17980									
-3627 3269 0	3624 3269 1	Climb-up;Stairs up;17976									
-3624 3269 1	3627 3269 0	Climb-down;Stairs down;17978									
-3632 3270 1	3629 3270 0	Climb-down;Stairs down;17978									
-3629 3270 0	3632 3270 1	Climb-up;Stairs up;17976									
-3631 3274 1	3633 3274 2	Climb-up;Ladder;17974									
-3633 3274 2	3631 3274 1	Climb-down;Ladder;17975									
-3613 3279 0	3615 3279 1	Climb-up;Ladder;17974									
-3615 3279 1	3613 3279 0	Climb-down;Ladder;17975									
-3598 3278 0	3598 3281 1	Climb-up;Stairs up;17976									
-3598 3281 1	3598 3278 0	Climb-down;Stairs down;17978									
-3593 9674 0	3593 3272 0	Climb-up;Stairs;32561									
-3593 3272 0	3593 9674 0	Climb-down;Stairs;32560									
-3596 9679 0	3596 9680 0	Open;Door;32562									
-3596 9680 0	3596 9679 0	Open;Door;32562									
-3606 3291 0	3606 3293 1	Climb-up;Ladder;17974									
-3606 3293 1	3606 3291 0	Climb-down;Ladder;17975									
-3607 3291 1	3609 3291 2	Climb-up;Ladder;17974									
-3609 3291 2	3607 3291 1	Climb-down;Ladder;17975									
-3615 3299 0	3613 3299 1	Climb-up;Ladder;17974									
-3613 3299 1	3615 3299 0	Climb-down;Ladder;17975									
-3638 3304 0	3638 3305 0	Walk-through;Slashed tapestry;18125									
-3638 3305 0	3638 3304 0	Walk-through;Slashed tapestry;18125									
-3642 3307 0	3641 3307 0	Open;Door;18047									
-3641 3307 0	3642 3307 0	Open;Door;18047									
-3637 9695 0	3643 3306 0	Climb-up;Staircase;18050									
-3643 3306 0	3637 9695 0	Climb-down;Staircase;18049									
-3629 9681 0	3629 9680 0	Open;Door;17911									
-3629 9680 0	3629 9681 0	Open;Door;17911									
-3630 9681 0	3630 9680 0	Open;Door;17912									
-3630 9680 0	3630 9681 0	Open;Door;17912									
-3513 9811 0	3492 9862 0	Enter;Cave;38016									
-3492 9862 0	3513 9811 0	Enter;Cave entrance;12771									
-3491 9876 0	3483 9832 0	Enter;Cave entrance;12771									
-3483 9832 0	3491 9876 0	Enter;Cave entrance;12770									
-3626 3293 0	3626 3291 1	Climb-up;Ladder;17974									
-3626 3291 1	3626 3293 0	Climb-down;Ladder;17975									
-3621 3317 0	3619 3317 1	Climb-up;Ladder;17974									
-3619 3317 1	3621 3317 0	Climb-down;Ladder;17975									
-											
-# Darkmeyer											
-3627 3328 0	3627 3332 0	Enter;Cracked wall;39170									
-3627 3332 0	3627 3328 0	Enter;Cracked wall;39170									
-3696 9764 2	3633 3339 0	Climb-up;Staircase;39093									
-3633 3339 0	3696 9764 2	Climb-down;Staircase;39092									
-3697 9764 2	3633 3339 0	Climb-up;Staircase;39093									
-3633 3340 0	3696 9764 2	Climb-down;Staircase;39092									
-3654 3384 0	2400 5969 0	Enter;Mausoleum Door;38574									
-2400 5969 0	3654 3384 0	Climb-up;Stairs;38601									
-2399 5969 0	3654 3384 0	Climb-up;Stairs;38601									
-2401 5969 0	3654 3384 0	Climb-up;Stairs;38601									
-3614 3362 0	3615 3361 0	Open;Large door;39253									
-3615 3361 0	3614 3361 0	Open;Large door;39253									
-3614 3361 0	3615 3361 0	Open;Large door;39253									
-3615 3362 0	3614 3361 0	Open;Large door;39253									
-3613 3338 0	3613 3342 1	Climb-up;Staircase;39491									
-3613 3342 1	3613 3338 0	Climb-down;Staircase;39492									
-3599 3317 0	3603 3317 1	Climb-up;Staircase;39491									
-3603 3317 1	3599 3317 0	Climb-down;Staircase;39492									
-3667 3375 0	3670 3375 0	Climb;Wall;39542									
-3670 3375 0	3667 3375 0	Climb;Wall;39542									
-3670 3375 0	3673 3375 0	Climb;Wall;39541									
-3673 3375 0	3670 3375 0	Climb;Wall;39541									
-3672 3376 0	3670 3375 0	Climb;Wall;39541									
-3672 3374 0	3670 3375 0	Climb;Wall;39541									
-											
-# The Hollows											
-3480 9837 0	3480 9836 0	Search;Wall;5052									
-3480 9836 0	3480 9837 0	Search;Wall;5052									
-3500 9811 0	3509 3449 0	Open;Wooden doors;5056									
-3509 3449 0	3500 9811 0	Open;Wooden doors;5061									
-3501 9811 0	3509 3449 0	Open;Wooden doors;5057									
-3510 3449 0	3500 9811 0	Open;Wooden doors;5060									
-3481 9824 0	3466 9820 0	Enter;Cave entrance;5046									
-3466 9820 0	3481 9824 0	Enter;Cave entrance;5046									
-3460 9813 0	3447 9822 0	Enter;Cave entrance;16308									
-3447 9822 0	3460 9813 0	Enter;Cave entrance;16308									
-3475 9806 0	3488 9815 0	Enter;Cave entrance;5046									
-3488 9815 0	3475 9806 0	Enter;Cave entrance;5046									
-3492 9809 0	3477 9799 0	Enter;Cave entrance;5046									
-3477 9799 0	3492 9809 0	Enter;Cave entrance;5046									
-3492 9824 0	3505 9832 0	Enter;Cave entrance;5046									
-3505 9832 0	3492 9824 0	Enter;Cave entrance;5046									
-											
-# Slepe											
-3703 3335 0	3700 3334 1	Climb-up;Stairs;32647									
-3700 3335 1	3703 3334 0	Climb-down;Stairs;32648									
-3703 3336 0	3700 3334 1	Climb-up;Stairs;32647									
-3703 3334 0	3700 3334 1	Climb-up;Stairs;32647									
-3720 3307 0	3732 9683 0	Climb-down;Trapdoor;32643									
-3732 9683 0	3720 3307 0	Climb-up;Ladder;32644									
-3727 3302 0	3738 9703 1	Climb-down;Stairs;32637									
-3738 9703 1	3728 3302 0	Climb-up;Stairs;32638									
-3728 3302 0	3738 9703 1	Climb-down;Stairs;32637									
-3739 9703 1	3728 3302 0	Climb-up;Stairs;32638									
-3729 3302 0	3738 9703 1	Climb-down;Stairs;32637									
-3735 3319 1	3736 3318 0	Climb-down;Staircase;24359									
-3736 3318 0	3735 3319 1	Climb-up;Staircase;24358									
-3736 3316 1	3736 3316 2	Climb-up;Ladder;24351									
-3736 3316 2	3736 3316 1	Climb-down;Ladder;24352									
-3741 3318 1	3742 3319 0	Climb-down;Staircase;24359									
-3742 3319 0	3741 3318 1	Climb-up;Staircase;24358									
-3741 3316 2	3741 3316 3	Climb-up;Ladder;24351									
-3741 3316 3	3741 3316 2	Climb-down;Ladder;24352									
-3745 3334 0	3745 3337 1	Climb-up;Stairs;32647									
-3746 3334 0	3745 3337 1	Climb-up;Stairs;32647									
-3747 3334 0	3745 3337 1	Climb-up;Stairs;32647									
-3746 3337 1	3745 3334 0	Climb-down;Stairs;32648									
-3728 9752 1	3728 9753 1	Open;Gate;39512									
-3728 9753 1	3728 9752 1	Open;Gate;39512									
-3727 9756 1	3725 3356 0	Climb-up;Ladder;32642									
-3725 3356 0	3727 9756 1	Climb-down;Trapdoor;32641									
-3725 3352 0	3725 3356 1	Climb-up;Staircase;32645									
-3725 3356 1	3725 3352 0	Climb-down;Staircase;32646									
-3726 3352 0	3726 3356 1	Climb-up;Staircase;32645									
-3726 3356 1	3726 3352 0	Climb-down;Staircase;32646									
-3728 9765 1	3728 9766 1	Open;Gate;39510									
-3728 9766 1	3728 9765 1	Open;Gate;39510									
-3728 9775 1	3728 9776 1	Open;Gate;39510									
-3728 9776 1	3728 9775 1	Open;Gate;39510									
-3737 9780 1	3738 9780 1	Open;Gate;39510									
-3738 9780 1	3737 9780 1	Open;Gate;39510									
-3746 9780 1	3747 9780 1	Open;Gate;39510									
-3747 9780 1	3746 9780 1	Open;Gate;39510									
-3788 9778 1	3792 9778 2	Climb-up;Stairs;37832									
-3792 9778 2	3788 9778 1	Climb-down;Stairs;37833									
-3788 9777 1	3792 9777 2	Climb-up;Stairs;37832									
-3792 9777 2	3788 9777 1	Climb-down;Stairs;37833									
-3824 9777 2	3828 9777 1	Climb-down;Stairs;37833									
-3828 9777 1	3824 9777 2	Climb-up;Stairs;37832									
-3828 9778 1	3824 9778 2	Climb-up;Stairs;37832									
-3824 9778 2	3828 9778 1	Climb-down;Stairs;37833									
-3807 9797 2	3807 9801 1	Climb-down;Stairs;37836									
-3807 9801 1	3807 9797 2	Climb-up;Stairs;37835									
-3808 9797 2	3808 9801 1	Climb-down;Stairs;37836									
-3808 9801 1	3808 9797 2	Climb-up;Stairs;37835									
-3809 9797 2	3809 9801 1	Climb-down;Stairs;37836									
-3809 9801 1	3809 9797 2	Climb-up;Stairs;37835									
-											
-# Ectofunctus											
-3672 3376 0	3670 3375 0	Climb;Wall;39541									
-3672 3374 0	3670 3375 0	Climb;Wall;39541									
-3666 3517 0	3666 3522 1	Climb-up;Staircase;16646									
-3666 3522 1	3666 3517 0	Climb-down;Staircase;16647									
-3667 3517 0	3667 3522 1	Climb-up;Staircase;16646									
-3667 3522 1	3667 3517 0	Climb-down;Staircase;16647									
-3669 9888 3	3654 3519 0	Climb-up;Ladder;16110									
-3654 3519 0	3669 9888 3	Climb-down;Trapdoor;16114									
-3653 3520 0	3669 9888 3	Climb-down;Trapdoor;16114									
-3653 3518 0	3669 9888 3	Climb-down;Trapdoor;16114									
-3652 3519 0	3669 9888 3	Climb-down;Trapdoor;16114									
-3671 9889 2	3675 9888 1	Climb-down;Stairs;16109									
-3675 9888 1	3671 9886 2	Climb-up;Stairs;16108									
-3671 9887 2	3675 9888 1	Climb-down;Stairs;16109									
-3675 9889 1	3671 9886 2	Climb-up;Stairs;16108									
-3671 9888 2	3675 9888 1	Climb-down;Stairs;16109									
-3675 9887 1	3671 9886 2	Climb-up;Stairs;16108									
-3674 9890 1	3671 9886 2	Climb-up;Stairs;16108									
-3672 9886 2	3675 9888 1	Climb-down;Stairs;16109									
-3673 9890 1	3671 9886 2	Climb-up;Stairs;16108									
-3674 9886 1	3671 9886 2	Climb-up;Stairs;16108									
-3673 9886 1	3671 9886 2	Climb-up;Stairs;16108									
-3687 9889 1	3683 9888 0	Climb-down;Stairs;16109									
-3683 9889 0	3687 9887 1	Climb-up;Stairs;16108									
-3687 9887 1	3683 9888 0	Climb-down;Stairs;16109									
-3683 9888 0	3687 9887 1	Climb-up;Stairs;16108									
-3687 9888 1	3683 9888 0	Climb-down;Stairs;16109									
-3683 9887 0	3687 9887 1	Climb-up;Stairs;16108									
-3686 9886 1	3683 9888 0	Climb-down;Stairs;16109									
-3686 9890 1	3683 9888 0	Climb-down;Stairs;16109									
-3689 9890 2	3692 9887 3	Climb-up;Stairs;16108									
-3688 9889 2	3692 9887 3	Climb-up;Stairs;16108									
-3688 9888 2	3692 9887 3	Climb-up;Stairs;16108									
-3688 9887 2	3692 9887 3	Climb-up;Stairs;16108									
-3690 9890 3	3688 9888 2	Climb-down;Stairs;16109									
-3691 9890 3	3688 9888 2	Climb-down;Stairs;16109									
-3692 9889 3	3688 9888 2	Climb-down;Stairs;16109									
-3692 9888 3	3688 9888 2	Climb-down;Stairs;16109									
-3692 9887 3	3688 9888 2	Climb-down;Stairs;16109									
-3691 9886 3	3688 9888 2	Climb-down;Stairs;16109									
-3690 9886 3	3688 9888 2	Climb-down;Stairs;16109									
-											
-# Shipwreck (Morytania)											
-3614 3541 1	3616 3541 2	Climb-up;Ship's ladder;16111									
-3616 3541 2	3614 3541 1	Climb-down;Ship's ladder;16112									
-3610 3543 0	3608 3543 1	Climb-up;Ship's ladder;16111									
-3608 3543 1	3610 3543 0	Climb-down;Ship's ladder;16112									
-3614 3543 1	3612 3543 0	Climb-down;Ship's ladder;16112									
-3612 3543 0	3614 3543 1	Climb-up;Ship's ladder;16111									
-3605 3545 1	3605 3548 0	Cross;Gangplank;16651								3	
-3605 3548 0	3605 3545 1	Cross;Gangplank;16652								3	
-3604 3550 0	3602 3550 0	Jump-To;Rock;16115									
-3602 3550 0	3604 3550 0	Jump-To;Rock;16115									
-3599 3552 0	3597 3552 0	Jump-To;Rock;16115									
-3597 3552 0	3599 3552 0	Jump-To;Rock;16115									
-3595 3554 0	3595 3556 0	Jump-To;Rock;16115									
-3595 3556 0	3595 3554 0	Jump-To;Rock;16115									
-3597 3559 0	3597 3561 0	Jump-To;Rock;16115									
-3597 3561 0	3597 3559 0	Jump-To;Rock;16115									
-3599 3564 0	3601 3564 0	Jump-To;Rock;16115									
-3601 3564 0	3599 3564 0	Jump-To;Rock;16115									
-											
-# Fenkenstrain's Castle											
-3559 3550 0	3559 3554 1	Climb-up;Staircase;5206									
-3559 3554 1	3559 3549 0	Climb-down;Staircase;5207									
-3560 3550 0	3559 3554 1	Climb-up;Staircase;5206									
-3560 3554 1	3559 3549 0	Climb-down;Staircase;5207									
-3538 3554 1	3537 3549 0	Climb-down;Staircase;5207									
-3537 3550 0	3537 3554 1	Climb-up;Staircase;5206									
-3537 3554 1	3537 3549 0	Climb-down;Staircase;5207									
-3538 3550 0	3537 3554 1	Climb-up;Staircase;5206									
-3540 3543 0	3540 3543 1	Climb-up;Ladder;16683									
-3540 3543 1	3540 3543 0	Climb-down;Ladder;16679									
-3539 3544 0	3539 3544 1	Climb-up;Ladder;16683									
-3539 3544 1	3539 3544 0	Climb-down;Ladder;16679									
-3539 3542 0	3539 3542 1	Climb-up;Ladder;16683									
-3539 3542 1	3539 3542 0	Climb-down;Ladder;16679									
-3538 3543 1	3538 3543 0	Climb-down;Ladder;16679									
-3538 3543 0	3538 3543 1	Climb-up;Ladder;16683									
-3548 3565 0	3547 3565 0	Open;Door;5174									
-3547 3565 0	3548 3565 0	Open;Door;5174									
-3548 3551 1	3548 3552 1	Open;Door;5172									
-3548 3552 1	3548 3551 1	Open;Door;5172									
-3548 3553 1	3548 3553 2	Climb-up;Ladder;16683									
-3548 3553 2	3548 3553 1	Climb-down;Ladder;16679									
-3547 3554 1	3547 3554 2	Climb-up;Ladder;16683									
-3547 3554 2	3547 3554 1	Climb-down;Ladder;16679									
-3548 3555 1	3548 3555 2	Climb-up;Ladder;16683									
-3548 3555 2	3548 3555 1	Climb-down;Ladder;16679									
-3549 3554 1	3549 3554 2	Climb-up;Ladder;16683									
-3549 3554 2	3549 3554 1	Climb-down;Ladder;16679									
-3549 3543 1	3549 3542 1	Open;Door;5183									
-3549 3542 1	3549 3543 1	Open;Door;5183									
-3548 3543 1	3548 3542 1	Open;Door;5186									
-3548 3542 1	3548 3543 1	Open;Door;5186									
-3548 3540 1	3548 3540 2	Climb-up;Ladder;16683									
-3548 3540 2	3548 3540 1	Climb-down;Ladder;16679									
-3549 3539 1	3549 3539 2	Climb-up;Ladder;16683									
-3549 3539 2	3549 3539 1	Climb-down;Ladder;16679									
-3548 3538 1	3548 3538 2	Climb-up;Ladder;16683									
-3548 3538 2	3548 3538 1	Climb-down;Ladder;16679									
-3547 3539 1	3547 3539 2	Climb-up;Ladder;16683									
-3547 3539 2	3547 3539 1	Climb-down;Ladder;16679									
-											
-# Slayer Tower											
-3417 3536 0	3412 9932 3	Climb-down;Ladder;30191									
-3412 9932 3	3417 3536 0	Climb-up;Ladder;30192									
-3421 3550 0	3421 3550 1	Climb-up;Spikey chain;16537									
-3422 3551 0	3422 3551 1	Climb-up;Spikey chain;16537									
-3423 3550 0	3423 3550 1	Climb-up;Spikey chain;16537									
-3422 3549 0	3422 3549 1	Climb-up;Spikey chain;16537									
-3421 3550 1	3421 3550 0	Climb-down;Spikey chain;16538									
-3422 3551 1	3422 3551 0	Climb-down;Spikey chain;16538									
-3422 3549 1	3422 3549 0	Climb-down;Spikey chain;16538									
-3423 3550 1	3423 3550 0	Climb-down;Spikey chain;16538									
-3427 3555 1	3427 3556 1	Open;Door;2104									
-3427 3556 1	3427 3555 1	Open;Door;2104									
-3426 3555 1	3426 3556 1	Open;Door;2102									
-3426 3556 1	3426 3555 1	Open;Door;2102									
-3433 3538 1	3438 3537 0	Climb-down;Staircase;2118									
-3438 3537 0	3433 3537 1	Climb-up;Staircase;2114									
-3433 3537 1	3438 3537 0	Climb-down;Staircase;2118									
-3438 3538 0	3433 3537 1	Climb-up;Staircase;2114									
-3417 3540 2	3412 3540 1	Climb-down;Staircase;2120									
-3412 3540 1	3417 3540 2	Climb-up;Staircase;2119									
-3417 3541 2	3412 3540 1	Climb-down;Staircase;2120									
-3412 3541 1	3417 3540 2	Climb-up;Staircase;2119									
-											
-# Monastery											
-3057 3484 0	3057 3484 1	Climb-up;Ladder;2641	31 Prayer							2	
-3056 3483 0	3056 3483 1	Climb-up;Ladder;2641	31 Prayer							2	
-3057 3482 0	3057 3482 1	Climb-up;Ladder;2641	31 Prayer							2	
-3058 3483 0	3058 3483 1	Climb-up;Ladder;2641	31 Prayer							2	
-3047 3483 0	3047 3483 1	Climb-up;Ladder;2641	31 Prayer							2	
-3046 3484 0	3046 3484 1	Climb-up;Ladder;2641	31 Prayer							2	
-3045 3483 0	3045 3483 1	Climb-up;Ladder;2641	31 Prayer							2	
-3046 3482 0	3046 3482 1	Climb-up;Ladder;2641	31 Prayer							2	
-3057 3484 1	3057 3484 0	Climb-down;Ladder;16679								2	
-3056 3483 1	3056 3483 0	Climb-down;Ladder;16679								2	
-3057 3482 1	3057 3482 0	Climb-down;Ladder;16679								2	
-3058 3483 1	3058 3483 0	Climb-down;Ladder;16679								2	
-3047 3483 1	3047 3483 0	Climb-down;Ladder;16679								2	
-3046 3484 1	3046 3484 0	Climb-down;Ladder;16679								2	
-3045 3483 1	3045 3483 0	Climb-down;Ladder;16679								2	
-3046 3482 1	3046 3482 0	Climb-down;Ladder;16679								2	
-											
-# Dwarven Mine											
-3018 3450 0	3018 9850 0	Climb-down;Trapdoor;11867									
-3018 9850 0	3018 3450 0	Climb-up;Ladder;17387									
-3020 3450 0	3020 9850 0	Climb-down;Trapdoor;11867									
-3058 9777 0	3061 3377 0	Climb-up;Staircase;23969									
-3061 3377 0	3058 9777 0	Climb-down;Staircase;16664									
-3058 9776 0	3061 3376 0	Climb-up;Staircase;23969									
-3061 3376 0	3058 9776 0	Climb-down;Staircase;16664									
-3728 5692 0	3060 9766 0	Exit;Tunnel;26655									
-3060 9766 0	3728 5692 0	Enter;Cave;26654									
-											
-# Rimmington											
-2964 3216 0	2968 3215 1	Climb-up;Staircase;18991								1	
-2968 3215 1	2964 3215 0	Climb-down;Staircase;18992								1	
-2964 3215 0	2968 3215 1	Climb-up;Staircase;18991								1	
-2968 3216 1	2964 3215 0	Climb-down;Staircase;18992								1	
-2949 3213 1	2949 3213 0	Climb-down;Ladder;9559								2	
-2949 3213 0	2949 3213 1	Climb-up;Ladder;9558								2	
-2915 3225 0	2915 3222 1	Cross;Gangplank;34669								3	
-2915 3222 1	2915 3225 0	Cross;Gangplank;34670								3	
-2913 3221 0	2913 3221 1	Climb-up;Ship's ladder;9744								2	
-2913 3221 1	2913 3221 0	Climb-down;Ship's ladder;9745								2	
-2914 3222 1	2913 3221 0	Climb-down;Ship's ladder;9745								2	
-2914 3220 1	2913 3221 0	Climb-down;Ship's ladder;9745								2	
-2915 3221 1	2913 3221 0	Climb-down;Ship's ladder;9745								2	
-2909 3226 0	2909 3229 1	Cross;Gangplank;34667								1	
-2909 3229 1	2909 3226 0	Cross;Gangplank;34668								1	
-2933 3289 0	2933 3288 0	Open;Guild Door;14910	40 Crafting	1757;20208;9780;9781;9782;13280;13281						1	
-2933 3288 0	2933 3289 0	Open;Guild Door;14910								1	
-2941 3248 0	2940 3248 0	Open;Door;2595		1542						1	
-2940 3248 0	2941 3248 0	Open;Door;2595								1	
-2938 3252 0	2937 3252 0	Open;Exit door;2602								1	
-2925 3244 0	2926 3244 0	Open;Red door;2596								1	
-2926 3244 0	2925 3244 0	Open;Red door;2596								1	
-2925 3248 0	2926 3248 0	Open;Red door;2596								1	
-2926 3248 0	2925 3248 0	Open;Red door;2596								1	
-2926 3253 0	2925 3253 0	Open;Red door;2596								1	
-2925 3253 0	2926 3253 0	Open;Red door;2596								1	
-											
-# Burthorpe											
-2892 3556 0	2892 3556 1	Climb-up;Ladder;16683								2	
-2892 3556 1	2892 3556 0	Climb-down;Ladder;16679								2	
-2891 3557 0	2891 3557 1	Climb-up;Ladder;16683								2	
-2891 3557 1	2891 3557 0	Climb-down;Ladder;16679								2	
-2905 3556 0	2905 3556 1	Climb-up;Ladder;16683								2	
-2905 3556 1	2905 3556 0	Climb-down;Ladder;16679								2	
-2906 3557 0	2906 3557 1	Climb-up;Ladder;16683								2	
-2906 3557 1	2906 3557 0	Climb-down;Ladder;16679								2	
-2899 3565 0	2205 4933 1	Climb-down;Stairs;4624									
-2205 4934 1	2899 3564 0	Climb-up;Stairs;4627									
-2900 3565 0	2205 4933 1	Climb-down;Stairs;4624									
-2206 4934 1	2900 3565 0	Climb-up;Stairs;4627									
-2207 4934 1	2207 4938 0	Climb-down;Stairs;4620									
-2207 4938 0	2207 4934 1	Climb-up;Stairs;4622									
-2208 4934 1	2207 4938 0	Climb-down;Stairs;4620									
-2208 4938 0	2207 4934 1	Climb-up;Stairs;4622									
-2212 4940 0	2212 4944 1	Climb-up;Stairs;4622									
-2213 4940 0	2212 4944 1	Climb-up;Stairs;4622									
-2212 4944 1	2212 4940 0	Climb-down;Stairs;4620									
-2213 4944 1	2212 4940 0	Climb-down;Stairs;4620									
-2898 3565 0	2897 3569 1	Climb-up;Stairs;4626									
-2897 3569 1	2897 3565 0	Climb-down;Stairs;4625									
-2897 3565 0	2897 3569 1	Climb-up;Stairs;4626									
-2898 3569 1	2897 3565 0	Climb-down;Stairs;4625									
-2905 3571 0	2905 3571 1	Climb-up;Ladder;16683								2	
-2905 3571 1	2905 3571 0	Climb-down;Ladder;16679								2	
-2906 3570 0	2906 3570 1	Climb-up;Ladder;16683								2	
-2906 3570 1	2906 3570 0	Climb-down;Ladder;16679								2	
-2877 3546 0	2876 3546 0	Open;Door;24318								1	
-2876 3546 0	2877 3546 0	Open;Door;24318								1	
-2855 3546 0	2855 3545 0	Open;Door;24309								1	
-2855 3545 0	2855 3546 0	Open;Door;24309								1	
-2854 3546 0	2854 3545 0	Open;Door;24306								1	
-2854 3545 0	2854 3546 0	Open;Door;24306								1	
-2841 3538 0	2840 3539 1	Climb-up;Staircase;16671								1	
-2840 3539 1	2841 3538 0	Climb-down;Staircase;16672								1	
-2841 3537 0	2840 3539 1	Climb-up;Staircase;16671								1	
-2841 3538 1	2841 3538 0	Climb-down;Staircase;16672								1	
-2840 3539 0	2840 3539 1	Climb-up;Staircase;16671								1	
-2839 3539 0	2840 3539 1	Climb-up;Staircase;16671								1	
-2838 3538 0	2840 3539 1	Climb-up;Staircase;16671								1	
-2838 3537 0	2840 3539 1	Climb-up;Staircase;16671								1	
-2840 3539 1	2840 3539 2	Climb-up;Staircase;16672								1	
-2840 3539 2	2841 3538 1	Climb-down;Staircase;24303								1	
-2841 3538 1	2840 3539 2	Climb-up;Staircase;16672								1	
-2842 3541 1	2842 3542 1	Open;Door;24312								1	
-2842 3542 1	2842 3541 1	Open;Door;24312								1	
-2852 3551 1	2853 3551 1	Open;Heavy door;15660									
-2853 3551 1	2852 3551 1	Open;Heavy door;15660									
-2852 3552 1	2853 3552 1	Open;Heavy door;15658									
-2853 3552 1	2852 3552 1	Open;Heavy door;15658									
-2834 3542 0	2907 9968 0	Climb-down;Ladder;10042								2	
-2907 9968 0	2834 3542 0	Climb-up;Ladder;9742								2	
-3061 4985 1	2906 3537 0	Enter;Passageway;7258									
-2906 3537 0	3061 4985 1	Enter;Trapdoor;7257									
-2915 3538 0	2914 3542 1	Climb-up;Staircase;15645								1	
-2914 3542 1	2914 3538 0	Climb-down;Staircase;15648								1	
-2914 3538 0	2914 3542 1	Climb-up;Staircase;15645								1	
-2915 3542 1	2914 3538 0	Climb-down;Staircase;15648								1	
-2929 3545 0	2929 3545 1	Climb-up;Ladder;17026								2	
-2929 3545 1	2929 3545 0	Climb-down;Ladder;16685								2	
-2857 3577 0	2269 4752 0	Enter;Cave Entrance;3735									
-2269 4752 0	2858 3577 0	Exit;Cave Exit;3736									
-2858 3577 0	2269 4752 0	Enter;Cave Entrance;3735									
-2270 4752 0	2858 3577 0	Exit;Cave Exit;3736									
-2859 3577 0	2269 4752 0	Enter;Cave Entrance;3735									
-2268 4752 0	2858 3577 0	Exit;Cave Exit;3736									
-2860 3578 0	2269 4752 0	Enter;Cave Entrance;3735									
-2892 3571 0	2892 3571 1	Climb-up;Ladder;16683								2	
-2892 3571 1	2892 3571 0	Climb-down;Ladder;16679								2	
-2891 3570 0	2891 3570 1	Climb-up;Ladder;16683								2	
-2891 3570 1	2891 3570 0	Climb-down;Ladder;16679								2	
-2894 3566 0	2894 3567 0	Open;Large door;3743									
-2894 3567 0	2894 3566 0	Open;Large door;3743									
-											
-# Wilderness											
-3158 3950 0	3158 3952 0	Slash;Web;733								4	
-3158 3952 0	3158 3950 0	Slash;Web;733								4	
-3232 10351 0	3233 3950 0	Use;Crevice;26763									
-3233 3950 0	3232 10351 0	Enter;Cavern;26762									
-3232 3950 0	3232 10351 0	Enter;Cavern;26762									
-3242 3948 0	3243 10351 0	Enter;Cavern;26762									
-3243 10351 0	3242 3948 0	Use;Crevice;26763									
-3243 3948 0	3243 10351 0	Enter;Cavern;26762									
-3232 3938 0	3233 10332 0	Enter;Cavern;26762									
-3233 10332 0	3233 3938 0	Use;Crevice;26763									
-3233 3938 0	3233 10332 0	Enter;Cavern;26762									
-3095 3957 0	3094 3957 0	Slash;Web;733								4	
-3093 3957 0	3092 3957 0	Slash;Web;733								4	
-3092 3957 0	3093 3957 0	Slash;Web;733								4	
-3094 3957 0	3095 3957 0	Slash;Web;733								4	
-3106 3959 0	3106 3957 0	Slash;Web;733								4	
-3105 3959 0	3105 3957 0	Slash;Web;733								4	
-3105 3957 0	3105 3959 0	Slash;Web;733								4	
-3106 3957 0	3106 3959 0	Slash;Web;733								4	
-3018 3958 0	3018 3958 1	Climb-up;Ship's ladder;272									
-3018 3958 1	3018 3958 0	Climb-down;Ship's ladder;273									
-3019 3958 1	3019 3960 2	Climb-up;Ship's ladder;245									
-3019 3960 2	3019 3958 1	Climb-down;Ship's ladder;246									
-3017 3958 1	3017 3960 2	Climb-up;Ship's ladder;245									
-3017 3960 2	3017 3958 1	Climb-down;Ship's ladder;246									
-2998 3931 0	2998 3916 0	Open;Gate;23552									
-2997 3931 0	2998 3916 0	Open;Gate;23554									
-3005 3962 0	3005 10362 0	Climb-down;Ladder;14758								2	
-3005 10362 0	3005 3962 0	Climb-up;Ladder;17385								2	
-3069 10255 0	3016 3849 0	Climb-up;Ladder;18988								2	
-3017 3850 0	3069 10255 0	Climb-down;Ladder;18987								2	
-3068 10256 0	3016 3849 0	Climb-up;Ladder;18988								2	
-3069 10257 0	3016 3849 0	Climb-up;Ladder;18988								2	
-3029 3852 0	3031 3852 0	Slash;Web;733								4	
-3031 3852 0	3029 3852 0	Slash;Web;733								4	
-3115 3858 0	3115 3860 0	Slash;Web;733								4	
-3115 3860 0	3115 3858 0	Slash;Web;733								4	
-3069 3857 0	3016 10249 0	Climb-down;Ladder;18989								2	
-3016 10249 0	3070 3856 0	Climb-up;Ladder;18990								2	
-3017 10250 0	3070 3856 0	Climb-up;Ladder;18990								2	
-3017 10248 0	3070 3856 0	Climb-up;Ladder;18990								2	
-3018 10249 0	3070 3856 0	Climb-up;Ladder;18990								2	
-3044 3927 0	3044 10322 0	Climb-down;Staircase;16664								1	
-3044 10323 0	3044 3927 0	Climb-up;Staircase;16665								1	
-3045 3927 0	3044 10322 0	Climb-down;Staircase;16664								1	
-3045 10323 0	3044 3927 0	Climb-up;Staircase;16665								1	
-2995 3530 0	2998 3530 0	Cross;Wilderness Ditch;23271								4	
-2998 3530 0	2995 3530 0	Cross;Wilderness Ditch;23271								4	
-2995 3531 0	2998 3531 0	Cross;Wilderness Ditch;23271								4	
-2998 3531 0	2995 3531 0	Cross;Wilderness Ditch;23271								4	
-2995 3532 0	2998 3532 0	Cross;Wilderness Ditch;23271								4	
-2998 3532 0	2995 3532 0	Cross;Wilderness Ditch;23271								4	
-2995 3533 0	2998 3533 0	Cross;Wilderness Ditch;23271								4	
-2998 3533 0	2995 3533 0	Cross;Wilderness Ditch;23271								4	
-2946 3520 0	2946 3523 0	Cross;Wilderness Ditch;23271								4	
-2946 3523 0	2946 3520 0	Cross;Wilderness Ditch;23271								4	
-2947 3520 0	2947 3523 0	Cross;Wilderness Ditch;23271								4	
-2947 3523 0	2947 3520 0	Cross;Wilderness Ditch;23271								4	
-2948 3520 0	2948 3523 0	Cross;Wilderness Ditch;23271								4	
-2948 3523 0	2948 3520 0	Cross;Wilderness Ditch;23271								4	
-2949 3520 0	2949 3523 0	Cross;Wilderness Ditch;23271								4	
-2949 3523 0	2949 3520 0	Cross;Wilderness Ditch;23271								4	
-2950 3520 0	2950 3523 0	Cross;Wilderness Ditch;23271								4	
-2950 3523 0	2950 3520 0	Cross;Wilderness Ditch;23271								4	
-2951 3520 0	2951 3523 0	Cross;Wilderness Ditch;23271								4	
-2951 3523 0	2951 3520 0	Cross;Wilderness Ditch;23271								4	
-2952 3520 0	2952 3523 0	Cross;Wilderness Ditch;23271								4	
-2952 3523 0	2952 3520 0	Cross;Wilderness Ditch;23271								4	
-2953 3520 0	2953 3523 0	Cross;Wilderness Ditch;23271								4	
-2953 3523 0	2953 3520 0	Cross;Wilderness Ditch;23271								4	
-2954 3520 0	2954 3523 0	Cross;Wilderness Ditch;23271								4	
-2954 3523 0	2954 3520 0	Cross;Wilderness Ditch;23271								4	
-2955 3520 0	2955 3523 0	Cross;Wilderness Ditch;23271								4	
-2955 3523 0	2955 3520 0	Cross;Wilderness Ditch;23271								4	
-2956 3520 0	2956 3523 0	Cross;Wilderness Ditch;23271								4	
-2956 3523 0	2956 3520 0	Cross;Wilderness Ditch;23271								4	
-2957 3520 0	2957 3523 0	Cross;Wilderness Ditch;23271								4	
-2957 3523 0	2957 3520 0	Cross;Wilderness Ditch;23271								4	
-2958 3520 0	2958 3523 0	Cross;Wilderness Ditch;23271								4	
-2958 3523 0	2958 3520 0	Cross;Wilderness Ditch;23271								4	
-2959 3520 0	2959 3523 0	Cross;Wilderness Ditch;23271								4	
-2959 3523 0	2959 3520 0	Cross;Wilderness Ditch;23271								4	
-2960 3520 0	2960 3523 0	Cross;Wilderness Ditch;23271								4	
-2960 3523 0	2960 3520 0	Cross;Wilderness Ditch;23271								4	
-2961 3520 0	2961 3523 0	Cross;Wilderness Ditch;23271								4	
-2961 3523 0	2961 3520 0	Cross;Wilderness Ditch;23271								4	
-2962 3520 0	2962 3523 0	Cross;Wilderness Ditch;23271								4	
-2962 3523 0	2962 3520 0	Cross;Wilderness Ditch;23271								4	
-2963 3520 0	2963 3523 0	Cross;Wilderness Ditch;23271								4	
-2963 3523 0	2963 3520 0	Cross;Wilderness Ditch;23271								4	
-2964 3520 0	2964 3523 0	Cross;Wilderness Ditch;23271								4	
-2964 3523 0	2964 3520 0	Cross;Wilderness Ditch;23271								4	
-2965 3520 0	2965 3523 0	Cross;Wilderness Ditch;23271								4	
-2965 3523 0	2965 3520 0	Cross;Wilderness Ditch;23271								4	
-2966 3520 0	2966 3523 0	Cross;Wilderness Ditch;23271								4	
-2966 3523 0	2966 3520 0	Cross;Wilderness Ditch;23271								4	
-2967 3520 0	2967 3523 0	Cross;Wilderness Ditch;23271								4	
-2967 3523 0	2967 3520 0	Cross;Wilderness Ditch;23271								4	
-2968 3520 0	2968 3523 0	Cross;Wilderness Ditch;23271								4	
-2968 3523 0	2968 3520 0	Cross;Wilderness Ditch;23271								4	
-2969 3520 0	2969 3523 0	Cross;Wilderness Ditch;23271								4	
-2969 3523 0	2969 3520 0	Cross;Wilderness Ditch;23271								4	
-2970 3520 0	2970 3523 0	Cross;Wilderness Ditch;23271								4	
-2970 3523 0	2970 3520 0	Cross;Wilderness Ditch;23271								4	
-2971 3520 0	2971 3523 0	Cross;Wilderness Ditch;23271								4	
-2971 3523 0	2971 3520 0	Cross;Wilderness Ditch;23271								4	
-2972 3520 0	2972 3523 0	Cross;Wilderness Ditch;23271								4	
-2972 3523 0	2972 3520 0	Cross;Wilderness Ditch;23271								4	
-2973 3520 0	2973 3523 0	Cross;Wilderness Ditch;23271								4	
-2973 3523 0	2973 3520 0	Cross;Wilderness Ditch;23271								4	
-2974 3520 0	2974 3523 0	Cross;Wilderness Ditch;23271								4	
-2974 3523 0	2974 3520 0	Cross;Wilderness Ditch;23271								4	
-2975 3520 0	2975 3523 0	Cross;Wilderness Ditch;23271								4	
-2975 3523 0	2975 3520 0	Cross;Wilderness Ditch;23271								4	
-2976 3520 0	2976 3523 0	Cross;Wilderness Ditch;23271								4	
-2976 3523 0	2976 3520 0	Cross;Wilderness Ditch;23271								4	
-2977 3520 0	2977 3523 0	Cross;Wilderness Ditch;23271								4	
-2977 3523 0	2977 3520 0	Cross;Wilderness Ditch;23271								4	
-2978 3520 0	2978 3523 0	Cross;Wilderness Ditch;23271								4	
-2978 3523 0	2978 3520 0	Cross;Wilderness Ditch;23271								4	
-2979 3520 0	2979 3523 0	Cross;Wilderness Ditch;23271								4	
-2979 3523 0	2979 3520 0	Cross;Wilderness Ditch;23271								4	
-2980 3520 0	2980 3523 0	Cross;Wilderness Ditch;23271								4	
-2980 3523 0	2980 3520 0	Cross;Wilderness Ditch;23271								4	
-2981 3520 0	2981 3523 0	Cross;Wilderness Ditch;23271								4	
-2981 3523 0	2981 3520 0	Cross;Wilderness Ditch;23271								4	
-2982 3520 0	2982 3523 0	Cross;Wilderness Ditch;23271								4	
-2982 3523 0	2982 3520 0	Cross;Wilderness Ditch;23271								4	
-2983 3520 0	2983 3523 0	Cross;Wilderness Ditch;23271								4	
-2983 3523 0	2983 3520 0	Cross;Wilderness Ditch;23271								4	
-2984 3520 0	2984 3523 0	Cross;Wilderness Ditch;23271								4	
-2984 3523 0	2984 3520 0	Cross;Wilderness Ditch;23271								4	
-2985 3520 0	2985 3523 0	Cross;Wilderness Ditch;23271								4	
-2985 3523 0	2985 3520 0	Cross;Wilderness Ditch;23271								4	
-2986 3520 0	2986 3523 0	Cross;Wilderness Ditch;23271								4	
-2986 3523 0	2986 3520 0	Cross;Wilderness Ditch;23271								4	
-2987 3520 0	2987 3523 0	Cross;Wilderness Ditch;23271								4	
-2987 3523 0	2987 3520 0	Cross;Wilderness Ditch;23271								4	
-2988 3520 0	2988 3523 0	Cross;Wilderness Ditch;23271								4	
-2988 3523 0	2988 3520 0	Cross;Wilderness Ditch;23271								4	
-2989 3520 0	2989 3523 0	Cross;Wilderness Ditch;23271								4	
-2989 3523 0	2989 3520 0	Cross;Wilderness Ditch;23271								4	
-2990 3520 0	2990 3523 0	Cross;Wilderness Ditch;23271								4	
-2990 3523 0	2990 3520 0	Cross;Wilderness Ditch;23271								4	
-2991 3520 0	2991 3523 0	Cross;Wilderness Ditch;23271								4	
-2991 3523 0	2991 3520 0	Cross;Wilderness Ditch;23271								4	
-3042 3520 0	3042 3523 0	Cross;Wilderness Ditch;23271								4	
-3042 3523 0	3042 3520 0	Cross;Wilderness Ditch;23271								4	
-3043 3520 0	3043 3523 0	Cross;Wilderness Ditch;23271								4	
-3043 3523 0	3043 3520 0	Cross;Wilderness Ditch;23271								4	
-3044 3520 0	3044 3523 0	Cross;Wilderness Ditch;23271								4	
-3044 3523 0	3044 3520 0	Cross;Wilderness Ditch;23271								4	
-3045 3520 0	3045 3523 0	Cross;Wilderness Ditch;23271								4	
-3045 3523 0	3045 3520 0	Cross;Wilderness Ditch;23271								4	
-3046 3520 0	3046 3523 0	Cross;Wilderness Ditch;23271								4	
-3046 3523 0	3046 3520 0	Cross;Wilderness Ditch;23271								4	
-3047 3520 0	3047 3523 0	Cross;Wilderness Ditch;23271								4	
-3047 3523 0	3047 3520 0	Cross;Wilderness Ditch;23271								4	
-3048 3520 0	3048 3523 0	Cross;Wilderness Ditch;23271								4	
-3048 3523 0	3048 3520 0	Cross;Wilderness Ditch;23271								4	
-3049 3520 0	3049 3523 0	Cross;Wilderness Ditch;23271								4	
-3049 3523 0	3049 3520 0	Cross;Wilderness Ditch;23271								4	
-3050 3520 0	3050 3523 0	Cross;Wilderness Ditch;23271								4	
-3050 3523 0	3050 3520 0	Cross;Wilderness Ditch;23271								4	
-3051 3520 0	3051 3523 0	Cross;Wilderness Ditch;23271								4	
-3051 3523 0	3051 3520 0	Cross;Wilderness Ditch;23271								4	
-3052 3520 0	3052 3523 0	Cross;Wilderness Ditch;23271								4	
-3052 3523 0	3052 3520 0	Cross;Wilderness Ditch;23271								4	
-3053 3520 0	3053 3523 0	Cross;Wilderness Ditch;23271								4	
-3053 3523 0	3053 3520 0	Cross;Wilderness Ditch;23271								4	
-3054 3520 0	3054 3523 0	Cross;Wilderness Ditch;23271								4	
-3054 3523 0	3054 3520 0	Cross;Wilderness Ditch;23271								4	
-3055 3520 0	3055 3523 0	Cross;Wilderness Ditch;23271								4	
-3055 3523 0	3055 3520 0	Cross;Wilderness Ditch;23271								4	
-3056 3520 0	3056 3523 0	Cross;Wilderness Ditch;23271								4	
-3056 3523 0	3056 3520 0	Cross;Wilderness Ditch;23271								4	
-3057 3520 0	3057 3523 0	Cross;Wilderness Ditch;23271								4	
-3057 3523 0	3057 3520 0	Cross;Wilderness Ditch;23271								4	
-3058 3520 0	3058 3523 0	Cross;Wilderness Ditch;23271								4	
-3058 3523 0	3058 3520 0	Cross;Wilderness Ditch;23271								4	
-3059 3520 0	3059 3523 0	Cross;Wilderness Ditch;23271								4	
-3059 3523 0	3059 3520 0	Cross;Wilderness Ditch;23271								4	
-3060 3520 0	3060 3523 0	Cross;Wilderness Ditch;23271								4	
-3060 3523 0	3060 3520 0	Cross;Wilderness Ditch;23271								4	
-3061 3520 0	3061 3523 0	Cross;Wilderness Ditch;23271								4	
-3061 3523 0	3061 3520 0	Cross;Wilderness Ditch;23271								4	
-3062 3520 0	3062 3523 0	Cross;Wilderness Ditch;23271								4	
-3062 3523 0	3062 3520 0	Cross;Wilderness Ditch;23271								4	
-3063 3520 0	3063 3523 0	Cross;Wilderness Ditch;23271								4	
-3063 3523 0	3063 3520 0	Cross;Wilderness Ditch;23271								4	
-3064 3520 0	3064 3523 0	Cross;Wilderness Ditch;23271								4	
-3064 3523 0	3064 3520 0	Cross;Wilderness Ditch;23271								4	
-3065 3520 0	3065 3523 0	Cross;Wilderness Ditch;23271								4	
-3065 3523 0	3065 3520 0	Cross;Wilderness Ditch;23271								4	
-3066 3520 0	3066 3523 0	Cross;Wilderness Ditch;23271								4	
-3066 3523 0	3066 3520 0	Cross;Wilderness Ditch;23271								4	
-3067 3520 0	3067 3523 0	Cross;Wilderness Ditch;23271								4	
-3067 3523 0	3067 3520 0	Cross;Wilderness Ditch;23271								4	
-3068 3520 0	3068 3523 0	Cross;Wilderness Ditch;23271								4	
-3068 3523 0	3068 3520 0	Cross;Wilderness Ditch;23271								4	
-3069 3520 0	3069 3523 0	Cross;Wilderness Ditch;23271								4	
-3069 3523 0	3069 3520 0	Cross;Wilderness Ditch;23271								4	
-3070 3520 0	3070 3523 0	Cross;Wilderness Ditch;23271								4	
-3070 3523 0	3070 3520 0	Cross;Wilderness Ditch;23271								4	
-3071 3520 0	3071 3523 0	Cross;Wilderness Ditch;23271								4	
-3071 3523 0	3071 3520 0	Cross;Wilderness Ditch;23271								4	
-3072 3520 0	3072 3523 0	Cross;Wilderness Ditch;23271								4	
-3072 3523 0	3072 3520 0	Cross;Wilderness Ditch;23271								4	
-3073 3520 0	3073 3523 0	Cross;Wilderness Ditch;23271								4	
-3073 3523 0	3073 3520 0	Cross;Wilderness Ditch;23271								4	
-3074 3520 0	3074 3523 0	Cross;Wilderness Ditch;23271								4	
-3074 3523 0	3074 3520 0	Cross;Wilderness Ditch;23271								4	
-3075 3520 0	3075 3523 0	Cross;Wilderness Ditch;23271								4	
-3075 3523 0	3075 3520 0	Cross;Wilderness Ditch;23271								4	
-3076 3520 0	3076 3523 0	Cross;Wilderness Ditch;23271								4	
-3076 3523 0	3076 3520 0	Cross;Wilderness Ditch;23271								4	
-3077 3520 0	3077 3523 0	Cross;Wilderness Ditch;23271								4	
-3077 3523 0	3077 3520 0	Cross;Wilderness Ditch;23271								4	
-3078 3520 0	3078 3523 0	Cross;Wilderness Ditch;23271								4	
-3078 3523 0	3078 3520 0	Cross;Wilderness Ditch;23271								4	
-3079 3520 0	3079 3523 0	Cross;Wilderness Ditch;23271								4	
-3079 3523 0	3079 3520 0	Cross;Wilderness Ditch;23271								4	
-3080 3520 0	3080 3523 0	Cross;Wilderness Ditch;23271								4	
-3080 3523 0	3080 3520 0	Cross;Wilderness Ditch;23271								4	
-3081 3520 0	3081 3523 0	Cross;Wilderness Ditch;23271								4	
-3081 3523 0	3081 3520 0	Cross;Wilderness Ditch;23271								4	
-3082 3520 0	3082 3523 0	Cross;Wilderness Ditch;23271								4	
-3082 3523 0	3082 3520 0	Cross;Wilderness Ditch;23271								4	
-3083 3520 0	3083 3523 0	Cross;Wilderness Ditch;23271								4	
-3083 3523 0	3083 3520 0	Cross;Wilderness Ditch;23271								4	
-3084 3520 0	3084 3523 0	Cross;Wilderness Ditch;23271								4	
-3084 3523 0	3084 3520 0	Cross;Wilderness Ditch;23271								4	
-3085 3520 0	3085 3523 0	Cross;Wilderness Ditch;23271								4	
-3085 3523 0	3085 3520 0	Cross;Wilderness Ditch;23271								4	
-3086 3520 0	3086 3523 0	Cross;Wilderness Ditch;23271								4	
-3086 3523 0	3086 3520 0	Cross;Wilderness Ditch;23271								4	
-3087 3520 0	3087 3523 0	Cross;Wilderness Ditch;23271								4	
-3087 3523 0	3087 3520 0	Cross;Wilderness Ditch;23271								4	
-3088 3520 0	3088 3523 0	Cross;Wilderness Ditch;23271								4	
-3088 3523 0	3088 3520 0	Cross;Wilderness Ditch;23271								4	
-3089 3520 0	3089 3523 0	Cross;Wilderness Ditch;23271								4	
-3089 3523 0	3089 3520 0	Cross;Wilderness Ditch;23271								4	
-3090 3520 0	3090 3523 0	Cross;Wilderness Ditch;23271								4	
-3090 3523 0	3090 3520 0	Cross;Wilderness Ditch;23271								4	
-3091 3520 0	3091 3523 0	Cross;Wilderness Ditch;23271								4	
-3091 3523 0	3091 3520 0	Cross;Wilderness Ditch;23271								4	
-3092 3520 0	3092 3523 0	Cross;Wilderness Ditch;23271								4	
-3092 3523 0	3092 3520 0	Cross;Wilderness Ditch;23271								4	
-3093 3520 0	3093 3523 0	Cross;Wilderness Ditch;23271								4	
-3093 3523 0	3093 3520 0	Cross;Wilderness Ditch;23271								4	
-3094 3520 0	3094 3523 0	Cross;Wilderness Ditch;23271								4	
-3094 3523 0	3094 3520 0	Cross;Wilderness Ditch;23271								4	
-3095 3520 0	3095 3523 0	Cross;Wilderness Ditch;23271								4	
-3095 3523 0	3095 3520 0	Cross;Wilderness Ditch;23271								4	
-3096 3520 0	3096 3523 0	Cross;Wilderness Ditch;23271								4	
-3096 3523 0	3096 3520 0	Cross;Wilderness Ditch;23271								4	
-3097 3520 0	3097 3523 0	Cross;Wilderness Ditch;23271								4	
-3097 3523 0	3097 3520 0	Cross;Wilderness Ditch;23271								4	
-3098 3520 0	3098 3523 0	Cross;Wilderness Ditch;23271								4	
-3098 3523 0	3098 3520 0	Cross;Wilderness Ditch;23271								4	
-3099 3520 0	3099 3523 0	Cross;Wilderness Ditch;23271								4	
-3099 3523 0	3099 3520 0	Cross;Wilderness Ditch;23271								4	
-3100 3520 0	3100 3523 0	Cross;Wilderness Ditch;23271								4	
-3100 3523 0	3100 3520 0	Cross;Wilderness Ditch;23271								4	
-3101 3520 0	3101 3523 0	Cross;Wilderness Ditch;23271								4	
-3101 3523 0	3101 3520 0	Cross;Wilderness Ditch;23271								4	
-3102 3520 0	3102 3523 0	Cross;Wilderness Ditch;23271								4	
-3102 3523 0	3102 3520 0	Cross;Wilderness Ditch;23271								4	
-3103 3520 0	3103 3523 0	Cross;Wilderness Ditch;23271								4	
-3103 3523 0	3103 3520 0	Cross;Wilderness Ditch;23271								4	
-3104 3520 0	3104 3523 0	Cross;Wilderness Ditch;23271								4	
-3104 3523 0	3104 3520 0	Cross;Wilderness Ditch;23271								4	
-3105 3520 0	3105 3523 0	Cross;Wilderness Ditch;23271								4	
-3105 3523 0	3105 3520 0	Cross;Wilderness Ditch;23271								4	
-3106 3520 0	3106 3523 0	Cross;Wilderness Ditch;23271								4	
-3106 3523 0	3106 3520 0	Cross;Wilderness Ditch;23271								4	
-3107 3520 0	3107 3523 0	Cross;Wilderness Ditch;23271								4	
-3107 3523 0	3107 3520 0	Cross;Wilderness Ditch;23271								4	
-3108 3520 0	3108 3523 0	Cross;Wilderness Ditch;23271								4	
-3108 3523 0	3108 3520 0	Cross;Wilderness Ditch;23271								4	
-3109 3520 0	3109 3523 0	Cross;Wilderness Ditch;23271								4	
-3109 3523 0	3109 3520 0	Cross;Wilderness Ditch;23271								4	
-3110 3520 0	3110 3523 0	Cross;Wilderness Ditch;23271								4	
-3110 3523 0	3110 3520 0	Cross;Wilderness Ditch;23271								4	
-3111 3520 0	3111 3523 0	Cross;Wilderness Ditch;23271								4	
-3111 3523 0	3111 3520 0	Cross;Wilderness Ditch;23271								4	
-3112 3520 0	3112 3523 0	Cross;Wilderness Ditch;23271								4	
-3112 3523 0	3112 3520 0	Cross;Wilderness Ditch;23271								4	
-3113 3520 0	3113 3523 0	Cross;Wilderness Ditch;23271								4	
-3113 3523 0	3113 3520 0	Cross;Wilderness Ditch;23271								4	
-3114 3520 0	3114 3523 0	Cross;Wilderness Ditch;23271								4	
-3114 3523 0	3114 3520 0	Cross;Wilderness Ditch;23271								4	
-3115 3520 0	3115 3523 0	Cross;Wilderness Ditch;23271								4	
-3115 3523 0	3115 3520 0	Cross;Wilderness Ditch;23271								4	
-3116 3520 0	3116 3523 0	Cross;Wilderness Ditch;23271								4	
-3116 3523 0	3116 3520 0	Cross;Wilderness Ditch;23271								4	
-3117 3520 0	3117 3523 0	Cross;Wilderness Ditch;23271								4	
-3117 3523 0	3117 3520 0	Cross;Wilderness Ditch;23271								4	
-3118 3520 0	3118 3523 0	Cross;Wilderness Ditch;23271								4	
-3118 3523 0	3118 3520 0	Cross;Wilderness Ditch;23271								4	
-3119 3520 0	3119 3523 0	Cross;Wilderness Ditch;23271								4	
-3119 3523 0	3119 3520 0	Cross;Wilderness Ditch;23271								4	
-3120 3520 0	3120 3523 0	Cross;Wilderness Ditch;23271								4	
-3120 3523 0	3120 3520 0	Cross;Wilderness Ditch;23271								4	
-3121 3520 0	3121 3523 0	Cross;Wilderness Ditch;23271								4	
-3121 3523 0	3121 3520 0	Cross;Wilderness Ditch;23271								4	
-3122 3520 0	3122 3523 0	Cross;Wilderness Ditch;23271								4	
-3122 3523 0	3122 3520 0	Cross;Wilderness Ditch;23271								4	
-3136 3520 0	3136 3523 0	Cross;Wilderness Ditch;23271								4	
-3136 3523 0	3136 3520 0	Cross;Wilderness Ditch;23271								4	
-3137 3520 0	3137 3523 0	Cross;Wilderness Ditch;23271								4	
-3137 3523 0	3137 3520 0	Cross;Wilderness Ditch;23271								4	
-3138 3520 0	3138 3523 0	Cross;Wilderness Ditch;23271								4	
-3138 3523 0	3138 3520 0	Cross;Wilderness Ditch;23271								4	
-3139 3520 0	3139 3523 0	Cross;Wilderness Ditch;23271								4	
-3139 3523 0	3139 3520 0	Cross;Wilderness Ditch;23271								4	
-3140 3520 0	3140 3523 0	Cross;Wilderness Ditch;23271								4	
-3140 3523 0	3140 3520 0	Cross;Wilderness Ditch;23271								4	
-3141 3520 0	3141 3523 0	Cross;Wilderness Ditch;23271								4	
-3141 3523 0	3141 3520 0	Cross;Wilderness Ditch;23271								4	
-3142 3520 0	3142 3523 0	Cross;Wilderness Ditch;23271								4	
-3142 3523 0	3142 3520 0	Cross;Wilderness Ditch;23271								4	
-3143 3520 0	3143 3523 0	Cross;Wilderness Ditch;23271								4	
-3143 3523 0	3143 3520 0	Cross;Wilderness Ditch;23271								4	
-3144 3520 0	3144 3523 0	Cross;Wilderness Ditch;23271								4	
-3144 3523 0	3144 3520 0	Cross;Wilderness Ditch;23271								4	
-3145 3520 0	3145 3523 0	Cross;Wilderness Ditch;23271								4	
-3145 3523 0	3145 3520 0	Cross;Wilderness Ditch;23271								4	
-3146 3520 0	3146 3523 0	Cross;Wilderness Ditch;23271								4	
-3146 3523 0	3146 3520 0	Cross;Wilderness Ditch;23271								4	
-3147 3520 0	3147 3523 0	Cross;Wilderness Ditch;23271								4	
-3147 3523 0	3147 3520 0	Cross;Wilderness Ditch;23271								4	
-3148 3520 0	3148 3523 0	Cross;Wilderness Ditch;23271								4	
-3148 3523 0	3148 3520 0	Cross;Wilderness Ditch;23271								4	
-3149 3520 0	3149 3523 0	Cross;Wilderness Ditch;23271								4	
-3149 3523 0	3149 3520 0	Cross;Wilderness Ditch;23271								4	
-3150 3520 0	3150 3523 0	Cross;Wilderness Ditch;23271								4	
-3150 3523 0	3150 3520 0	Cross;Wilderness Ditch;23271								4	
-3151 3520 0	3151 3523 0	Cross;Wilderness Ditch;23271								4	
-3151 3523 0	3151 3520 0	Cross;Wilderness Ditch;23271								4	
-3152 3520 0	3152 3523 0	Cross;Wilderness Ditch;23271								4	
-3152 3523 0	3152 3520 0	Cross;Wilderness Ditch;23271								4	
-3153 3520 0	3153 3523 0	Cross;Wilderness Ditch;23271								4	
-3153 3523 0	3153 3520 0	Cross;Wilderness Ditch;23271								4	
-3154 3520 0	3154 3523 0	Cross;Wilderness Ditch;23271								4	
-3154 3523 0	3154 3520 0	Cross;Wilderness Ditch;23271								4	
-3155 3520 0	3155 3523 0	Cross;Wilderness Ditch;23271								4	
-3155 3523 0	3155 3520 0	Cross;Wilderness Ditch;23271								4	
-3156 3520 0	3156 3523 0	Cross;Wilderness Ditch;23271								4	
-3156 3523 0	3156 3520 0	Cross;Wilderness Ditch;23271								4	
-3157 3520 0	3157 3523 0	Cross;Wilderness Ditch;23271								4	
-3157 3523 0	3157 3520 0	Cross;Wilderness Ditch;23271								4	
-3158 3520 0	3158 3523 0	Cross;Wilderness Ditch;23271								4	
-3158 3523 0	3158 3520 0	Cross;Wilderness Ditch;23271								4	
-3159 3520 0	3159 3523 0	Cross;Wilderness Ditch;23271								4	
-3159 3523 0	3159 3520 0	Cross;Wilderness Ditch;23271								4	
-3160 3520 0	3160 3523 0	Cross;Wilderness Ditch;23271								4	
-3160 3523 0	3160 3520 0	Cross;Wilderness Ditch;23271								4	
-3161 3520 0	3161 3523 0	Cross;Wilderness Ditch;23271								4	
-3161 3523 0	3161 3520 0	Cross;Wilderness Ditch;23271								4	
-3162 3520 0	3162 3523 0	Cross;Wilderness Ditch;23271								4	
-3162 3523 0	3162 3520 0	Cross;Wilderness Ditch;23271								4	
-3163 3520 0	3163 3523 0	Cross;Wilderness Ditch;23271								4	
-3163 3523 0	3163 3520 0	Cross;Wilderness Ditch;23271								4	
-3164 3520 0	3164 3523 0	Cross;Wilderness Ditch;23271								4	
-3164 3523 0	3164 3520 0	Cross;Wilderness Ditch;23271								4	
-3165 3520 0	3165 3523 0	Cross;Wilderness Ditch;23271								4	
-3165 3523 0	3165 3520 0	Cross;Wilderness Ditch;23271								4	
-3166 3520 0	3166 3523 0	Cross;Wilderness Ditch;23271								4	
-3166 3523 0	3166 3520 0	Cross;Wilderness Ditch;23271								4	
-3167 3520 0	3167 3523 0	Cross;Wilderness Ditch;23271								4	
-3167 3523 0	3167 3520 0	Cross;Wilderness Ditch;23271								4	
-3168 3520 0	3168 3523 0	Cross;Wilderness Ditch;23271								4	
-3168 3523 0	3168 3520 0	Cross;Wilderness Ditch;23271								4	
-3169 3520 0	3169 3523 0	Cross;Wilderness Ditch;23271								4	
-3169 3523 0	3169 3520 0	Cross;Wilderness Ditch;23271								4	
-3170 3520 0	3170 3523 0	Cross;Wilderness Ditch;23271								4	
-3170 3523 0	3170 3520 0	Cross;Wilderness Ditch;23271								4	
-3171 3520 0	3171 3523 0	Cross;Wilderness Ditch;23271								4	
-3171 3523 0	3171 3520 0	Cross;Wilderness Ditch;23271								4	
-3172 3520 0	3172 3523 0	Cross;Wilderness Ditch;23271								4	
-3172 3523 0	3172 3520 0	Cross;Wilderness Ditch;23271								4	
-3173 3520 0	3173 3523 0	Cross;Wilderness Ditch;23271								4	
-3173 3523 0	3173 3520 0	Cross;Wilderness Ditch;23271								4	
-3174 3520 0	3174 3523 0	Cross;Wilderness Ditch;23271								4	
-3174 3523 0	3174 3520 0	Cross;Wilderness Ditch;23271								4	
-3175 3520 0	3175 3523 0	Cross;Wilderness Ditch;23271								4	
-3175 3523 0	3175 3520 0	Cross;Wilderness Ditch;23271								4	
-3176 3520 0	3176 3523 0	Cross;Wilderness Ditch;23271								4	
-3176 3523 0	3176 3520 0	Cross;Wilderness Ditch;23271								4	
-3177 3520 0	3177 3523 0	Cross;Wilderness Ditch;23271								4	
-3177 3523 0	3177 3520 0	Cross;Wilderness Ditch;23271								4	
-3178 3520 0	3178 3523 0	Cross;Wilderness Ditch;23271								4	
-3178 3523 0	3178 3520 0	Cross;Wilderness Ditch;23271								4	
-3179 3520 0	3179 3523 0	Cross;Wilderness Ditch;23271								4	
-3179 3523 0	3179 3520 0	Cross;Wilderness Ditch;23271								4	
-3180 3520 0	3180 3523 0	Cross;Wilderness Ditch;23271								4	
-3180 3523 0	3180 3520 0	Cross;Wilderness Ditch;23271								4	
-3181 3520 0	3181 3523 0	Cross;Wilderness Ditch;23271								4	
-3181 3523 0	3181 3520 0	Cross;Wilderness Ditch;23271								4	
-3182 3520 0	3182 3523 0	Cross;Wilderness Ditch;23271								4	
-3182 3523 0	3182 3520 0	Cross;Wilderness Ditch;23271								4	
-3183 3520 0	3183 3523 0	Cross;Wilderness Ditch;23271								4	
-3183 3523 0	3183 3520 0	Cross;Wilderness Ditch;23271								4	
-3184 3520 0	3184 3523 0	Cross;Wilderness Ditch;23271								4	
-3184 3523 0	3184 3520 0	Cross;Wilderness Ditch;23271								4	
-3185 3520 0	3185 3523 0	Cross;Wilderness Ditch;23271								4	
-3185 3523 0	3185 3520 0	Cross;Wilderness Ditch;23271								4	
-3186 3520 0	3186 3523 0	Cross;Wilderness Ditch;23271								4	
-3186 3523 0	3186 3520 0	Cross;Wilderness Ditch;23271								4	
-3187 3520 0	3187 3523 0	Cross;Wilderness Ditch;23271								4	
-3187 3523 0	3187 3520 0	Cross;Wilderness Ditch;23271								4	
-3188 3520 0	3188 3523 0	Cross;Wilderness Ditch;23271								4	
-3188 3523 0	3188 3520 0	Cross;Wilderness Ditch;23271								4	
-3189 3520 0	3189 3523 0	Cross;Wilderness Ditch;23271								4	
-3189 3523 0	3189 3520 0	Cross;Wilderness Ditch;23271								4	
-3190 3520 0	3190 3523 0	Cross;Wilderness Ditch;23271								4	
-3190 3523 0	3190 3520 0	Cross;Wilderness Ditch;23271								4	
-3191 3520 0	3191 3523 0	Cross;Wilderness Ditch;23271								4	
-3191 3523 0	3191 3520 0	Cross;Wilderness Ditch;23271								4	
-3192 3520 0	3192 3523 0	Cross;Wilderness Ditch;23271								4	
-3192 3523 0	3192 3520 0	Cross;Wilderness Ditch;23271								4	
-3193 3520 0	3193 3523 0	Cross;Wilderness Ditch;23271								4	
-3193 3523 0	3193 3520 0	Cross;Wilderness Ditch;23271								4	
-3194 3520 0	3194 3523 0	Cross;Wilderness Ditch;23271								4	
-3194 3523 0	3194 3520 0	Cross;Wilderness Ditch;23271								4	
-3195 3520 0	3195 3523 0	Cross;Wilderness Ditch;23271								4	
-3195 3523 0	3195 3520 0	Cross;Wilderness Ditch;23271								4	
-3196 3520 0	3196 3523 0	Cross;Wilderness Ditch;23271								4	
-3196 3523 0	3196 3520 0	Cross;Wilderness Ditch;23271								4	
-3197 3520 0	3197 3523 0	Cross;Wilderness Ditch;23271								4	
-3197 3523 0	3197 3520 0	Cross;Wilderness Ditch;23271								4	
-3198 3520 0	3198 3523 0	Cross;Wilderness Ditch;23271								4	
-3198 3523 0	3198 3520 0	Cross;Wilderness Ditch;23271								4	
-3199 3520 0	3199 3523 0	Cross;Wilderness Ditch;23271								4	
-3199 3523 0	3199 3520 0	Cross;Wilderness Ditch;23271								4	
-3200 3520 0	3200 3523 0	Cross;Wilderness Ditch;23271								4	
-3200 3523 0	3200 3520 0	Cross;Wilderness Ditch;23271								4	
-3201 3520 0	3201 3523 0	Cross;Wilderness Ditch;23271								4	
-3201 3523 0	3201 3520 0	Cross;Wilderness Ditch;23271								4	
-3202 3520 0	3202 3523 0	Cross;Wilderness Ditch;23271								4	
-3202 3523 0	3202 3520 0	Cross;Wilderness Ditch;23271								4	
-3203 3520 0	3203 3523 0	Cross;Wilderness Ditch;23271								4	
-3203 3523 0	3203 3520 0	Cross;Wilderness Ditch;23271								4	
-3204 3520 0	3204 3523 0	Cross;Wilderness Ditch;23271								4	
-3204 3523 0	3204 3520 0	Cross;Wilderness Ditch;23271								4	
-3205 3520 0	3205 3523 0	Cross;Wilderness Ditch;23271								4	
-3205 3523 0	3205 3520 0	Cross;Wilderness Ditch;23271								4	
-3206 3520 0	3206 3523 0	Cross;Wilderness Ditch;23271								4	
-3206 3523 0	3206 3520 0	Cross;Wilderness Ditch;23271								4	
-3207 3520 0	3207 3523 0	Cross;Wilderness Ditch;23271								4	
-3207 3523 0	3207 3520 0	Cross;Wilderness Ditch;23271								4	
-3208 3520 0	3208 3523 0	Cross;Wilderness Ditch;23271								4	
-3208 3523 0	3208 3520 0	Cross;Wilderness Ditch;23271								4	
-3209 3520 0	3209 3523 0	Cross;Wilderness Ditch;23271								4	
-3209 3523 0	3209 3520 0	Cross;Wilderness Ditch;23271								4	
-3210 3520 0	3210 3523 0	Cross;Wilderness Ditch;23271								4	
-3210 3523 0	3210 3520 0	Cross;Wilderness Ditch;23271								4	
-3211 3520 0	3211 3523 0	Cross;Wilderness Ditch;23271								4	
-3211 3523 0	3211 3520 0	Cross;Wilderness Ditch;23271								4	
-3212 3520 0	3212 3523 0	Cross;Wilderness Ditch;23271								4	
-3212 3523 0	3212 3520 0	Cross;Wilderness Ditch;23271								4	
-3213 3520 0	3213 3523 0	Cross;Wilderness Ditch;23271								4	
-3213 3523 0	3213 3520 0	Cross;Wilderness Ditch;23271								4	
-3214 3520 0	3214 3523 0	Cross;Wilderness Ditch;23271								4	
-3214 3523 0	3214 3520 0	Cross;Wilderness Ditch;23271								4	
-3215 3520 0	3215 3523 0	Cross;Wilderness Ditch;23271								4	
-3215 3523 0	3215 3520 0	Cross;Wilderness Ditch;23271								4	
-3216 3520 0	3216 3523 0	Cross;Wilderness Ditch;23271								4	
-3216 3523 0	3216 3520 0	Cross;Wilderness Ditch;23271								4	
-3217 3520 0	3217 3523 0	Cross;Wilderness Ditch;23271								4	
-3217 3523 0	3217 3520 0	Cross;Wilderness Ditch;23271								4	
-3218 3520 0	3218 3523 0	Cross;Wilderness Ditch;23271								4	
-3218 3523 0	3218 3520 0	Cross;Wilderness Ditch;23271								4	
-3219 3520 0	3219 3523 0	Cross;Wilderness Ditch;23271								4	
-3219 3523 0	3219 3520 0	Cross;Wilderness Ditch;23271								4	
-3220 3520 0	3220 3523 0	Cross;Wilderness Ditch;23271								4	
-3220 3523 0	3220 3520 0	Cross;Wilderness Ditch;23271								4	
-3221 3520 0	3221 3523 0	Cross;Wilderness Ditch;23271								4	
-3221 3523 0	3221 3520 0	Cross;Wilderness Ditch;23271								4	
-3222 3520 0	3222 3523 0	Cross;Wilderness Ditch;23271								4	
-3222 3523 0	3222 3520 0	Cross;Wilderness Ditch;23271								4	
-3223 3520 0	3223 3523 0	Cross;Wilderness Ditch;23271								4	
-3223 3523 0	3223 3520 0	Cross;Wilderness Ditch;23271								4	
-3224 3520 0	3224 3523 0	Cross;Wilderness Ditch;23271								4	
-3224 3523 0	3224 3520 0	Cross;Wilderness Ditch;23271								4	
-3225 3520 0	3225 3523 0	Cross;Wilderness Ditch;23271								4	
-3225 3523 0	3225 3520 0	Cross;Wilderness Ditch;23271								4	
-3226 3520 0	3226 3523 0	Cross;Wilderness Ditch;23271								4	
-3226 3523 0	3226 3520 0	Cross;Wilderness Ditch;23271								4	
-3227 3520 0	3227 3523 0	Cross;Wilderness Ditch;23271								4	
-3227 3523 0	3227 3520 0	Cross;Wilderness Ditch;23271								4	
-3228 3520 0	3228 3523 0	Cross;Wilderness Ditch;23271								4	
-3228 3523 0	3228 3520 0	Cross;Wilderness Ditch;23271								4	
-3229 3520 0	3229 3523 0	Cross;Wilderness Ditch;23271								4	
-3229 3523 0	3229 3520 0	Cross;Wilderness Ditch;23271								4	
-3230 3520 0	3230 3523 0	Cross;Wilderness Ditch;23271								4	
-3230 3523 0	3230 3520 0	Cross;Wilderness Ditch;23271								4	
-3231 3520 0	3231 3523 0	Cross;Wilderness Ditch;23271								4	
-3231 3523 0	3231 3520 0	Cross;Wilderness Ditch;23271								4	
-3232 3520 0	3232 3523 0	Cross;Wilderness Ditch;23271								4	
-3232 3523 0	3232 3520 0	Cross;Wilderness Ditch;23271								4	
-3233 3520 0	3233 3523 0	Cross;Wilderness Ditch;23271								4	
-3233 3523 0	3233 3520 0	Cross;Wilderness Ditch;23271								4	
-3234 3520 0	3234 3523 0	Cross;Wilderness Ditch;23271								4	
-3234 3523 0	3234 3520 0	Cross;Wilderness Ditch;23271								4	
-3235 3520 0	3235 3523 0	Cross;Wilderness Ditch;23271								4	
-3235 3523 0	3235 3520 0	Cross;Wilderness Ditch;23271								4	
-3236 3520 0	3236 3523 0	Cross;Wilderness Ditch;23271								4	
-3236 3523 0	3236 3520 0	Cross;Wilderness Ditch;23271								4	
-3237 3520 0	3237 3523 0	Cross;Wilderness Ditch;23271								4	
-3237 3523 0	3237 3520 0	Cross;Wilderness Ditch;23271								4	
-3238 3520 0	3238 3523 0	Cross;Wilderness Ditch;23271								4	
-3238 3523 0	3238 3520 0	Cross;Wilderness Ditch;23271								4	
-3239 3520 0	3239 3523 0	Cross;Wilderness Ditch;23271								4	
-3239 3523 0	3239 3520 0	Cross;Wilderness Ditch;23271								4	
-3240 3520 0	3240 3523 0	Cross;Wilderness Ditch;23271								4	
-3240 3523 0	3240 3520 0	Cross;Wilderness Ditch;23271								4	
-3241 3520 0	3241 3523 0	Cross;Wilderness Ditch;23271								4	
-3241 3523 0	3241 3520 0	Cross;Wilderness Ditch;23271								4	
-3242 3520 0	3242 3523 0	Cross;Wilderness Ditch;23271								4	
-3242 3523 0	3242 3520 0	Cross;Wilderness Ditch;23271								4	
-3243 3520 0	3243 3523 0	Cross;Wilderness Ditch;23271								4	
-3243 3523 0	3243 3520 0	Cross;Wilderness Ditch;23271								4	
-3244 3520 0	3244 3523 0	Cross;Wilderness Ditch;23271								4	
-3244 3523 0	3244 3520 0	Cross;Wilderness Ditch;23271								4	
-3245 3520 0	3245 3523 0	Cross;Wilderness Ditch;23271								4	
-3245 3523 0	3245 3520 0	Cross;Wilderness Ditch;23271								4	
-3246 3520 0	3246 3523 0	Cross;Wilderness Ditch;23271								4	
-3246 3523 0	3246 3520 0	Cross;Wilderness Ditch;23271								4	
-3247 3520 0	3247 3523 0	Cross;Wilderness Ditch;23271								4	
-3247 3523 0	3247 3520 0	Cross;Wilderness Ditch;23271								4	
-3248 3520 0	3248 3523 0	Cross;Wilderness Ditch;23271								4	
-3248 3523 0	3248 3520 0	Cross;Wilderness Ditch;23271								4	
-3249 3520 0	3249 3523 0	Cross;Wilderness Ditch;23271								4	
-3249 3523 0	3249 3520 0	Cross;Wilderness Ditch;23271								4	
-3250 3520 0	3250 3523 0	Cross;Wilderness Ditch;23271								4	
-3250 3523 0	3250 3520 0	Cross;Wilderness Ditch;23271								4	
-3251 3520 0	3251 3523 0	Cross;Wilderness Ditch;23271								4	
-3251 3523 0	3251 3520 0	Cross;Wilderness Ditch;23271								4	
-3252 3520 0	3252 3523 0	Cross;Wilderness Ditch;23271								4	
-3252 3523 0	3252 3520 0	Cross;Wilderness Ditch;23271								4	
-3253 3520 0	3253 3523 0	Cross;Wilderness Ditch;23271								4	
-3253 3523 0	3253 3520 0	Cross;Wilderness Ditch;23271								4	
-3254 3520 0	3254 3523 0	Cross;Wilderness Ditch;23271								4	
-3254 3523 0	3254 3520 0	Cross;Wilderness Ditch;23271								4	
-3255 3520 0	3255 3523 0	Cross;Wilderness Ditch;23271								4	
-3255 3523 0	3255 3520 0	Cross;Wilderness Ditch;23271								4	
-3256 3520 0	3256 3523 0	Cross;Wilderness Ditch;23271								4	
-3256 3523 0	3256 3520 0	Cross;Wilderness Ditch;23271								4	
-3257 3520 0	3257 3523 0	Cross;Wilderness Ditch;23271								4	
-3257 3523 0	3257 3520 0	Cross;Wilderness Ditch;23271								4	
-3258 3520 0	3258 3523 0	Cross;Wilderness Ditch;23271								4	
-3258 3523 0	3258 3520 0	Cross;Wilderness Ditch;23271								4	
-3259 3520 0	3259 3523 0	Cross;Wilderness Ditch;23271								4	
-3259 3523 0	3259 3520 0	Cross;Wilderness Ditch;23271								4	
-3260 3520 0	3260 3523 0	Cross;Wilderness Ditch;23271								4	
-3260 3523 0	3260 3520 0	Cross;Wilderness Ditch;23271								4	
-3261 3520 0	3261 3523 0	Cross;Wilderness Ditch;23271								4	
-3261 3523 0	3261 3520 0	Cross;Wilderness Ditch;23271								4	
-3262 3520 0	3262 3523 0	Cross;Wilderness Ditch;23271								4	
-3262 3523 0	3262 3520 0	Cross;Wilderness Ditch;23271								4	
-3263 3520 0	3263 3523 0	Cross;Wilderness Ditch;23271								4	
-3263 3523 0	3263 3520 0	Cross;Wilderness Ditch;23271								4	
-3264 3520 0	3264 3523 0	Cross;Wilderness Ditch;23271								4	
-3264 3523 0	3264 3520 0	Cross;Wilderness Ditch;23271								4	
-3265 3520 0	3265 3523 0	Cross;Wilderness Ditch;23271								4	
-3265 3523 0	3265 3520 0	Cross;Wilderness Ditch;23271								4	
-3266 3520 0	3266 3523 0	Cross;Wilderness Ditch;23271								4	
-3266 3523 0	3266 3520 0	Cross;Wilderness Ditch;23271								4	
-3267 3520 0	3267 3523 0	Cross;Wilderness Ditch;23271								4	
-3267 3523 0	3267 3520 0	Cross;Wilderness Ditch;23271								4	
-3268 3520 0	3268 3523 0	Cross;Wilderness Ditch;23271								4	
-3268 3523 0	3268 3520 0	Cross;Wilderness Ditch;23271								4	
-3269 3520 0	3269 3523 0	Cross;Wilderness Ditch;23271								4	
-3269 3523 0	3269 3520 0	Cross;Wilderness Ditch;23271								4	
-3270 3520 0	3270 3523 0	Cross;Wilderness Ditch;23271								4	
-3270 3523 0	3270 3520 0	Cross;Wilderness Ditch;23271								4	
-3271 3520 0	3271 3523 0	Cross;Wilderness Ditch;23271								4	
-3271 3523 0	3271 3520 0	Cross;Wilderness Ditch;23271								4	
-3272 3520 0	3272 3523 0	Cross;Wilderness Ditch;23271								4	
-3272 3523 0	3272 3520 0	Cross;Wilderness Ditch;23271								4	
-3273 3520 0	3273 3523 0	Cross;Wilderness Ditch;23271								4	
-3273 3523 0	3273 3520 0	Cross;Wilderness Ditch;23271								4	
-3274 3520 0	3274 3523 0	Cross;Wilderness Ditch;23271								4	
-3274 3523 0	3274 3520 0	Cross;Wilderness Ditch;23271								4	
-3275 3520 0	3275 3523 0	Cross;Wilderness Ditch;23271								4	
-3275 3523 0	3275 3520 0	Cross;Wilderness Ditch;23271								4	
-3276 3520 0	3276 3523 0	Cross;Wilderness Ditch;23271								4	
-3276 3523 0	3276 3520 0	Cross;Wilderness Ditch;23271								4	
-3277 3520 0	3277 3523 0	Cross;Wilderness Ditch;23271								4	
-3277 3523 0	3277 3520 0	Cross;Wilderness Ditch;23271								4	
-3278 3520 0	3278 3523 0	Cross;Wilderness Ditch;23271								4	
-3278 3523 0	3278 3520 0	Cross;Wilderness Ditch;23271								4	
-3279 3520 0	3279 3523 0	Cross;Wilderness Ditch;23271								4	
-3279 3523 0	3279 3520 0	Cross;Wilderness Ditch;23271								4	
-3280 3520 0	3280 3523 0	Cross;Wilderness Ditch;23271								4	
-3280 3523 0	3280 3520 0	Cross;Wilderness Ditch;23271								4	
-3281 3520 0	3281 3523 0	Cross;Wilderness Ditch;23271								4	
-3281 3523 0	3281 3520 0	Cross;Wilderness Ditch;23271								4	
-3282 3520 0	3282 3523 0	Cross;Wilderness Ditch;23271								4	
-3282 3523 0	3282 3520 0	Cross;Wilderness Ditch;23271								4	
-3283 3520 0	3283 3523 0	Cross;Wilderness Ditch;23271								4	
-3283 3523 0	3283 3520 0	Cross;Wilderness Ditch;23271								4	
-3284 3520 0	3284 3523 0	Cross;Wilderness Ditch;23271								4	
-3284 3523 0	3284 3520 0	Cross;Wilderness Ditch;23271								4	
-3285 3520 0	3285 3523 0	Cross;Wilderness Ditch;23271								4	
-3285 3523 0	3285 3520 0	Cross;Wilderness Ditch;23271								4	
-3286 3520 0	3286 3523 0	Cross;Wilderness Ditch;23271								4	
-3286 3523 0	3286 3520 0	Cross;Wilderness Ditch;23271								4	
-3287 3520 0	3287 3523 0	Cross;Wilderness Ditch;23271								4	
-3287 3523 0	3287 3520 0	Cross;Wilderness Ditch;23271								4	
-3288 3520 0	3288 3523 0	Cross;Wilderness Ditch;23271								4	
-3288 3523 0	3288 3520 0	Cross;Wilderness Ditch;23271								4	
-3289 3520 0	3289 3523 0	Cross;Wilderness Ditch;23271								4	
-3289 3523 0	3289 3520 0	Cross;Wilderness Ditch;23271								4	
-3290 3520 0	3290 3523 0	Cross;Wilderness Ditch;23271								4	
-3290 3523 0	3290 3520 0	Cross;Wilderness Ditch;23271								4	
-3291 3520 0	3291 3523 0	Cross;Wilderness Ditch;23271								4	
-3291 3523 0	3291 3520 0	Cross;Wilderness Ditch;23271								4	
-3292 3520 0	3292 3523 0	Cross;Wilderness Ditch;23271								4	
-3292 3523 0	3292 3520 0	Cross;Wilderness Ditch;23271								4	
-3293 3520 0	3293 3523 0	Cross;Wilderness Ditch;23271								4	
-3293 3523 0	3293 3520 0	Cross;Wilderness Ditch;23271								4	
-3294 3520 0	3294 3523 0	Cross;Wilderness Ditch;23271								4	
-3294 3523 0	3294 3520 0	Cross;Wilderness Ditch;23271								4	
-3295 3520 0	3295 3523 0	Cross;Wilderness Ditch;23271								4	
-3295 3523 0	3295 3520 0	Cross;Wilderness Ditch;23271								4	
-3296 3520 0	3296 3523 0	Cross;Wilderness Ditch;23271								4	
-3296 3523 0	3296 3520 0	Cross;Wilderness Ditch;23271								4	
-3297 3520 0	3297 3523 0	Cross;Wilderness Ditch;23271								4	
-3297 3523 0	3297 3520 0	Cross;Wilderness Ditch;23271								4	
-3298 3520 0	3298 3523 0	Cross;Wilderness Ditch;23271								4	
-3298 3523 0	3298 3520 0	Cross;Wilderness Ditch;23271								4	
-3299 3520 0	3299 3523 0	Cross;Wilderness Ditch;23271								4	
-3299 3523 0	3299 3520 0	Cross;Wilderness Ditch;23271								4	
-3300 3520 0	3300 3523 0	Cross;Wilderness Ditch;23271								4	
-3300 3523 0	3300 3520 0	Cross;Wilderness Ditch;23271								4	
-3301 3520 0	3301 3523 0	Cross;Wilderness Ditch;23271								4	
-3301 3523 0	3301 3520 0	Cross;Wilderness Ditch;23271								4	
-3302 3520 0	3302 3523 0	Cross;Wilderness Ditch;23271								4	
-3302 3523 0	3302 3520 0	Cross;Wilderness Ditch;23271								4	
-3303 3520 0	3303 3523 0	Cross;Wilderness Ditch;23271								4	
-3303 3523 0	3303 3520 0	Cross;Wilderness Ditch;23271								4	
-3304 3520 0	3304 3523 0	Cross;Wilderness Ditch;23271								4	
-3304 3523 0	3304 3520 0	Cross;Wilderness Ditch;23271								4	
-3305 3520 0	3305 3523 0	Cross;Wilderness Ditch;23271								4	
-3305 3523 0	3305 3520 0	Cross;Wilderness Ditch;23271								4	
-3306 3520 0	3306 3523 0	Cross;Wilderness Ditch;23271								4	
-3306 3523 0	3306 3520 0	Cross;Wilderness Ditch;23271								4	
-3307 3520 0	3307 3523 0	Cross;Wilderness Ditch;23271								4	
-3307 3523 0	3307 3520 0	Cross;Wilderness Ditch;23271								4	
-3308 3520 0	3308 3523 0	Cross;Wilderness Ditch;23271								4	
-3308 3523 0	3308 3520 0	Cross;Wilderness Ditch;23271								4	
-3309 3520 0	3309 3523 0	Cross;Wilderness Ditch;23271								4	
-3309 3523 0	3309 3520 0	Cross;Wilderness Ditch;23271								4	
-3310 3520 0	3310 3523 0	Cross;Wilderness Ditch;23271								4	
-3310 3523 0	3310 3520 0	Cross;Wilderness Ditch;23271								4	
-3311 3520 0	3311 3523 0	Cross;Wilderness Ditch;23271								4	
-3311 3523 0	3311 3520 0	Cross;Wilderness Ditch;23271								4	
-3312 3520 0	3312 3523 0	Cross;Wilderness Ditch;23271								4	
-3312 3523 0	3312 3520 0	Cross;Wilderness Ditch;23271								4	
-3313 3520 0	3313 3523 0	Cross;Wilderness Ditch;23271								4	
-3313 3523 0	3313 3520 0	Cross;Wilderness Ditch;23271								4	
-3314 3520 0	3314 3523 0	Cross;Wilderness Ditch;23271								4	
-3314 3523 0	3314 3520 0	Cross;Wilderness Ditch;23271								4	
-3315 3520 0	3315 3523 0	Cross;Wilderness Ditch;23271								4	
-3315 3523 0	3315 3520 0	Cross;Wilderness Ditch;23271								4	
-3316 3520 0	3316 3523 0	Cross;Wilderness Ditch;23271								4	
-3316 3523 0	3316 3520 0	Cross;Wilderness Ditch;23271								4	
-3317 3520 0	3317 3523 0	Cross;Wilderness Ditch;23271								4	
-3317 3523 0	3317 3520 0	Cross;Wilderness Ditch;23271								4	
-3318 3520 0	3318 3523 0	Cross;Wilderness Ditch;23271								4	
-3318 3523 0	3318 3520 0	Cross;Wilderness Ditch;23271								4	
-3319 3520 0	3319 3523 0	Cross;Wilderness Ditch;23271								4	
-3319 3523 0	3319 3520 0	Cross;Wilderness Ditch;23271								4	
-3320 3520 0	3320 3523 0	Cross;Wilderness Ditch;23271								4	
-3320 3523 0	3320 3520 0	Cross;Wilderness Ditch;23271								4	
-3321 3520 0	3321 3523 0	Cross;Wilderness Ditch;23271								4	
-3321 3523 0	3321 3520 0	Cross;Wilderness Ditch;23271								4	
-3322 3520 0	3322 3523 0	Cross;Wilderness Ditch;23271								4	
-3322 3523 0	3322 3520 0	Cross;Wilderness Ditch;23271								4	
-3323 3520 0	3323 3523 0	Cross;Wilderness Ditch;23271								4	
-3323 3523 0	3323 3520 0	Cross;Wilderness Ditch;23271								4	
-3324 3520 0	3324 3523 0	Cross;Wilderness Ditch;23271								4	
-3324 3523 0	3324 3520 0	Cross;Wilderness Ditch;23271								4	
-3325 3520 0	3325 3523 0	Cross;Wilderness Ditch;23271								4	
-3325 3523 0	3325 3520 0	Cross;Wilderness Ditch;23271								4	
-3326 3520 0	3326 3523 0	Cross;Wilderness Ditch;23271								4	
-3326 3523 0	3326 3520 0	Cross;Wilderness Ditch;23271								4	
-3327 3520 0	3327 3523 0	Cross;Wilderness Ditch;23271								4	
-3327 3523 0	3327 3520 0	Cross;Wilderness Ditch;23271								4	
-3328 3520 0	3328 3523 0	Cross;Wilderness Ditch;23271								4	
-3328 3523 0	3328 3520 0	Cross;Wilderness Ditch;23271								4	
-3329 3520 0	3329 3523 0	Cross;Wilderness Ditch;23271								4	
-3329 3523 0	3329 3520 0	Cross;Wilderness Ditch;23271								4	
-											
-# Nardah											
-3409 2932 0	3409 2932 1	Climb-up;Ladder;10493								2	
-3409 2932 1	3409 2932 0	Climb-down;Ladder;10494								2	
-3429 2905 0	3429 2905 1	Climb-up;Ladder;10493								2	
-3429 2905 1	3429 2905 0	Climb-down;Ladder;10494								2	
-3426 2901 0	3426 2901 1	Climb-up;Ladder;10493								2	
-3426 2901 1	3426 2901 0	Climb-down;Ladder;10494								2	
-3439 2892 1	3439 2892 0	Climb-down;Ladder;10494								2	
-3439 2892 0	3439 2892 1	Climb-up;Ladder;10493								2	
-3449 2898 0	3449 2898 1	Climb-up;Ladder;10493								2	
-3449 2898 1	3449 2898 0	Climb-down;Ladder;10494								2	
-3445 2911 0	3449 2911 1	Climb-up;Staircase;10525								1	
-3449 2911 1	3445 2911 0	Climb-down;Staircase;10526								1	
-3445 2912 0	3449 2911 1	Climb-up;Staircase;10525								1	
-3449 2912 1	3445 2911 0	Climb-down;Staircase;10526								1	
-3417 2905 1	3417 2905 0	Climb-down;Ladder;10494								2	
-3417 2905 0	3417 2905 1	Climb-up;Ladder;10493								2	
-3403 2926 0	3403 2926 1	Climb-up;Ladder;10493								2	
-3403 2926 1	3403 2926 0	Climb-down;Ladder;10494								2	
-3371 9312 0	3371 9313 0	Open;Door;10431								1	
-3371 9313 0	3371 9312 0	Open;Door;10431								1	
-3371 9312 0	3371 9313 0	Open;Door;10431								1	
-3371 9313 0	3371 9312 0	Open;Door;10431								1	
-3373 9304 0	3375 2904 0	Climb;Rope;10434									
-3375 2904 0	3374 9305 0	Climb-down;Crevice;10416									
-3374 9305 0	3375 2904 0	Climb;Rope;10434									
-3375 2905 0	3374 9305 0	Climb-down;Crevice;10416									
-3373 9306 0	3375 2904 0	Climb;Rope;10434									
-3375 2906 0	3374 9305 0	Climb-down;Crevice;10416									
-3372 9305 0	3375 2904 0	Climb;Rope;10434									
-3374 2903 0	3374 9305 0	Climb-down;Crevice;10416									
-3374 2902 0	3374 9305 0	Climb-down;Crevice;10416									
-3372 2902 0	3374 9305 0	Climb-down;Crevice;10416									
-3372 2903 0	3374 9305 0	Climb-down;Crevice;10416									
-3372 2904 0	3374 9305 0	Climb-down;Crevice;10416									
-3372 2905 0	3374 9305 0	Climb-down;Crevice;10416									
-3372 2906 0	3374 9305 0	Climb-down;Crevice;10416									
-3372 2907 0	3374 9305 0	Climb-down;Crevice;10416									
-3374 2907 0	3374 9305 0	Climb-down;Crevice;10416									
-											
-# Agility Pyramid											
-3334 2829 0	3338 2829 0	Climb;Climbing rocks;11948									
-3338 2829 0	3334 2829 0	Climb;Climbing rocks;11948									
-3334 2828 0	3338 2828 0	Climb;Climbing rocks;11948									
-3338 2828 0	3334 2828 0	Climb;Climbing rocks;11948									
-3334 2827 0	3338 2827 0	Climb;Climbing rocks;11948									
-3338 2827 0	3334 2827 0	Climb;Climbing rocks;11948									
-3338 2826 0	3334 2826 0	Climb;Climbing rocks;11948									
-3334 2826 0	3338 2826 0	Climb;Climbing rocks;11948									
-3348 2829 0	3352 2829 0	Climb;Climbing rocks;11949									
-3352 2829 0	3348 2829 0	Climb;Climbing rocks;11949									
-3348 2828 0	3352 2828 0	Climb;Climbing rocks;11949									
-3352 2828 0	3348 2828 0	Climb;Climbing rocks;11949									
-3348 2827 0	3352 2827 0	Climb;Climbing rocks;11949									
-3352 2827 0	3348 2827 0	Climb;Climbing rocks;11949									
-											
-# Sophanem											
-3284 2810 0	3283 2809 0	Open;Gate;20391								1	
-3283 2809 0	3283 2810 0	Open;Gate;20391								1	
-3283 2810 0	3283 2809 0	Open;Gate;20391								1	
-3284 2809 0	3283 2810 0	Open;Gate;20391								1	
-3317 2786 1	3317 2788 0	Climb-down;Ladder;20354								2	
-3317 2788 0	3317 2786 1	Climb-up;Ladder;20353								2	
-3317 2784 1	3317 2782 2	Climb-up;Ladder;20353								2	
-3317 2782 2	3317 2784 1	Climb-down;Ladder;20354								2	
-3316 2766 1	3316 2768 0	Climb-down;Ladder;20354								2	
-3316 2768 0	3316 2766 1	Climb-up;Ladder;20353								2	
-3315 2777 1	3315 2775 2	Climb-up;Ladder;20353								2	
-3315 2775 2	3315 2777 1	Climb-down;Ladder;20354								2	
-3314 2755 0	3314 2753 1	Climb-up;Ladder;20353								2	
-3314 2753 1	3314 2755 0	Climb-down;Ladder;20354								2	
-3315 2796 0	2800 5160 0	Climb-down;Ladder;20275								2	
-2799 5160 0	3315 2796 0	Climb-up;Ladder;20277								2	
-2800 5160 0	3318 9273 2	Climb-down;Ladder;20278								2	
-3318 9273 2	2800 5160 0	Climb-up;Ladder;20281								2	
-3286 9275 2	3286 9273 0	Climb-down;Ladder;20285								2	
-3286 9273 0	3286 9275 2	Climb-up;Ladder;20284								2	
-3323 9240 0	3323 9242 2	Climb-up;Ladder;20284								2	
-3323 9242 2	3323 9240 0	Climb-down;Ladder;20285								2	
-3317 9251 0	3317 9249 2	Climb-up;Ladder;20284								2	
-3317 9249 2	3317 9251 0	Climb-down;Ladder;20285								2	
-3317 9223 0	3317 9225 2	Climb-up;Ladder;20284								2	
-3317 9225 2	3317 9223 0	Climb-down;Ladder;20285								2	
-3268 9228 2	3257 9226 0	Climb-down;Ladder;20287								2	
-3257 9226 0	3268 9228 2	Climb-up;Ladder;20286								2	
-3267 9220 2	3267 9222 0	Climb-down;Ladder;20285								2	
-3267 9222 0	3267 9220 2	Climb-up;Ladder;20284								2	
-3270 9274 2	3272 9274 0	Climb-down;Ladder;20285								2	
-3272 9274 0	3270 9274 2	Climb-up;Ladder;20284								2	
-3272 9235 2	3270 9235 0	Climb-down;Ladder;20285								2	
-3270 9235 0	3272 9235 2	Climb-up;Ladder;20284								2	
-3280 9254 0	3280 9256 2	Climb-up;Ladder;20284								2	
-3280 9256 2	3280 9254 0	Climb-down;Ladder;20285								2	
-3307 2803 2	3309 2803 0	Climb-down;Ladder;20357								2	
-3309 2803 0	3307 2803 2	Climb-up;Ladder;20356								2	
-3283 2756 0	3283 2754 1	Climb-up;Ladder;20353								2	
-3283 2754 1	3283 2756 0	Climb-down;Ladder;20354								2	
-3281 2754 2	3281 2756 1	Climb-down;Ladder;20354								2	
-3281 2756 1	3281 2754 2	Climb-up;Ladder;20353								2	
-3277 2768 0	3279 2768 1	Climb-up;Ladder;20353								2	
-3279 2768 1	3277 2768 0	Climb-down;Ladder;20354								2	
-3285 2768 0	3283 2768 1	Climb-up;Ladder;20353								2	
-3283 2768 1	3285 2768 0	Climb-down;Ladder;20354								2	
-3283 2772 1	3283 2770 3	Climb-up;Ladder;20356								2	
-3283 2770 3	3283 2772 1	Climb-down;Ladder;20357								2	
-3279 2772 1	3279 2770 3	Climb-up;Ladder;20356								2	
-3279 2770 3	3279 2772 1	Climb-down;Ladder;20357								2	
-3320 2796 0	3321 2858 0	Climb-through;Hole;6620									
-3322 2858 0	3319 2796 0	Enter;Rock;6621									
-3322 2859 0	3319 2796 0	Enter;Rock;6621									
-3323 2860 0	3319 2796 0	Enter;Rock;6621									
-3324 2860 0	3319 2796 0	Enter;Rock;6621									
-3322 2857 0	3319 2796 0	Enter;Rock;6621									
-3323 2856 0	3319 2796 0	Enter;Rock;6621									
-3324 2856 0	3319 2796 0	Enter;Rock;6621									
-3325 2856 0	3319 2796 0	Enter;Rock;6621									
-3325 2860 0	3319 2796 0	Enter;Rock;6621									
-3326 2859 0	3319 2796 0	Enter;Rock;6621									
-3326 2857 0	3319 2796 0	Enter;Rock;6621									
-3326 2858 0	3319 2796 0	Enter;Rock;6621									
-											
-# Pyramid											
-3233 2900 0	3233 2898 0	Open;Pyramid entrance;6545									
-3232 2900 0	3232 2898 0	Open;Pyramid entrance;6547									
-3233 2898 0	3233 2900 0	Open;Pyramid entrance;6545									
-3232 2898 0	3232 2900 0	Open;Pyramid entrance;6547									
-3232 2897 0	2913 4954 3	Climb-down;Ladder;6497								2	
-2913 4954 3	3233 2898 0	Climb-up;Ladder;6504								2	
-3233 2898 0	2913 4954 3	Climb-down;Ladder;6497								2	
-2914 4953 3	3233 2898 0	Climb-up;Ladder;6504								2	
-3234 2897 0	2913 4954 3	Climb-down;Ladder;6497								2	
-2912 4953 3	3233 2898 0	Climb-up;Ladder;6504								2	
-3233 2896 0	2913 4954 3	Climb-down;Ladder;6497								2	
-2913 4952 3	3233 2898 0	Climb-up;Ladder;6504								2	
-2909 4965 3	2846 4964 2	Climb-down;Ladder;6498								2	
-2846 4964 2	2909 4965 3	Climb-up;Ladder;6503								2	
-2908 4964 3	2846 4964 2	Climb-down;Ladder;6498								2	
-2845 4965 2	2909 4965 3	Climb-up;Ladder;6503								2	
-2910 4964 3	2846 4964 2	Climb-down;Ladder;6498								2	
-2845 4963 2	2909 4965 3	Climb-up;Ladder;6503								2	
-2909 4963 3	2846 4964 2	Climb-down;Ladder;6498								2	
-2844 4964 2	2909 4965 3	Climb-up;Ladder;6503								2	
-3233 2887 0	3233 9313 0	Enter;Tunnel;6481									
-3233 9323 0	3233 9325 0	Open;Doorway;6555									
-3233 9325 0	3233 9323 0	Open;Doorway;6555									
-3234 9323 0	3234 9325 0	Open;Doorway;6553									
-3234 9325 0	3234 9323 0	Open;Doorway;6553									
-3233 9293 0	2783 4941 1	Climb-up;Ladder;6501								2	
-2783 4941 1	3233 9293 0	Climb-down;Ladder;6500								2	
-3232 9294 0	2783 4941 1	Climb-up;Ladder;6501								2	
-2784 4942 1	3233 9293 0	Climb-down;Ladder;6500								2	
-3232 9292 0	2783 4941 1	Climb-up;Ladder;6501								2	
-3231 9293 0	2783 4941 1	Climb-up;Ladder;6501								2	
-2785 4941 1	3233 9293 0	Climb-down;Ladder;6500								2	
-2784 4940 1	3233 9293 0	Climb-down;Ladder;6500								2	
-2782 4972 1	2845 4973 2	Climb-up;Ladder;6502								2	
-2845 4973 2	2782 4972 1	Climb-down;Ladder;6499								2	
-2781 4973 1	2845 4973 2	Climb-up;Ladder;6502								2	
-2782 4974 1	2845 4973 2	Climb-up;Ladder;6502								2	
-2783 4973 1	2845 4973 2	Climb-up;Ladder;6502								2	
-											
-# Kalphite Lair											
-3226 3108 0	3483 9510 2	Climb-down;Tunnel entrance;3827									
-3483 9510 2	3226 3108 0	Climb-up;Rope;3829									
-3226 3109 0	3483 9510 2	Climb-down;Tunnel entrance;3827									
-3227 3110 0	3483 9510 2	Climb-down;Tunnel entrance;3827									
-3228 3110 0	3483 9510 2	Climb-down;Tunnel entrance;3827									
-3227 3107 0	3483 9510 2	Climb-down;Tunnel entrance;3827									
-3228 3107 0	3483 9510 2	Climb-down;Tunnel entrance;3827									
-3229 3109 0	3483 9510 2	Climb-down;Tunnel entrance;3827									
-3229 3108 0	3483 9510 2	Climb-down;Tunnel entrance;3827									
-3484 9510 2	3226 3108 0	Climb-up;Rope;3829									
-3483 9509 2	3226 3108 0	Climb-up;Rope;3829									
-3514 9521 2	2711 5206 0	Enter;Tunnel;23596									
-2711 5206 0	3514 9521 2	Enter;Blocked tunnel;22656									
-3514 9520 2	2711 5206 0	Enter;Tunnel;23596									
-2711 5207 0	3514 9520 2	Enter;Blocked tunnel;22657									
-3508 9498 2	3508 9493 0	Climb-down;Tunnel entrance;23609									
-3508 9493 0	3508 9497 2	Climb-up;Rope;3832									
-3508 9497 2	3508 9493 0	Climb-down;Tunnel entrance;23609									
-3507 9494 0	3508 9497 2	Climb-up;Rope;3832									
-3509 9496 2	3508 9493 0	Climb-down;Tunnel entrance;23609									
-3510 9496 2	3508 9493 0	Climb-down;Tunnel entrance;23609									
-3508 9494 0	3508 9497 2	Climb-up;Rope;3832									
-3509 9499 2	3508 9493 0	Climb-down;Tunnel entrance;23609									
-3510 9499 2	3508 9493 0	Climb-down;Tunnel entrance;23609									
-3511 9497 2	3508 9493 0	Climb-down;Tunnel entrance;23609									
-3511 9498 2	3508 9493 0	Climb-down;Tunnel entrance;23609									
-											
-# Dorgesh-Kaan											
-2715 5241 0	2719 5241 3	Climb-up;Ladder;22600								2	
-2719 5241 3	2715 5241 0	Climb-down;Ladder top;22666								2	
-											
-# Uzer											
-3491 3090 0	2721 4886 0	Climb-down;Staircase;6373								1	
-2721 4886 0	3491 3090 0	Climb-up;Staircase;6372								1	
-2720 4885 0	3491 3090 0	Climb-up;Staircase;6372								1	
-2720 4884 0	3491 3090 0	Climb-up;Staircase;6372								1	
-2722 4886 0	3491 3090 0	Climb-up;Staircase;6372								1	
-2723 4885 0	3491 3090 0	Climb-up;Staircase;6372								1	
-2723 4884 0	3491 3090 0	Climb-up;Staircase;6372								1	
-2722 4883 0	3491 3090 0	Climb-up;Staircase;6372								1	
-2721 4883 0	3491 3090 0	Climb-up;Staircase;6372								1	
-2719 4913 0	2720 4884 2	Enter;Door;6310								1	
-2721 4911 0	2720 4884 2	Enter;Door;6310								1	
-2720 4911 0	2720 4884 2	Enter;Door;6310								1	
-2719 4912 0	2720 4884 2	Enter;Door;6310								1	
-2722 4911 0	2720 4884 2	Enter;Door;6310								1	
-2723 4911 0	2720 4884 2	Enter;Door;6310								1	
-2724 4912 0	2720 4884 2	Enter;Door;6310								1	
-2724 4913 0	2720 4884 2	Enter;Door;6310								1	
-2723 4914 0	2720 4884 2	Enter;Door;6310								1	
-2722 4914 0	2720 4884 2	Enter;Door;6310								1	
-2721 4914 0	2720 4884 2	Enter;Door;6310								1	
-2720 4914 0	2720 4884 2	Enter;Door;6310								1	
-											
-# River Elid Dungeon											
-3371 3129 0	3349 9536 0	Use;Rope -> Root;6382									
-3349 9536 0	3371 3129 0	Leave;Cave exit;10417									
-											
-# Pollnivneach											
-3364 3002 0	3364 3002 1	Climb-up;Ladder;6261								2	
-3364 3002 1	3364 3002 0	Climb-down;Ladder;6260								2	
-3368 2991 0	3368 2991 1	Climb-up;Ladder;6261								2	
-3368 2991 1	3368 2991 0	Climb-down;Ladder;6260								2	
-3349 2963 1	3349 2963 0	Climb-down;Ladder;6260								2	
-3356 2982 1	3356 2982 2	Climb-up;Ladder;6261								2	
-3356 2982 2	3356 2982 1	Climb-down;Ladder;6260								2	
-3370 2971 0	3371 2971 0	Open;Door;6238								1	
-3371 2971 0	3370 2971 0	Open;Door;6238								1	
-3370 2970 0	3371 2970 0	Open;Door;6240								1	
-3371 2970 0	3370 2970 0	Open;Door;6240								1	
-3373 2977 0	3374 2979 1	Climb-up;Staircase;6244								1	
-3374 2979 1	3373 2977 0	Climb-down;Staircase;6245								1	
-3374 2978 1	3373 2977 0	Climb-down;Staircase;6245								1	
-3353 2961 0	3354 2958 1	Climb-up;Staircase;6242								1	
-3354 2958 1	3353 2961 0	Climb-down;Staircase;6243								1	
-3354 2959 1	3353 2961 0	Climb-down;Staircase;6243								1	
-											
-# Smoke Dungeon											
-3310 2961 0	3206 9379 0	Climb-down;Smokey well;6279									
-3206 9379 0	3310 2961 0	Climb-up;Rope;6439									
-3309 2962 0	3206 9379 0	Climb-down;Smokey well;6279									
-3205 9380 0	3310 2961 0	Climb-up;Rope;6439									
-3311 2962 0	3206 9379 0	Climb-down;Smokey well;6279									
-3204 9379 0	3310 2961 0	Climb-up;Rope;6439									
-3310 2963 0	3206 9379 0	Climb-down;Smokey well;6279									
-3205 9378 0	3310 2961 0	Climb-up;Rope;6439									
-3304 9376 0	3305 9376 0	Open;Gate;6452									
-3305 9376 0	3304 9376 0	Open;Gate;6452									
-3304 9375 0	3305 9375 0	Open;Gate;6451									
-3305 9375 0	3304 9375 0	Open;Gate;6451									
-											
-# Kalphite Cave											
-3321 3122 0	3305 9497 0	Enter;Cave;30180									
-3305 9497 0	3321 3122 0	Use;Crevice;26712									
-											
-# Mos Le'Harmless											
-3696 2996 0	3696 2996 1	Climb-up;Bamboo Ladder;4772									
-3696 2996 1	3696 2996 0	Climb-down;Bamboo Ladder;4778									
-3653 2991 1	3653 2991 0	Climb-down;Bamboo Ladder;4778									
-3653 2991 0	3653 2991 1	Climb-up;Bamboo Ladder;4772									
-3664 2992 1	3664 2992 0	Climb-down;Bamboo Ladder;4778									
-3664 2992 0	3664 2992 1	Climb-up;Bamboo Ladder;4772									
-3667 2983 0	3667 2983 1	Climb-up;Bamboo Ladder;4772									
-3667 2983 1	3667 2983 0	Climb-down;Bamboo Ladder;4778									
-3669 2977 0	3669 2977 1	Climb-up;Bamboo Ladder;4772									
-3669 2977 1	3669 2977 0	Climb-down;Bamboo Ladder;4778									
-3684 2953 0	3684 2950 1	Cross;Gangplank;11211								3	
-3684 2950 1	3684 2953 0	Cross;Gangplank;11212								3	
-3685 2950 1	3687 2950 2	Climb-up;Ship's ladder;11289									
-3687 2950 2	3685 2950 1	Climb-down;Ship's ladder;11290									
-3685 2946 1	3687 2946 2	Climb-up;Ship's ladder;11289									
-3687 2946 2	3685 2946 1	Climb-down;Ship's ladder;11290									
-3677 2948 1	3677 2948 0	Climb-down;Ship's ladder;11309									
-3677 2948 0	3677 2948 1	Climb-up;Ship's ladder;11308									
-3671 2931 0	3668 2931 1	Cross;Gangplank;17406								3	
-3668 2931 1	3671 2931 0	Cross;Gangplank;17407								3	
-3749 2973 0	3748 9373 0	Enter;Cave entrance;3650									
-3748 9373 0	3749 2973 0	Exit;Cave;5553									
-3748 9374 0	3749 2973 0	Exit;Cave;6702									
-3814 3061 0	3814 9464 0	Climb-down;Staircase;5270								1	
-3815 3061 0	3814 9464 0	Climb-down;Staircase;5270								1	
-3813 3062 0	3814 9464 0	Climb-down;Staircase;5270								1	
-3816 3062 0	3814 9464 0	Climb-down;Staircase;5270								1	
-3814 9464 0	3814 3061 0	Climb-up;Staircase;5269								1	
-3815 9464 0	3814 3061 0	Climb-up;Staircase;5269								1	
-3813 9463 0	3814 3061 0	Climb-up;Staircase;5269								1	
-3816 9463 0	3814 3061 0	Climb-up;Staircase;5269								1	
-3816 3063 0	3814 9464 0	Climb-down;Staircase;5270								1	
-3813 9462 0	3814 3061 0	Climb-up;Staircase;5269								1	
-3814 9461 0	3814 3061 0	Climb-up;Staircase;5269								1	
-3815 9461 0	3814 3061 0	Climb-up;Staircase;5269								1	
-3816 9462 0	3814 3061 0	Climb-up;Staircase;5269								1	
-											
-# Harmony Island											
-3794 2844 0	3785 9254 0	Climb-down;Statue;22355									
-3785 9254 0	3796 2843 0	Climb;Ladder;22371								2	
-3804 2844 0	3806 2844 0	Open;Door;22119								1	
-3806 2844 0	3804 2844 0	Open;Door;22119								1	
-3816 2847 0	3817 2847 0	Open;Door;22007								1	
-3817 2847 0	3816 2847 0	Open;Door;22007								1	
-3818 2853 1	3818 2851 0	Climb-down;Ladder;22122								2	
-3818 2851 0	3818 2853 1	Climb-up;Ladder;22121								2	
-3816 2841 0	3817 2841 0	Open;Door;22007									
-3817 2841 0	3816 2841 0	Open;Door;22007									
-3787 2821 0	3787 2822 0	Open;Large door;22437									
-3787 2822 0	3787 2821 0	Open;Large door;22437									
-3786 2821 0	3786 2822 0	Open;Large door;22435									
-3786 2822 0	3786 2821 0	Open;Large door;22435									
-3784 2825 0	3784 2825 1	Climb-up;Ladder;22432								2	
-3784 2825 1	3784 2825 0	Climb-down;Ladder;22433								2	
-3784 2825 1	3784 2825 2	Climb-up;Ladder;22433								2	
-3784 2825 2	3784 2825 1	Climb-down;Ladder;22434								2	
-3788 2826 0	3788 9226 0	Climb-down;Ladder;22173								2	
-3788 9226 0	3788 2826 0	Climb-up;Ladder;22172								2	
-3829 3061 0	3829 9464 0	Climb-down;Staircase;5270								1	
-3829 9464 0	3829 3061 0	Climb-up;Staircase;5269								1	
-3830 3061 0	3829 9464 0	Climb-down;Staircase;5270								1	
-3830 9464 0	3829 3061 0	Climb-up;Staircase;5269								1	
-3828 3062 0	3829 9464 0	Climb-down;Staircase;5270								1	
-3828 9463 0	3829 3061 0	Climb-up;Staircase;5269								1	
-3828 3063 0	3829 9464 0	Climb-down;Staircase;5270								1	
-3831 9463 0	3829 3061 0	Climb-up;Staircase;5269								1	
-3829 3064 0	3829 9464 0	Climb-down;Staircase;5270								1	
-3828 9462 0	3829 3061 0	Climb-up;Staircase;5269								1	
-3830 3064 0	3829 9464 0	Climb-down;Staircase;5270								1	
-3829 9461 0	3829 3061 0	Climb-up;Staircase;5269								1	
-3831 3062 0	3829 9464 0	Climb-down;Staircase;5270								1	
-3830 9461 0	3829 3061 0	Climb-up;Staircase;5269								1	
-3831 3063 0	3829 9464 0	Climb-down;Staircase;5270								1	
-3831 9462 0	3829 3061 0	Climb-up;Staircase;5269								1	
-											
-# Mort'ton											
-3495 3465 0	3477 9845 0	Open;Trapdoor;5055									
-3477 9845 0	3495 3465 0	Climb-up;Ladder;5054								2	
-3495 3464 0	3477 9845 0	Open;Trapdoor;5055									
-3478 9846 0	3495 3465 0	Climb-up;Ladder;5054								2	
-3476 9846 0	3495 3465 0	Climb-up;Ladder;5054								2	
-3477 9847 0	3495 3465 0	Climb-up;Ladder;5054								2	
-3502 3432 0	3502 3425 0	Cross-bridge;Tree;5003									
-3502 3425 0	3502 3432 0	Cross-bridge;Tree;5003									
-3503 3431 0	3502 3425 0	Cross-bridge;Tree;5003									
-3501 3426 0	3502 3432 0	Cross-bridge;Tree;5003									
-3485 3322 0	3493 9725 0	Open;Wooden doors;4132								1	
-3484 3322 0	3493 9725 0	Open;Wooden doors;4133								1	
-3493 9726 0	3485 3322 0	Open;Solid bronze door;17900								1	
-# Burgh de Rott											
-3484 3244 0	3484 3243 0	Open;Gate;12817									
-3484 3243 0	3484 3244 0	Open;Gate;12817									
-3485 3244 0	3485 3243 0	Open;Gate;12816									
-3485 3243 0	3485 3244 0	Open;Gate;12816									
-3513 3237 0	3513 3239 2	Climb-up;Ladder;12780								2	
-3513 3239 2	3513 3237 0	Climb-down;Ladder;12781								2	
-3474 3221 0	3473 3221 0	Jump-over;Low fence;12776				In Aid of the Myreque				5	
-3473 3221 0	3475 3221 0	Jump-over;Low fence;12776				In Aid of the Myreque				5	
-3491 3230 0	3491 3231 0	Climb-over;Broken wall;12737								3	
-3491 3231 0	3491 3230 0	Climb-over;Broken wall;12737								3	
-3490 3232 0	3490 9631 0	Climb-down;Trapdoor;12743								2	
-3490 9631 0	3490 3232 0	Climb-up;Ladder;12779								2	
-3582 3264 0	3582 3263 0	Climb-over;Broken fence;18411				In Aid of the Myreque					 
-3582 3263 0	3582 3264 0	Climb-over;Broken fence;18411				In Aid of the Myreque					 
-											
-# Haunted Mine											
-3446 3236 0	3444 3236 0	Climb-over;Mine cart;4918									
-3444 3236 0	3446 3236 0	Climb-over;Mine cart;4918									
-3441 3232 0	3436 9637 0	Crawl-down;Cart tunnel;4913									
-3436 9637 0	3441 3232 0	Crawl-through;Cart tunnel;4920									
-3435 9635 0	2800 4429 0	Crawl-through;Cart tunnel;29332									
-2800 4429 0	3435 9635 0	Crawl-through;Cart tunnel;29333									
-2758 4454 0	2691 4437 0	Walk-up;Stairs;4973									
-2712 4593 0	2691 4437 0	Walk-up;Stairs;4972									
-2712 4592 0	2691 4437 0	Walk-up;Stairs;4972									
-2730 4563 0	2750 4437 0	Walk-up;Stairs;4972									
-2730 4562 0	2750 4437 0	Walk-up;Stairs;4972									
-2691 4437 0	2712 4593 0	Walk-down;Stairs;4971									
-2691 4438 0	2712 4593 0	Walk-down;Stairs;4971									
-2750 4437 0	2730 4563 0	Walk-down;Stairs;4971									
-2750 4438 0	2730 4563 0	Walk-down;Stairs;4971									
-2750 4436 0	2730 4563 0	Walk-down;Stairs;4971									
-2807 4493 0	2725 4452 0	Go-down;Lift;4940									
-2725 4452 0	2807 4493 0	Go-up;Lift;4942									
-2724 4452 0	2807 4493 0	Go-up;Lift;4942									
-2723 4452 0	2807 4493 0	Go-up;Lift;4942									
-2722 4452 0	2807 4493 0	Go-up;Lift;4942									
-2797 4529 0	2733 4529 0	Climb-up;Ladder;4968								2	
-2733 4529 0	2797 4529 0	Climb-down;Ladder;4967								2	
-2796 4528 0	2732 4528 0	Climb-up;Ladder;4968								2	
-2732 4528 0	2796 4528 0	Climb-down;Ladder;4967								2	
-2796 4530 0	2732 4530 0	Climb-up;Ladder;4968								2	
-2731 4529 0	2795 4529 0	Climb-down;Ladder;4967								2	
-2795 4529 0	2731 4529 0	Climb-up;Ladder;4968								2	
-2732 4530 0	2796 4530 0	Climb-down;Ladder;4967								2	
-2733 4534 0	2797 4598 0	Climb-up;Ladder;4970								2	
-2797 4598 0	2733 4534 0	Climb-down;Ladder;4969								2	
-2732 4535 0	2796 4599 0	Climb-up;Ladder;4970								2	
-2796 4599 0	2732 4535 0	Climb-down;Ladder;4969								2	
-2733 4536 0	2797 4600 0	Climb-up;Ladder;4970								2	
-2797 4600 0	2733 4536 0	Climb-down;Ladder;4969								2	
-2734 4535 0	2798 4599 0	Climb-up;Ladder;4970								2	
-2798 4599 0	2734 4535 0	Climb-down;Ladder;4969								2	
-2710 4539 0	2774 4539 0	Climb-down;Ladder;4967								2	
-2774 4539 0	2710 4539 0	Climb-up;Ladder;4968								2	
-2711 4540 0	2775 4540 0	Climb-down;Ladder;4967								2	
-2775 4540 0	2711 4540 0	Climb-up;Ladder;4968								2	
-2709 4540 0	2773 4540 0	Climb-down;Ladder;4967								2	
-2773 4540 0	2709 4540 0	Climb-up;Ladder;4968								2	
-2710 4541 0	2774 4541 0	Climb-down;Ladder;4967								2	
-2774 4541 0	2710 4541 0	Climb-up;Ladder;4968								2	
-2760 4496 0	2696 4496 0	Climb-up;Ladder;4968								2	
-2696 4496 0	2760 4496 0	Climb-down;Ladder;4967								2	
-2761 4497 0	2697 4497 0	Climb-up;Ladder;4968								2	
-2697 4497 0	2761 4497 0	Climb-down;Ladder;4967								2	
-2760 4498 0	2696 4498 0	Climb-up;Ladder;4968								2	
-2696 4498 0	2760 4498 0	Climb-down;Ladder;4967								2	
-2759 4497 0	2695 4497 0	Climb-up;Ladder;4968								2	
-2695 4497 0	2759 4497 0	Climb-down;Ladder;4967								2	
-2773 4578 0	3413 9634 0	Climb-up;Ladder;4966								2	
-3413 9634 0	2773 4578 0	Climb-down;Ladder;4965								2	
-2774 4577 0	3414 9633 0	Climb-up;Ladder;4966								2	
-3414 9633 0	2774 4577 0	Climb-down;Ladder;4965								2	
-2773 4576 0	3413 9632 0	Climb-up;Ladder;4966								2	
-3413 9632 0	2773 4576 0	Climb-down;Ladder;4965								2	
-2772 4577 0	3412 9633 0	Climb-up;Ladder;4966								2	
-3412 9633 0	2772 4577 0	Climb-down;Ladder;4965								2	
-3405 9631 0	3429 3233 0	Crawl-through;Cart tunnel;4921									
-3429 3233 0	3405 9631 0	Crawl-down;Cart tunnel;4914									
-3428 3225 0	3409 9623 0	Crawl-down;Cart tunnel;4915									
-3409 9623 0	3428 3225 0	Crawl-through;Cart tunnel;15830									
-3423 9625 0	2783 4569 0	Climb-down;Ladder;4965								2	
-2783 4569 0	3423 9625 0	Climb-up;Ladder;4966								2	
-3422 9624 0	2782 4568 0	Climb-down;Ladder;4965								2	
-2782 4568 0	3422 9624 0	Climb-up;Ladder;4966								2	
-3421 9625 0	2781 4569 0	Climb-down;Ladder;4965								2	
-2781 4569 0	3421 9625 0	Climb-up;Ladder;4966								2	
-3422 9626 0	2782 4570 0	Climb-down;Ladder;4965								2	
-2782 4570 0	3422 9626 0	Climb-up;Ladder;4966								2	
-2798 4568 0	2734 4504 0	Climb-down;Ladder;4969								2	
-2734 4504 0	2798 4568 0	Climb-up;Ladder;4970								2	
-2797 4567 0	2733 4503 0	Climb-down;Ladder;4969								2	
-2733 4503 0	2797 4567 0	Climb-up;Ladder;4970								2	
-2798 4566 0	2734 4502 0	Climb-down;Ladder;4969								2	
-2734 4502 0	2798 4566 0	Climb-up;Ladder;4970								2	
-2799 4567 0	2735 4503 0	Climb-down;Ladder;4969								2	
-2735 4503 0	2799 4567 0	Climb-up;Ladder;4970								2	
-2724 4486 0	2788 4486 0	Climb-down;Ladder;4967								2	
-2788 4486 0	2724 4486 0	Climb-up;Ladder;4968								2	
-2725 4487 0	2789 4487 0	Climb-down;Ladder;4967								2	
-2789 4487 0	2725 4487 0	Climb-up;Ladder;4968								2	
-2726 4486 0	2790 4486 0	Climb-down;Ladder;4967								2	
-2790 4486 0	2726 4486 0	Climb-up;Ladder;4968								2	
-2725 4485 0	2789 4485 0	Climb-down;Ladder;4967								2	
-2789 4485 0	2725 4485 0	Climb-up;Ladder;4968								2	
-3454 3242 0	2792 4592 0	Walk-down;Stairs;4919									
-2792 4592 0	3454 3242 0	Walk-up;Stairs;4923									
-2791 4592 0	3454 3242 0	Walk-up;Stairs;4923									
-2772 4449 0	2772 4450 0	Open;Large door;4964									
-2773 4449 0	2773 4450 0	Open;Large door;4964									
-2758 4453 0	2691 4437 0	Walk-up;Stairs;4973									
-2811 4454 0	2750 4437 0	Walk-up;Stairs;4973									
-2811 4453 0	2750 4437 0	Walk-up;Stairs;4973									
-2750 4438 0	2811 4454 0	Walk-down;Stairs;4971		4075							
-2750 4437 0	2811 4454 0	Walk-down;Stairs;4971		4075							
-2750 4436 0	2811 4454 0	Walk-down;Stairs;4971		4075							
-2799 4453 0	2798 4453 0	Open;Door;4962									
-2798 4453 0	2799 4453 0	Open;Door;4962									
-2691 4438 0	2758 4454 0	Walk-down;Stairs;4971		4075							
-2691 4437 0	2758 4454 0	Walk-down;Stairs;4971		4075							
-2773 4450 0	2773 4449 0	Open;Large door;4963		4077							
-2772 4450 0	2772 4449 0	Open;Large door;4964		4077							
-											
-# Tarn's Lair											
-3424 9660 0	3166 4547 0	Enter;Entrance;20822									
-3166 4547 0	3424 9660 0	Enter;Passageway;20482									
-3158 4552 0	3158 4557 1	Enter;Passageway;16132									
-3158 4557 1	3158 4552 0	Climb;Stairs;17098									
-3174 4561 1	3179 4561 0	Enter;Passageway;20516									
-3179 4561 0	3174 4561 1	Enter;Passageway;20515									
-3195 4570 0	3195 4575 1	Enter;Passageway;20517									
-3195 4575 1	3195 4570 0	Enter;Passageway;20518									
-3186 4585 1	3186 4578 2	Enter;Passageway;20522									
-3186 4578 2	3186 4585 1	Enter;Passageway;20521									
-3184 4585 1	3184 4579 0	Enter;Passageway;20512									
-3184 4579 0	3184 4585 1	Enter;Passageway;20511									
-3184 4571 0	3184 4566 1	Enter;Passageway;20510									
-3184 4566 1	3184 4571 0	Enter;Passageway;20509									
-3184 4552 0	3184 4557 1	Enter;Passageway;16132									
-3184 4557 1	3184 4552 0	Climb;Stairs;17098									
-3158 4563 1	3158 4568 2	Enter;Passageway;18308									
-3158 4568 2	3158 4563 1	Climb;Stairs;18973									
-3172 4569 1	3167 4569 0	Climb;Stairs;17098									
-3167 4569 0	3172 4569 1	Enter;Passageway;16132									
-3163 4565 0	3163 4560 0	Enter;Passageway;20489									
-3163 4560 0	3163 4565 0	Enter;Passageway;20490									
-3161 4559 0	3155 4559 0	Enter;Passageway;20491									
-3155 4559 0	3161 4559 0	Enter;Passageway;20492									
-3148 4548 0	3143 4548 1	Enter;Passageway;16132									
-3143 4548 1	3148 4548 0	Climb;Stairs;17098									
-3141 4550 1	3141 4555 2	Enter;Passageway;18308									
-3141 4555 2	3141 4550 1	Climb;Stairs;18973									
-3141 4560 2	3141 4565 1	Enter;Passageway;20497									
-3141 4565 1	3141 4560 2	Enter;Passageway;20498									
-3144 4566 1	3144 4571 2	Enter;Passageway;20499									
-3144 4571 2	3144 4566 1	Enter;Passageway;20500									
-3144 4576 2	3144 4574 2	Jump-to;Pillar;20557									
-3144 4574 2	3144 4572 2	Jump-to;Ledge;20568									
-3144 4572 2	3144 4574 2	Jump-to;Pillar;20557									
-3144 4574 2	3144 4576 2	Jump-to;Ledge;20569									
-3144 4577 2	3144 4582 1	Enter;Passageway;20501									
-3144 4582 1	3144 4577 2	Enter;Passageway;20502									
-3146 4583 1	3151 4583 0	Enter;Passageway;20503									
-3151 4583 0	3146 4583 1	Enter;Passageway;20504									
-3161 4577 0	3166 4577 0	Enter;Passageway;20505									
-3166 4577 0	3161 4577 0	Enter;Passageway;20506									
-3170 4577 0	3175 4577 1	Enter;Passageway;20514									
-3175 4577 1	3170 4577 0	Enter;Passageway;20513									
-3176 4577 1	3181 4577 2	Enter;Passageway;18308									
-3181 4577 2	3176 4577 1	Enter;Passageway;19029									
-3189 4577 2	3194 4577 1	Enter;Passageway;20520									
-3194 4577 1	3189 4577 2	Enter;Passageway;20519									
-3184 4564 1	3184 4562 1	Jump-to;Pillar;20541									
-3184 4562 1	3184 4560 1	Jump-to;Pillar;20540									
-3184 4560 1	3184 4558 1	Jump-to;Ledge;20558									
-3184 4558 1	3184 4560 1	Jump-to;Pillar;20540									
-3184 4560 1	3184 4562 1	Jump-to;Pillar;20541									
-3184 4562 1	3184 4564 1	Jump-to;Ledge;20559									
-3168 4579 0	3168 4586 0	Enter;Passageway;20523									
-3168 4586 0	3168 4579 0	Enter;Passageway;20524									
-3168 4592 0	3168 4597 0	Enter;Passageway;20532									
-3168 4597 0	3168 4592 0	Enter;Passageway;20531									
-3160 4598 0	3149 4598 0	Enter;Passageway;20530									
-3149 4598 0	3160 4598 0	Enter;Passageway;20529									
-3145 4594 0	3145 4589 1	Enter;Passageway;20528									
-3145 4589 1	3145 4594 0	Enter;Passageway;20527									
-3161 4589 1	3166 4589 0	Enter;Passageway;20526									
-3166 4589 0	3161 4589 1	Enter;Passageway;20525									
-3150 4597 1	3148 4597 1	Jump-to;Pillar;20542									
-3148 4597 1	3150 4597 1	Jump-to;Ledge;20560									
-3148 4597 1	3148 4595 1	Jump-to;Pillar;20543									
-3148 4595 1	3148 4597 1	Jump-to;Pillar;20542									
-3148 4595 1	3146 4595 1	Jump-to;Pillar;20544									
-3146 4595 1	3148 4595 1	Jump-to;Pillar;20543									
-3146 4595 1	3144 4595 1	Jump-to;Pillar;20545									
-3144 4595 1	3146 4595 1	Jump-to;Pillar;20544									
-3144 4595 1	3142 4595 1	Jump-to;Pillar;20546									
-3142 4595 1	3144 4595 1	Jump-to;Pillar;20545									
-3142 4595 1	3140 4595 1	Jump-to;Ledge;20562									
-3140 4595 1	3142 4595 1	Jump-to;Pillar;20546									
-3144 4595 1	3144 4597 1	Jump-to;Pillar;20547									
-3144 4597 1	3144 4599 1	Jump-to;Pillar;20548									
-3144 4599 1	3144 4601 1	Jump-to;Ledge;20563									
-3144 4601 1	3144 4599 1	Jump-to;Pillar;20548									
-3144 4599 1	3144 4597 1	Jump-to;Pillar;20547									
-3144 4597 1	3144 4595 1	Jump-to;Pillar;20545									
-3175 4598 1	3179 4598 1	Enter;Passageway;20535									
-3179 4598 1	3175 4598 1	Enter;Passageway;20536									
-3180 4596 1	3182 4596 1	Jump-to;Pillar;20549									
-3182 4596 1	3180 4596 1	Jump-to;Ledge;20564									
-3180 4600 1	3182 4600 1	Jump-to;Pillar;20550									
-3182 4600 1	3180 4600 1	Jump-to;Ledge;20565									
-3184 4600 1	3182 4600 1	Jump-to;Pillar;20550									
-3182 4600 1	3184 4600 1	Jump-to;Pillar;20551									
-3184 4600 1	3184 4598 1	Jump-to;Pillar;20552									
-3184 4598 1	3184 4600 1	Jump-to;Pillar;20551									
-3184 4598 1	3186 4598 1	Jump-to;Pillar;20553									
-3186 4598 1	3184 4598 1	Jump-to;Pillar;20552									
-3186 4598 1	3186 4596 1	Jump-to;Pillar;20554									
-3186 4596 1	3186 4598 1	Jump-to;Pillar;20553									
-3186 4596 1	3188 4596 1	Jump-to;Pillar;20555									
-3188 4596 1	3186 4596 1	Jump-to;Pillar;20554									
-3188 4596 1	3190 4596 1	Jump-to;Ledge;20566									
-3190 4596 1	3188 4596 1	Jump-to;Pillar;20555									
-3190 4600 1	3188 4600 1	Jump-to;Pillar;20556									
-3188 4600 1	3190 4600 1	Jump-to;Ledge;20567									
-3194 4598 1	3189 4598 0	Climb;Stairs;17098									
-3189 4598 0	3194 4598 1	Enter;Passageway;16132									
-3185 4601 0	3149 4644 0	Enter;Passageway;20539									
-3149 4644 0	3185 4601 0	Enter;Passageway;15771									
-											
-# Mort Myre											
-3440 3331 0	3441 3329 0	Jump;Bridge;3522									
-3441 3329 0	3440 3331 0	Jump;Bridge;3522									
-3441 3331 0	3441 3329 0	Jump;Bridge;3522									
-3440 3329 0	3440 3331 0	Jump;Bridge;3522									
-3441 3328 0	3440 3331 0	Jump;Bridge;3522									
-3440 3332 0	3441 3329 0	Jump;Bridge;3522									
-3440 3328 0	3440 3331 0	Jump;Bridge;3522									
-3441 3332 0	3441 3329 0	Jump;Bridge;3522									
-3440 3337 0	3442 9734 1	Enter;Grotto;3516									
-3442 9734 1	3440 3337 0	Exit;Grotto;3526									
-3439 3337 0	3442 9734 1	Enter;Grotto;3516									
-3441 3337 0	3442 9734 1	Enter;Grotto;3516									
-3444 3458 0	3444 3457 0	Open;Gate;3506									
-3443 3458 0	3443 3457 0	Open;Gate;3507									
-3444 3457 0	3444 3458 0	Open;Gate;3506									
-3443 3457 0	3443 3458 0	Open;Gate;3507									
-											
-# Paterdomus											
-3405 3506 0	3405 9906 0	Climb-down;Trapdoor;1581									
-3405 9906 0	3405 3506 0	Climb-up;Ladder;17385								2	
-3405 9895 0	3405 9894 0	Open;Gate;3444									
-3405 9894 0	3405 9895 0	Open;Gate;3444									
-3431 9897 0	3432 9897 0	Open;Gate;3445									
-3432 9897 0	3431 9897 0	Open;Gate;3445									
-3360 9904 0	3440 9899 0	Climb-up;Ladder;12764								2	
-3440 9899 0	3360 9904 0	Climb-down;Trapdoor;12762									
-3440 9887 0	3423 3485 0	Pass-through;Holy barrier;3443									
-3423 3485 0	3440 9887 0	Climb-down;Trapdoor;3433									
-3422 3484 0	3440 9887 0	Climb-down;Trapdoor;3433									
-3408 3489 0	3409 3489 0	Open;Large door;3489									
-3409 3489 0	3408 3489 0	Open;Large door;3489									
-3408 3488 0	3409 3488 0	Open;Large door;3490									
-3409 3488 0	3408 3488 0	Open;Large door;3490									
-3417 3494 0	3416 3493 1	Climb-up;Staircase;16671								1	
-3416 3493 1	3417 3494 0	Climb-down;Staircase;16673								1	
-3416 3493 0	3416 3493 1	Climb-up;Staircase;16671								1	
-3416 3492 0	3416 3493 1	Climb-up;Staircase;16671								1	
-3417 3491 0	3416 3493 1	Climb-up;Staircase;16671								1	
-3418 3491 0	3416 3493 1	Climb-up;Staircase;16671								1	
-3416 3485 0	3416 3485 1	Climb-up;Staircase;16671								1	
-3416 3485 1	3417 3486 0	Climb-down;Staircase;16673								1	
-3417 3486 0	3416 3485 1	Climb-up;Staircase;16671								1	
-3418 3486 0	3416 3485 1	Climb-up;Staircase;16671								1	
-3416 3484 0	3416 3485 1	Climb-up;Staircase;16671								1	
-3417 3483 0	3416 3485 1	Climb-up;Staircase;16671								1	
-3410 3486 1	3410 3486 2	Climb-up;Ladder;16683								2	
-3410 3486 2	3410 3486 1	Climb-down;Ladder;16679								2	
-3411 3485 1	3411 3485 2	Climb-up;Ladder;16683								2	
-3411 3485 2	3411 3485 1	Climb-down;Ladder;16679								2	
-3410 3484 1	3410 3484 2	Climb-up;Ladder;16683								2	
-3410 3484 2	3410 3484 1	Climb-down;Ladder;16679								2	
-3409 3485 1	3409 3485 2	Climb-up;Ladder;16683								2	
-3409 3485 2	3409 3485 1	Climb-down;Ladder;16679								2	
-3415 3489 2	3416 3489 2	Open;Cell door;3463									
-3416 3489 2	3415 3489 2	Open;Cell door;3463									
-											
-# Enakhra's Lament											
-3194 2926 0	3124 9328 1	Climb-down;Secret entrance;11046									
-3124 9328 1	3194 2926 0	Climb;Sand pile;10950									
-3195 2925 0	3124 9328 1	Climb-down;Secret entrance;11046									
-3125 9328 1	3194 2926 0	Climb;Sand pile;10950									
-3193 2925 0	3124 9328 1	Climb-down;Secret entrance;11046									
-3126 9329 1	3194 2926 0	Climb;Sand pile;10950									
-3194 2924 0	3124 9328 1	Climb-down;Secret entrance;11046									
-3126 9330 1	3194 2926 0	Climb;Sand pile;10950									
-3127 9328 1	3127 9330 0	Climb-down;Ladder;11042								2	
-3127 9330 0	3127 9330 1	Climb-up;Ladder;11041								2	
-3127 9330 1	3127 9330 0	Climb-down;Ladder;11042								2	
-3128 9329 1	3127 9330 0	Climb-down;Ladder;11042								2	
-3126 9329 1	3127 9330 0	Climb-down;Ladder;11042								2	
-3129 9290 0	3129 9289 0	Open;Door;11070								1	
-3129 9289 0	3129 9290 0	Open;Door;11070								1	
-3122 9286 0	3122 9286 1	Climb-up;Ladder;11041								2	
-3122 9286 1	3122 9286 0	Climb-down;Ladder;11042								2	
-3121 9287 1	3122 9286 0	Climb-down;Ladder;11042								2	
-3120 9286 1	3122 9286 0	Climb-down;Ladder;11042								2	
-3121 9285 1	3122 9286 0	Climb-down;Ladder;11042								2	
-3121 9288 1	3189 2889 0	Climb;Sand pile;10950									
-3189 2889 0	3120 9288 1	Climb-down;Secret entrance;11047									
-3120 9288 1	3189 2889 0	Climb;Sand pile;10950									
-3190 2888 0	3120 9288 1	Climb-down;Secret entrance;11047									
-3122 9289 1	3189 2889 0	Climb;Sand pile;10950									
-3188 2888 0	3120 9288 1	Climb-down;Secret entrance;11047									
-3122 9290 1	3189 2889 0	Climb;Sand pile;10950									
-3189 2887 0	3120 9288 1	Climb-down;Secret entrance;11047									
-3104 9305 0	3104 9306 0	Open;Door;11051								1	
-3104 9306 0	3104 9305 0	Open;Door;11051								1	
-3110 9312 0	3111 9312 0	Open;Door;11057								1	
-3111 9312 0	3110 9312 0	Open;Door;11057								1	
-3104 9318 0	3104 9319 0	Open;Door;11055								1	
-3104 9319 0	3104 9318 0	Open;Door;11055								1	
-3088 9336 1	3088 9336 0	Climb-down;Ladder;11042								2	
-3087 9337 1	3088 9336 0	Climb-down;Ladder;11042								2	
-3086 9336 0	3088 9336 1	Climb-up;Ladder;11041								2	
-3086 9336 1	3088 9336 0	Climb-down;Ladder;11042								2	
-3087 9335 1	3088 9336 0	Climb-down;Ladder;11042								2	
-3088 9335 1	3148 2938 0	Climb;Sand pile;10950									
-3148 2938 0	3086 9333 1	Climb-down;Secret entrance;11045									
-3086 9333 1	3148 2938 0	Climb;Sand pile;10950									
-3149 2937 0	3086 9333 1	Climb-down;Secret entrance;11045									
-3086 9334 1	3148 2938 0	Climb;Sand pile;10950									
-3147 2937 0	3086 9333 1	Climb-down;Secret entrance;11045									
-3087 9335 1	3148 2938 0	Climb;Sand pile;10950									
-3148 2936 0	3086 9333 1	Climb-down;Secret entrance;11045									
-3079 9335 0	3079 9334 0	Open;Door;11068								1	
-3079 9334 0	3079 9335 0	Open;Door;11068								1	
-3079 9307 1	3079 9307 0	Climb-down;Ladder;11042								2	
-3078 9306 1	3079 9307 0	Climb-down;Ladder;11042								2	
-3079 9305 0	3079 9307 1	Climb-up;Ladder;11041								2	
-3079 9305 1	3079 9307 0	Climb-down;Ladder;11042								2	
-3080 9306 1	3079 9307 0	Climb-down;Ladder;11042								2	
-3080 9306 1	3146 2909 0	Climb;Sand pile;10950									
-3146 2909 0	3080 9306 1	Climb-down;Secret entrance;11048									
-3080 9307 1	3146 2909 0	Climb;Sand pile;10950									
-3145 2908 0	3080 9306 1	Climb-down;Secret entrance;11048									
-3081 9305 1	3146 2909 0	Climb;Sand pile;10950									
-3146 2907 0	3080 9306 1	Climb-down;Secret entrance;11048									
-3082 9305 1	3146 2909 0	Climb;Sand pile;10950									
-3147 2908 0	3080 9306 1	Climb-down;Secret entrance;11048									
-3081 9287 0	3082 9287 0	Open;Door;11064								1	
-3082 9287 0	3081 9287 0	Open;Door;11064								1	
-3097 9312 0	3098 9312 0	Open;Door;11053								1	
-3098 9312 0	3097 9312 0	Open;Door;11053								1	
-3104 9308 0	3104 9310 1	Climb-up;Ladder;11041								2	
-3104 9310 1	3104 9310 0	Climb-down;Ladder;11042								2	
-3103 9309 1	3104 9310 0	Climb-down;Ladder;11042								2	
-3104 9308 1	3104 9310 0	Climb-down;Ladder;11042								2	
-3105 9309 1	3104 9310 0	Climb-down;Ladder;11042								2	
-3103 9318 1	3103 9320 1	Pass-through;Magic barrier;11005									
-3103 9320 1	3103 9318 1	Pass-through;Magic barrier;11005									
-3104 9318 1	3104 9320 1	Pass-through;Magic barrier;11005									
-3104 9320 1	3104 9318 1	Pass-through;Magic barrier;11005									
-3105 9318 1	3105 9320 1	Pass-through;Magic barrier;11005									
-3105 9320 1	3105 9318 1	Pass-through;Magic barrier;11005									
-3104 9331 1	3105 9332 2	Climb-up;Ladder;11041								2	
-3105 9332 2	3105 9332 1	Climb-down;Ladder;11042								2	
-3104 9331 2	3105 9332 1	Climb-down;Ladder;11042								2	
-3104 9333 2	3105 9332 1	Climb-down;Ladder;11042								2	
-3103 9332 2	3105 9332 1	Climb-down;Ladder;11042								2	
-3105 9308 2	3105 9306 2	Climb-over;Pile of rubble;33342									
-3105 9306 2	3105 9308 2	Climb-over;Pile of rubble;33342									
-3104 9308 2	3104 9306 2	Climb-over;Pile of bones;18342									
-3104 9306 2	3104 9308 2	Climb-over;Pile of bones;18342									
-3105 9301 2	3105 9299 1	Climb-down;Stone Ladder;11044									
-3105 9299 1	3105 9301 2	Climb-up;Stone Ladder;11043									
-3104 9301 2	3104 9299 1	Climb-down;Stone Ladder;11044									
-3104 9299 1	3104 9301 2	Climb-up;Stone Ladder;11043									
-3105 9284 2	3105 9286 1	Climb-down;Stone Ladder;11044									
-3105 9286 1	3105 9284 2	Climb-up;Stone Ladder;11043									
-3104 9284 2	3104 9286 1	Climb-down;Stone Ladder;11044									
-3104 9286 1	3104 9284 2	Climb-up;Stone Ladder;11043									
-3127 9337 0	3126 9337 0	Open;Door;11066								1	
-3126 9337 0	3127 9337 0	Open;Door;11066								1	
-											
-# Rellekka											
-2666 3694 0	2666 3694 1	Climb-up;Ladder;4187								2	
-2666 3694 1	2666 3694 0	Climb-down;Ladder;4189								2	
-2621 3694 0	2472 3994 0	Travel;Fremennik Boat;37432								2			
-2472 3994 0	2621 3692 0	Travel;Fremennik Boat;37408								2			
-2621 3693 0	2472 3994 0	Travel;Fremennik Boat;37432								2			
-2473 3994 0	2621 3692 0	Travel;Fremennik Boat;37408								2			
-2621 3692 0	2472 3994 0	Travel;Fremennik Boat;37432								2			
-2621 3691 0	2472 3994 0	Travel;Fremennik Boat;37432								2			
-2621 3690 0	2472 3994 0	Travel;Fremennik Boat;37432								2			
-2598 3608 0	2596 3608 0	Cross;Broken bridge;4616								2			
-2596 3608 0	2598 3608 0	Cross;Broken bridge;4615								2			                           						
-											
-# Isle of Stone											
-2465 4010 0	2461 10417 0	Enter;Cave;37433									
-2461 10417 0	2465 4010 0	Exit;Steps;37411									
-2468 10403 0	2471 10403 0	Climb;Steps;37417									
-2471 10403 0	2468 10403 0	Climb;Steps;37417									
-											
-# Pirates' Cove											
-2213 3794 0	2213 3796 1	Climb;Ladder;16960									
-2213 3796 1	2213 3794 0	Climb;Ladder;16962									
-2214 3802 1	2214 3800 2	Climb;Ladder;16959									
-2214 3800 2	2214 3802 1	Climb;Ladder;16961									
-2221 3795 2	2221 3792 3	Climb;Stairs;16945									
-2221 3792 3	2221 3795 2	Climb;Stairs;16947									
-2227 3795 2	2227 3792 3	Climb;Stairs;16945									
-2227 3792 3	2227 3795 2	Climb;Stairs;16947									
-2220 3792 2	2223 3792 1	Climb;Stairs;16947									
-2223 3792 1	2220 3792 2	Climb;Stairs;16945									
-2225 3792 1	2228 3792 2	Climb;Stairs;16945									
-2228 3792 2	2225 3792 1	Climb;Stairs;16947									
-2225 3806 1	2225 3809 0	Climb;Stairs;16948									
-2225 3809 0	2225 3806 1	Climb;Stairs;16946									
-2221 3805 2	2221 3808 3	Climb;Stairs;16945									
-2221 3808 3	2221 3805 2	Climb;Stairs;16947									
-2227 3805 2	2227 3808 3	Climb;Stairs;16945									
-2227 3808 3	2227 3805 2	Climb;Stairs;16947									
-2213 3809 1	2211 3809 0	Climb;Ladder;16962									
-2211 3809 0	2213 3809 1	Climb;Ladder;16960									
-											
-# Miscellania											
-2509 3847 0	2509 10245 0	Climb-down;Ladder;15116								2	
-2509 10245 0	2510 3846 0	Climb-up;Ladder;15115								2	
-2505 10280 0	2505 10283 0	Squeeze-through;Crevice;15186									
-2505 10283 0	2505 10280 0	Squeeze-through;Crevice;15187									
-2507 10288 0	2509 10288 1	Use-Lift;Platform;15239									
-2509 10288 1	2507 10288 0	Use-Lift;Lift Platform;15242									
-2508 10289 0	2509 10288 1	Use-Lift;Platform;15239									
-2510 10287 1	2514 10291 0	Enter;Tunnel;15188									
-2514 10291 0	2510 10287 1	Enter;Tunnel;15189									
-2539 10299 0	2543 10299 0	Swing-on;Ropeswing;15252									
-2540 10296 0	2536 10296 0	Swing-on;Ropeswing;15216									
-2549 10288 0	2547 10288 0	Use;Plank -> Rocks;15213									
-2547 10288 0	2549 10288 0	Use;Plank -> Rocks;15213									
-2546 10287 0	2544 10287 0	Use;Plank -> Rocks;15213									
-2544 10287 0	2546 10287 0	Use;Plank -> Rocks;15213									
-2543 10287 0	2541 10287 0	Use;Plank -> Rocks;15213									
-2541 10287 0	2543 10287 0	Use;Plank -> Rocks;15213									
-2540 10286 0	2538 10286 0	Use;Plank -> Rocks;15213									
-2538 10286 0	2540 10286 0	Use;Plank -> Rocks;15213									
-2585 10259 0	2585 10262 0	Squeeze-through;Crevice;15194									
-2585 10262 0	2585 10259 0	Squeeze-through;Crevice;15195									
-2618 10266 0	2620 3864 0	Climb-up;Exit;15193									
-2620 3864 0	2619 10265 0	Climb-down;Hole;15203									
-2619 10265 0	2620 3864 0	Climb-up;Exit;15193									
-2619 3865 0	2619 10265 0	Climb-down;Hole;15203									
-2618 10264 0	2620 3864 0	Climb-up;Exit;15193									
-2617 10265 0	2620 3864 0	Climb-up;Exit;15193									
-2621 3865 0	2619 10265 0	Climb-down;Hole;15203									
-2614 3866 0	2615 3867 1	Climb-up;Staircase;16671								1	
-2615 3867 1	2614 3866 0	Climb-down;Staircase;16673								1	
-2613 3866 0	2615 3867 1	Climb-up;Staircase;16671								1	
-2612 3867 0	2615 3867 1	Climb-up;Staircase;16671								1	
-2612 3868 0	2615 3867 1	Climb-up;Staircase;16671								1	
-2613 3869 0	2615 3867 1	Climb-up;Staircase;16671								1	
-2614 3869 0	2615 3867 1	Climb-up;Staircase;16671								1	
-2615 3868 0	2615 3867 1	Climb-up;Staircase;16671								1	
-2615 3867 0	2615 3867 1	Climb-up;Staircase;16671								1	
-2506 3870 0	2507 3871 1	Climb-up;Staircase;16675								1	
-2507 3871 1	2506 3870 0	Climb-down;Staircase;16676								1	
-2505 3870 0	2507 3871 1	Climb-up;Staircase;16675								1	
-2506 3870 1	2506 3870 0	Climb-down;Staircase;16676								1	
-2504 3871 0	2507 3871 1	Climb-up;Staircase;16675								1	
-2507 3871 0	2507 3871 1	Climb-up;Staircase;16675								1	
-2507 3872 0	2507 3871 1	Climb-up;Staircase;16675								1	
-2504 3872 0	2507 3871 1	Climb-up;Staircase;16675								1	
-2506 3870 1	2507 3871 2	Climb-up;Staircase;16676								1	
-2507 3871 2	2506 3870 1	Climb-down;Staircase;16676								1	
-2507 3871 1	2507 3871 2	Climb-up;Staircase;16676								1	
-2506 3870 2	2506 3870 1	Climb-down;Staircase;16676								1	
-2507 3871 2	2507 3871 3	Climb-up;Staircase;16676								1	
-2507 3871 3	2506 3870 2	Climb-down;Staircase;16677								1	
-2506 3870 2	2507 3871 3	Climb-up;Staircase;16676								1	
-2506 3856 1	2506 3857 1	Open;Throne Room Door;4672									
-2506 3857 1	2506 3856 1	Open;Throne Room Door;4672									
-2506 3863 1	2506 3864 1	Open;Throne Room Door;4672									
-2506 3864 1	2506 3863 1	Open;Throne Room Door;4672									
-2505 3850 1	2505 3850 0	Climb-down;Staircase;16676								1	
-2505 3850 0	2504 3849 1	Climb-up;Staircase;16675								1	
-2504 3849 1	2505 3850 0	Climb-down;Staircase;16676								1	
-2506 3850 0	2504 3849 1	Climb-up;Staircase;16675								1	
-2507 3849 0	2504 3849 1	Climb-up;Staircase;16675								1	
-2507 3848 0	2504 3849 1	Climb-up;Staircase;16675								1	
-2506 3847 0	2504 3849 1	Climb-up;Staircase;16675								1	
-2505 3847 0	2504 3849 1	Climb-up;Staircase;16675								1	
-2504 3849 0	2504 3849 1	Climb-up;Staircase;16675								1	
-2504 3848 0	2504 3849 1	Climb-up;Staircase;16675								1	
-2504 3849 2	2505 3850 1	Climb-down;Staircase;16676								1	
-2505 3850 1	2504 3849 2	Climb-up;Staircase;16676								1	
-2505 3850 2	2505 3850 1	Climb-down;Staircase;16676								1	
-2504 3849 1	2504 3849 2	Climb-up;Staircase;16676								1	
-2504 3849 2	2504 3849 3	Climb-up;Staircase;16676								1	
-2504 3849 3	2505 3850 2	Climb-down;Staircase;16677								1	
-2505 3850 2	2504 3849 3	Climb-up;Staircase;16676								1	
-											
-# Ungael											
-2266 4039 0	2264 4039 0	Climb-over;Ice chunks;29868									
-2264 4039 0	2266 4039 0	Climb-over;Ice chunks;29868									
-2263 4040 0	2263 4048 0	Climb-up;Ice chunks;29870									
-2263 4048 0	2263 4040 0	Climb-down;Ice chunks;29869									
-2247 4078 0	2259 10482 0	Enter;Cave;31999									
-2259 10482 0	2247 4078 0	Enter;Cave Entrance;32047									
-											
-# Jatizso											
-2331 3810 0	2329 3810 1	Climb-up;Ladder;21514								2	
-2329 3810 1	2331 3810 0	Climb-down;Ladder;21515								2	
-2410 3824 0	2410 3824 2	Climb-up;Ladder;21395								2	
-2410 3824 2	2410 3824 0	Climb-down;Ladder;21396								2	
-2421 3824 0	2421 3824 2	Climb-up;Ladder;21395								2	
-2421 3824 2	2421 3824 0	Climb-down;Ladder;21396								2	
-2387 3804 0	2387 3804 2	Climb-up;Ladder;21395								2	
-2387 3804 2	2387 3804 0	Climb-down;Ladder;21396								2	
-2387 3793 0	2387 3793 2	Climb-up;Ladder;21395								2	
-2387 3793 2	2387 3793 0	Climb-down;Ladder;21396								2	
-2372 3800 0	2372 3800 2	Climb-up;Ladder;21395								2	
-2372 3800 2	2372 3800 0	Climb-down;Ladder;21396								2	
-2399 3812 0	2405 10188 0	Climb-down;Staircase;21455								1	
-2405 10188 0	2399 3812 0	Climb-up;Staircase;21578								1	
-2399 3813 0	2405 10188 0	Climb-down;Staircase;21455								1	
-2405 10189 0	2399 3812 0	Climb-up;Staircase;21578								1	
-2406 10187 0	2399 3812 0	Climb-up;Staircase;21578								1	
-2407 10187 0	2399 3812 0	Climb-up;Staircase;21578								1	
-2406 10190 0	2399 3812 0	Climb-up;Staircase;21578								1	
-2398 3811 0	2405 10188 0	Climb-down;Staircase;21455								1	
-2407 10190 0	2399 3812 0	Climb-up;Staircase;21578								1	
-2397 3811 0	2405 10188 0	Climb-down;Staircase;21455								1	
-2408 10189 0	2399 3812 0	Climb-up;Staircase;21578								1	
-2398 3814 0	2405 10188 0	Climb-down;Staircase;21455								1	
-2408 10188 0	2399 3812 0	Climb-up;Staircase;21578								1	
-2397 3814 0	2405 10188 0	Climb-down;Staircase;21455								1	
-2396 3813 0	2405 10188 0	Climb-down;Staircase;21455								1	
-2396 3812 0	2405 10188 0	Climb-down;Staircase;21455								1	
-2317 3893 0	2420 10279 1	Open;Cave;21585									
-2421 10278 1	2319 3892 0	Climb-up;Stone ladder;21592									
-2318 3894 0	2420 10279 1	Open;Cave;21585									
-2420 10279 1	2319 3892 0	Climb-up;Stone ladder;21592									
-2316 3893 0	2420 10279 1	Open;Cave;21585									
-2315 3894 0	2420 10279 1	Open;Cave;21585									
-2400 3889 0	2394 10300 1	Open;Cave;21584				The Fremennik Isles					
-2401 3888 0	2394 10300 1	Open;Cave;21584				The Fremennik Isles					
-2403 3889 0	2394 10300 1	Open;Cave;21584				The Fremennik Isles					
-2398 10258 1	2393 10258 1	Walk-across;Rope bridge;21318									
-2393 10258 1	2398 10258 1	Walk-across;Rope bridge;21319									
-2385 10259 1	2385 10264 1	Walk-across;Rope bridge;21317									
-2385 10264 1	2385 10260 1	Walk-across;Rope bridge;21316									
-2393 10300 1	2401 3888 0	Exit;Cave opening;21597									
-2385 10260 1	2385 10264 1	Walk-across;Rope bridge;21317									
-2394 10300 1	2401 3888 0	Exit;Cave opening;21598									
-2395 10300 1	2401 3888 0	Exit;Cave opening;21599									
-2314 3848 0	2314 3839 0	Walk-across;Rope bridge;21311									
-2314 3839 0	2314 3848 0	Walk-across;Rope bridge;21310									
-2355 3848 0	2355 3839 0	Walk-across;Rope bridge;21313									
-2355 3839 0	2355 3848 0	Walk-across;Rope bridge;21312									
-2378 3839 0	2378 3848 0	Cross-bridge;Rope bridge;21314									
-2378 3848 0	2378 3839 0	Walk-across;Rope bridge;21315									
-2343 3829 0	2343 3820 0	Walk-across;Rope bridge;21309									
-2343 3820 0	2343 3829 0	Walk-across;Rope bridge;21308									
-2317 3823 0	2317 3832 0	Walk-across;Rope bridge;21306									
-2317 3832 0	2317 3823 0	Walk-across;Rope bridge;21307									
-2331 3802 0	2329 3802 1	Climb-up;Ladder;21514								2	
-2329 3802 1	2331 3802 0	Climb-down;Ladder;21515								2	
-2362 3799 0	2364 3799 2	Climb-up;Ladder;21512								2	
-2364 3799 2	2362 3799 0	Climb-down;Ladder;21513								2	
-											
-# Iceberg											
-2630 4013 1	2656 10423 0	Use;A crack;21245									
-2656 10423 0	2631 4013 1	Use;Chasm;21035									
-2631 4013 1	2656 10423 0	Use;A crack;21245									
-2638 10424 0	2639 10424 0	Open;Door;21167									
-2639 10424 0	2638 10424 0	Open;Door;21167									
-											
-# Weiss											
-2852 3966 0	2852 3964 0	Climb;Rockslide;33184									
-2852 3964 0	2852 3966 0	Climb;Rockslide;33184									
-2852 3964 0	2855 3964 0	Climb;Rockslide;33185									
-2855 3964 0	2852 3964 0	Climb;Rockslide;33185									
-2855 3964 0	2853 3961 0	Climb;Rope;33328									
-2853 3961 0	2855 3964 0	Climb;Roped tree;33327									
-2853 3961 0	2857 3961 0	Cross;Ledge;33190									
-2857 3961 0	2853 3961 0	Cross;Ledge;33190									
-2859 3962 0	2859 3960 0	Climb;Rockslide;33191									
-2859 3960 0	2859 3962 0	Climb;Rockslide;33191									
-2857 3957 0	2857 3954 0	Pass;Fallen Tree;33192									
-2857 3954 0	2857 3957 0	Pass;Fallen Tree;33192									
-2852 3936 0	2850 3936 0	Cross;Little boulder;33312									
-2850 3936 0	2852 3936 0	Cross;Little boulder;33312									
-2858 3968 0	2854 3941 0	Enter;Cave Entrance;33329									
-2855 3941 0	2859 3968 0	Descend;Hole;33227									
-2859 3968 0	2854 3941 0	Enter;Cave Entrance;33329									
-2854 3941 0	2859 3968 0	Descend;Hole;33227									
-2860 3968 0	2854 3941 0	Enter;Cave Entrance;33329									
-2853 3941 0	2859 3968 0	Descend;Hole;33227									
-2856 3941 0	2859 3968 0	Descend;Hole;33227									
-2852 3941 0	2859 3968 0	Descend;Hole;33227									
-2869 3941 0	2845 10351 0	Descend;Stairs;33234									
-2845 10351 0	2869 3941 0	Climb;Steps;33261									
-2844 10351 0	2869 3941 0	Climb;Steps;33261									
-2846 10351 0	2869 3941 0	Climb;Steps;33261									
-2855 10334 0	2845 3960 0	Enter;Smelly hole;33262									
-2856 10335 0	2845 3960 0	Enter;Smelly hole;33262									
-											
-# Hunter Area											
-2716 3798 0	2716 3802 1	Ascend;Steps;19690									
-2716 3802 1	2716 3798 0	Descend;Steps;19691									
-2715 3798 0	2715 3802 1	Ascend;Steps;19690									
-2715 3802 1	2715 3798 0	Descend;Steps;19691									
-2726 3805 1	2726 3801 0	Descend;Steps;19691									
-2726 3801 0	2726 3805 1	Ascend;Steps;19690									
-2727 3805 1	2727 3801 0	Descend;Steps;19691									
-2727 3801 0	2727 3805 1	Ascend;Steps;19690									
-2740 3830 1	2744 3830 1	Climb;Rocky handholds;19846									
-2744 3830 1	2740 3830 1	Climb;Rocky handholds;19847									
-2744 3830 1	2707 10205 0	Enter;Cave;19762									
-2707 10205 0	2744 3830 1	Exit;Cave;19764									
-2707 10206 0	2744 3830 1	Exit;Cave;19764									
-2707 10204 0	2744 3830 1	Exit;Cave;19764									
-											
-# Keldagrim											
-2730 3714 0	2773 10162 0	Enter;Tunnel;5008									
-2773 10162 0	2730 3713 0	Enter;Tunnel;5014									
-2730 3713 0	2773 10162 0	Enter;Tunnel;5008									
-2773 10163 0	2730 3713 0	Enter;Tunnel;5014									
-2730 3712 0	2773 10162 0	Enter;Tunnel;5008									
-2773 10161 0	2730 3713 0	Enter;Tunnel;5014									
-2731 3711 0	2773 10162 0	Enter;Tunnel;5008									
-2780 10161 0	2838 10124 0	Go-through;Cave Entrance;5973									
-2838 10124 0	2778 10161 0	Go-through;Entrance;5998									
-2799 10134 0	2797 3719 0	Enter;Tunnel;5013									
-2797 3719 0	2799 10134 0	Enter;Tunnel;5012									
-2800 10134 0	2797 3719 0	Enter;Tunnel;5013									
-2795 3719 0	2799 10134 0	Enter;Tunnel;5012									
-2796 3719 0	2799 10134 0	Enter;Tunnel;5012									
-2917 10196 0	2914 10196 1	Climb-up;Stairs;6085									
-2914 10196 1	2917 10196 0	Climb-down;Stairs;6086									
-2914 10187 0	1943 4705 1	Climb-down;Stairs;10288									
-1943 4705 1	2914 10187 0	Climb-up;Stairs;10287									
-1942 4706 1	1942 4703 0	Climb-down;Stairs;6086									
-1942 4703 0	1942 4706 1	Climb-up;Stairs;6085									
-2931 10182 0	2930 10179 1	Climb-up;Stairs;6087									
-2930 10179 1	2930 10182 0	Climb-down;Stairs;6088									
-2930 10182 0	2930 10179 1	Climb-up;Stairs;6087									
-2931 10179 1	2930 10182 0	Climb-down;Stairs;6088									
-2933 10165 1	2930 10165 0	Climb-down;Stairs;6086									
-2930 10165 0	2933 10165 1	Climb-up;Stairs;6085									
-2913 10163 1	2910 10163 0	Climb-down;Stairs;6086									
-2910 10163 0	2913 10163 1	Climb-up;Stairs;6085									
-2904 10208 0	2907 10208 1	Climb-up;Stairs;6085									
-2907 10208 1	2904 10208 0	Climb-down;Stairs;6086									
-2893 10210 0	2896 10209 1	Climb-up;Stairs;6087									
-2896 10209 1	2893 10209 0	Climb-down;Stairs;6088									
-2893 10209 0	2896 10209 1	Climb-up;Stairs;6087									
-2896 10210 1	2893 10209 0	Climb-down;Stairs;6088									
-2896 10189 1	2893 10188 0	Climb-down;Stairs;6088									
-2893 10188 0	2896 10188 1	Climb-up;Stairs;6087									
-2896 10188 1	2893 10188 0	Climb-down;Stairs;6088									
-2893 10189 0	2896 10188 1	Climb-up;Stairs;6087									
-2890 10200 1	2893 10198 2	Climb-up;Stairs;6089									
-2893 10198 2	2890 10198 1	Climb-down;Stairs;6090									
-2890 10198 1	2893 10198 2	Climb-up;Stairs;6089									
-2893 10199 2	2890 10198 1	Climb-down;Stairs;6090									
-2890 10199 1	2893 10198 2	Climb-up;Stairs;6089									
-2893 10200 2	2890 10198 1	Climb-down;Stairs;6090									
-2865 10200 2	2868 10198 1	Climb-down;Stairs;6090									
-2868 10198 1	2865 10198 2	Climb-up;Stairs;6089									
-2865 10198 2	2868 10198 1	Climb-down;Stairs;6090									
-2868 10199 1	2865 10198 2	Climb-up;Stairs;6089									
-2865 10199 2	2868 10198 1	Climb-down;Stairs;6090									
-2868 10200 1	2865 10198 2	Climb-up;Stairs;6089									
-2862 10210 1	2865 10209 0	Climb-down;Stairs;6088									
-2865 10209 0	2862 10209 1	Climb-up;Stairs;6087									
-2862 10209 1	2865 10209 0	Climb-down;Stairs;6088									
-2865 10210 0	2862 10209 1	Climb-up;Stairs;6087									
-2862 10188 1	2865 10188 0	Climb-down;Stairs;6088									
-2865 10188 0	2862 10188 1	Climb-up;Stairs;6087									
-2862 10189 1	2865 10188 0	Climb-down;Stairs;6088									
-2865 10189 0	2862 10188 1	Climb-up;Stairs;6087									
-2865 10221 0	2865 10224 1	Climb-up;Stairs;6085									
-2865 10224 1	2865 10221 0	Climb-down;Stairs;6086									
-2834 10223 0	2834 10226 1	Climb-up;Stairs;6085									
-2834 10226 1	2834 10223 0	Climb-down;Stairs;6086									
-2835 10226 1	2835 10223 2	Climb-up;Stairs;6085									
-2835 10223 2	2835 10226 1	Climb-down;Stairs;6086									
-2828 10217 0	2828 10214 1	Climb-up;Stairs;6085									
-2828 10214 1	2828 10217 0	Climb-down;Stairs;6086									
-2834 10196 0	2837 10196 1	Climb-up;Stairs;6085									
-2837 10196 1	2834 10196 0	Climb-down;Stairs;6086									
-2828 10224 0	2828 10227 1	Climb-up;Stairs;6085									
-2828 10227 1	2828 10224 0	Climb-down;Stairs;6086									
-2930 10185 0	2930 10186 0	Open;Door;6977									
-2930 10186 0	2930 10185 0	Open;Door;6977									
-2930 10194 0	2930 10195 0	Open;Door;6975									
-2930 10195 0	2930 10194 0	Open;Door;6975									
-2931 10197 0	1940 4958 0	Climb-down;Stairs;9084									
-1940 4958 0	2931 10196 0	Climb-up;Stairs;9138									
-2931 10196 0	1940 4958 0	Climb-down;Stairs;9084									
-1939 4958 0	2931 10196 0	Climb-up;Stairs;9138									
-1937 4969 0	1937 4970 0	Open;Gate;9141									
-1937 4970 0	1937 4969 0	Open;Gate;9141									
-2941 10179 0	2438 5535 0	Enter;Doorway;23287									
-2435 5535 0	2941 10179 0	Enter;Doorway;23286									
-2488 5536 0	2696 5277 1	Enter;Doorway;23285									
-2696 5277 1	2488 5536 0	Enter;Doorway;23052									
-											
-# Slayer Cave											
-2796 3616 0	2808 10002 0	Enter;Cave Entrance;2123									
-2808 10002 0	2796 3615 0	Enter;Tunnel;2141									
-2796 3615 0	2808 10002 0	Enter;Cave Entrance;2123									
-2808 10003 0	2796 3615 0	Enter;Tunnel;2141									
-2796 3614 0	2808 10002 0	Enter;Cave Entrance;2123									
-2808 10001 0	2796 3615 0	Enter;Tunnel;2141									
-2703 9991 0	2703 9989 0	Climb;Steps;29993									
-2703 9989 0	2703 9991 0	Climb;Steps;29993									
-2823 3555 0	2822 3555 0	Open;Door;3745								1	
-2822 3555 0	2823 3555 0	Open;Door;3745								1	
-2820 3557 0	2820 3558 0	Open;Door;3746								1	
-2820 3558 0	2820 3557 0	Open;Door;3746								1	
-2817 3561 0	2817 3564 0	Climb-over;Stile;3730								6	
-2816 3563 0	2817 3561 0	Climb-over;Stile;3730								6	
-2818 3562 0	2817 3564 0	Climb-over;Stile;3730								6	
-2817 3564 0	2817 3561 0	Climb-over;Stile;3730								6	
-2816 3562 0	2817 3564 0	Climb-over;Stile;3730								6	
-2880 3596 0	2880 3593 0	Climb;Rocks;3722									
-2880 3593 0	2880 3596 0	Climb;Rocks;3723									
-2881 3596 0	2881 3593 0	Climb;Rocks;3722									
-2881 3593 0	2881 3596 0	Climb;Rocks;3723									
-2857 3611 0	2857 3613 0	Climb;Rocks;3748									
-2857 3613 0	2857 3611 0	Climb;Rocks;3748									
-2856 3611 0	2856 3613 0	Climb;Rocks;3748									
-2856 3613 0	2856 3611 0	Climb;Rocks;3748									
-2858 3627 0	2861 3627 0	Climb;Rocks;3790									
-2861 3627 0	2858 3627 0	Climb;Rocks;3791									
-2858 3626 0	2861 3626 0	Climb;Rocks;3790									
-2861 3626 0	2858 3626 0	Climb;Rocks;3791									
-2877 3623 0	2880 3623 0	Climb;Rocks;3791									
-2880 3623 0	2877 3623 0	Climb;Rocks;3790									
-2877 3622 0	2880 3622 0	Climb;Rocks;3791									
-2880 3622 0	2877 3622 0	Climb;Rocks;3790									
-2896 3619 0	2897 3619 0	Open;Arena Entrance;3783									
-2897 3619 0	2896 3619 0	Open;Arena Entrance;3783									
-2896 3618 0	2897 3618 0	Open;Arena Entrance;3782									
-2897 3618 0	2896 3618 0	Open;Arena Entrance;3782									
-2917 3628 0	2917 3629 0	Open;Arena Exit;3786									
-2917 3629 0	2917 3628 0	Open;Arena Exit;3786									
-2916 3628 0	2916 3629 0	Open;Arena Exit;3785									
-2916 3629 0	2916 3628 0	Open;Arena Exit;3785									
-2905 3643 0	2907 10019 0	Enter;Cave Entrance;3757									
-2907 10019 0	2904 3643 0	Exit;Cave Exit;3758									
-2904 3643 0	2907 10019 0	Enter;Cave Entrance;3757									
-2908 10019 0	2904 3643 0	Exit;Cave Exit;3758									
-2903 3643 0	2907 10019 0	Enter;Cave Entrance;3757									
-2906 10019 0	2904 3643 0	Exit;Cave Exit;3758									
-2908 10035 0	2908 3654 0	Exit;Cave Exit;3758									
-2908 3654 0	2907 10035 0	Enter;Cave Entrance;3757									
-2907 10035 0	2908 3654 0	Exit;Cave Exit;3758									
-2909 3654 0	2907 10035 0	Enter;Cave Entrance;3757									
-2906 10035 0	2908 3654 0	Exit;Cave Exit;3758									
-2907 3654 0	2907 10035 0	Enter;Cave Entrance;3757									
-2834 3627 0	2834 3629 0	Climb;Rocks;3748									
-2834 3629 0	2834 3627 0	Climb;Rocks;3748									
-2833 3627 0	2833 3629 0	Climb;Rocks;3748									
-2833 3629 0	2833 3627 0	Climb;Rocks;3748									
-2822 3635 0	2820 3635 0	Climb;Rocks;3748									
-2820 3635 0	2822 3635 0	Climb;Rocks;3748									
-2827 3646 0	2823 10050 0	Open;Secret Door;3762									
-2823 10050 0	2827 3646 0	Open;Exit;3761									
-2828 3646 0	2823 10050 0	Open;Secret Door;3762									
-2824 10050 0	2827 3646 0	Open;Exit;3761									
-2825 10050 0	2827 3646 0	Open;Exit;3761									
-2852 10105 0	2852 10109 1	Climb-up;Stone Staircase;3788									
-2852 10109 1	2852 10105 0	Climb-down;Stone Staircase;3789									
-2853 10105 0	2852 10109 1	Climb-up;Stone Staircase;3788									
-2853 10109 1	2852 10105 0	Climb-down;Stone Staircase;3789									
-2848 10107 1	2847 10107 1	Unlock;Prison Door;3780									
-2847 10107 1	2848 10107 1	Unlock;Prison Door;3780									
-2841 10052 1	2845 10051 2	Climb-up;Stone Staircase;3788									
-2845 10051 2	2841 10051 1	Climb-down;Stone Staircase;3789									
-2841 10051 1	2845 10051 2	Climb-up;Stone Staircase;3788									
-2845 10052 2	2841 10051 1	Climb-down;Stone Staircase;3789									
-2831 10076 2	2831 3676 0	Climb-up;Troll ladder;18834									
-2831 3676 0	2831 10076 2	Climb-down;Troll ladder;18833									
-2830 10077 2	2831 3676 0	Climb-up;Troll ladder;18834									
-2830 3677 0	2831 10076 2	Climb-down;Troll ladder;18833									
-2832 3677 0	2831 10076 2	Climb-down;Troll ladder;18833									
-2831 3678 0	2831 10076 2	Climb-down;Troll ladder;18833									
-2840 3690 0	2837 10090 2	Enter;Stronghold;3771									
-2837 10090 2	2840 3690 0	Leave;Exit;3774									
-2837 10089 2	2840 3690 0	Leave;Exit;3773									
-2837 10091 2	2840 3690 0	Use;Exit;3772									
-2845 10109 2	2841 10108 1	Climb-down;Stone Staircase;3789									
-2841 10108 1	2845 10108 2	Climb-up;Stone Staircase;3788									
-2845 10108 2	2841 10108 1	Climb-down;Stone Staircase;3789									
-2841 10109 1	2845 10108 2	Climb-up;Stone Staircase;3788									
-2853 10060 1	2852 10064 0	Climb-down;Stone Staircase;3789									
-2852 10064 0	2852 10060 1	Climb-up;Stone Staircase;3788									
-2852 10060 1	2852 10064 0	Climb-down;Stone Staircase;3789									
-2853 10064 0	2852 10060 1	Climb-up;Stone Staircase;3788									
-2869 10084 0	2869 10085 0	Open;Storeroom Door;3810									
-2869 10085 0	2869 10084 0	Open;Storeroom Door;3810									
-2888 3662 0	2888 3660 0	Climb;Rocks;3803									
-2888 3660 0	2888 3662 0	Climb;Rocks;3803									
-2887 3662 0	2887 3660 0	Climb;Rocks;3804									
-2887 3660 0	2887 3662 0	Climb;Rocks;3804									
-2892 3671 0	2893 10074 2	Enter;Cave Entrance;3759									
-2893 10074 2	2893 3671 0	Exit;Cave Exit;3760									
-2893 3671 0	2893 10074 2	Enter;Cave Entrance;3759									
-2892 10074 2	2893 3671 0	Exit;Cave Exit;3760									
-2894 3671 0	2893 10074 2	Enter;Cave Entrance;3759									
-2894 10074 2	2893 3671 0	Exit;Cave Exit;3760									
-2837 3736 0	2839 3739 0	Go-through;Ice gate;5044									
-2839 3739 0	2837 3739 0	Go-through;Ice gate;5043									
-2837 3739 0	2839 3739 0	Go-through;Ice gate;5043									
-2839 3737 0	2837 3739 0	Go-through;Ice gate;5044									
-2837 3738 0	2839 3739 0	Go-through;Ice gate;5044									
-2839 3738 0	2837 3739 0	Go-through;Ice gate;5044									
-2837 3737 0	2839 3739 0	Go-through;Ice gate;5044									
-2839 3736 0	2837 3739 0	Go-through;Ice gate;5044									
-2837 3740 0	2839 3739 0	Go-through;Ice gate;5043									
-2839 3740 0	2837 3739 0	Go-through;Ice gate;5043									
-2839 3741 0	2837 3739 0	Go-through;Ice gate;5043									
-2867 3720 0	2874 3720 0	Enter;Cave Entrance;6440									
-2874 3720 0	2867 3719 0	Enter;Cave Exit;6447									
-2867 3719 0	2874 3720 0	Enter;Cave Entrance;6440									
-2874 3721 0	2867 3719 0	Enter;Cave Exit;6447									
-2867 3718 0	2874 3720 0	Enter;Cave Entrance;6440									
-2874 3719 0	2867 3719 0	Enter;Cave Exit;6447									
-2868 3721 0	2874 3720 0	Enter;Cave Entrance;6440									
-2899 3715 0	2898 3719 0	Move;Boulder;26415									
-2898 3719 0	2898 3715 0	Move;Boulder;26415									
-2898 3715 0	2898 3719 0	Move;Boulder;26415									
-2899 3719 0	2898 3715 0	Move;Boulder;26415									
-2900 3719 0	2898 3715 0	Move;Boulder;26415									
-2899 3713 0	2904 3720 0	Crawl-through;Little crack;26382									
-2904 3720 0	2899 3713 0	Crawl-through;Little crack;26382									
-2916 3748 0	2882 5311 2	Climb-down;Hole;26419									
-2880 5311 2	2916 3745 0	Climb;Rope;26370									
-2916 3745 0	2882 5311 2	Climb-down;Hole;26419									
-2882 5311 2	2916 3745 0	Climb;Rope;26370									
-2916 3746 0	2882 5311 2	Climb-down;Hole;26419									
-2881 5310 2	2916 3745 0	Climb;Rope;26370									
-2917 3744 0	2882 5311 2	Climb-down;Hole;26419									
-2918 3744 0	2882 5311 2	Climb-down;Hole;26419									
-2919 3744 0	2882 5311 2	Climb-down;Hole;26419									
-2920 3744 0	2882 5311 2	Climb-down;Hole;26419									
-2916 3747 0	2882 5311 2	Climb-down;Hole;26419									
-2917 3749 0	2882 5311 2	Climb-down;Hole;26419									
-2918 3749 0	2882 5311 2	Climb-down;Hole;26419									
-2919 3749 0	2882 5311 2	Climb-down;Hole;26419									
-2920 3749 0	2882 5311 2	Climb-down;Hole;26419									
-2921 3748 0	2882 5311 2	Climb-down;Hole;26419									
-2921 3747 0	2882 5311 2	Climb-down;Hole;26419									
-2921 3746 0	2882 5311 2	Climb-down;Hole;26419									
-2912 5300 2	2914 5300 1	Climb-down;Rock;26561									
-2914 5300 1	2912 5299 2	Climb-up;Rope;26371									
-2920 5276 1	2920 5274 0	Climb-down;Rock;26562									
-2920 5274 0	2919 5276 1	Climb-up;Rope;26375									
-2919 5274 0	2919 5276 1	Climb-up;Rope;26375									
-2915 5300 1	2912 5299 2	Climb-up;Rope;26371									
-2909 3686 0	2911 3686 0	Climb;Rocks;3748									
-2911 3686 0	2909 3686 0	Climb;Rocks;3748									
-2909 3687 0	2911 3687 0	Climb;Rocks;3748									
-2911 3687 0	2909 3687 0	Climb;Rocks;3748									
-2943 3769 0	2950 3767 0	Climb;Rocky handholds;26405									
-2943 3769 0	2950 3767 0	Climb;Rocky handholds;26405									
-2943 3767 0	2950 3767 0	Climb;Rocky handholds;26405									
-2942 3768 0	2950 3767 0	Climb;Rocky handholds;26405									
-											
-# Hemenster											
-2661 3500 0	2662 3500 0	Squeeze-through;Loose Railing;51									
-2662 3500 0	2661 3500 0	Squeeze-through;Loose Railing;51									
-2612 3476 0	2612 3476 1	Climb-up;Ladder;16683								2	
-2612 3476 1	2612 3476 0	Climb-down;Ladder;16679								2	
-2611 3475 0	2611 3475 1	Climb-up;Ladder;16683								2	
-2611 3475 1	2611 3475 0	Climb-down;Ladder;16679								2	
-2612 3474 0	2612 3474 1	Climb-up;Ladder;16683								2	
-2612 3474 1	2612 3474 0	Climb-down;Ladder;16679								2	
-2613 3475 0	2613 3475 1	Climb-up;Ladder;16683								2	
-2613 3475 1	2613 3475 0	Climb-down;Ladder;16679								2	
-2642 3429 0	2642 3429 1	Climb-up;Ladder;16683								2	
-2642 3429 1	2642 3429 0	Climb-down;Ladder;16679								2	
-2641 3428 0	2641 3428 1	Climb-up;Ladder;16683								2	
-2641 3428 1	2641 3428 0	Climb-down;Ladder;16679								2	
-2657 3438 0	2659 3437 0	Open;Guild door;11665									
-2658 3439 0	2659 3437 0	Open;Guild door;11665									
-2658 3437 0	2657 3439 0	Open;Guild door;11665									
-2659 3438 0	2657 3439 0	Open;Guild door;11665									
-2668 3429 0	2668 3429 2	Climb-up;Tower ladder;11661									
-2667 3428 0	2668 3429 2	Climb-up;Tower ladder;11661									
-2668 3427 0	2668 3429 2	Climb-up;Tower ladder;11661									
-2669 3428 0	2668 3429 2	Climb-up;Tower ladder;11661									
-2668 3429 2	2667 3429 0	Climb-down;Tower ladder;11662									
-2667 3428 2	2667 3429 0	Climb-down;Tower ladder;11662									
-2668 3427 2	2667 3429 0	Climb-down;Tower ladder;11662									
-2669 3428 2	2667 3429 0	Climb-down;Tower ladder;11662									
-2620 9797 0	2623 3391 0	Climb-over;Mud pile;13									
-2623 3391 0	2619 9797 0	Enter;Cave Entrance;2									
-2620 9796 0	2623 3391 0	Climb-over;Mud pile;13									
-2624 3391 0	2619 9797 0	Enter;Cave Entrance;2									
-2621 9795 0	2623 3391 0	Climb-over;Mud pile;13									
-2625 3391 0	2619 9797 0	Enter;Cave Entrance;2									
-2622 3391 0	2619 9797 0	Enter;Cave Entrance;2									
-2611 3393 0	2611 3394 0	Open;Door;20925								1	
-2611 3394 0	2611 3393 0	Open;Door;20925								1	
-2630 3385 0	2630 3385 1	Climb-up;Ladder;16683								2	
-2630 3385 1	2630 3385 0	Climb-down;Ladder;16684								2	
-2631 3386 0	2631 3386 1	Climb-up;Ladder;16683								2	
-2631 3386 1	2631 3386 0	Climb-down;Ladder;16684								2	
-2631 3386 1	2631 3386 2	Climb-up;Ladder;16684								2	
-2631 3386 2	2631 3386 1	Climb-down;Ladder;16679								2	
-2630 3385 1	2630 3385 2	Climb-up;Ladder;16684								2	
-2630 3385 2	2630 3385 1	Climb-down;Ladder;16679								2	
-2647 3376 0	2649 3375 0	Climb-over;Stile;993								6	
-2649 3375 0	2646 3375 0	Climb-over;Stile;993								6	
-2646 3375 0	2649 3375 0	Climb-over;Stile;993								6	
-2648 3374 0	2646 3375 0	Climb-over;Stile;993								6	
-2647 3374 0	2649 3375 0	Climb-over;Stile;993								6	
-2648 3376 0	2646 3375 0	Climb-over;Stile;993								6	
-2637 3350 0	2640 3350 0	Climb-over;Stile;993								6	
-2640 3350 0	2637 3350 0	Climb-over;Stile;993								6	
-2638 3351 0	2640 3350 0	Climb-over;Stile;993								6	
-2639 3349 0	2637 3350 0	Climb-over;Stile;993								6	
-2638 3349 0	2640 3350 0	Climb-over;Stile;993								6	
-2639 3351 0	2637 3350 0	Climb-over;Stile;993								6	
-2654 3347 0	2657 3347 0	Climb-over;Stile;993								6	
-2657 3347 0	2654 3347 0	Climb-over;Stile;993								6	
-2655 3348 0	2657 3347 0	Climb-over;Stile;993								6	
-2656 3348 0	2654 3347 0	Climb-over;Stile;993								6	
-2655 3346 0	2657 3347 0	Climb-over;Stile;993								6	
-											
-# Entrana											
-2834 3335 0	2834 3332 1	Cross;Gangplank;2415								3	
-2834 3332 1	2834 3335 0	Cross;Gangplank;2415								3	
-											
-# Karamja											
-2910 3049 0	2906 3049 0	Cross;A wooden log;23644								5	
-2906 3049 0	2910 3049 0	Cross;A wooden log;23644								5	
-2879 2954 0	2876 2952 0	Climb over;Broken cart;2216				Shilo Village				2	
-2880 2953 0	2876 2952 0	Climb over;Broken cart;2216				Shilo Village				2	
-2880 2952 0	2876 2952 0	Climb over;Broken cart;2216				Shilo Village				2	
-2880 2951 0	2876 2952 0	Climb over;Broken cart;2216	  			Shilo Village				2	
-2879 2950 0	2876 2952 0	Climb over;Broken cart;2216				Shilo Village				2	
-2877 2954 0	2880 2952 0	Climb over;Broken cart;2216				Shilo Village				2	
-2876 2953 0	2880 2952 0	Climb over;Broken cart;2216				Shilo Village				2	
-2876 2952 0	2880 2952 0	Climb over;Broken cart;2216				Shilo Village				2	
-2876 2951 0	2880 2952 0	Climb over;Broken cart;2216				Shilo Village				2	
-2877 2950 0	2880 2952 0	Climb over;Broken cart;2216				Shilo Village				2	
-2777 3214 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5	
-2778 3214 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5	
-2776 3213 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5	
-2776 3212 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5	
-2776 3211 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5	
-2779 3213 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5	
-2779 3212 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5	
-2779 3211 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5	
-2777 3210 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5	
-2778 3210 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5	
-2830 2953 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5	
-2830 2952 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5	
-2831 2954 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5	
-2832 2954 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5	
-2833 2954 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5	
-2831 2951 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5	
-2832 2951 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5	
-2833 2951 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5	
-2834 2953 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5	
-2834 2952 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5	
-2836 9599 0	2836 9600 0	Open;Wall;2606				Dragon Slayer I				2	
-2836 9600 0	2836 9599 0	Open;Wall;2606								2	
-2832 9657 0	2834 3258 0	Climb;Climbing rope;25213								1	
-2833 9658 0	2834 3258 0	Climb;Climbing rope;25213								1	
-2833 9656 0	2834 3258 0	Climb;Climbing rope;25213								1	
-2834 9657 0	2834 3258 0	Climb;Climbing rope;25213								1	
-2832 3255 0	2833 9658 0	Enter;Hole;25154								1	
-2832 3256 0	2833 9658 0	Enter;Hole;25154								1	
-2832 3257 0	2833 9658 0	Enter;Hole;25154								1	
-2833 3258 0	2833 9658 0	Enter;Hole;25154								1	
-2834 3258 0	2833 9658 0	Enter;Hole;25154								1	
-2835 3258 0	2833 9658 0	Enter;Hole;25154								1	
-2833 3254 0	2833 9658 0	Enter;Hole;25154								1	
-2834 3254 0	2833 9658 0	Enter;Hole;25154								1	
-2835 3254 0	2833 9658 0	Enter;Hole;25154								1	
-2836 3255 0	2833 9658 0	Enter;Hole;25154								1	
-2836 3256 0	2833 9658 0	Enter;Hole;25154								1	
-2836 3257 0	2833 9658 0	Enter;Hole;25154								1	
-2998 3032 1	3001 3032 0	Cross;Gangplank;17397									
-3001 3032 0	2998 3032 1	Cross;Gangplank;17396									
-2795 2978 0	2791 2978 0	Climb;Rocks;2231								3	
-2791 2978 0	2795 2978 0	Climb;Rocks;2231								3	
-2795 2979 0	2791 2979 0	Climb;Rocks;2231								3	
-2791 2979 0	2795 2979 0	Climb;Rocks;2231								3	
-2795 2980 0	2791 2980 0	Climb;Rocks;2231								3	
-2791 2980 0	2795 2980 0	Climb;Rocks;2231								3	
-2871 2970 0	2871 2970 1	Climb-up;Ladder;16683									
-2871 2970 1	2871 2970 0	Climb-down;Ladder;16679									
-2871 2972 0	2871 2972 1	Climb-up;Ladder;16683									
-2871 2972 1	2871 2972 0	Climb-down;Ladder;16679									
-											
-# Lunar Isle											
-2128 3893 2	2126 3893 1	Climb;Ladder;16961								2	
-2126 3893 1	2128 3893 2	Climb;Ladder;16959								2	
-2118 3893 1	2118 3895 0	Climb;Ladder;16962								2	
-2118 3895 0	2118 3893 1	Climb;Ladder;16960								2	
-2451 4645 0	2090 3930 0	Open;Door;16774								2	
-											
-# Zanaris											
-2452 4473 0	3201 3169 0	Use;Fairy ring;12094								6	
-3202 3169 0	2452 4473 0	Open;Door;2406								6	
-2486 4471 0	3260 3171 0	Use;Fairy ring;12003								6	
-											
-# Wintertodt											
-1630 3968 0	1630 3963 0	Enter;Doors of dinh;29322								1	
-1630 3963 0	1630 3968 0	Enter;Doors of dinh;29322								1	
-											
-# Camdozaal											
-2998 3494 0	2952 5762 0	Enter;Ruins Entrance;41357				Below Ice Mountain					
-2952 5762 0	2998 3494 0	Exit;Ruins Exit;41446				Below Ice Mountain					
-											
-# Magic guild											
-2590 3088 0	2590 3092 1	Climb-up;Staircase;15645									
-2591 3088 0	2591 3092 1	Climb-up;Staircase;15645									
-2591 3092 1	2590 3088 0	Climb-down;Staircase;15648									
-2590 3092 1	2590 3088 0	Climb-down;Staircase;15648									
-											
-# Asgarnian ice dungeon											
-3009 3150 0	3009 9550 0	Climb-down;Trapdoor;1738									
-3007 9550 0	3007 3150 0	Climb-up;Ladder;17385									
-3009 9550 0	3009 3150 0	Climb-up;Ladder;17385									
-3056 9562 0	3056 9555 0	Enter;Icy Cavern;10596	 								
-3056 9555 0	3056 9562 0	Enter;Icy Cavern;10595	 								
-3060 9555 0	3060 9557 0	Climb;Steps;8729									
-3060 9557 0	3060 9555 0	Climb;Steps;8729									
-											
-# Sawmill											
-3310 3508 1	3310 3508 0	Climb-down;Ladder;11795									
-3310 3508 0	3310 3508 1	Climb-up;Ladder;11794									
-											
-# Desert mining camp											
-3290 3035 0	3290 3035 1	Climb-up;Ladder;18903									
-3290 3037 1	3290 3037 0	Climb-down;Ladder;18904									
-											
-# Kovac											
-3366 11483 0	3361 3148 0	Exit;Exit;44636									
-3361 3148 0	3366 11483 0	Enter;Cave;44635									
-											
-# Hazeel cult											
-2567 9680 0	2606 9692 0	Board;Raft;2849									
-2606 9692 0	2567 9680 0	Board;Raft;2849									
-											
-# Murder mystery											
-2736 3580 1	2736 3580 0	Climb-down;Staircase;25683									
-2736 3580 0	2736 3580 1	Climb-up;Staircase;25682									
-											
-# Lumbridge basement / cavern											
-3219 9618 0	3221 9618 0	Squeeze-through;Hole;6898				The Lost Tribe					
-3221 9618 0	3219 9618 0	Squeeze-through;Hole;6899				The Lost Tribe					
-3224 9604 0	3224 9600 0	Squeeze-through;Hole;6912									
-3224 9600 0	3224 9604 0	Squeeze-through;Hole;6912									
-3226 9542 0	3219 9532 2	Enter;Tunnel;6659									
-3219 9532 2	3226 9542 0	Enter;Tunnel;6658									
-3317 9603 0	2748 5374 0	Open;Door;6919									
-2748 5374 0	3317 9603 0	Open;Bone door;22945									
-											
-# Mountain camp											
-2761 3657 0	2761 3660 0	Climb-over;Rockslide;5847									
-2761 3660 0	2761 3657 0	Climb-over;Rockslide;5847									
-											
-# Varrock pub											
-3285 3496 0	3285 3492 1	Climb-up;Staircase;11797									
-3285 3492 1	3285 3496 0	Climb-down;Staircase;11799									
-											
-# Dungeon Zogre flesh eaters											
-2477 9437 2	2485 3045 0	Climb-up;Stairs;6842									
-2457 3048 0	2455 3048 0	Climb-over;Crushed barricade;6878									
-2442 9417 0	2446 9417 2	Climb-over;Stairs;6842									
-											
-# Shayzien Encampent											
-1482 3633 0	1482 3633 1	Climb-up;Ladder;42207									
-1482 3633 1	1482 3633 0	Climb-down;Ladder;42208									
-											
-# Chasm of Fire											
-1435 3671 0	1435 10077 3	Enter;Chasm;30236									
-1435 10077 3	1435 3671 0	Climb-up;Rope;30234									
-1437 10093 3	1437 10093 2	Enter;Lift;30258									
-1438 10093 3	1438 10093 2	Enter;Lift;30258									
-1437 10093 2	1437 10093 3	Enter;Lift;30259									
-1438 10093 2	1438 10093 3	Enter;Lift;30259									
-1451 10068 3	1451 10068 2	Enter;Lift;30258									
-1451 10069 3	1451 10069 2	Enter;Lift;30258									
-1451 10068 2	1451 10068 3	Enter;Lift;30259									
-1451 10069 2	1451 10069 3	Enter;Lift;30259									
-1457 10096 2	1457 10096 1	Enter;Lift;30258									
-1457 10095 2	1457 10095 1	Enter;Lift;30258									
-1457 10096 1	1457 10096 2	Enter;Lift;30259									
-1457 10095 1	1457 10095 2	Enter;Lift;30259									
-1457 10075 2	1457 10075 1	Enter;Lift;30258									
-1457 10076 2	1457 10076 1	Enter;Lift;30258									
-1457 10075 1	1457 10075 2	Enter;Lift;30259									
-1457 10076 1	1457 10076 2	Enter;Lift;30259									
-											
-# dungeon shayzien mountain camp											
-1169 9973 0	1171 9946 0	Pass;Magic gate;31967									
-9363 1050 0	1214 3557 0	Climb;Rope;32507									
-											
-# dragon slayer 2											
-2458 2860 0	2458 2862 0	Pass;Magical Barrier;31616									
-2457 2860 0	2457 2862 0	Pass;Magical Barrier;31616									
-2456 2860 0	2456 2862 0	Pass;Magical Barrier;31616									
-2458 2862 0	2458 2860 0	Pass;Magical Barrier;31616									
-2457 2862 0	2457 2860 0	Pass;Magical Barrier;31616									
-2456 2862 0	2456 2860 0	Pass;Magical Barrier;31616									
-											
-# watchtower											
-2933 4712 2	2549 3112 1	Climb-down;Ladder;2797									
-2549 3112 1	2933 4712 2	Climb-down;Ladder;2797									
-2544 3112 1	2544 3112 0	Climb-down;Ladder;17122									
-2544 3112 0	2544 3112 1	Climb-down;Ladder;17122									
-											
-# kourend											
-1618 3680 0	1614 3680 1	Climb-up;Staircase;11807									
-1614 3680 1	1618 3680 0	Climb-down;Staircase;11799									
-1616 3686 1	1616 3686 2	Climb-up;Staircase;12536									
-1616 3686 2	1616 3686 1	Climb-down;Staircase;12538									
-1639 3673 0	1666 10050 0	Investigate;Statue;27785									
-1666 10050 0	1639 3673 0	Climb-up;Vine ladder;28894									
-1562 3791 0	1617 10101 0	Enter;Hole;28921					5090=1				
-1617 10101 0	1562 3791 0	Climb-up;Vine;28895									
-1469 3653 0	1650 9987 0	Enter;Hole;28919					5080=1				
-1650 9987 0	1469 3653 0	Climb-up;Vine;28895									
-1696 3864 0	1719 10101 0	Enter;Hole;28920					5070=1				
-1719 10101 0	1696 3864 0	Climb-up;Vine;28898									
-1727 9993 0	1803 9968 0	Climb-up;Vine;28897	 								
-1803 9968 0	1727 9993 0	Enter;Strange passage;28918	 				5087=1				
-1670 3569 0	1800 9968 0	Climb-down;Staircase;34865									
-1800 9968 0	1670 3569 0	Climb-up;Staircase;34864									
-1830 9973 0	1702 3575 0	Climb-up;Ladder;34863									
-1830 9975 0	1702 3575 0	Climb-up;Ladder;34863									
-1702 3575 0	1830 9973 0	Climb-down;Ladder;34862								10	
-1833 9944 0	1833 9943 0	Slash;Web;733									
-1833 9943 0	1833 9944 0	Slash;Web;733									
-1841 9934 0	1841 9933 0	Slash;Web;733									
-1841 9933 0	1841 9934 0	Slash;Web;733									
-1842 9934 0	1842 9933 0	Slash;Web;733									
-1842 9933 0	1842 9934 0	Slash;Web;733									
-1849 9934 0	1849 9935 0	Slash;Web;733									
-1849 9935 0	1849 9934 0	Slash;Web;733									
-1850 9934 0	1850 9935 0	Slash;Web;733									
-1850 9935 0	1850 9934 0	Slash;Web;733									
-1847 9920 0	1847 9919 0	Slash;Web;733									
-1847 9919 0	1847 9920 0	Slash;Web;733									
-											
-# Arceuus Library											
-1617 3826 0	1610 3826 1	Climb;Stairs;27853									
-1617 3827 0	1610 3827 1	Climb;Stairs;27854									
-1610 3826 1	1617 3826 0	Climb;Stairs;27855									
-1610 3827 1	1617 3827 0	Climb;Stairs;27856									
-1615 3818 1	1608 3818 2	Climb;Stairs;27851	 								
-1615 3819 1	1608 3819 2	Climb;Stairs;27851	 								
-1608 3818 2	1615 3818 1	Climb;Stairs;27852	 								
-1608 3819 2	1615 3819 1	Climb;Stairs;27852	 								
-1639 3810 1	1639 3803 2	Climb;Stairs;27851									
-1638 3810 1	1638 3803 2	Climb;Stairs;27851									
-1639 3803 2	1639 3810 1	Climb;Stairs;27852									
-1638 3803 2	1638 3810 1	Climb;Stairs;27852									
-1617 3795 0	1610 3795 1	Climb;Stairs;27853									
-1617 3796 0	1610 3796 1	Climb;Stairs;27854									
-1610 3795 1	1617 3795 0	Climb;Stairs;27855									
-1610 3796 1	1617 3796 0	Climb;Stairs;27856									
-1621 3791 1	1621 3798 2	Climb;Stairs;27851									
-1622 3791 1	1622 3798 2	Climb;Stairs;27851									
-1621 3798 2	1621 3791 1	Climb;Stairs;27852									
-1622 3798 2	1622 3791 1	Climb;Stairs;27852									
-1644 3818 0	1644 3825 1	Climb;Stairs;27853									
-1645 3818 0	1645 3825 1	Climb;Stairs;27854									
-1644 3825 1	1644 3818 0	Climb;Stairs;27855									
-1645 3825 1	1645 3818 0	Climb;Stairs;27856									
-1643 3829 1	1650 3829 2	Climb;Stairs;27851									
-1643 3828 1	1650 3828 2	Climb;Stairs;27851									
-1650 3829 2	1643 3829 1	Climb;Stairs;27852									
-1650 3828 2	1643 3828 1	Climb;Stairs;27852									
-# Corsair Cove											
-2578 2840 0	2578 2837 1	Cross;Gangplank;31756								1	
-2578 2837 1	2578 2840 0	Cross;Gangplank;31756								1	
-2523 2860 0	2012 9004 1	Enter;Hole;31791								2	
-2012 9004 1	2523 2860 0	Climb;Vine ladder;31790								2	
-2483 2889 0	1971 9035 1	Enter;Cave;31766								2	
-1971 9035 1	2483 2889 0	Enter;Cave;31806								2	
-											
-# mining guild											
-3021 9739 0	3021 3339 0	Climb-up;Ladder;17385									
-3021 3339 0	3021 9739 0	Climb-down;Ladder;30367									
-											
-# portal to gotr											
-3104 9573 0	3615 9470 0	Enter;Portal;43841									
-3615 9470 0	3104 9573 0	Enter;Portal;43692									
-											
-# Necropolis											
-3347 2759 0	3349 2759 0	Climb-over;Rubble;44003								4	
-3349 2759 0	3347 2759 0	Climb-over;Rubble;44003								4	
-											
-# Villa entry aldarin											
-1425 2933 0	1427 2933 0	Pass-through;Entryway;54707								4	
-1427 2933 0	1425 2933 0	Pass-through;Entryway;54707								4	
-											
-# Fortis Colosseum											
-1795 3107 0	1799 9506 0	Enter;Colosseum entrance;50749								8	
-1799 9506 0	1795 3107 0	Exit;Stairs;50750								8	
-											
-# Hunter Guild											
-1558 3047 0	1558 9451 0	Climb-down;Stairs;51641								8	
-1558 9451 0	1558 3047 0	Climb-up;Stairs;51642								8	
-1553 3033 0	1553 3033 1	Climb-up;Ladder;52614									
-1553 3033 1	1553 3033 0	Climb-down;Ladder;52620									
-1556 3034 1	1556 3034 2	Climb-up;Ladder;52614									
-1556 3034 2	1556 3034 1	Climb-down;Ladder;52620									
-											
-# Piscatoris Hunting Area											
-2371 3622 0	2371 3620 0	Climb-over;Stile;19222								8	
-2371 3620 0	2371 3622 0	Climb-over;Stile;19222								8	
-											
-# Taverly dungeon											
+2466 3494 2	2466 3494 1	Climb-down;Ladder;56232
+2466 3494 2	2466 3494 3	Climb-up;Ladder;56232
+2466 3494 3	2466 3494 2	Climb-down;Ladder;56229
+2465 3495 2	2465 3495 3	Climb-up;Ladder;56232
+2465 3495 3	2465 3495 2	Climb-down;Ladder;56229
+2466 3496 2	2466 3496 3	Climb-up;Ladder;56232
+2466 3496 3	2466 3496 2	Climb-down;Ladder;56229
+2464 3497 0	2464 9897 0	Open;Trapdoor;2446
+2464 9897 0	2464 3497 0	Climb-up;Ladder;17385
+2467 9903 0	2467 9905 0	Push;Roots;2451
+2467 9905 0	2467 9903 0	Push;Roots;2451
+2468 9903 0	2468 9905 0	Push;Roots;2451
+2468 9905 0	2468 9903 0	Push;Roots;2451
+2430 3424 0	2429 9824 0	Enter;Cave;26709
+2429 9824 0	2430 3424 0	Use;Tunnel;27257
+2429 9825 0	2430 3424 0	Use;Tunnel;27258
+2435 9807 0	2429 9807 0	Enter;Tunnel;30174
+2435 9806 0	2429 9806 0	Enter;Tunnel;30174
+2402 3420 0	2409 9812 0	Enter;Cave entrance;17209
+2409 9812 0	2402 3419 0	Exit;Tunnel;17223
+2402 3419 0	2409 9812 0	Enter;Cave entrance;17209
+2402 3418 0	2409 9812 0	Enter;Cave entrance;17209
+2403 3421 0	2409 9812 0	Enter;Cave entrance;17209
+2408 9812 0	2402 3419 0	Exit;Tunnel;17222
+2403 3417 0	2409 9812 0	Enter;Cave entrance;17209
+2405 3420 0	2409 9812 0	Enter;Cave entrance;17209
+2405 3419 0	2409 9812 0	Enter;Cave entrance;17209
+2405 3418 0	2409 9812 0	Enter;Cave entrance;17209
+2435 3519 0	1987 5568 0	Pass-through;Opening;28807
+1987 5568 0	2435 3519 0	Pass-through;Opening;28807
+
+# Tolna's Rift
+3309 3452 0	3297 9824 0	Enter;Rift;13968
+3297 9824 0	3312 3450 0	Climb-up;Rope;13999
+3298 9823 0	3312 3450 0	Climb-up;Rope;13999
+3296 9823 0	3312 3450 0	Climb-up;Rope;13999
+3297 9822 0	3312 3450 0	Climb-up;Rope;13999
+2484 3463 1	2486 3465 2	Climb-up;Tree;2447
+2485 3465 2	2484 3463 1	Climb-down;Tree;28800
+
+# Land's End
+1504 3396 1	1504 3399 0	Cross;Gangplank;29724								3
+1504 3399 0	1504 3396 1	Cross;Gangplank;29723								3
+1512 3416 0	1512 3416 1	Climb-up;Ladder;18324
+1512 3416 1	1512 3416 0	Climb-down;Ladder;18325
+1493 3403 1	1496 3403 0	Cross;Gangplank;50066
+1496 3403 0	1493 3403 1	Cross;Gangplank;50065
+
+# Shayzien
+1483 3549 0	1483 9951 3	Enter;Crypt Entrance;32403
+1483 9951 3	1483 3549 0	Climb-up;Ladder;32401
+1561 3596 0	1561 3592 1	Climb;Stairs;27201
+1561 3592 1	1561 3596 0	Climb;Stairs;27202
+1562 3596 0	1562 3592 1	Climb;Stairs;27201
+1562 3592 1	1562 3596 0	Climb;Stairs;27202
+1579 3590 0	1579 3586 1	Climb;Stairs;27201
+1579 3586 1	1579 3590 0	Climb;Stairs;27202
+1580 3590 0	1580 3586 1	Climb;Stairs;27201
+1580 3586 1	1580 3590 0	Climb;Stairs;27202
+1420 3589 0	1432 9913 0	Enter;Cave;42248
+1420 3588 0	1432 9913 0	Enter;Cave;42248
+1432 9913 0	1420 3588 0	Exit;Cave;42247
+1509 3593 0	1509 3593 1	Climb-up;Ladder;42207
+1509 3593 1	1509 3593 0	Climb-down;Ladder;42208
+1511 3592 1	1507 3592 2	Climb;Stairs;27199
+1507 3592 2	1511 3592 1	Climb;Stairs;27200
+
+# Meyerditch
+3649 3220 0	3631 3219 0	Enter;Door;32660				Darkness of Hallowvale
+3631 3219 0	3649 3219 0	Enter;Door;32659				Darkness of Hallowvale
+3649 3219 0	3631 3219 0	Enter;Door;32660				Darkness of Hallowvale
+3631 3220 0	3649 3219 0	Enter;Door;32659				Darkness of Hallowvale
+3649 3218 0	3631 3219 0	Enter;Door;32660				Darkness of Hallowvale
+3631 3218 0	3649 3219 0	Enter;Door;32659				Darkness of Hallowvale
+3632 3205 0	3632 3202 1	Climb-up;Stairs up;17976
+3632 3202 1	3632 3205 0	Climb-down;Stairs down;17978
+3604 3202 0	3602 3202 1	Climb-up;Ladder;17974
+3602 3202 1	3604 3202 0	Climb-down;Ladder;17975
+3588 3180 0	3592 3180 0	Climb-over;Wall rubble;18037
+3592 3180 0	3588 3180 0	Climb-over;Wall rubble;18038
+3589 3179 0	3592 3180 0	Climb-over;Wall rubble;18037
+3590 3173 1	3588 3173 0	Climb-down;Floor;18122
+3588 3173 0	3590 3173 1	Climb-up;Floor;18124
+3589 3174 1	3588 3173 0	Climb-down;Floor;18122
+3589 3174 0	3590 3173 1	Climb-up;Floor;18124
+3589 3173 1	3588 3173 0	Climb-down;Floor;18122
+3588 3173 1	3588 3173 0	Climb-down;Floor;18122
+3589 3173 0	3590 3173 1	Climb-up;Floor;18124
+3588 3211 0	3588 3209 1	Climb-up;Ladder;18000
+3588 3209 1	3588 3211 0	Climb-down;Ladder;17999
+3589 3214 0	3589 3215 0	Open;Barricade;18054
+3589 3215 0	3589 3214 0	Open;Barricade;18054
+3592 3230 0	3594 3230 1	Climb-up;Ladder;18000
+3594 3230 1	3592 3230 0	Climb-down;Ladder;17999
+3588 3250 1	3588 3252 2	Climb-up;Ladder;18002
+3588 3252 2	3588 3250 1	Climb-down;Ladder;18001
+3588 3258 2	3588 3260 1	Climb-down;Ladder;18001
+3588 3260 1	3588 3258 2	Climb-up;Ladder;18002
+3595 3310 1	3595 3312 0	Climb-up;Wall;39173
+3595 3312 0	3595 3310 1	Climb-down;Wall;39172
+3601 3163 1	3605 3163 1	Climb-down;Rock;17960
+3605 3163 1	3601 3163 1	Climb-up;Rock;17959
+3605 3161 1	3605 3163 1	Jump-onto;Rock;17958
+3595 3203 0	3595 3205 1	Climb-up;Ladder;17974
+3595 3205 1	3595 3203 0	Climb-down;Ladder;17975
+3598 3203 1	3598 3201 1	Jump-to;Floorboards;18070
+3598 3201 1	3598 3203 1	Jump-to;Floorboards;18071
+3599 3200 1	3601 3200 1	Jump-to;Floorboards;18072
+3601 3200 1	3599 3200 1	Jump-to;Floorboards;18073
+3605 3203 1	3605 3206 1	Walk-across;Floor;18129
+3605 3206 1	3605 3203 1	Walk-across;Floor;18130
+3606 3207 1	3606 3208 1	Crawl-under;Wall;18078
+3606 3208 1	3606 3207 1	Crawl-under;Wall;18078
+3604 3214 1	3601 3214 1	Walk-across;Floor;18132
+3601 3214 1	3604 3214 1	Walk-across;Floor;18133
+3601 3216 1	3601 3214 0	Climb-down;Ladder;17975
+3601 3214 0	3601 3216 1	Climb-up;Ladder;17974
+3598 3215 0	3598 3220 0	Climb-into;Trapdoor tunnel;18083
+3598 3220 0	3598 3215 0	Climb-into;Tunnel;18085
+3597 3219 0	3598 3215 0	Climb-into;Tunnel;18085
+3594 3223 0	3595 3223 1	Climb-up;Shelf;18086
+3595 3223 1	3594 3223 0	Climb-down;Shelf;18087
+3596 3223 1	3597 3223 1	Crawl-under;Wall;18088
+3597 3223 1	3596 3223 1	Crawl-under;Wall;18088
+3598 3222 1	3601 3222 1	Jump-to;Floorboards;18089
+3601 3222 1	3598 3222 1	Jump-to;Floorboards;18090
+3603 3223 1	3603 3221 0	Climb-down;Ladder;17975
+3603 3221 0	3603 3223 1	Climb-up;Ladder;17974
+3608 3221 0	3609 3221 0	Open;Door;18091
+3609 3221 0	3608 3221 0	Open;Door;18091
+3619 3219 0	3617 3219 1	Climb-up;Ladder;17974
+3617 3219 1	3619 3219 0	Climb-down;Ladder;17975
+3615 3218 1	3615 3216 1	Jump-to;Floorboards;18093
+3615 3216 1	3615 3218 1	Jump-to;Floorboards;18094
+3615 3210 1	3614 3210 2	Climb-up;Shelf;18095
+3614 3210 2	3615 3210 1	Climb-down;Shelf;18096
+3610 3211 2	3610 3209 3	Climb-up;Ladder;17974
+3610 3209 3	3610 3211 2	Climb-down;Ladder;17975
+3613 3208 3	3613 3205 3	Jump-to;Floorboards;18097
+3613 3205 3	3613 3208 3	Jump-to;Floorboards;18098
+3613 3203 3	3611 3203 2	Climb-down;Ladder;17975
+3611 3203 2	3613 3203 3	Climb-up;Ladder;17974
+3612 3201 2	3610 3201 1	Climb-down;Ladder;17975
+3610 3201 1	3612 3201 2	Climb-up;Ladder;17974
+3611 3199 1	3611 3201 0	Climb-down;Ladder;17975
+3611 3201 0	3611 3199 1	Climb-up;Ladder;17974
+3616 3202 2	3622 3202 2	Walk-across;Washing line;18099
+3622 3202 2	3616 3202 2	Walk-across;Washing line;18100
+3625 3202 2	3625 3204 1	Climb-down;Ladder;17975
+3625 3204 1	3625 3202 2	Climb-up;Ladder;17974
+3623 3207 1	3623 3210 1	Walk-across;Floor;18135
+3623 3210 1	3623 3207 1	Walk-across;Floor;18136
+3623 3217 1	3623 3218 2	Climb-up;Shelf;18105
+3623 3218 2	3623 3217 1	Climb-down;Shelf;18106
+3623 3218 0	3621 3218 1	Climb-up;Ladder;17974
+3621 3218 1	3623 3218 0	Climb-down;Ladder;17975
+3625 3223 0	3625 3224 0	Open;Door;18057
+3625 3224 0	3625 3223 0	Open;Door;18057
+3625 3221 2	3626 3221 1	Climb-down;Shelf;18107
+3626 3221 1	3625 3221 2	Climb-up;Shelf;18108
+3623 3223 1	3623 3226 1	Jump-to;Floorboards;18109
+3623 3226 1	3623 3223 1	Jump-to;Floorboards;18110
+3622 3230 1	3622 3232 1	Jump-to;Floorboards;18111
+3622 3232 1	3622 3230 1	Jump-to;Floorboards;18112
+3624 3240 1	3626 3240 1	Jump-to;Floorboards;18113
+3626 3240 1	3624 3240 1	Jump-to;Floorboards;18114
+3631 3239 2	3629 3239 1	Climb-down;Ladder;17975
+3629 3239 1	3631 3239 2	Climb-up;Ladder;17974
+3628 3240 1	3630 3240 0	Climb-down;Ladder;18116
+3630 3240 0	3628 3240 1	Climb-up;Ladder;17974
+3625 3251 0	3627 3251 1	Climb-up;Ladder;17974
+3627 3251 1	3625 3251 0	Climb-down;Ladder;17975
+3632 3258 0	3630 3258 1	Climb-up;Ladder;17974
+3630 3258 1	3632 3258 0	Climb-down;Ladder;17975
+3633 3256 1	3636 3256 1	Jump-to;Floorboards;18117
+3636 3256 1	3633 3256 1	Jump-to;Floorboards;18118
+3639 3255 1	3639 3258 0	Climb-down;Stairs down;17978
+3639 3258 0	3639 3255 1	Climb-up;Stairs up;17976
+3640 3253 0	3640 3252 0	Push;Wall;17980
+3640 3252 0	3640 3253 0	Push;Wall;17980
+3627 3269 0	3624 3269 1	Climb-up;Stairs up;17976
+3624 3269 1	3627 3269 0	Climb-down;Stairs down;17978
+3632 3270 1	3629 3270 0	Climb-down;Stairs down;17978
+3629 3270 0	3632 3270 1	Climb-up;Stairs up;17976
+3631 3274 1	3633 3274 2	Climb-up;Ladder;17974
+3633 3274 2	3631 3274 1	Climb-down;Ladder;17975
+3613 3279 0	3615 3279 1	Climb-up;Ladder;17974
+3615 3279 1	3613 3279 0	Climb-down;Ladder;17975
+3598 3278 0	3598 3281 1	Climb-up;Stairs up;17976
+3598 3281 1	3598 3278 0	Climb-down;Stairs down;17978
+3593 9674 0	3593 3272 0	Climb-up;Stairs;32561
+3593 3272 0	3593 9674 0	Climb-down;Stairs;32560
+3596 9679 0	3596 9680 0	Open;Door;32562
+3596 9680 0	3596 9679 0	Open;Door;32562
+3606 3291 0	3606 3293 1	Climb-up;Ladder;17974
+3606 3293 1	3606 3291 0	Climb-down;Ladder;17975
+3607 3291 1	3609 3291 2	Climb-up;Ladder;17974
+3609 3291 2	3607 3291 1	Climb-down;Ladder;17975
+3615 3299 0	3613 3299 1	Climb-up;Ladder;17974
+3613 3299 1	3615 3299 0	Climb-down;Ladder;17975
+3638 3304 0	3638 3305 0	Walk-through;Slashed tapestry;18125
+3638 3305 0	3638 3304 0	Walk-through;Slashed tapestry;18125
+3642 3307 0	3641 3307 0	Open;Door;18047
+3641 3307 0	3642 3307 0	Open;Door;18047
+3637 9695 0	3643 3306 0	Climb-up;Staircase;18050
+3643 3306 0	3637 9695 0	Climb-down;Staircase;18049
+3629 9681 0	3629 9680 0	Open;Door;17911
+3629 9680 0	3629 9681 0	Open;Door;17911
+3630 9681 0	3630 9680 0	Open;Door;17912
+3630 9680 0	3630 9681 0	Open;Door;17912
+3513 9811 0	3492 9862 0	Enter;Cave;38016
+3492 9862 0	3513 9811 0	Enter;Cave entrance;12771
+3491 9876 0	3483 9832 0	Enter;Cave entrance;12771
+3483 9832 0	3491 9876 0	Enter;Cave entrance;12770
+3626 3293 0	3626 3291 1	Climb-up;Ladder;17974
+3626 3291 1	3626 3293 0	Climb-down;Ladder;17975
+3621 3317 0	3619 3317 1	Climb-up;Ladder;17974
+3619 3317 1	3621 3317 0	Climb-down;Ladder;17975
+
+# Darkmeyer
+3627 3328 0	3627 3332 0	Enter;Cracked wall;39170
+3627 3332 0	3627 3328 0	Enter;Cracked wall;39170
+3696 9764 2	3633 3339 0	Climb-up;Staircase;39093
+3633 3339 0	3696 9764 2	Climb-down;Staircase;39092
+3697 9764 2	3633 3339 0	Climb-up;Staircase;39093
+3633 3340 0	3696 9764 2	Climb-down;Staircase;39092
+3654 3384 0	2400 5969 0	Enter;Mausoleum Door;38574
+2400 5969 0	3654 3384 0	Climb-up;Stairs;38601
+2399 5969 0	3654 3384 0	Climb-up;Stairs;38601
+2401 5969 0	3654 3384 0	Climb-up;Stairs;38601
+3614 3362 0	3615 3361 0	Open;Large door;39253
+3615 3361 0	3614 3361 0	Open;Large door;39253
+3614 3361 0	3615 3361 0	Open;Large door;39253
+3615 3362 0	3614 3361 0	Open;Large door;39253
+3613 3338 0	3613 3342 1	Climb-up;Staircase;39491
+3613 3342 1	3613 3338 0	Climb-down;Staircase;39492
+3599 3317 0	3603 3317 1	Climb-up;Staircase;39491
+3603 3317 1	3599 3317 0	Climb-down;Staircase;39492
+3667 3375 0	3670 3375 0	Climb;Wall;39542
+3670 3375 0	3667 3375 0	Climb;Wall;39542
+3670 3375 0	3673 3375 0	Climb;Wall;39541
+3673 3375 0	3670 3375 0	Climb;Wall;39541
+3672 3376 0	3670 3375 0	Climb;Wall;39541
+3672 3374 0	3670 3375 0	Climb;Wall;39541
+
+# The Hollows
+3480 9837 0	3480 9836 0	Search;Wall;5052
+3480 9836 0	3480 9837 0	Search;Wall;5052
+3500 9811 0	3509 3449 0	Open;Wooden doors;5056
+3509 3449 0	3500 9811 0	Open;Wooden doors;5061
+3501 9811 0	3509 3449 0	Open;Wooden doors;5057
+3510 3449 0	3500 9811 0	Open;Wooden doors;5060
+3481 9824 0	3466 9820 0	Enter;Cave entrance;5046
+3466 9820 0	3481 9824 0	Enter;Cave entrance;5046
+3460 9813 0	3447 9822 0	Enter;Cave entrance;16308
+3447 9822 0	3460 9813 0	Enter;Cave entrance;16308
+3475 9806 0	3488 9815 0	Enter;Cave entrance;5046
+3488 9815 0	3475 9806 0	Enter;Cave entrance;5046
+3492 9809 0	3477 9799 0	Enter;Cave entrance;5046
+3477 9799 0	3492 9809 0	Enter;Cave entrance;5046
+3492 9824 0	3505 9832 0	Enter;Cave entrance;5046
+3505 9832 0	3492 9824 0	Enter;Cave entrance;5046
+
+# Slepe
+3703 3335 0	3700 3334 1	Climb-up;Stairs;32647
+3700 3335 1	3703 3334 0	Climb-down;Stairs;32648
+3703 3336 0	3700 3334 1	Climb-up;Stairs;32647
+3703 3334 0	3700 3334 1	Climb-up;Stairs;32647
+3720 3307 0	3732 9683 0	Climb-down;Trapdoor;32643
+3732 9683 0	3720 3307 0	Climb-up;Ladder;32644
+3727 3302 0	3738 9703 1	Climb-down;Stairs;32637
+3738 9703 1	3728 3302 0	Climb-up;Stairs;32638
+3728 3302 0	3738 9703 1	Climb-down;Stairs;32637
+3739 9703 1	3728 3302 0	Climb-up;Stairs;32638
+3729 3302 0	3738 9703 1	Climb-down;Stairs;32637
+3735 3319 1	3736 3318 0	Climb-down;Staircase;24359
+3736 3318 0	3735 3319 1	Climb-up;Staircase;24358
+3736 3316 1	3736 3316 2	Climb-up;Ladder;24351
+3736 3316 2	3736 3316 1	Climb-down;Ladder;24352
+3741 3318 1	3742 3319 0	Climb-down;Staircase;24359
+3742 3319 0	3741 3318 1	Climb-up;Staircase;24358
+3741 3316 2	3741 3316 3	Climb-up;Ladder;24351
+3741 3316 3	3741 3316 2	Climb-down;Ladder;24352
+3745 3334 0	3745 3337 1	Climb-up;Stairs;32647
+3746 3334 0	3745 3337 1	Climb-up;Stairs;32647
+3747 3334 0	3745 3337 1	Climb-up;Stairs;32647
+3746 3337 1	3745 3334 0	Climb-down;Stairs;32648
+3728 9752 1	3728 9753 1	Open;Gate;39512
+3728 9753 1	3728 9752 1	Open;Gate;39512
+3727 9756 1	3725 3356 0	Climb-up;Ladder;32642
+3725 3356 0	3727 9756 1	Climb-down;Trapdoor;32641
+3725 3352 0	3725 3356 1	Climb-up;Staircase;32645
+3725 3356 1	3725 3352 0	Climb-down;Staircase;32646
+3726 3352 0	3726 3356 1	Climb-up;Staircase;32645
+3726 3356 1	3726 3352 0	Climb-down;Staircase;32646
+3728 9765 1	3728 9766 1	Open;Gate;39510
+3728 9766 1	3728 9765 1	Open;Gate;39510
+3728 9775 1	3728 9776 1	Open;Gate;39510
+3728 9776 1	3728 9775 1	Open;Gate;39510
+3737 9780 1	3738 9780 1	Open;Gate;39510
+3738 9780 1	3737 9780 1	Open;Gate;39510
+3746 9780 1	3747 9780 1	Open;Gate;39510
+3747 9780 1	3746 9780 1	Open;Gate;39510
+3788 9778 1	3792 9778 2	Climb-up;Stairs;37832
+3792 9778 2	3788 9778 1	Climb-down;Stairs;37833
+3788 9777 1	3792 9777 2	Climb-up;Stairs;37832
+3792 9777 2	3788 9777 1	Climb-down;Stairs;37833
+3824 9777 2	3828 9777 1	Climb-down;Stairs;37833
+3828 9777 1	3824 9777 2	Climb-up;Stairs;37832
+3828 9778 1	3824 9778 2	Climb-up;Stairs;37832
+3824 9778 2	3828 9778 1	Climb-down;Stairs;37833
+3807 9797 2	3807 9801 1	Climb-down;Stairs;37836
+3807 9801 1	3807 9797 2	Climb-up;Stairs;37835
+3808 9797 2	3808 9801 1	Climb-down;Stairs;37836
+3808 9801 1	3808 9797 2	Climb-up;Stairs;37835
+3809 9797 2	3809 9801 1	Climb-down;Stairs;37836
+3809 9801 1	3809 9797 2	Climb-up;Stairs;37835
+
+# Ectofunctus
+3672 3376 0	3670 3375 0	Climb;Wall;39541
+3672 3374 0	3670 3375 0	Climb;Wall;39541
+3666 3517 0	3666 3522 1	Climb-up;Staircase;16646
+3666 3522 1	3666 3517 0	Climb-down;Staircase;16647
+3667 3517 0	3667 3522 1	Climb-up;Staircase;16646
+3667 3522 1	3667 3517 0	Climb-down;Staircase;16647
+3669 9888 3	3654 3519 0	Climb-up;Ladder;16110
+3654 3519 0	3669 9888 3	Climb-down;Trapdoor;16114
+3653 3520 0	3669 9888 3	Climb-down;Trapdoor;16114
+3653 3518 0	3669 9888 3	Climb-down;Trapdoor;16114
+3652 3519 0	3669 9888 3	Climb-down;Trapdoor;16114
+3671 9889 2	3675 9888 1	Climb-down;Stairs;16109
+3675 9888 1	3671 9886 2	Climb-up;Stairs;16108
+3671 9887 2	3675 9888 1	Climb-down;Stairs;16109
+3675 9889 1	3671 9886 2	Climb-up;Stairs;16108
+3671 9888 2	3675 9888 1	Climb-down;Stairs;16109
+3675 9887 1	3671 9886 2	Climb-up;Stairs;16108
+3674 9890 1	3671 9886 2	Climb-up;Stairs;16108
+3672 9886 2	3675 9888 1	Climb-down;Stairs;16109
+3673 9890 1	3671 9886 2	Climb-up;Stairs;16108
+3674 9886 1	3671 9886 2	Climb-up;Stairs;16108
+3673 9886 1	3671 9886 2	Climb-up;Stairs;16108
+3687 9889 1	3683 9888 0	Climb-down;Stairs;16109
+3683 9889 0	3687 9887 1	Climb-up;Stairs;16108
+3687 9887 1	3683 9888 0	Climb-down;Stairs;16109
+3683 9888 0	3687 9887 1	Climb-up;Stairs;16108
+3687 9888 1	3683 9888 0	Climb-down;Stairs;16109
+3683 9887 0	3687 9887 1	Climb-up;Stairs;16108
+3686 9886 1	3683 9888 0	Climb-down;Stairs;16109
+3686 9890 1	3683 9888 0	Climb-down;Stairs;16109
+3689 9890 2	3692 9887 3	Climb-up;Stairs;16108
+3688 9889 2	3692 9887 3	Climb-up;Stairs;16108
+3688 9888 2	3692 9887 3	Climb-up;Stairs;16108
+3688 9887 2	3692 9887 3	Climb-up;Stairs;16108
+3690 9890 3	3688 9888 2	Climb-down;Stairs;16109
+3691 9890 3	3688 9888 2	Climb-down;Stairs;16109
+3692 9889 3	3688 9888 2	Climb-down;Stairs;16109
+3692 9888 3	3688 9888 2	Climb-down;Stairs;16109
+3692 9887 3	3688 9888 2	Climb-down;Stairs;16109
+3691 9886 3	3688 9888 2	Climb-down;Stairs;16109
+3690 9886 3	3688 9888 2	Climb-down;Stairs;16109
+
+# Shipwreck (Morytania)
+3614 3541 1	3616 3541 2	Climb-up;Ship's ladder;16111
+3616 3541 2	3614 3541 1	Climb-down;Ship's ladder;16112
+3610 3543 0	3608 3543 1	Climb-up;Ship's ladder;16111
+3608 3543 1	3610 3543 0	Climb-down;Ship's ladder;16112
+3614 3543 1	3612 3543 0	Climb-down;Ship's ladder;16112
+3612 3543 0	3614 3543 1	Climb-up;Ship's ladder;16111
+3605 3545 1	3605 3548 0	Cross;Gangplank;16651								3
+3605 3548 0	3605 3545 1	Cross;Gangplank;16652								3
+3604 3550 0	3602 3550 0	Jump-To;Rock;16115
+3602 3550 0	3604 3550 0	Jump-To;Rock;16115
+3599 3552 0	3597 3552 0	Jump-To;Rock;16115
+3597 3552 0	3599 3552 0	Jump-To;Rock;16115
+3595 3554 0	3595 3556 0	Jump-To;Rock;16115
+3595 3556 0	3595 3554 0	Jump-To;Rock;16115
+3597 3559 0	3597 3561 0	Jump-To;Rock;16115
+3597 3561 0	3597 3559 0	Jump-To;Rock;16115
+3599 3564 0	3601 3564 0	Jump-To;Rock;16115
+3601 3564 0	3599 3564 0	Jump-To;Rock;16115
+
+# Fenkenstrain's Castle
+3559 3550 0	3559 3554 1	Climb-up;Staircase;5206
+3559 3554 1	3559 3549 0	Climb-down;Staircase;5207
+3560 3550 0	3559 3554 1	Climb-up;Staircase;5206
+3560 3554 1	3559 3549 0	Climb-down;Staircase;5207
+3538 3554 1	3537 3549 0	Climb-down;Staircase;5207
+3537 3550 0	3537 3554 1	Climb-up;Staircase;5206
+3537 3554 1	3537 3549 0	Climb-down;Staircase;5207
+3538 3550 0	3537 3554 1	Climb-up;Staircase;5206
+3540 3543 0	3540 3543 1	Climb-up;Ladder;16683
+3540 3543 1	3540 3543 0	Climb-down;Ladder;16679
+3539 3544 0	3539 3544 1	Climb-up;Ladder;16683
+3539 3544 1	3539 3544 0	Climb-down;Ladder;16679
+3539 3542 0	3539 3542 1	Climb-up;Ladder;16683
+3539 3542 1	3539 3542 0	Climb-down;Ladder;16679
+3538 3543 1	3538 3543 0	Climb-down;Ladder;16679
+3538 3543 0	3538 3543 1	Climb-up;Ladder;16683
+3548 3565 0	3547 3565 0	Open;Door;5174
+3547 3565 0	3548 3565 0	Open;Door;5174
+3548 3551 1	3548 3552 1	Open;Door;5172
+3548 3552 1	3548 3551 1	Open;Door;5172
+3548 3553 1	3548 3553 2	Climb-up;Ladder;16683
+3548 3553 2	3548 3553 1	Climb-down;Ladder;16679
+3547 3554 1	3547 3554 2	Climb-up;Ladder;16683
+3547 3554 2	3547 3554 1	Climb-down;Ladder;16679
+3548 3555 1	3548 3555 2	Climb-up;Ladder;16683
+3548 3555 2	3548 3555 1	Climb-down;Ladder;16679
+3549 3554 1	3549 3554 2	Climb-up;Ladder;16683
+3549 3554 2	3549 3554 1	Climb-down;Ladder;16679
+3549 3543 1	3549 3542 1	Open;Door;5183
+3549 3542 1	3549 3543 1	Open;Door;5183
+3548 3543 1	3548 3542 1	Open;Door;5186
+3548 3542 1	3548 3543 1	Open;Door;5186
+3548 3540 1	3548 3540 2	Climb-up;Ladder;16683
+3548 3540 2	3548 3540 1	Climb-down;Ladder;16679
+3549 3539 1	3549 3539 2	Climb-up;Ladder;16683
+3549 3539 2	3549 3539 1	Climb-down;Ladder;16679
+3548 3538 1	3548 3538 2	Climb-up;Ladder;16683
+3548 3538 2	3548 3538 1	Climb-down;Ladder;16679
+3547 3539 1	3547 3539 2	Climb-up;Ladder;16683
+3547 3539 2	3547 3539 1	Climb-down;Ladder;16679
+
+# Slayer Tower
+3417 3536 0	3412 9932 3	Climb-down;Ladder;30191
+3412 9932 3	3417 3536 0	Climb-up;Ladder;30192
+3421 3550 0	3421 3550 1	Climb-up;Spikey chain;16537
+3422 3551 0	3422 3551 1	Climb-up;Spikey chain;16537
+3423 3550 0	3423 3550 1	Climb-up;Spikey chain;16537
+3422 3549 0	3422 3549 1	Climb-up;Spikey chain;16537
+3421 3550 1	3421 3550 0	Climb-down;Spikey chain;16538
+3422 3551 1	3422 3551 0	Climb-down;Spikey chain;16538
+3422 3549 1	3422 3549 0	Climb-down;Spikey chain;16538
+3423 3550 1	3423 3550 0	Climb-down;Spikey chain;16538
+3427 3555 1	3427 3556 1	Open;Door;2104
+3427 3556 1	3427 3555 1	Open;Door;2104
+3426 3555 1	3426 3556 1	Open;Door;2102
+3426 3556 1	3426 3555 1	Open;Door;2102
+3433 3538 1	3438 3537 0	Climb-down;Staircase;2118
+3438 3537 0	3433 3537 1	Climb-up;Staircase;2114
+3433 3537 1	3438 3537 0	Climb-down;Staircase;2118
+3438 3538 0	3433 3537 1	Climb-up;Staircase;2114
+3417 3540 2	3412 3540 1	Climb-down;Staircase;2120
+3412 3540 1	3417 3540 2	Climb-up;Staircase;2119
+3417 3541 2	3412 3540 1	Climb-down;Staircase;2120
+3412 3541 1	3417 3540 2	Climb-up;Staircase;2119
+
+# Monastery
+3057 3484 0	3057 3484 1	Climb-up;Ladder;2641	31 Prayer							2
+3056 3483 0	3056 3483 1	Climb-up;Ladder;2641	31 Prayer							2
+3057 3482 0	3057 3482 1	Climb-up;Ladder;2641	31 Prayer							2
+3058 3483 0	3058 3483 1	Climb-up;Ladder;2641	31 Prayer							2
+3047 3483 0	3047 3483 1	Climb-up;Ladder;2641	31 Prayer							2
+3046 3484 0	3046 3484 1	Climb-up;Ladder;2641	31 Prayer							2
+3045 3483 0	3045 3483 1	Climb-up;Ladder;2641	31 Prayer							2
+3046 3482 0	3046 3482 1	Climb-up;Ladder;2641	31 Prayer							2
+3057 3484 1	3057 3484 0	Climb-down;Ladder;16679								2
+3056 3483 1	3056 3483 0	Climb-down;Ladder;16679								2
+3057 3482 1	3057 3482 0	Climb-down;Ladder;16679								2
+3058 3483 1	3058 3483 0	Climb-down;Ladder;16679								2
+3047 3483 1	3047 3483 0	Climb-down;Ladder;16679								2
+3046 3484 1	3046 3484 0	Climb-down;Ladder;16679								2
+3045 3483 1	3045 3483 0	Climb-down;Ladder;16679								2
+3046 3482 1	3046 3482 0	Climb-down;Ladder;16679								2
+
+# Dwarven Mine
+3018 3450 0	3018 9850 0	Climb-down;Trapdoor;11867
+3018 9850 0	3018 3450 0	Climb-up;Ladder;17387
+3020 3450 0	3020 9850 0	Climb-down;Trapdoor;11867
+3058 9777 0	3061 3377 0	Climb-up;Staircase;23969
+3061 3377 0	3058 9777 0	Climb-down;Staircase;16664
+3058 9776 0	3061 3376 0	Climb-up;Staircase;23969
+3061 3376 0	3058 9776 0	Climb-down;Staircase;16664
+3728 5692 0	3060 9766 0	Exit;Tunnel;26655
+3060 9766 0	3728 5692 0	Enter;Cave;26654
+
+# Rimmington
+2964 3216 0	2968 3215 1	Climb-up;Staircase;18991								1
+2968 3215 1	2964 3215 0	Climb-down;Staircase;18992								1
+2964 3215 0	2968 3215 1	Climb-up;Staircase;18991								1
+2968 3216 1	2964 3215 0	Climb-down;Staircase;18992								1
+2949 3213 1	2949 3213 0	Climb-down;Ladder;9559								2
+2949 3213 0	2949 3213 1	Climb-up;Ladder;9558								2
+2915 3225 0	2915 3222 1	Cross;Gangplank;34669								3
+2915 3222 1	2915 3225 0	Cross;Gangplank;34670								3
+2913 3221 0	2913 3221 1	Climb-up;Ship's ladder;9744								2
+2913 3221 1	2913 3221 0	Climb-down;Ship's ladder;9745								2
+2914 3222 1	2913 3221 0	Climb-down;Ship's ladder;9745								2
+2914 3220 1	2913 3221 0	Climb-down;Ship's ladder;9745								2
+2915 3221 1	2913 3221 0	Climb-down;Ship's ladder;9745								2
+2909 3226 0	2909 3229 1	Cross;Gangplank;34667								1
+2909 3229 1	2909 3226 0	Cross;Gangplank;34668								1
+2933 3289 0	2933 3288 0	Open;Guild Door;14910	40 Crafting	1757;20208;9780;9781;9782;13280;13281						1
+2933 3288 0	2933 3289 0	Open;Guild Door;14910								1
+2941 3248 0	2940 3248 0	Open;Door;2595		1542						1
+2940 3248 0	2941 3248 0	Open;Door;2595								1
+2938 3252 0	2937 3252 0	Open;Exit door;2602								1
+2925 3244 0	2926 3244 0	Open;Red door;2596								1
+2926 3244 0	2925 3244 0	Open;Red door;2596								1
+2925 3248 0	2926 3248 0	Open;Red door;2596								1
+2926 3248 0	2925 3248 0	Open;Red door;2596								1
+2926 3253 0	2925 3253 0	Open;Red door;2596								1
+2925 3253 0	2926 3253 0	Open;Red door;2596								1
+
+# Burthorpe
+2892 3556 0	2892 3556 1	Climb-up;Ladder;16683								2
+2892 3556 1	2892 3556 0	Climb-down;Ladder;16679								2
+2891 3557 0	2891 3557 1	Climb-up;Ladder;16683								2
+2891 3557 1	2891 3557 0	Climb-down;Ladder;16679								2
+2905 3556 0	2905 3556 1	Climb-up;Ladder;16683								2
+2905 3556 1	2905 3556 0	Climb-down;Ladder;16679								2
+2906 3557 0	2906 3557 1	Climb-up;Ladder;16683								2
+2906 3557 1	2906 3557 0	Climb-down;Ladder;16679								2
+2899 3565 0	2205 4933 1	Climb-down;Stairs;4624
+2205 4934 1	2899 3564 0	Climb-up;Stairs;4627
+2900 3565 0	2205 4933 1	Climb-down;Stairs;4624
+2206 4934 1	2900 3565 0	Climb-up;Stairs;4627
+2207 4934 1	2207 4938 0	Climb-down;Stairs;4620
+2207 4938 0	2207 4934 1	Climb-up;Stairs;4622
+2208 4934 1	2207 4938 0	Climb-down;Stairs;4620
+2208 4938 0	2207 4934 1	Climb-up;Stairs;4622
+2212 4940 0	2212 4944 1	Climb-up;Stairs;4622
+2213 4940 0	2212 4944 1	Climb-up;Stairs;4622
+2212 4944 1	2212 4940 0	Climb-down;Stairs;4620
+2213 4944 1	2212 4940 0	Climb-down;Stairs;4620
+2898 3565 0	2897 3569 1	Climb-up;Stairs;4626
+2897 3569 1	2897 3565 0	Climb-down;Stairs;4625
+2897 3565 0	2897 3569 1	Climb-up;Stairs;4626
+2898 3569 1	2897 3565 0	Climb-down;Stairs;4625
+2905 3571 0	2905 3571 1	Climb-up;Ladder;16683								2
+2905 3571 1	2905 3571 0	Climb-down;Ladder;16679								2
+2906 3570 0	2906 3570 1	Climb-up;Ladder;16683								2
+2906 3570 1	2906 3570 0	Climb-down;Ladder;16679								2
+2877 3546 0	2876 3546 0	Open;Door;24318								1
+2876 3546 0	2877 3546 0	Open;Door;24318								1
+2855 3546 0	2855 3545 0	Open;Door;24309								1
+2855 3545 0	2855 3546 0	Open;Door;24309								1
+2854 3546 0	2854 3545 0	Open;Door;24306								1
+2854 3545 0	2854 3546 0	Open;Door;24306								1
+2841 3538 0	2840 3539 1	Climb-up;Staircase;16671								1
+2840 3539 1	2841 3538 0	Climb-down;Staircase;16672								1
+2841 3537 0	2840 3539 1	Climb-up;Staircase;16671								1
+2841 3538 1	2841 3538 0	Climb-down;Staircase;16672								1
+2840 3539 0	2840 3539 1	Climb-up;Staircase;16671								1
+2839 3539 0	2840 3539 1	Climb-up;Staircase;16671								1
+2838 3538 0	2840 3539 1	Climb-up;Staircase;16671								1
+2838 3537 0	2840 3539 1	Climb-up;Staircase;16671								1
+2840 3539 1	2840 3539 2	Climb-up;Staircase;16672								1
+2840 3539 2	2841 3538 1	Climb-down;Staircase;24303								1
+2841 3538 1	2840 3539 2	Climb-up;Staircase;16672								1
+2842 3541 1	2842 3542 1	Open;Door;24312								1
+2842 3542 1	2842 3541 1	Open;Door;24312								1
+2852 3551 1	2853 3551 1	Open;Heavy door;15660
+2853 3551 1	2852 3551 1	Open;Heavy door;15660
+2852 3552 1	2853 3552 1	Open;Heavy door;15658
+2853 3552 1	2852 3552 1	Open;Heavy door;15658
+2834 3542 0	2907 9968 0	Climb-down;Ladder;10042								2
+2907 9968 0	2834 3542 0	Climb-up;Ladder;9742								2
+3061 4985 1	2906 3537 0	Enter;Passageway;7258
+2906 3537 0	3061 4985 1	Enter;Trapdoor;7257
+2915 3538 0	2914 3542 1	Climb-up;Staircase;15645								1
+2914 3542 1	2914 3538 0	Climb-down;Staircase;15648								1
+2914 3538 0	2914 3542 1	Climb-up;Staircase;15645								1
+2915 3542 1	2914 3538 0	Climb-down;Staircase;15648								1
+2929 3545 0	2929 3545 1	Climb-up;Ladder;17026								2
+2929 3545 1	2929 3545 0	Climb-down;Ladder;16685								2
+2857 3577 0	2269 4752 0	Enter;Cave Entrance;3735
+2269 4752 0	2858 3577 0	Exit;Cave Exit;3736
+2858 3577 0	2269 4752 0	Enter;Cave Entrance;3735
+2270 4752 0	2858 3577 0	Exit;Cave Exit;3736
+2859 3577 0	2269 4752 0	Enter;Cave Entrance;3735
+2268 4752 0	2858 3577 0	Exit;Cave Exit;3736
+2860 3578 0	2269 4752 0	Enter;Cave Entrance;3735
+2892 3571 0	2892 3571 1	Climb-up;Ladder;16683								2
+2892 3571 1	2892 3571 0	Climb-down;Ladder;16679								2
+2891 3570 0	2891 3570 1	Climb-up;Ladder;16683								2
+2891 3570 1	2891 3570 0	Climb-down;Ladder;16679								2
+2894 3566 0	2894 3567 0	Open;Large door;3743
+2894 3567 0	2894 3566 0	Open;Large door;3743
+
+# Wilderness
+3158 3950 0	3158 3952 0	Slash;Web;733								4
+3158 3952 0	3158 3950 0	Slash;Web;733								4
+3232 10351 0	3233 3950 0	Use;Crevice;26763
+3233 3950 0	3232 10351 0	Enter;Cavern;26762
+3232 3950 0	3232 10351 0	Enter;Cavern;26762
+3242 3948 0	3243 10351 0	Enter;Cavern;26762
+3243 10351 0	3242 3948 0	Use;Crevice;26763
+3243 3948 0	3243 10351 0	Enter;Cavern;26762
+3232 3938 0	3233 10332 0	Enter;Cavern;26762
+3233 10332 0	3233 3938 0	Use;Crevice;26763
+3233 3938 0	3233 10332 0	Enter;Cavern;26762
+3095 3957 0	3094 3957 0	Slash;Web;733								4
+3093 3957 0	3092 3957 0	Slash;Web;733								4
+3092 3957 0	3093 3957 0	Slash;Web;733								4
+3094 3957 0	3095 3957 0	Slash;Web;733								4
+3106 3959 0	3106 3957 0	Slash;Web;733								4
+3105 3959 0	3105 3957 0	Slash;Web;733								4
+3105 3957 0	3105 3959 0	Slash;Web;733								4
+3106 3957 0	3106 3959 0	Slash;Web;733								4
+3018 3958 0	3018 3958 1	Climb-up;Ship's ladder;272
+3018 3958 1	3018 3958 0	Climb-down;Ship's ladder;273
+3019 3958 1	3019 3960 2	Climb-up;Ship's ladder;245
+3019 3960 2	3019 3958 1	Climb-down;Ship's ladder;246
+3017 3958 1	3017 3960 2	Climb-up;Ship's ladder;245
+3017 3960 2	3017 3958 1	Climb-down;Ship's ladder;246
+2998 3931 0	2998 3916 0	Open;Gate;23552
+2997 3931 0	2998 3916 0	Open;Gate;23554
+3005 3962 0	3005 10362 0	Climb-down;Ladder;14758								2
+3005 10362 0	3005 3962 0	Climb-up;Ladder;17385								2
+3069 10255 0	3016 3849 0	Climb-up;Ladder;18988								2
+3017 3850 0	3069 10255 0	Climb-down;Ladder;18987								2
+3068 10256 0	3016 3849 0	Climb-up;Ladder;18988								2
+3069 10257 0	3016 3849 0	Climb-up;Ladder;18988								2
+3029 3852 0	3031 3852 0	Slash;Web;733								4
+3031 3852 0	3029 3852 0	Slash;Web;733								4
+3115 3858 0	3115 3860 0	Slash;Web;733								4
+3115 3860 0	3115 3858 0	Slash;Web;733								4
+3069 3857 0	3016 10249 0	Climb-down;Ladder;18989								2
+3016 10249 0	3070 3856 0	Climb-up;Ladder;18990								2
+3017 10250 0	3070 3856 0	Climb-up;Ladder;18990								2
+3017 10248 0	3070 3856 0	Climb-up;Ladder;18990								2
+3018 10249 0	3070 3856 0	Climb-up;Ladder;18990								2
+3044 3927 0	3044 10322 0	Climb-down;Staircase;16664								1
+3044 10323 0	3044 3927 0	Climb-up;Staircase;16665								1
+3045 3927 0	3044 10322 0	Climb-down;Staircase;16664								1
+3045 10323 0	3044 3927 0	Climb-up;Staircase;16665								1
+2995 3530 0	2998 3530 0	Cross;Wilderness Ditch;23271								4
+2998 3530 0	2995 3530 0	Cross;Wilderness Ditch;23271								4
+2995 3531 0	2998 3531 0	Cross;Wilderness Ditch;23271								4
+2998 3531 0	2995 3531 0	Cross;Wilderness Ditch;23271								4
+2995 3532 0	2998 3532 0	Cross;Wilderness Ditch;23271								4
+2998 3532 0	2995 3532 0	Cross;Wilderness Ditch;23271								4
+2995 3533 0	2998 3533 0	Cross;Wilderness Ditch;23271								4
+2998 3533 0	2995 3533 0	Cross;Wilderness Ditch;23271								4
+2946 3520 0	2946 3523 0	Cross;Wilderness Ditch;23271								4
+2946 3523 0	2946 3520 0	Cross;Wilderness Ditch;23271								4
+2947 3520 0	2947 3523 0	Cross;Wilderness Ditch;23271								4
+2947 3523 0	2947 3520 0	Cross;Wilderness Ditch;23271								4
+2948 3520 0	2948 3523 0	Cross;Wilderness Ditch;23271								4
+2948 3523 0	2948 3520 0	Cross;Wilderness Ditch;23271								4
+2949 3520 0	2949 3523 0	Cross;Wilderness Ditch;23271								4
+2949 3523 0	2949 3520 0	Cross;Wilderness Ditch;23271								4
+2950 3520 0	2950 3523 0	Cross;Wilderness Ditch;23271								4
+2950 3523 0	2950 3520 0	Cross;Wilderness Ditch;23271								4
+2951 3520 0	2951 3523 0	Cross;Wilderness Ditch;23271								4
+2951 3523 0	2951 3520 0	Cross;Wilderness Ditch;23271								4
+2952 3520 0	2952 3523 0	Cross;Wilderness Ditch;23271								4
+2952 3523 0	2952 3520 0	Cross;Wilderness Ditch;23271								4
+2953 3520 0	2953 3523 0	Cross;Wilderness Ditch;23271								4
+2953 3523 0	2953 3520 0	Cross;Wilderness Ditch;23271								4
+2954 3520 0	2954 3523 0	Cross;Wilderness Ditch;23271								4
+2954 3523 0	2954 3520 0	Cross;Wilderness Ditch;23271								4
+2955 3520 0	2955 3523 0	Cross;Wilderness Ditch;23271								4
+2955 3523 0	2955 3520 0	Cross;Wilderness Ditch;23271								4
+2956 3520 0	2956 3523 0	Cross;Wilderness Ditch;23271								4
+2956 3523 0	2956 3520 0	Cross;Wilderness Ditch;23271								4
+2957 3520 0	2957 3523 0	Cross;Wilderness Ditch;23271								4
+2957 3523 0	2957 3520 0	Cross;Wilderness Ditch;23271								4
+2958 3520 0	2958 3523 0	Cross;Wilderness Ditch;23271								4
+2958 3523 0	2958 3520 0	Cross;Wilderness Ditch;23271								4
+2959 3520 0	2959 3523 0	Cross;Wilderness Ditch;23271								4
+2959 3523 0	2959 3520 0	Cross;Wilderness Ditch;23271								4
+2960 3520 0	2960 3523 0	Cross;Wilderness Ditch;23271								4
+2960 3523 0	2960 3520 0	Cross;Wilderness Ditch;23271								4
+2961 3520 0	2961 3523 0	Cross;Wilderness Ditch;23271								4
+2961 3523 0	2961 3520 0	Cross;Wilderness Ditch;23271								4
+2962 3520 0	2962 3523 0	Cross;Wilderness Ditch;23271								4
+2962 3523 0	2962 3520 0	Cross;Wilderness Ditch;23271								4
+2963 3520 0	2963 3523 0	Cross;Wilderness Ditch;23271								4
+2963 3523 0	2963 3520 0	Cross;Wilderness Ditch;23271								4
+2964 3520 0	2964 3523 0	Cross;Wilderness Ditch;23271								4
+2964 3523 0	2964 3520 0	Cross;Wilderness Ditch;23271								4
+2965 3520 0	2965 3523 0	Cross;Wilderness Ditch;23271								4
+2965 3523 0	2965 3520 0	Cross;Wilderness Ditch;23271								4
+2966 3520 0	2966 3523 0	Cross;Wilderness Ditch;23271								4
+2966 3523 0	2966 3520 0	Cross;Wilderness Ditch;23271								4
+2967 3520 0	2967 3523 0	Cross;Wilderness Ditch;23271								4
+2967 3523 0	2967 3520 0	Cross;Wilderness Ditch;23271								4
+2968 3520 0	2968 3523 0	Cross;Wilderness Ditch;23271								4
+2968 3523 0	2968 3520 0	Cross;Wilderness Ditch;23271								4
+2969 3520 0	2969 3523 0	Cross;Wilderness Ditch;23271								4
+2969 3523 0	2969 3520 0	Cross;Wilderness Ditch;23271								4
+2970 3520 0	2970 3523 0	Cross;Wilderness Ditch;23271								4
+2970 3523 0	2970 3520 0	Cross;Wilderness Ditch;23271								4
+2971 3520 0	2971 3523 0	Cross;Wilderness Ditch;23271								4
+2971 3523 0	2971 3520 0	Cross;Wilderness Ditch;23271								4
+2972 3520 0	2972 3523 0	Cross;Wilderness Ditch;23271								4
+2972 3523 0	2972 3520 0	Cross;Wilderness Ditch;23271								4
+2973 3520 0	2973 3523 0	Cross;Wilderness Ditch;23271								4
+2973 3523 0	2973 3520 0	Cross;Wilderness Ditch;23271								4
+2974 3520 0	2974 3523 0	Cross;Wilderness Ditch;23271								4
+2974 3523 0	2974 3520 0	Cross;Wilderness Ditch;23271								4
+2975 3520 0	2975 3523 0	Cross;Wilderness Ditch;23271								4
+2975 3523 0	2975 3520 0	Cross;Wilderness Ditch;23271								4
+2976 3520 0	2976 3523 0	Cross;Wilderness Ditch;23271								4
+2976 3523 0	2976 3520 0	Cross;Wilderness Ditch;23271								4
+2977 3520 0	2977 3523 0	Cross;Wilderness Ditch;23271								4
+2977 3523 0	2977 3520 0	Cross;Wilderness Ditch;23271								4
+2978 3520 0	2978 3523 0	Cross;Wilderness Ditch;23271								4
+2978 3523 0	2978 3520 0	Cross;Wilderness Ditch;23271								4
+2979 3520 0	2979 3523 0	Cross;Wilderness Ditch;23271								4
+2979 3523 0	2979 3520 0	Cross;Wilderness Ditch;23271								4
+2980 3520 0	2980 3523 0	Cross;Wilderness Ditch;23271								4
+2980 3523 0	2980 3520 0	Cross;Wilderness Ditch;23271								4
+2981 3520 0	2981 3523 0	Cross;Wilderness Ditch;23271								4
+2981 3523 0	2981 3520 0	Cross;Wilderness Ditch;23271								4
+2982 3520 0	2982 3523 0	Cross;Wilderness Ditch;23271								4
+2982 3523 0	2982 3520 0	Cross;Wilderness Ditch;23271								4
+2983 3520 0	2983 3523 0	Cross;Wilderness Ditch;23271								4
+2983 3523 0	2983 3520 0	Cross;Wilderness Ditch;23271								4
+2984 3520 0	2984 3523 0	Cross;Wilderness Ditch;23271								4
+2984 3523 0	2984 3520 0	Cross;Wilderness Ditch;23271								4
+2985 3520 0	2985 3523 0	Cross;Wilderness Ditch;23271								4
+2985 3523 0	2985 3520 0	Cross;Wilderness Ditch;23271								4
+2986 3520 0	2986 3523 0	Cross;Wilderness Ditch;23271								4
+2986 3523 0	2986 3520 0	Cross;Wilderness Ditch;23271								4
+2987 3520 0	2987 3523 0	Cross;Wilderness Ditch;23271								4
+2987 3523 0	2987 3520 0	Cross;Wilderness Ditch;23271								4
+2988 3520 0	2988 3523 0	Cross;Wilderness Ditch;23271								4
+2988 3523 0	2988 3520 0	Cross;Wilderness Ditch;23271								4
+2989 3520 0	2989 3523 0	Cross;Wilderness Ditch;23271								4
+2989 3523 0	2989 3520 0	Cross;Wilderness Ditch;23271								4
+2990 3520 0	2990 3523 0	Cross;Wilderness Ditch;23271								4
+2990 3523 0	2990 3520 0	Cross;Wilderness Ditch;23271								4
+2991 3520 0	2991 3523 0	Cross;Wilderness Ditch;23271								4
+2991 3523 0	2991 3520 0	Cross;Wilderness Ditch;23271								4
+3042 3520 0	3042 3523 0	Cross;Wilderness Ditch;23271								4
+3042 3523 0	3042 3520 0	Cross;Wilderness Ditch;23271								4
+3043 3520 0	3043 3523 0	Cross;Wilderness Ditch;23271								4
+3043 3523 0	3043 3520 0	Cross;Wilderness Ditch;23271								4
+3044 3520 0	3044 3523 0	Cross;Wilderness Ditch;23271								4
+3044 3523 0	3044 3520 0	Cross;Wilderness Ditch;23271								4
+3045 3520 0	3045 3523 0	Cross;Wilderness Ditch;23271								4
+3045 3523 0	3045 3520 0	Cross;Wilderness Ditch;23271								4
+3046 3520 0	3046 3523 0	Cross;Wilderness Ditch;23271								4
+3046 3523 0	3046 3520 0	Cross;Wilderness Ditch;23271								4
+3047 3520 0	3047 3523 0	Cross;Wilderness Ditch;23271								4
+3047 3523 0	3047 3520 0	Cross;Wilderness Ditch;23271								4
+3048 3520 0	3048 3523 0	Cross;Wilderness Ditch;23271								4
+3048 3523 0	3048 3520 0	Cross;Wilderness Ditch;23271								4
+3049 3520 0	3049 3523 0	Cross;Wilderness Ditch;23271								4
+3049 3523 0	3049 3520 0	Cross;Wilderness Ditch;23271								4
+3050 3520 0	3050 3523 0	Cross;Wilderness Ditch;23271								4
+3050 3523 0	3050 3520 0	Cross;Wilderness Ditch;23271								4
+3051 3520 0	3051 3523 0	Cross;Wilderness Ditch;23271								4
+3051 3523 0	3051 3520 0	Cross;Wilderness Ditch;23271								4
+3052 3520 0	3052 3523 0	Cross;Wilderness Ditch;23271								4
+3052 3523 0	3052 3520 0	Cross;Wilderness Ditch;23271								4
+3053 3520 0	3053 3523 0	Cross;Wilderness Ditch;23271								4
+3053 3523 0	3053 3520 0	Cross;Wilderness Ditch;23271								4
+3054 3520 0	3054 3523 0	Cross;Wilderness Ditch;23271								4
+3054 3523 0	3054 3520 0	Cross;Wilderness Ditch;23271								4
+3055 3520 0	3055 3523 0	Cross;Wilderness Ditch;23271								4
+3055 3523 0	3055 3520 0	Cross;Wilderness Ditch;23271								4
+3056 3520 0	3056 3523 0	Cross;Wilderness Ditch;23271								4
+3056 3523 0	3056 3520 0	Cross;Wilderness Ditch;23271								4
+3057 3520 0	3057 3523 0	Cross;Wilderness Ditch;23271								4
+3057 3523 0	3057 3520 0	Cross;Wilderness Ditch;23271								4
+3058 3520 0	3058 3523 0	Cross;Wilderness Ditch;23271								4
+3058 3523 0	3058 3520 0	Cross;Wilderness Ditch;23271								4
+3059 3520 0	3059 3523 0	Cross;Wilderness Ditch;23271								4
+3059 3523 0	3059 3520 0	Cross;Wilderness Ditch;23271								4
+3060 3520 0	3060 3523 0	Cross;Wilderness Ditch;23271								4
+3060 3523 0	3060 3520 0	Cross;Wilderness Ditch;23271								4
+3061 3520 0	3061 3523 0	Cross;Wilderness Ditch;23271								4
+3061 3523 0	3061 3520 0	Cross;Wilderness Ditch;23271								4
+3062 3520 0	3062 3523 0	Cross;Wilderness Ditch;23271								4
+3062 3523 0	3062 3520 0	Cross;Wilderness Ditch;23271								4
+3063 3520 0	3063 3523 0	Cross;Wilderness Ditch;23271								4
+3063 3523 0	3063 3520 0	Cross;Wilderness Ditch;23271								4
+3064 3520 0	3064 3523 0	Cross;Wilderness Ditch;23271								4
+3064 3523 0	3064 3520 0	Cross;Wilderness Ditch;23271								4
+3065 3520 0	3065 3523 0	Cross;Wilderness Ditch;23271								4
+3065 3523 0	3065 3520 0	Cross;Wilderness Ditch;23271								4
+3066 3520 0	3066 3523 0	Cross;Wilderness Ditch;23271								4
+3066 3523 0	3066 3520 0	Cross;Wilderness Ditch;23271								4
+3067 3520 0	3067 3523 0	Cross;Wilderness Ditch;23271								4
+3067 3523 0	3067 3520 0	Cross;Wilderness Ditch;23271								4
+3068 3520 0	3068 3523 0	Cross;Wilderness Ditch;23271								4
+3068 3523 0	3068 3520 0	Cross;Wilderness Ditch;23271								4
+3069 3520 0	3069 3523 0	Cross;Wilderness Ditch;23271								4
+3069 3523 0	3069 3520 0	Cross;Wilderness Ditch;23271								4
+3070 3520 0	3070 3523 0	Cross;Wilderness Ditch;23271								4
+3070 3523 0	3070 3520 0	Cross;Wilderness Ditch;23271								4
+3071 3520 0	3071 3523 0	Cross;Wilderness Ditch;23271								4
+3071 3523 0	3071 3520 0	Cross;Wilderness Ditch;23271								4
+3072 3520 0	3072 3523 0	Cross;Wilderness Ditch;23271								4
+3072 3523 0	3072 3520 0	Cross;Wilderness Ditch;23271								4
+3073 3520 0	3073 3523 0	Cross;Wilderness Ditch;23271								4
+3073 3523 0	3073 3520 0	Cross;Wilderness Ditch;23271								4
+3074 3520 0	3074 3523 0	Cross;Wilderness Ditch;23271								4
+3074 3523 0	3074 3520 0	Cross;Wilderness Ditch;23271								4
+3075 3520 0	3075 3523 0	Cross;Wilderness Ditch;23271								4
+3075 3523 0	3075 3520 0	Cross;Wilderness Ditch;23271								4
+3076 3520 0	3076 3523 0	Cross;Wilderness Ditch;23271								4
+3076 3523 0	3076 3520 0	Cross;Wilderness Ditch;23271								4
+3077 3520 0	3077 3523 0	Cross;Wilderness Ditch;23271								4
+3077 3523 0	3077 3520 0	Cross;Wilderness Ditch;23271								4
+3078 3520 0	3078 3523 0	Cross;Wilderness Ditch;23271								4
+3078 3523 0	3078 3520 0	Cross;Wilderness Ditch;23271								4
+3079 3520 0	3079 3523 0	Cross;Wilderness Ditch;23271								4
+3079 3523 0	3079 3520 0	Cross;Wilderness Ditch;23271								4
+3080 3520 0	3080 3523 0	Cross;Wilderness Ditch;23271								4
+3080 3523 0	3080 3520 0	Cross;Wilderness Ditch;23271								4
+3081 3520 0	3081 3523 0	Cross;Wilderness Ditch;23271								4
+3081 3523 0	3081 3520 0	Cross;Wilderness Ditch;23271								4
+3082 3520 0	3082 3523 0	Cross;Wilderness Ditch;23271								4
+3082 3523 0	3082 3520 0	Cross;Wilderness Ditch;23271								4
+3083 3520 0	3083 3523 0	Cross;Wilderness Ditch;23271								4
+3083 3523 0	3083 3520 0	Cross;Wilderness Ditch;23271								4
+3084 3520 0	3084 3523 0	Cross;Wilderness Ditch;23271								4
+3084 3523 0	3084 3520 0	Cross;Wilderness Ditch;23271								4
+3085 3520 0	3085 3523 0	Cross;Wilderness Ditch;23271								4
+3085 3523 0	3085 3520 0	Cross;Wilderness Ditch;23271								4
+3086 3520 0	3086 3523 0	Cross;Wilderness Ditch;23271								4
+3086 3523 0	3086 3520 0	Cross;Wilderness Ditch;23271								4
+3087 3520 0	3087 3523 0	Cross;Wilderness Ditch;23271								4
+3087 3523 0	3087 3520 0	Cross;Wilderness Ditch;23271								4
+3088 3520 0	3088 3523 0	Cross;Wilderness Ditch;23271								4
+3088 3523 0	3088 3520 0	Cross;Wilderness Ditch;23271								4
+3089 3520 0	3089 3523 0	Cross;Wilderness Ditch;23271								4
+3089 3523 0	3089 3520 0	Cross;Wilderness Ditch;23271								4
+3090 3520 0	3090 3523 0	Cross;Wilderness Ditch;23271								4
+3090 3523 0	3090 3520 0	Cross;Wilderness Ditch;23271								4
+3091 3520 0	3091 3523 0	Cross;Wilderness Ditch;23271								4
+3091 3523 0	3091 3520 0	Cross;Wilderness Ditch;23271								4
+3092 3520 0	3092 3523 0	Cross;Wilderness Ditch;23271								4
+3092 3523 0	3092 3520 0	Cross;Wilderness Ditch;23271								4
+3093 3520 0	3093 3523 0	Cross;Wilderness Ditch;23271								4
+3093 3523 0	3093 3520 0	Cross;Wilderness Ditch;23271								4
+3094 3520 0	3094 3523 0	Cross;Wilderness Ditch;23271								4
+3094 3523 0	3094 3520 0	Cross;Wilderness Ditch;23271								4
+3095 3520 0	3095 3523 0	Cross;Wilderness Ditch;23271								4
+3095 3523 0	3095 3520 0	Cross;Wilderness Ditch;23271								4
+3096 3520 0	3096 3523 0	Cross;Wilderness Ditch;23271								4
+3096 3523 0	3096 3520 0	Cross;Wilderness Ditch;23271								4
+3097 3520 0	3097 3523 0	Cross;Wilderness Ditch;23271								4
+3097 3523 0	3097 3520 0	Cross;Wilderness Ditch;23271								4
+3098 3520 0	3098 3523 0	Cross;Wilderness Ditch;23271								4
+3098 3523 0	3098 3520 0	Cross;Wilderness Ditch;23271								4
+3099 3520 0	3099 3523 0	Cross;Wilderness Ditch;23271								4
+3099 3523 0	3099 3520 0	Cross;Wilderness Ditch;23271								4
+3100 3520 0	3100 3523 0	Cross;Wilderness Ditch;23271								4
+3100 3523 0	3100 3520 0	Cross;Wilderness Ditch;23271								4
+3101 3520 0	3101 3523 0	Cross;Wilderness Ditch;23271								4
+3101 3523 0	3101 3520 0	Cross;Wilderness Ditch;23271								4
+3102 3520 0	3102 3523 0	Cross;Wilderness Ditch;23271								4
+3102 3523 0	3102 3520 0	Cross;Wilderness Ditch;23271								4
+3103 3520 0	3103 3523 0	Cross;Wilderness Ditch;23271								4
+3103 3523 0	3103 3520 0	Cross;Wilderness Ditch;23271								4
+3104 3520 0	3104 3523 0	Cross;Wilderness Ditch;23271								4
+3104 3523 0	3104 3520 0	Cross;Wilderness Ditch;23271								4
+3105 3520 0	3105 3523 0	Cross;Wilderness Ditch;23271								4
+3105 3523 0	3105 3520 0	Cross;Wilderness Ditch;23271								4
+3106 3520 0	3106 3523 0	Cross;Wilderness Ditch;23271								4
+3106 3523 0	3106 3520 0	Cross;Wilderness Ditch;23271								4
+3107 3520 0	3107 3523 0	Cross;Wilderness Ditch;23271								4
+3107 3523 0	3107 3520 0	Cross;Wilderness Ditch;23271								4
+3108 3520 0	3108 3523 0	Cross;Wilderness Ditch;23271								4
+3108 3523 0	3108 3520 0	Cross;Wilderness Ditch;23271								4
+3109 3520 0	3109 3523 0	Cross;Wilderness Ditch;23271								4
+3109 3523 0	3109 3520 0	Cross;Wilderness Ditch;23271								4
+3110 3520 0	3110 3523 0	Cross;Wilderness Ditch;23271								4
+3110 3523 0	3110 3520 0	Cross;Wilderness Ditch;23271								4
+3111 3520 0	3111 3523 0	Cross;Wilderness Ditch;23271								4
+3111 3523 0	3111 3520 0	Cross;Wilderness Ditch;23271								4
+3112 3520 0	3112 3523 0	Cross;Wilderness Ditch;23271								4
+3112 3523 0	3112 3520 0	Cross;Wilderness Ditch;23271								4
+3113 3520 0	3113 3523 0	Cross;Wilderness Ditch;23271								4
+3113 3523 0	3113 3520 0	Cross;Wilderness Ditch;23271								4
+3114 3520 0	3114 3523 0	Cross;Wilderness Ditch;23271								4
+3114 3523 0	3114 3520 0	Cross;Wilderness Ditch;23271								4
+3115 3520 0	3115 3523 0	Cross;Wilderness Ditch;23271								4
+3115 3523 0	3115 3520 0	Cross;Wilderness Ditch;23271								4
+3116 3520 0	3116 3523 0	Cross;Wilderness Ditch;23271								4
+3116 3523 0	3116 3520 0	Cross;Wilderness Ditch;23271								4
+3117 3520 0	3117 3523 0	Cross;Wilderness Ditch;23271								4
+3117 3523 0	3117 3520 0	Cross;Wilderness Ditch;23271								4
+3118 3520 0	3118 3523 0	Cross;Wilderness Ditch;23271								4
+3118 3523 0	3118 3520 0	Cross;Wilderness Ditch;23271								4
+3119 3520 0	3119 3523 0	Cross;Wilderness Ditch;23271								4
+3119 3523 0	3119 3520 0	Cross;Wilderness Ditch;23271								4
+3120 3520 0	3120 3523 0	Cross;Wilderness Ditch;23271								4
+3120 3523 0	3120 3520 0	Cross;Wilderness Ditch;23271								4
+3121 3520 0	3121 3523 0	Cross;Wilderness Ditch;23271								4
+3121 3523 0	3121 3520 0	Cross;Wilderness Ditch;23271								4
+3122 3520 0	3122 3523 0	Cross;Wilderness Ditch;23271								4
+3122 3523 0	3122 3520 0	Cross;Wilderness Ditch;23271								4
+3136 3520 0	3136 3523 0	Cross;Wilderness Ditch;23271								4
+3136 3523 0	3136 3520 0	Cross;Wilderness Ditch;23271								4
+3137 3520 0	3137 3523 0	Cross;Wilderness Ditch;23271								4
+3137 3523 0	3137 3520 0	Cross;Wilderness Ditch;23271								4
+3138 3520 0	3138 3523 0	Cross;Wilderness Ditch;23271								4
+3138 3523 0	3138 3520 0	Cross;Wilderness Ditch;23271								4
+3139 3520 0	3139 3523 0	Cross;Wilderness Ditch;23271								4
+3139 3523 0	3139 3520 0	Cross;Wilderness Ditch;23271								4
+3140 3520 0	3140 3523 0	Cross;Wilderness Ditch;23271								4
+3140 3523 0	3140 3520 0	Cross;Wilderness Ditch;23271								4
+3141 3520 0	3141 3523 0	Cross;Wilderness Ditch;23271								4
+3141 3523 0	3141 3520 0	Cross;Wilderness Ditch;23271								4
+3142 3520 0	3142 3523 0	Cross;Wilderness Ditch;23271								4
+3142 3523 0	3142 3520 0	Cross;Wilderness Ditch;23271								4
+3143 3520 0	3143 3523 0	Cross;Wilderness Ditch;23271								4
+3143 3523 0	3143 3520 0	Cross;Wilderness Ditch;23271								4
+3144 3520 0	3144 3523 0	Cross;Wilderness Ditch;23271								4
+3144 3523 0	3144 3520 0	Cross;Wilderness Ditch;23271								4
+3145 3520 0	3145 3523 0	Cross;Wilderness Ditch;23271								4
+3145 3523 0	3145 3520 0	Cross;Wilderness Ditch;23271								4
+3146 3520 0	3146 3523 0	Cross;Wilderness Ditch;23271								4
+3146 3523 0	3146 3520 0	Cross;Wilderness Ditch;23271								4
+3147 3520 0	3147 3523 0	Cross;Wilderness Ditch;23271								4
+3147 3523 0	3147 3520 0	Cross;Wilderness Ditch;23271								4
+3148 3520 0	3148 3523 0	Cross;Wilderness Ditch;23271								4
+3148 3523 0	3148 3520 0	Cross;Wilderness Ditch;23271								4
+3149 3520 0	3149 3523 0	Cross;Wilderness Ditch;23271								4
+3149 3523 0	3149 3520 0	Cross;Wilderness Ditch;23271								4
+3150 3520 0	3150 3523 0	Cross;Wilderness Ditch;23271								4
+3150 3523 0	3150 3520 0	Cross;Wilderness Ditch;23271								4
+3151 3520 0	3151 3523 0	Cross;Wilderness Ditch;23271								4
+3151 3523 0	3151 3520 0	Cross;Wilderness Ditch;23271								4
+3152 3520 0	3152 3523 0	Cross;Wilderness Ditch;23271								4
+3152 3523 0	3152 3520 0	Cross;Wilderness Ditch;23271								4
+3153 3520 0	3153 3523 0	Cross;Wilderness Ditch;23271								4
+3153 3523 0	3153 3520 0	Cross;Wilderness Ditch;23271								4
+3154 3520 0	3154 3523 0	Cross;Wilderness Ditch;23271								4
+3154 3523 0	3154 3520 0	Cross;Wilderness Ditch;23271								4
+3155 3520 0	3155 3523 0	Cross;Wilderness Ditch;23271								4
+3155 3523 0	3155 3520 0	Cross;Wilderness Ditch;23271								4
+3156 3520 0	3156 3523 0	Cross;Wilderness Ditch;23271								4
+3156 3523 0	3156 3520 0	Cross;Wilderness Ditch;23271								4
+3157 3520 0	3157 3523 0	Cross;Wilderness Ditch;23271								4
+3157 3523 0	3157 3520 0	Cross;Wilderness Ditch;23271								4
+3158 3520 0	3158 3523 0	Cross;Wilderness Ditch;23271								4
+3158 3523 0	3158 3520 0	Cross;Wilderness Ditch;23271								4
+3159 3520 0	3159 3523 0	Cross;Wilderness Ditch;23271								4
+3159 3523 0	3159 3520 0	Cross;Wilderness Ditch;23271								4
+3160 3520 0	3160 3523 0	Cross;Wilderness Ditch;23271								4
+3160 3523 0	3160 3520 0	Cross;Wilderness Ditch;23271								4
+3161 3520 0	3161 3523 0	Cross;Wilderness Ditch;23271								4
+3161 3523 0	3161 3520 0	Cross;Wilderness Ditch;23271								4
+3162 3520 0	3162 3523 0	Cross;Wilderness Ditch;23271								4
+3162 3523 0	3162 3520 0	Cross;Wilderness Ditch;23271								4
+3163 3520 0	3163 3523 0	Cross;Wilderness Ditch;23271								4
+3163 3523 0	3163 3520 0	Cross;Wilderness Ditch;23271								4
+3164 3520 0	3164 3523 0	Cross;Wilderness Ditch;23271								4
+3164 3523 0	3164 3520 0	Cross;Wilderness Ditch;23271								4
+3165 3520 0	3165 3523 0	Cross;Wilderness Ditch;23271								4
+3165 3523 0	3165 3520 0	Cross;Wilderness Ditch;23271								4
+3166 3520 0	3166 3523 0	Cross;Wilderness Ditch;23271								4
+3166 3523 0	3166 3520 0	Cross;Wilderness Ditch;23271								4
+3167 3520 0	3167 3523 0	Cross;Wilderness Ditch;23271								4
+3167 3523 0	3167 3520 0	Cross;Wilderness Ditch;23271								4
+3168 3520 0	3168 3523 0	Cross;Wilderness Ditch;23271								4
+3168 3523 0	3168 3520 0	Cross;Wilderness Ditch;23271								4
+3169 3520 0	3169 3523 0	Cross;Wilderness Ditch;23271								4
+3169 3523 0	3169 3520 0	Cross;Wilderness Ditch;23271								4
+3170 3520 0	3170 3523 0	Cross;Wilderness Ditch;23271								4
+3170 3523 0	3170 3520 0	Cross;Wilderness Ditch;23271								4
+3171 3520 0	3171 3523 0	Cross;Wilderness Ditch;23271								4
+3171 3523 0	3171 3520 0	Cross;Wilderness Ditch;23271								4
+3172 3520 0	3172 3523 0	Cross;Wilderness Ditch;23271								4
+3172 3523 0	3172 3520 0	Cross;Wilderness Ditch;23271								4
+3173 3520 0	3173 3523 0	Cross;Wilderness Ditch;23271								4
+3173 3523 0	3173 3520 0	Cross;Wilderness Ditch;23271								4
+3174 3520 0	3174 3523 0	Cross;Wilderness Ditch;23271								4
+3174 3523 0	3174 3520 0	Cross;Wilderness Ditch;23271								4
+3175 3520 0	3175 3523 0	Cross;Wilderness Ditch;23271								4
+3175 3523 0	3175 3520 0	Cross;Wilderness Ditch;23271								4
+3176 3520 0	3176 3523 0	Cross;Wilderness Ditch;23271								4
+3176 3523 0	3176 3520 0	Cross;Wilderness Ditch;23271								4
+3177 3520 0	3177 3523 0	Cross;Wilderness Ditch;23271								4
+3177 3523 0	3177 3520 0	Cross;Wilderness Ditch;23271								4
+3178 3520 0	3178 3523 0	Cross;Wilderness Ditch;23271								4
+3178 3523 0	3178 3520 0	Cross;Wilderness Ditch;23271								4
+3179 3520 0	3179 3523 0	Cross;Wilderness Ditch;23271								4
+3179 3523 0	3179 3520 0	Cross;Wilderness Ditch;23271								4
+3180 3520 0	3180 3523 0	Cross;Wilderness Ditch;23271								4
+3180 3523 0	3180 3520 0	Cross;Wilderness Ditch;23271								4
+3181 3520 0	3181 3523 0	Cross;Wilderness Ditch;23271								4
+3181 3523 0	3181 3520 0	Cross;Wilderness Ditch;23271								4
+3182 3520 0	3182 3523 0	Cross;Wilderness Ditch;23271								4
+3182 3523 0	3182 3520 0	Cross;Wilderness Ditch;23271								4
+3183 3520 0	3183 3523 0	Cross;Wilderness Ditch;23271								4
+3183 3523 0	3183 3520 0	Cross;Wilderness Ditch;23271								4
+3184 3520 0	3184 3523 0	Cross;Wilderness Ditch;23271								4
+3184 3523 0	3184 3520 0	Cross;Wilderness Ditch;23271								4
+3185 3520 0	3185 3523 0	Cross;Wilderness Ditch;23271								4
+3185 3523 0	3185 3520 0	Cross;Wilderness Ditch;23271								4
+3186 3520 0	3186 3523 0	Cross;Wilderness Ditch;23271								4
+3186 3523 0	3186 3520 0	Cross;Wilderness Ditch;23271								4
+3187 3520 0	3187 3523 0	Cross;Wilderness Ditch;23271								4
+3187 3523 0	3187 3520 0	Cross;Wilderness Ditch;23271								4
+3188 3520 0	3188 3523 0	Cross;Wilderness Ditch;23271								4
+3188 3523 0	3188 3520 0	Cross;Wilderness Ditch;23271								4
+3189 3520 0	3189 3523 0	Cross;Wilderness Ditch;23271								4
+3189 3523 0	3189 3520 0	Cross;Wilderness Ditch;23271								4
+3190 3520 0	3190 3523 0	Cross;Wilderness Ditch;23271								4
+3190 3523 0	3190 3520 0	Cross;Wilderness Ditch;23271								4
+3191 3520 0	3191 3523 0	Cross;Wilderness Ditch;23271								4
+3191 3523 0	3191 3520 0	Cross;Wilderness Ditch;23271								4
+3192 3520 0	3192 3523 0	Cross;Wilderness Ditch;23271								4
+3192 3523 0	3192 3520 0	Cross;Wilderness Ditch;23271								4
+3193 3520 0	3193 3523 0	Cross;Wilderness Ditch;23271								4
+3193 3523 0	3193 3520 0	Cross;Wilderness Ditch;23271								4
+3194 3520 0	3194 3523 0	Cross;Wilderness Ditch;23271								4
+3194 3523 0	3194 3520 0	Cross;Wilderness Ditch;23271								4
+3195 3520 0	3195 3523 0	Cross;Wilderness Ditch;23271								4
+3195 3523 0	3195 3520 0	Cross;Wilderness Ditch;23271								4
+3196 3520 0	3196 3523 0	Cross;Wilderness Ditch;23271								4
+3196 3523 0	3196 3520 0	Cross;Wilderness Ditch;23271								4
+3197 3520 0	3197 3523 0	Cross;Wilderness Ditch;23271								4
+3197 3523 0	3197 3520 0	Cross;Wilderness Ditch;23271								4
+3198 3520 0	3198 3523 0	Cross;Wilderness Ditch;23271								4
+3198 3523 0	3198 3520 0	Cross;Wilderness Ditch;23271								4
+3199 3520 0	3199 3523 0	Cross;Wilderness Ditch;23271								4
+3199 3523 0	3199 3520 0	Cross;Wilderness Ditch;23271								4
+3200 3520 0	3200 3523 0	Cross;Wilderness Ditch;23271								4
+3200 3523 0	3200 3520 0	Cross;Wilderness Ditch;23271								4
+3201 3520 0	3201 3523 0	Cross;Wilderness Ditch;23271								4
+3201 3523 0	3201 3520 0	Cross;Wilderness Ditch;23271								4
+3202 3520 0	3202 3523 0	Cross;Wilderness Ditch;23271								4
+3202 3523 0	3202 3520 0	Cross;Wilderness Ditch;23271								4
+3203 3520 0	3203 3523 0	Cross;Wilderness Ditch;23271								4
+3203 3523 0	3203 3520 0	Cross;Wilderness Ditch;23271								4
+3204 3520 0	3204 3523 0	Cross;Wilderness Ditch;23271								4
+3204 3523 0	3204 3520 0	Cross;Wilderness Ditch;23271								4
+3205 3520 0	3205 3523 0	Cross;Wilderness Ditch;23271								4
+3205 3523 0	3205 3520 0	Cross;Wilderness Ditch;23271								4
+3206 3520 0	3206 3523 0	Cross;Wilderness Ditch;23271								4
+3206 3523 0	3206 3520 0	Cross;Wilderness Ditch;23271								4
+3207 3520 0	3207 3523 0	Cross;Wilderness Ditch;23271								4
+3207 3523 0	3207 3520 0	Cross;Wilderness Ditch;23271								4
+3208 3520 0	3208 3523 0	Cross;Wilderness Ditch;23271								4
+3208 3523 0	3208 3520 0	Cross;Wilderness Ditch;23271								4
+3209 3520 0	3209 3523 0	Cross;Wilderness Ditch;23271								4
+3209 3523 0	3209 3520 0	Cross;Wilderness Ditch;23271								4
+3210 3520 0	3210 3523 0	Cross;Wilderness Ditch;23271								4
+3210 3523 0	3210 3520 0	Cross;Wilderness Ditch;23271								4
+3211 3520 0	3211 3523 0	Cross;Wilderness Ditch;23271								4
+3211 3523 0	3211 3520 0	Cross;Wilderness Ditch;23271								4
+3212 3520 0	3212 3523 0	Cross;Wilderness Ditch;23271								4
+3212 3523 0	3212 3520 0	Cross;Wilderness Ditch;23271								4
+3213 3520 0	3213 3523 0	Cross;Wilderness Ditch;23271								4
+3213 3523 0	3213 3520 0	Cross;Wilderness Ditch;23271								4
+3214 3520 0	3214 3523 0	Cross;Wilderness Ditch;23271								4
+3214 3523 0	3214 3520 0	Cross;Wilderness Ditch;23271								4
+3215 3520 0	3215 3523 0	Cross;Wilderness Ditch;23271								4
+3215 3523 0	3215 3520 0	Cross;Wilderness Ditch;23271								4
+3216 3520 0	3216 3523 0	Cross;Wilderness Ditch;23271								4
+3216 3523 0	3216 3520 0	Cross;Wilderness Ditch;23271								4
+3217 3520 0	3217 3523 0	Cross;Wilderness Ditch;23271								4
+3217 3523 0	3217 3520 0	Cross;Wilderness Ditch;23271								4
+3218 3520 0	3218 3523 0	Cross;Wilderness Ditch;23271								4
+3218 3523 0	3218 3520 0	Cross;Wilderness Ditch;23271								4
+3219 3520 0	3219 3523 0	Cross;Wilderness Ditch;23271								4
+3219 3523 0	3219 3520 0	Cross;Wilderness Ditch;23271								4
+3220 3520 0	3220 3523 0	Cross;Wilderness Ditch;23271								4
+3220 3523 0	3220 3520 0	Cross;Wilderness Ditch;23271								4
+3221 3520 0	3221 3523 0	Cross;Wilderness Ditch;23271								4
+3221 3523 0	3221 3520 0	Cross;Wilderness Ditch;23271								4
+3222 3520 0	3222 3523 0	Cross;Wilderness Ditch;23271								4
+3222 3523 0	3222 3520 0	Cross;Wilderness Ditch;23271								4
+3223 3520 0	3223 3523 0	Cross;Wilderness Ditch;23271								4
+3223 3523 0	3223 3520 0	Cross;Wilderness Ditch;23271								4
+3224 3520 0	3224 3523 0	Cross;Wilderness Ditch;23271								4
+3224 3523 0	3224 3520 0	Cross;Wilderness Ditch;23271								4
+3225 3520 0	3225 3523 0	Cross;Wilderness Ditch;23271								4
+3225 3523 0	3225 3520 0	Cross;Wilderness Ditch;23271								4
+3226 3520 0	3226 3523 0	Cross;Wilderness Ditch;23271								4
+3226 3523 0	3226 3520 0	Cross;Wilderness Ditch;23271								4
+3227 3520 0	3227 3523 0	Cross;Wilderness Ditch;23271								4
+3227 3523 0	3227 3520 0	Cross;Wilderness Ditch;23271								4
+3228 3520 0	3228 3523 0	Cross;Wilderness Ditch;23271								4
+3228 3523 0	3228 3520 0	Cross;Wilderness Ditch;23271								4
+3229 3520 0	3229 3523 0	Cross;Wilderness Ditch;23271								4
+3229 3523 0	3229 3520 0	Cross;Wilderness Ditch;23271								4
+3230 3520 0	3230 3523 0	Cross;Wilderness Ditch;23271								4
+3230 3523 0	3230 3520 0	Cross;Wilderness Ditch;23271								4
+3231 3520 0	3231 3523 0	Cross;Wilderness Ditch;23271								4
+3231 3523 0	3231 3520 0	Cross;Wilderness Ditch;23271								4
+3232 3520 0	3232 3523 0	Cross;Wilderness Ditch;23271								4
+3232 3523 0	3232 3520 0	Cross;Wilderness Ditch;23271								4
+3233 3520 0	3233 3523 0	Cross;Wilderness Ditch;23271								4
+3233 3523 0	3233 3520 0	Cross;Wilderness Ditch;23271								4
+3234 3520 0	3234 3523 0	Cross;Wilderness Ditch;23271								4
+3234 3523 0	3234 3520 0	Cross;Wilderness Ditch;23271								4
+3235 3520 0	3235 3523 0	Cross;Wilderness Ditch;23271								4
+3235 3523 0	3235 3520 0	Cross;Wilderness Ditch;23271								4
+3236 3520 0	3236 3523 0	Cross;Wilderness Ditch;23271								4
+3236 3523 0	3236 3520 0	Cross;Wilderness Ditch;23271								4
+3237 3520 0	3237 3523 0	Cross;Wilderness Ditch;23271								4
+3237 3523 0	3237 3520 0	Cross;Wilderness Ditch;23271								4
+3238 3520 0	3238 3523 0	Cross;Wilderness Ditch;23271								4
+3238 3523 0	3238 3520 0	Cross;Wilderness Ditch;23271								4
+3239 3520 0	3239 3523 0	Cross;Wilderness Ditch;23271								4
+3239 3523 0	3239 3520 0	Cross;Wilderness Ditch;23271								4
+3240 3520 0	3240 3523 0	Cross;Wilderness Ditch;23271								4
+3240 3523 0	3240 3520 0	Cross;Wilderness Ditch;23271								4
+3241 3520 0	3241 3523 0	Cross;Wilderness Ditch;23271								4
+3241 3523 0	3241 3520 0	Cross;Wilderness Ditch;23271								4
+3242 3520 0	3242 3523 0	Cross;Wilderness Ditch;23271								4
+3242 3523 0	3242 3520 0	Cross;Wilderness Ditch;23271								4
+3243 3520 0	3243 3523 0	Cross;Wilderness Ditch;23271								4
+3243 3523 0	3243 3520 0	Cross;Wilderness Ditch;23271								4
+3244 3520 0	3244 3523 0	Cross;Wilderness Ditch;23271								4
+3244 3523 0	3244 3520 0	Cross;Wilderness Ditch;23271								4
+3245 3520 0	3245 3523 0	Cross;Wilderness Ditch;23271								4
+3245 3523 0	3245 3520 0	Cross;Wilderness Ditch;23271								4
+3246 3520 0	3246 3523 0	Cross;Wilderness Ditch;23271								4
+3246 3523 0	3246 3520 0	Cross;Wilderness Ditch;23271								4
+3247 3520 0	3247 3523 0	Cross;Wilderness Ditch;23271								4
+3247 3523 0	3247 3520 0	Cross;Wilderness Ditch;23271								4
+3248 3520 0	3248 3523 0	Cross;Wilderness Ditch;23271								4
+3248 3523 0	3248 3520 0	Cross;Wilderness Ditch;23271								4
+3249 3520 0	3249 3523 0	Cross;Wilderness Ditch;23271								4
+3249 3523 0	3249 3520 0	Cross;Wilderness Ditch;23271								4
+3250 3520 0	3250 3523 0	Cross;Wilderness Ditch;23271								4
+3250 3523 0	3250 3520 0	Cross;Wilderness Ditch;23271								4
+3251 3520 0	3251 3523 0	Cross;Wilderness Ditch;23271								4
+3251 3523 0	3251 3520 0	Cross;Wilderness Ditch;23271								4
+3252 3520 0	3252 3523 0	Cross;Wilderness Ditch;23271								4
+3252 3523 0	3252 3520 0	Cross;Wilderness Ditch;23271								4
+3253 3520 0	3253 3523 0	Cross;Wilderness Ditch;23271								4
+3253 3523 0	3253 3520 0	Cross;Wilderness Ditch;23271								4
+3254 3520 0	3254 3523 0	Cross;Wilderness Ditch;23271								4
+3254 3523 0	3254 3520 0	Cross;Wilderness Ditch;23271								4
+3255 3520 0	3255 3523 0	Cross;Wilderness Ditch;23271								4
+3255 3523 0	3255 3520 0	Cross;Wilderness Ditch;23271								4
+3256 3520 0	3256 3523 0	Cross;Wilderness Ditch;23271								4
+3256 3523 0	3256 3520 0	Cross;Wilderness Ditch;23271								4
+3257 3520 0	3257 3523 0	Cross;Wilderness Ditch;23271								4
+3257 3523 0	3257 3520 0	Cross;Wilderness Ditch;23271								4
+3258 3520 0	3258 3523 0	Cross;Wilderness Ditch;23271								4
+3258 3523 0	3258 3520 0	Cross;Wilderness Ditch;23271								4
+3259 3520 0	3259 3523 0	Cross;Wilderness Ditch;23271								4
+3259 3523 0	3259 3520 0	Cross;Wilderness Ditch;23271								4
+3260 3520 0	3260 3523 0	Cross;Wilderness Ditch;23271								4
+3260 3523 0	3260 3520 0	Cross;Wilderness Ditch;23271								4
+3261 3520 0	3261 3523 0	Cross;Wilderness Ditch;23271								4
+3261 3523 0	3261 3520 0	Cross;Wilderness Ditch;23271								4
+3262 3520 0	3262 3523 0	Cross;Wilderness Ditch;23271								4
+3262 3523 0	3262 3520 0	Cross;Wilderness Ditch;23271								4
+3263 3520 0	3263 3523 0	Cross;Wilderness Ditch;23271								4
+3263 3523 0	3263 3520 0	Cross;Wilderness Ditch;23271								4
+3264 3520 0	3264 3523 0	Cross;Wilderness Ditch;23271								4
+3264 3523 0	3264 3520 0	Cross;Wilderness Ditch;23271								4
+3265 3520 0	3265 3523 0	Cross;Wilderness Ditch;23271								4
+3265 3523 0	3265 3520 0	Cross;Wilderness Ditch;23271								4
+3266 3520 0	3266 3523 0	Cross;Wilderness Ditch;23271								4
+3266 3523 0	3266 3520 0	Cross;Wilderness Ditch;23271								4
+3267 3520 0	3267 3523 0	Cross;Wilderness Ditch;23271								4
+3267 3523 0	3267 3520 0	Cross;Wilderness Ditch;23271								4
+3268 3520 0	3268 3523 0	Cross;Wilderness Ditch;23271								4
+3268 3523 0	3268 3520 0	Cross;Wilderness Ditch;23271								4
+3269 3520 0	3269 3523 0	Cross;Wilderness Ditch;23271								4
+3269 3523 0	3269 3520 0	Cross;Wilderness Ditch;23271								4
+3270 3520 0	3270 3523 0	Cross;Wilderness Ditch;23271								4
+3270 3523 0	3270 3520 0	Cross;Wilderness Ditch;23271								4
+3271 3520 0	3271 3523 0	Cross;Wilderness Ditch;23271								4
+3271 3523 0	3271 3520 0	Cross;Wilderness Ditch;23271								4
+3272 3520 0	3272 3523 0	Cross;Wilderness Ditch;23271								4
+3272 3523 0	3272 3520 0	Cross;Wilderness Ditch;23271								4
+3273 3520 0	3273 3523 0	Cross;Wilderness Ditch;23271								4
+3273 3523 0	3273 3520 0	Cross;Wilderness Ditch;23271								4
+3274 3520 0	3274 3523 0	Cross;Wilderness Ditch;23271								4
+3274 3523 0	3274 3520 0	Cross;Wilderness Ditch;23271								4
+3275 3520 0	3275 3523 0	Cross;Wilderness Ditch;23271								4
+3275 3523 0	3275 3520 0	Cross;Wilderness Ditch;23271								4
+3276 3520 0	3276 3523 0	Cross;Wilderness Ditch;23271								4
+3276 3523 0	3276 3520 0	Cross;Wilderness Ditch;23271								4
+3277 3520 0	3277 3523 0	Cross;Wilderness Ditch;23271								4
+3277 3523 0	3277 3520 0	Cross;Wilderness Ditch;23271								4
+3278 3520 0	3278 3523 0	Cross;Wilderness Ditch;23271								4
+3278 3523 0	3278 3520 0	Cross;Wilderness Ditch;23271								4
+3279 3520 0	3279 3523 0	Cross;Wilderness Ditch;23271								4
+3279 3523 0	3279 3520 0	Cross;Wilderness Ditch;23271								4
+3280 3520 0	3280 3523 0	Cross;Wilderness Ditch;23271								4
+3280 3523 0	3280 3520 0	Cross;Wilderness Ditch;23271								4
+3281 3520 0	3281 3523 0	Cross;Wilderness Ditch;23271								4
+3281 3523 0	3281 3520 0	Cross;Wilderness Ditch;23271								4
+3282 3520 0	3282 3523 0	Cross;Wilderness Ditch;23271								4
+3282 3523 0	3282 3520 0	Cross;Wilderness Ditch;23271								4
+3283 3520 0	3283 3523 0	Cross;Wilderness Ditch;23271								4
+3283 3523 0	3283 3520 0	Cross;Wilderness Ditch;23271								4
+3284 3520 0	3284 3523 0	Cross;Wilderness Ditch;23271								4
+3284 3523 0	3284 3520 0	Cross;Wilderness Ditch;23271								4
+3285 3520 0	3285 3523 0	Cross;Wilderness Ditch;23271								4
+3285 3523 0	3285 3520 0	Cross;Wilderness Ditch;23271								4
+3286 3520 0	3286 3523 0	Cross;Wilderness Ditch;23271								4
+3286 3523 0	3286 3520 0	Cross;Wilderness Ditch;23271								4
+3287 3520 0	3287 3523 0	Cross;Wilderness Ditch;23271								4
+3287 3523 0	3287 3520 0	Cross;Wilderness Ditch;23271								4
+3288 3520 0	3288 3523 0	Cross;Wilderness Ditch;23271								4
+3288 3523 0	3288 3520 0	Cross;Wilderness Ditch;23271								4
+3289 3520 0	3289 3523 0	Cross;Wilderness Ditch;23271								4
+3289 3523 0	3289 3520 0	Cross;Wilderness Ditch;23271								4
+3290 3520 0	3290 3523 0	Cross;Wilderness Ditch;23271								4
+3290 3523 0	3290 3520 0	Cross;Wilderness Ditch;23271								4
+3291 3520 0	3291 3523 0	Cross;Wilderness Ditch;23271								4
+3291 3523 0	3291 3520 0	Cross;Wilderness Ditch;23271								4
+3292 3520 0	3292 3523 0	Cross;Wilderness Ditch;23271								4
+3292 3523 0	3292 3520 0	Cross;Wilderness Ditch;23271								4
+3293 3520 0	3293 3523 0	Cross;Wilderness Ditch;23271								4
+3293 3523 0	3293 3520 0	Cross;Wilderness Ditch;23271								4
+3294 3520 0	3294 3523 0	Cross;Wilderness Ditch;23271								4
+3294 3523 0	3294 3520 0	Cross;Wilderness Ditch;23271								4
+3295 3520 0	3295 3523 0	Cross;Wilderness Ditch;23271								4
+3295 3523 0	3295 3520 0	Cross;Wilderness Ditch;23271								4
+3296 3520 0	3296 3523 0	Cross;Wilderness Ditch;23271								4
+3296 3523 0	3296 3520 0	Cross;Wilderness Ditch;23271								4
+3297 3520 0	3297 3523 0	Cross;Wilderness Ditch;23271								4
+3297 3523 0	3297 3520 0	Cross;Wilderness Ditch;23271								4
+3298 3520 0	3298 3523 0	Cross;Wilderness Ditch;23271								4
+3298 3523 0	3298 3520 0	Cross;Wilderness Ditch;23271								4
+3299 3520 0	3299 3523 0	Cross;Wilderness Ditch;23271								4
+3299 3523 0	3299 3520 0	Cross;Wilderness Ditch;23271								4
+3300 3520 0	3300 3523 0	Cross;Wilderness Ditch;23271								4
+3300 3523 0	3300 3520 0	Cross;Wilderness Ditch;23271								4
+3301 3520 0	3301 3523 0	Cross;Wilderness Ditch;23271								4
+3301 3523 0	3301 3520 0	Cross;Wilderness Ditch;23271								4
+3302 3520 0	3302 3523 0	Cross;Wilderness Ditch;23271								4
+3302 3523 0	3302 3520 0	Cross;Wilderness Ditch;23271								4
+3303 3520 0	3303 3523 0	Cross;Wilderness Ditch;23271								4
+3303 3523 0	3303 3520 0	Cross;Wilderness Ditch;23271								4
+3304 3520 0	3304 3523 0	Cross;Wilderness Ditch;23271								4
+3304 3523 0	3304 3520 0	Cross;Wilderness Ditch;23271								4
+3305 3520 0	3305 3523 0	Cross;Wilderness Ditch;23271								4
+3305 3523 0	3305 3520 0	Cross;Wilderness Ditch;23271								4
+3306 3520 0	3306 3523 0	Cross;Wilderness Ditch;23271								4
+3306 3523 0	3306 3520 0	Cross;Wilderness Ditch;23271								4
+3307 3520 0	3307 3523 0	Cross;Wilderness Ditch;23271								4
+3307 3523 0	3307 3520 0	Cross;Wilderness Ditch;23271								4
+3308 3520 0	3308 3523 0	Cross;Wilderness Ditch;23271								4
+3308 3523 0	3308 3520 0	Cross;Wilderness Ditch;23271								4
+3309 3520 0	3309 3523 0	Cross;Wilderness Ditch;23271								4
+3309 3523 0	3309 3520 0	Cross;Wilderness Ditch;23271								4
+3310 3520 0	3310 3523 0	Cross;Wilderness Ditch;23271								4
+3310 3523 0	3310 3520 0	Cross;Wilderness Ditch;23271								4
+3311 3520 0	3311 3523 0	Cross;Wilderness Ditch;23271								4
+3311 3523 0	3311 3520 0	Cross;Wilderness Ditch;23271								4
+3312 3520 0	3312 3523 0	Cross;Wilderness Ditch;23271								4
+3312 3523 0	3312 3520 0	Cross;Wilderness Ditch;23271								4
+3313 3520 0	3313 3523 0	Cross;Wilderness Ditch;23271								4
+3313 3523 0	3313 3520 0	Cross;Wilderness Ditch;23271								4
+3314 3520 0	3314 3523 0	Cross;Wilderness Ditch;23271								4
+3314 3523 0	3314 3520 0	Cross;Wilderness Ditch;23271								4
+3315 3520 0	3315 3523 0	Cross;Wilderness Ditch;23271								4
+3315 3523 0	3315 3520 0	Cross;Wilderness Ditch;23271								4
+3316 3520 0	3316 3523 0	Cross;Wilderness Ditch;23271								4
+3316 3523 0	3316 3520 0	Cross;Wilderness Ditch;23271								4
+3317 3520 0	3317 3523 0	Cross;Wilderness Ditch;23271								4
+3317 3523 0	3317 3520 0	Cross;Wilderness Ditch;23271								4
+3318 3520 0	3318 3523 0	Cross;Wilderness Ditch;23271								4
+3318 3523 0	3318 3520 0	Cross;Wilderness Ditch;23271								4
+3319 3520 0	3319 3523 0	Cross;Wilderness Ditch;23271								4
+3319 3523 0	3319 3520 0	Cross;Wilderness Ditch;23271								4
+3320 3520 0	3320 3523 0	Cross;Wilderness Ditch;23271								4
+3320 3523 0	3320 3520 0	Cross;Wilderness Ditch;23271								4
+3321 3520 0	3321 3523 0	Cross;Wilderness Ditch;23271								4
+3321 3523 0	3321 3520 0	Cross;Wilderness Ditch;23271								4
+3322 3520 0	3322 3523 0	Cross;Wilderness Ditch;23271								4
+3322 3523 0	3322 3520 0	Cross;Wilderness Ditch;23271								4
+3323 3520 0	3323 3523 0	Cross;Wilderness Ditch;23271								4
+3323 3523 0	3323 3520 0	Cross;Wilderness Ditch;23271								4
+3324 3520 0	3324 3523 0	Cross;Wilderness Ditch;23271								4
+3324 3523 0	3324 3520 0	Cross;Wilderness Ditch;23271								4
+3325 3520 0	3325 3523 0	Cross;Wilderness Ditch;23271								4
+3325 3523 0	3325 3520 0	Cross;Wilderness Ditch;23271								4
+3326 3520 0	3326 3523 0	Cross;Wilderness Ditch;23271								4
+3326 3523 0	3326 3520 0	Cross;Wilderness Ditch;23271								4
+3327 3520 0	3327 3523 0	Cross;Wilderness Ditch;23271								4
+3327 3523 0	3327 3520 0	Cross;Wilderness Ditch;23271								4
+3328 3520 0	3328 3523 0	Cross;Wilderness Ditch;23271								4
+3328 3523 0	3328 3520 0	Cross;Wilderness Ditch;23271								4
+3329 3520 0	3329 3523 0	Cross;Wilderness Ditch;23271								4
+3329 3523 0	3329 3520 0	Cross;Wilderness Ditch;23271								4
+
+# Nardah
+3409 2932 0	3409 2932 1	Climb-up;Ladder;10493								2
+3409 2932 1	3409 2932 0	Climb-down;Ladder;10494								2
+3429 2905 0	3429 2905 1	Climb-up;Ladder;10493								2
+3429 2905 1	3429 2905 0	Climb-down;Ladder;10494								2
+3426 2901 0	3426 2901 1	Climb-up;Ladder;10493								2
+3426 2901 1	3426 2901 0	Climb-down;Ladder;10494								2
+3439 2892 1	3439 2892 0	Climb-down;Ladder;10494								2
+3439 2892 0	3439 2892 1	Climb-up;Ladder;10493								2
+3449 2898 0	3449 2898 1	Climb-up;Ladder;10493								2
+3449 2898 1	3449 2898 0	Climb-down;Ladder;10494								2
+3445 2911 0	3449 2911 1	Climb-up;Staircase;10525								1
+3449 2911 1	3445 2911 0	Climb-down;Staircase;10526								1
+3445 2912 0	3449 2911 1	Climb-up;Staircase;10525								1
+3449 2912 1	3445 2911 0	Climb-down;Staircase;10526								1
+3417 2905 1	3417 2905 0	Climb-down;Ladder;10494								2
+3417 2905 0	3417 2905 1	Climb-up;Ladder;10493								2
+3403 2926 0	3403 2926 1	Climb-up;Ladder;10493								2
+3403 2926 1	3403 2926 0	Climb-down;Ladder;10494								2
+3371 9312 0	3371 9313 0	Open;Door;10431								1
+3371 9313 0	3371 9312 0	Open;Door;10431								1
+3371 9312 0	3371 9313 0	Open;Door;10431								1
+3371 9313 0	3371 9312 0	Open;Door;10431								1
+3373 9304 0	3375 2904 0	Climb;Rope;10434
+3375 2904 0	3374 9305 0	Climb-down;Crevice;10416
+3374 9305 0	3375 2904 0	Climb;Rope;10434
+3375 2905 0	3374 9305 0	Climb-down;Crevice;10416
+3373 9306 0	3375 2904 0	Climb;Rope;10434
+3375 2906 0	3374 9305 0	Climb-down;Crevice;10416
+3372 9305 0	3375 2904 0	Climb;Rope;10434
+3374 2903 0	3374 9305 0	Climb-down;Crevice;10416
+3374 2902 0	3374 9305 0	Climb-down;Crevice;10416
+3372 2902 0	3374 9305 0	Climb-down;Crevice;10416
+3372 2903 0	3374 9305 0	Climb-down;Crevice;10416
+3372 2904 0	3374 9305 0	Climb-down;Crevice;10416
+3372 2905 0	3374 9305 0	Climb-down;Crevice;10416
+3372 2906 0	3374 9305 0	Climb-down;Crevice;10416
+3372 2907 0	3374 9305 0	Climb-down;Crevice;10416
+3374 2907 0	3374 9305 0	Climb-down;Crevice;10416
+
+# Agility Pyramid
+3334 2829 0	3338 2829 0	Climb;Climbing rocks;11948
+3338 2829 0	3334 2829 0	Climb;Climbing rocks;11948
+3334 2828 0	3338 2828 0	Climb;Climbing rocks;11948
+3338 2828 0	3334 2828 0	Climb;Climbing rocks;11948
+3334 2827 0	3338 2827 0	Climb;Climbing rocks;11948
+3338 2827 0	3334 2827 0	Climb;Climbing rocks;11948
+3338 2826 0	3334 2826 0	Climb;Climbing rocks;11948
+3334 2826 0	3338 2826 0	Climb;Climbing rocks;11948
+3348 2829 0	3352 2829 0	Climb;Climbing rocks;11949
+3352 2829 0	3348 2829 0	Climb;Climbing rocks;11949
+3348 2828 0	3352 2828 0	Climb;Climbing rocks;11949
+3352 2828 0	3348 2828 0	Climb;Climbing rocks;11949
+3348 2827 0	3352 2827 0	Climb;Climbing rocks;11949
+3352 2827 0	3348 2827 0	Climb;Climbing rocks;11949
+
+# Sophanem
+3284 2810 0	3283 2809 0	Open;Gate;20391								1
+3283 2809 0	3283 2810 0	Open;Gate;20391								1
+3283 2810 0	3283 2809 0	Open;Gate;20391								1
+3284 2809 0	3283 2810 0	Open;Gate;20391								1
+3317 2786 1	3317 2788 0	Climb-down;Ladder;20354								2
+3317 2788 0	3317 2786 1	Climb-up;Ladder;20353								2
+3317 2784 1	3317 2782 2	Climb-up;Ladder;20353								2
+3317 2782 2	3317 2784 1	Climb-down;Ladder;20354								2
+3316 2766 1	3316 2768 0	Climb-down;Ladder;20354								2
+3316 2768 0	3316 2766 1	Climb-up;Ladder;20353								2
+3315 2777 1	3315 2775 2	Climb-up;Ladder;20353								2
+3315 2775 2	3315 2777 1	Climb-down;Ladder;20354								2
+3314 2755 0	3314 2753 1	Climb-up;Ladder;20353								2
+3314 2753 1	3314 2755 0	Climb-down;Ladder;20354								2
+3315 2796 0	2800 5160 0	Climb-down;Ladder;20275								2
+2799 5160 0	3315 2796 0	Climb-up;Ladder;20277								2
+2800 5160 0	3318 9273 2	Climb-down;Ladder;20278								2
+3318 9273 2	2800 5160 0	Climb-up;Ladder;20281								2
+3286 9275 2	3286 9273 0	Climb-down;Ladder;20285								2
+3286 9273 0	3286 9275 2	Climb-up;Ladder;20284								2
+3323 9240 0	3323 9242 2	Climb-up;Ladder;20284								2
+3323 9242 2	3323 9240 0	Climb-down;Ladder;20285								2
+3317 9251 0	3317 9249 2	Climb-up;Ladder;20284								2
+3317 9249 2	3317 9251 0	Climb-down;Ladder;20285								2
+3317 9223 0	3317 9225 2	Climb-up;Ladder;20284								2
+3317 9225 2	3317 9223 0	Climb-down;Ladder;20285								2
+3268 9228 2	3257 9226 0	Climb-down;Ladder;20287								2
+3257 9226 0	3268 9228 2	Climb-up;Ladder;20286								2
+3267 9220 2	3267 9222 0	Climb-down;Ladder;20285								2
+3267 9222 0	3267 9220 2	Climb-up;Ladder;20284								2
+3270 9274 2	3272 9274 0	Climb-down;Ladder;20285								2
+3272 9274 0	3270 9274 2	Climb-up;Ladder;20284								2
+3272 9235 2	3270 9235 0	Climb-down;Ladder;20285								2
+3270 9235 0	3272 9235 2	Climb-up;Ladder;20284								2
+3280 9254 0	3280 9256 2	Climb-up;Ladder;20284								2
+3280 9256 2	3280 9254 0	Climb-down;Ladder;20285								2
+3307 2803 2	3309 2803 0	Climb-down;Ladder;20357								2
+3309 2803 0	3307 2803 2	Climb-up;Ladder;20356								2
+3283 2756 0	3283 2754 1	Climb-up;Ladder;20353								2
+3283 2754 1	3283 2756 0	Climb-down;Ladder;20354								2
+3281 2754 2	3281 2756 1	Climb-down;Ladder;20354								2
+3281 2756 1	3281 2754 2	Climb-up;Ladder;20353								2
+3277 2768 0	3279 2768 1	Climb-up;Ladder;20353								2
+3279 2768 1	3277 2768 0	Climb-down;Ladder;20354								2
+3285 2768 0	3283 2768 1	Climb-up;Ladder;20353								2
+3283 2768 1	3285 2768 0	Climb-down;Ladder;20354								2
+3283 2772 1	3283 2770 3	Climb-up;Ladder;20356								2
+3283 2770 3	3283 2772 1	Climb-down;Ladder;20357								2
+3279 2772 1	3279 2770 3	Climb-up;Ladder;20356								2
+3279 2770 3	3279 2772 1	Climb-down;Ladder;20357								2
+3320 2796 0	3321 2858 0	Climb-through;Hole;6620
+3322 2858 0	3319 2796 0	Enter;Rock;6621
+3322 2859 0	3319 2796 0	Enter;Rock;6621
+3323 2860 0	3319 2796 0	Enter;Rock;6621
+3324 2860 0	3319 2796 0	Enter;Rock;6621
+3322 2857 0	3319 2796 0	Enter;Rock;6621
+3323 2856 0	3319 2796 0	Enter;Rock;6621
+3324 2856 0	3319 2796 0	Enter;Rock;6621
+3325 2856 0	3319 2796 0	Enter;Rock;6621
+3325 2860 0	3319 2796 0	Enter;Rock;6621
+3326 2859 0	3319 2796 0	Enter;Rock;6621
+3326 2857 0	3319 2796 0	Enter;Rock;6621
+3326 2858 0	3319 2796 0	Enter;Rock;6621
+
+# Pyramid
+3233 2900 0	3233 2898 0	Open;Pyramid entrance;6545
+3232 2900 0	3232 2898 0	Open;Pyramid entrance;6547
+3233 2898 0	3233 2900 0	Open;Pyramid entrance;6545
+3232 2898 0	3232 2900 0	Open;Pyramid entrance;6547
+3232 2897 0	2913 4954 3	Climb-down;Ladder;6497								2
+2913 4954 3	3233 2898 0	Climb-up;Ladder;6504								2
+3233 2898 0	2913 4954 3	Climb-down;Ladder;6497								2
+2914 4953 3	3233 2898 0	Climb-up;Ladder;6504								2
+3234 2897 0	2913 4954 3	Climb-down;Ladder;6497								2
+2912 4953 3	3233 2898 0	Climb-up;Ladder;6504								2
+3233 2896 0	2913 4954 3	Climb-down;Ladder;6497								2
+2913 4952 3	3233 2898 0	Climb-up;Ladder;6504								2
+2909 4965 3	2846 4964 2	Climb-down;Ladder;6498								2
+2846 4964 2	2909 4965 3	Climb-up;Ladder;6503								2
+2908 4964 3	2846 4964 2	Climb-down;Ladder;6498								2
+2845 4965 2	2909 4965 3	Climb-up;Ladder;6503								2
+2910 4964 3	2846 4964 2	Climb-down;Ladder;6498								2
+2845 4963 2	2909 4965 3	Climb-up;Ladder;6503								2
+2909 4963 3	2846 4964 2	Climb-down;Ladder;6498								2
+2844 4964 2	2909 4965 3	Climb-up;Ladder;6503								2
+3233 2887 0	3233 9313 0	Enter;Tunnel;6481
+3233 9323 0	3233 9325 0	Open;Doorway;6555
+3233 9325 0	3233 9323 0	Open;Doorway;6555
+3234 9323 0	3234 9325 0	Open;Doorway;6553
+3234 9325 0	3234 9323 0	Open;Doorway;6553
+3233 9293 0	2783 4941 1	Climb-up;Ladder;6501								2
+2783 4941 1	3233 9293 0	Climb-down;Ladder;6500								2
+3232 9294 0	2783 4941 1	Climb-up;Ladder;6501								2
+2784 4942 1	3233 9293 0	Climb-down;Ladder;6500								2
+3232 9292 0	2783 4941 1	Climb-up;Ladder;6501								2
+3231 9293 0	2783 4941 1	Climb-up;Ladder;6501								2
+2785 4941 1	3233 9293 0	Climb-down;Ladder;6500								2
+2784 4940 1	3233 9293 0	Climb-down;Ladder;6500								2
+2782 4972 1	2845 4973 2	Climb-up;Ladder;6502								2
+2845 4973 2	2782 4972 1	Climb-down;Ladder;6499								2
+2781 4973 1	2845 4973 2	Climb-up;Ladder;6502								2
+2782 4974 1	2845 4973 2	Climb-up;Ladder;6502								2
+2783 4973 1	2845 4973 2	Climb-up;Ladder;6502								2
+
+# Kalphite Lair
+3226 3108 0	3483 9510 2	Climb-down;Tunnel entrance;3827
+3483 9510 2	3226 3108 0	Climb-up;Rope;3829
+3226 3109 0	3483 9510 2	Climb-down;Tunnel entrance;3827
+3227 3110 0	3483 9510 2	Climb-down;Tunnel entrance;3827
+3228 3110 0	3483 9510 2	Climb-down;Tunnel entrance;3827
+3227 3107 0	3483 9510 2	Climb-down;Tunnel entrance;3827
+3228 3107 0	3483 9510 2	Climb-down;Tunnel entrance;3827
+3229 3109 0	3483 9510 2	Climb-down;Tunnel entrance;3827
+3229 3108 0	3483 9510 2	Climb-down;Tunnel entrance;3827
+3484 9510 2	3226 3108 0	Climb-up;Rope;3829
+3483 9509 2	3226 3108 0	Climb-up;Rope;3829
+3514 9521 2	2711 5206 0	Enter;Tunnel;23596
+2711 5206 0	3514 9521 2	Enter;Blocked tunnel;22656
+3514 9520 2	2711 5206 0	Enter;Tunnel;23596
+2711 5207 0	3514 9520 2	Enter;Blocked tunnel;22657
+3508 9498 2	3508 9493 0	Climb-down;Tunnel entrance;23609
+3508 9493 0	3508 9497 2	Climb-up;Rope;3832
+3508 9497 2	3508 9493 0	Climb-down;Tunnel entrance;23609
+3507 9494 0	3508 9497 2	Climb-up;Rope;3832
+3509 9496 2	3508 9493 0	Climb-down;Tunnel entrance;23609
+3510 9496 2	3508 9493 0	Climb-down;Tunnel entrance;23609
+3508 9494 0	3508 9497 2	Climb-up;Rope;3832
+3509 9499 2	3508 9493 0	Climb-down;Tunnel entrance;23609
+3510 9499 2	3508 9493 0	Climb-down;Tunnel entrance;23609
+3511 9497 2	3508 9493 0	Climb-down;Tunnel entrance;23609
+3511 9498 2	3508 9493 0	Climb-down;Tunnel entrance;23609
+
+# Dorgesh-Kaan
+2715 5241 0	2719 5241 3	Climb-up;Ladder;22600								2
+2719 5241 3	2715 5241 0	Climb-down;Ladder top;22666								2
+
+# Uzer
+3491 3090 0	2721 4886 0	Climb-down;Staircase;6373								1
+2721 4886 0	3491 3090 0	Climb-up;Staircase;6372								1
+2720 4885 0	3491 3090 0	Climb-up;Staircase;6372								1
+2720 4884 0	3491 3090 0	Climb-up;Staircase;6372								1
+2722 4886 0	3491 3090 0	Climb-up;Staircase;6372								1
+2723 4885 0	3491 3090 0	Climb-up;Staircase;6372								1
+2723 4884 0	3491 3090 0	Climb-up;Staircase;6372								1
+2722 4883 0	3491 3090 0	Climb-up;Staircase;6372								1
+2721 4883 0	3491 3090 0	Climb-up;Staircase;6372								1
+2719 4913 0	2720 4884 2	Enter;Door;6310								1
+2721 4911 0	2720 4884 2	Enter;Door;6310								1
+2720 4911 0	2720 4884 2	Enter;Door;6310								1
+2719 4912 0	2720 4884 2	Enter;Door;6310								1
+2722 4911 0	2720 4884 2	Enter;Door;6310								1
+2723 4911 0	2720 4884 2	Enter;Door;6310								1
+2724 4912 0	2720 4884 2	Enter;Door;6310								1
+2724 4913 0	2720 4884 2	Enter;Door;6310								1
+2723 4914 0	2720 4884 2	Enter;Door;6310								1
+2722 4914 0	2720 4884 2	Enter;Door;6310								1
+2721 4914 0	2720 4884 2	Enter;Door;6310								1
+2720 4914 0	2720 4884 2	Enter;Door;6310								1
+
+# River Elid Dungeon
+3371 3129 0	3349 9536 0	Use;Rope -> Root;6382
+3349 9536 0	3371 3129 0	Leave;Cave exit;10417
+
+# Pollnivneach
+3364 3002 0	3364 3002 1	Climb-up;Ladder;6261								2
+3364 3002 1	3364 3002 0	Climb-down;Ladder;6260								2
+3368 2991 0	3368 2991 1	Climb-up;Ladder;6261								2
+3368 2991 1	3368 2991 0	Climb-down;Ladder;6260								2
+3349 2963 1	3349 2963 0	Climb-down;Ladder;6260								2
+3356 2982 1	3356 2982 2	Climb-up;Ladder;6261								2
+3356 2982 2	3356 2982 1	Climb-down;Ladder;6260								2
+3370 2971 0	3371 2971 0	Open;Door;6238								1
+3371 2971 0	3370 2971 0	Open;Door;6238								1
+3370 2970 0	3371 2970 0	Open;Door;6240								1
+3371 2970 0	3370 2970 0	Open;Door;6240								1
+3373 2977 0	3374 2979 1	Climb-up;Staircase;6244								1
+3374 2979 1	3373 2977 0	Climb-down;Staircase;6245								1
+3374 2978 1	3373 2977 0	Climb-down;Staircase;6245								1
+3353 2961 0	3354 2958 1	Climb-up;Staircase;6242								1
+3354 2958 1	3353 2961 0	Climb-down;Staircase;6243								1
+3354 2959 1	3353 2961 0	Climb-down;Staircase;6243								1
+
+# Smoke Dungeon
+3310 2961 0	3206 9379 0	Climb-down;Smokey well;6279
+3206 9379 0	3310 2961 0	Climb-up;Rope;6439
+3309 2962 0	3206 9379 0	Climb-down;Smokey well;6279
+3205 9380 0	3310 2961 0	Climb-up;Rope;6439
+3311 2962 0	3206 9379 0	Climb-down;Smokey well;6279
+3204 9379 0	3310 2961 0	Climb-up;Rope;6439
+3310 2963 0	3206 9379 0	Climb-down;Smokey well;6279
+3205 9378 0	3310 2961 0	Climb-up;Rope;6439
+3304 9376 0	3305 9376 0	Open;Gate;6452
+3305 9376 0	3304 9376 0	Open;Gate;6452
+3304 9375 0	3305 9375 0	Open;Gate;6451
+3305 9375 0	3304 9375 0	Open;Gate;6451
+
+# Kalphite Cave
+3321 3122 0	3305 9497 0	Enter;Cave;30180
+3305 9497 0	3321 3122 0	Use;Crevice;26712
+
+# Mos Le'Harmless
+3696 2996 0	3696 2996 1	Climb-up;Bamboo Ladder;4772
+3696 2996 1	3696 2996 0	Climb-down;Bamboo Ladder;4778
+3653 2991 1	3653 2991 0	Climb-down;Bamboo Ladder;4778
+3653 2991 0	3653 2991 1	Climb-up;Bamboo Ladder;4772
+3664 2992 1	3664 2992 0	Climb-down;Bamboo Ladder;4778
+3664 2992 0	3664 2992 1	Climb-up;Bamboo Ladder;4772
+3667 2983 0	3667 2983 1	Climb-up;Bamboo Ladder;4772
+3667 2983 1	3667 2983 0	Climb-down;Bamboo Ladder;4778
+3669 2977 0	3669 2977 1	Climb-up;Bamboo Ladder;4772
+3669 2977 1	3669 2977 0	Climb-down;Bamboo Ladder;4778
+3684 2953 0	3684 2950 1	Cross;Gangplank;11211								3
+3684 2950 1	3684 2953 0	Cross;Gangplank;11212								3
+3685 2950 1	3687 2950 2	Climb-up;Ship's ladder;11289
+3687 2950 2	3685 2950 1	Climb-down;Ship's ladder;11290
+3685 2946 1	3687 2946 2	Climb-up;Ship's ladder;11289
+3687 2946 2	3685 2946 1	Climb-down;Ship's ladder;11290
+3677 2948 1	3677 2948 0	Climb-down;Ship's ladder;11309
+3677 2948 0	3677 2948 1	Climb-up;Ship's ladder;11308
+3671 2931 0	3668 2931 1	Cross;Gangplank;17406								3
+3668 2931 1	3671 2931 0	Cross;Gangplank;17407								3
+3749 2973 0	3748 9373 0	Enter;Cave entrance;3650
+3748 9373 0	3749 2973 0	Exit;Cave;5553
+3748 9374 0	3749 2973 0	Exit;Cave;6702
+3814 3061 0	3814 9464 0	Climb-down;Staircase;5270								1
+3815 3061 0	3814 9464 0	Climb-down;Staircase;5270								1
+3813 3062 0	3814 9464 0	Climb-down;Staircase;5270								1
+3816 3062 0	3814 9464 0	Climb-down;Staircase;5270								1
+3814 9464 0	3814 3061 0	Climb-up;Staircase;5269								1
+3815 9464 0	3814 3061 0	Climb-up;Staircase;5269								1
+3813 9463 0	3814 3061 0	Climb-up;Staircase;5269								1
+3816 9463 0	3814 3061 0	Climb-up;Staircase;5269								1
+3816 3063 0	3814 9464 0	Climb-down;Staircase;5270								1
+3813 9462 0	3814 3061 0	Climb-up;Staircase;5269								1
+3814 9461 0	3814 3061 0	Climb-up;Staircase;5269								1
+3815 9461 0	3814 3061 0	Climb-up;Staircase;5269								1
+3816 9462 0	3814 3061 0	Climb-up;Staircase;5269								1
+
+# Harmony Island
+3794 2844 0	3785 9254 0	Climb-down;Statue;22355
+3785 9254 0	3796 2843 0	Climb;Ladder;22371								2
+3804 2844 0	3806 2844 0	Open;Door;22119								1
+3806 2844 0	3804 2844 0	Open;Door;22119								1
+3816 2847 0	3817 2847 0	Open;Door;22007								1
+3817 2847 0	3816 2847 0	Open;Door;22007								1
+3818 2853 1	3818 2851 0	Climb-down;Ladder;22122								2
+3818 2851 0	3818 2853 1	Climb-up;Ladder;22121								2
+3816 2841 0	3817 2841 0	Open;Door;22007
+3817 2841 0	3816 2841 0	Open;Door;22007
+3787 2821 0	3787 2822 0	Open;Large door;22437
+3787 2822 0	3787 2821 0	Open;Large door;22437
+3786 2821 0	3786 2822 0	Open;Large door;22435
+3786 2822 0	3786 2821 0	Open;Large door;22435
+3784 2825 0	3784 2825 1	Climb-up;Ladder;22432								2
+3784 2825 1	3784 2825 0	Climb-down;Ladder;22433								2
+3784 2825 1	3784 2825 2	Climb-up;Ladder;22433								2
+3784 2825 2	3784 2825 1	Climb-down;Ladder;22434								2
+3788 2826 0	3788 9226 0	Climb-down;Ladder;22173								2
+3788 9226 0	3788 2826 0	Climb-up;Ladder;22172								2
+3829 3061 0	3829 9464 0	Climb-down;Staircase;5270								1
+3829 9464 0	3829 3061 0	Climb-up;Staircase;5269								1
+3830 3061 0	3829 9464 0	Climb-down;Staircase;5270								1
+3830 9464 0	3829 3061 0	Climb-up;Staircase;5269								1
+3828 3062 0	3829 9464 0	Climb-down;Staircase;5270								1
+3828 9463 0	3829 3061 0	Climb-up;Staircase;5269								1
+3828 3063 0	3829 9464 0	Climb-down;Staircase;5270								1
+3831 9463 0	3829 3061 0	Climb-up;Staircase;5269								1
+3829 3064 0	3829 9464 0	Climb-down;Staircase;5270								1
+3828 9462 0	3829 3061 0	Climb-up;Staircase;5269								1
+3830 3064 0	3829 9464 0	Climb-down;Staircase;5270								1
+3829 9461 0	3829 3061 0	Climb-up;Staircase;5269								1
+3831 3062 0	3829 9464 0	Climb-down;Staircase;5270								1
+3830 9461 0	3829 3061 0	Climb-up;Staircase;5269								1
+3831 3063 0	3829 9464 0	Climb-down;Staircase;5270								1
+3831 9462 0	3829 3061 0	Climb-up;Staircase;5269								1
+
+# Mort'ton
+3495 3465 0	3477 9845 0	Open;Trapdoor;5055
+3477 9845 0	3495 3465 0	Climb-up;Ladder;5054								2
+3495 3464 0	3477 9845 0	Open;Trapdoor;5055
+3478 9846 0	3495 3465 0	Climb-up;Ladder;5054								2
+3476 9846 0	3495 3465 0	Climb-up;Ladder;5054								2
+3477 9847 0	3495 3465 0	Climb-up;Ladder;5054								2
+3502 3432 0	3502 3425 0	Cross-bridge;Tree;5003
+3502 3425 0	3502 3432 0	Cross-bridge;Tree;5003
+3503 3431 0	3502 3425 0	Cross-bridge;Tree;5003
+3501 3426 0	3502 3432 0	Cross-bridge;Tree;5003
+3485 3322 0	3493 9725 0	Open;Wooden doors;4132								1
+3484 3322 0	3493 9725 0	Open;Wooden doors;4133								1
+3493 9726 0	3485 3322 0	Open;Solid bronze door;17900								1
+# Burgh de Rott
+3484 3244 0	3484 3243 0	Open;Gate;12817
+3484 3243 0	3484 3244 0	Open;Gate;12817
+3485 3244 0	3485 3243 0	Open;Gate;12816
+3485 3243 0	3485 3244 0	Open;Gate;12816
+3513 3237 0	3513 3239 2	Climb-up;Ladder;12780								2
+3513 3239 2	3513 3237 0	Climb-down;Ladder;12781								2
+3474 3221 0	3473 3221 0	Jump-over;Low fence;12776				In Aid of the Myreque				5
+3473 3221 0	3475 3221 0	Jump-over;Low fence;12776				In Aid of the Myreque				5
+3491 3230 0	3491 3231 0	Climb-over;Broken wall;12737								3
+3491 3231 0	3491 3230 0	Climb-over;Broken wall;12737								3
+3490 3232 0	3490 9631 0	Climb-down;Trapdoor;12743								2
+3490 9631 0	3490 3232 0	Climb-up;Ladder;12779								2
+3582 3264 0	3582 3263 0	Climb-over;Broken fence;18411				In Aid of the Myreque
+3582 3263 0	3582 3264 0	Climb-over;Broken fence;18411				In Aid of the Myreque
+
+# Haunted Mine
+3446 3236 0	3444 3236 0	Climb-over;Mine cart;4918
+3444 3236 0	3446 3236 0	Climb-over;Mine cart;4918
+3441 3232 0	3436 9637 0	Crawl-down;Cart tunnel;4913
+3436 9637 0	3441 3232 0	Crawl-through;Cart tunnel;4920
+3435 9635 0	2800 4429 0	Crawl-through;Cart tunnel;29332
+2800 4429 0	3435 9635 0	Crawl-through;Cart tunnel;29333
+2758 4454 0	2691 4437 0	Walk-up;Stairs;4973
+2712 4593 0	2691 4437 0	Walk-up;Stairs;4972
+2712 4592 0	2691 4437 0	Walk-up;Stairs;4972
+2730 4563 0	2750 4437 0	Walk-up;Stairs;4972
+2730 4562 0	2750 4437 0	Walk-up;Stairs;4972
+2691 4437 0	2712 4593 0	Walk-down;Stairs;4971
+2691 4438 0	2712 4593 0	Walk-down;Stairs;4971
+2750 4437 0	2730 4563 0	Walk-down;Stairs;4971
+2750 4438 0	2730 4563 0	Walk-down;Stairs;4971
+2750 4436 0	2730 4563 0	Walk-down;Stairs;4971
+2807 4493 0	2725 4452 0	Go-down;Lift;4940
+2725 4452 0	2807 4493 0	Go-up;Lift;4942
+2724 4452 0	2807 4493 0	Go-up;Lift;4942
+2723 4452 0	2807 4493 0	Go-up;Lift;4942
+2722 4452 0	2807 4493 0	Go-up;Lift;4942
+2797 4529 0	2733 4529 0	Climb-up;Ladder;4968								2
+2733 4529 0	2797 4529 0	Climb-down;Ladder;4967								2
+2796 4528 0	2732 4528 0	Climb-up;Ladder;4968								2
+2732 4528 0	2796 4528 0	Climb-down;Ladder;4967								2
+2796 4530 0	2732 4530 0	Climb-up;Ladder;4968								2
+2731 4529 0	2795 4529 0	Climb-down;Ladder;4967								2
+2795 4529 0	2731 4529 0	Climb-up;Ladder;4968								2
+2732 4530 0	2796 4530 0	Climb-down;Ladder;4967								2
+2733 4534 0	2797 4598 0	Climb-up;Ladder;4970								2
+2797 4598 0	2733 4534 0	Climb-down;Ladder;4969								2
+2732 4535 0	2796 4599 0	Climb-up;Ladder;4970								2
+2796 4599 0	2732 4535 0	Climb-down;Ladder;4969								2
+2733 4536 0	2797 4600 0	Climb-up;Ladder;4970								2
+2797 4600 0	2733 4536 0	Climb-down;Ladder;4969								2
+2734 4535 0	2798 4599 0	Climb-up;Ladder;4970								2
+2798 4599 0	2734 4535 0	Climb-down;Ladder;4969								2
+2710 4539 0	2774 4539 0	Climb-down;Ladder;4967								2
+2774 4539 0	2710 4539 0	Climb-up;Ladder;4968								2
+2711 4540 0	2775 4540 0	Climb-down;Ladder;4967								2
+2775 4540 0	2711 4540 0	Climb-up;Ladder;4968								2
+2709 4540 0	2773 4540 0	Climb-down;Ladder;4967								2
+2773 4540 0	2709 4540 0	Climb-up;Ladder;4968								2
+2710 4541 0	2774 4541 0	Climb-down;Ladder;4967								2
+2774 4541 0	2710 4541 0	Climb-up;Ladder;4968								2
+2760 4496 0	2696 4496 0	Climb-up;Ladder;4968								2
+2696 4496 0	2760 4496 0	Climb-down;Ladder;4967								2
+2761 4497 0	2697 4497 0	Climb-up;Ladder;4968								2
+2697 4497 0	2761 4497 0	Climb-down;Ladder;4967								2
+2760 4498 0	2696 4498 0	Climb-up;Ladder;4968								2
+2696 4498 0	2760 4498 0	Climb-down;Ladder;4967								2
+2759 4497 0	2695 4497 0	Climb-up;Ladder;4968								2
+2695 4497 0	2759 4497 0	Climb-down;Ladder;4967								2
+2773 4578 0	3413 9634 0	Climb-up;Ladder;4966								2
+3413 9634 0	2773 4578 0	Climb-down;Ladder;4965								2
+2774 4577 0	3414 9633 0	Climb-up;Ladder;4966								2
+3414 9633 0	2774 4577 0	Climb-down;Ladder;4965								2
+2773 4576 0	3413 9632 0	Climb-up;Ladder;4966								2
+3413 9632 0	2773 4576 0	Climb-down;Ladder;4965								2
+2772 4577 0	3412 9633 0	Climb-up;Ladder;4966								2
+3412 9633 0	2772 4577 0	Climb-down;Ladder;4965								2
+3405 9631 0	3429 3233 0	Crawl-through;Cart tunnel;4921
+3429 3233 0	3405 9631 0	Crawl-down;Cart tunnel;4914
+3428 3225 0	3409 9623 0	Crawl-down;Cart tunnel;4915
+3409 9623 0	3428 3225 0	Crawl-through;Cart tunnel;15830
+3423 9625 0	2783 4569 0	Climb-down;Ladder;4965								2
+2783 4569 0	3423 9625 0	Climb-up;Ladder;4966								2
+3422 9624 0	2782 4568 0	Climb-down;Ladder;4965								2
+2782 4568 0	3422 9624 0	Climb-up;Ladder;4966								2
+3421 9625 0	2781 4569 0	Climb-down;Ladder;4965								2
+2781 4569 0	3421 9625 0	Climb-up;Ladder;4966								2
+3422 9626 0	2782 4570 0	Climb-down;Ladder;4965								2
+2782 4570 0	3422 9626 0	Climb-up;Ladder;4966								2
+2798 4568 0	2734 4504 0	Climb-down;Ladder;4969								2
+2734 4504 0	2798 4568 0	Climb-up;Ladder;4970								2
+2797 4567 0	2733 4503 0	Climb-down;Ladder;4969								2
+2733 4503 0	2797 4567 0	Climb-up;Ladder;4970								2
+2798 4566 0	2734 4502 0	Climb-down;Ladder;4969								2
+2734 4502 0	2798 4566 0	Climb-up;Ladder;4970								2
+2799 4567 0	2735 4503 0	Climb-down;Ladder;4969								2
+2735 4503 0	2799 4567 0	Climb-up;Ladder;4970								2
+2724 4486 0	2788 4486 0	Climb-down;Ladder;4967								2
+2788 4486 0	2724 4486 0	Climb-up;Ladder;4968								2
+2725 4487 0	2789 4487 0	Climb-down;Ladder;4967								2
+2789 4487 0	2725 4487 0	Climb-up;Ladder;4968								2
+2726 4486 0	2790 4486 0	Climb-down;Ladder;4967								2
+2790 4486 0	2726 4486 0	Climb-up;Ladder;4968								2
+2725 4485 0	2789 4485 0	Climb-down;Ladder;4967								2
+2789 4485 0	2725 4485 0	Climb-up;Ladder;4968								2
+3454 3242 0	2792 4592 0	Walk-down;Stairs;4919
+2792 4592 0	3454 3242 0	Walk-up;Stairs;4923
+2791 4592 0	3454 3242 0	Walk-up;Stairs;4923
+2772 4449 0	2772 4450 0	Open;Large door;4964
+2773 4449 0	2773 4450 0	Open;Large door;4964
+2758 4453 0	2691 4437 0	Walk-up;Stairs;4973
+2811 4454 0	2750 4437 0	Walk-up;Stairs;4973
+2811 4453 0	2750 4437 0	Walk-up;Stairs;4973
+2750 4438 0	2811 4454 0	Walk-down;Stairs;4971		4075
+2750 4437 0	2811 4454 0	Walk-down;Stairs;4971		4075
+2750 4436 0	2811 4454 0	Walk-down;Stairs;4971		4075
+2799 4453 0	2798 4453 0	Open;Door;4962
+2798 4453 0	2799 4453 0	Open;Door;4962
+2691 4438 0	2758 4454 0	Walk-down;Stairs;4971		4075
+2691 4437 0	2758 4454 0	Walk-down;Stairs;4971		4075
+2773 4450 0	2773 4449 0	Open;Large door;4963		4077
+2772 4450 0	2772 4449 0	Open;Large door;4964		4077
+
+# Tarn's Lair
+3424 9660 0	3166 4547 0	Enter;Entrance;20822
+3166 4547 0	3424 9660 0	Enter;Passageway;20482
+3158 4552 0	3158 4557 1	Enter;Passageway;16132
+3158 4557 1	3158 4552 0	Climb;Stairs;17098
+3174 4561 1	3179 4561 0	Enter;Passageway;20516
+3179 4561 0	3174 4561 1	Enter;Passageway;20515
+3195 4570 0	3195 4575 1	Enter;Passageway;20517
+3195 4575 1	3195 4570 0	Enter;Passageway;20518
+3186 4585 1	3186 4578 2	Enter;Passageway;20522
+3186 4578 2	3186 4585 1	Enter;Passageway;20521
+3184 4585 1	3184 4579 0	Enter;Passageway;20512
+3184 4579 0	3184 4585 1	Enter;Passageway;20511
+3184 4571 0	3184 4566 1	Enter;Passageway;20510
+3184 4566 1	3184 4571 0	Enter;Passageway;20509
+3184 4552 0	3184 4557 1	Enter;Passageway;16132
+3184 4557 1	3184 4552 0	Climb;Stairs;17098
+3158 4563 1	3158 4568 2	Enter;Passageway;18308
+3158 4568 2	3158 4563 1	Climb;Stairs;18973
+3172 4569 1	3167 4569 0	Climb;Stairs;17098
+3167 4569 0	3172 4569 1	Enter;Passageway;16132
+3163 4565 0	3163 4560 0	Enter;Passageway;20489
+3163 4560 0	3163 4565 0	Enter;Passageway;20490
+3161 4559 0	3155 4559 0	Enter;Passageway;20491
+3155 4559 0	3161 4559 0	Enter;Passageway;20492
+3148 4548 0	3143 4548 1	Enter;Passageway;16132
+3143 4548 1	3148 4548 0	Climb;Stairs;17098
+3141 4550 1	3141 4555 2	Enter;Passageway;18308
+3141 4555 2	3141 4550 1	Climb;Stairs;18973
+3141 4560 2	3141 4565 1	Enter;Passageway;20497
+3141 4565 1	3141 4560 2	Enter;Passageway;20498
+3144 4566 1	3144 4571 2	Enter;Passageway;20499
+3144 4571 2	3144 4566 1	Enter;Passageway;20500
+3144 4576 2	3144 4574 2	Jump-to;Pillar;20557
+3144 4574 2	3144 4572 2	Jump-to;Ledge;20568
+3144 4572 2	3144 4574 2	Jump-to;Pillar;20557
+3144 4574 2	3144 4576 2	Jump-to;Ledge;20569
+3144 4577 2	3144 4582 1	Enter;Passageway;20501
+3144 4582 1	3144 4577 2	Enter;Passageway;20502
+3146 4583 1	3151 4583 0	Enter;Passageway;20503
+3151 4583 0	3146 4583 1	Enter;Passageway;20504
+3161 4577 0	3166 4577 0	Enter;Passageway;20505
+3166 4577 0	3161 4577 0	Enter;Passageway;20506
+3170 4577 0	3175 4577 1	Enter;Passageway;20514
+3175 4577 1	3170 4577 0	Enter;Passageway;20513
+3176 4577 1	3181 4577 2	Enter;Passageway;18308
+3181 4577 2	3176 4577 1	Enter;Passageway;19029
+3189 4577 2	3194 4577 1	Enter;Passageway;20520
+3194 4577 1	3189 4577 2	Enter;Passageway;20519
+3184 4564 1	3184 4562 1	Jump-to;Pillar;20541
+3184 4562 1	3184 4560 1	Jump-to;Pillar;20540
+3184 4560 1	3184 4558 1	Jump-to;Ledge;20558
+3184 4558 1	3184 4560 1	Jump-to;Pillar;20540
+3184 4560 1	3184 4562 1	Jump-to;Pillar;20541
+3184 4562 1	3184 4564 1	Jump-to;Ledge;20559
+3168 4579 0	3168 4586 0	Enter;Passageway;20523
+3168 4586 0	3168 4579 0	Enter;Passageway;20524
+3168 4592 0	3168 4597 0	Enter;Passageway;20532
+3168 4597 0	3168 4592 0	Enter;Passageway;20531
+3160 4598 0	3149 4598 0	Enter;Passageway;20530
+3149 4598 0	3160 4598 0	Enter;Passageway;20529
+3145 4594 0	3145 4589 1	Enter;Passageway;20528
+3145 4589 1	3145 4594 0	Enter;Passageway;20527
+3161 4589 1	3166 4589 0	Enter;Passageway;20526
+3166 4589 0	3161 4589 1	Enter;Passageway;20525
+3150 4597 1	3148 4597 1	Jump-to;Pillar;20542
+3148 4597 1	3150 4597 1	Jump-to;Ledge;20560
+3148 4597 1	3148 4595 1	Jump-to;Pillar;20543
+3148 4595 1	3148 4597 1	Jump-to;Pillar;20542
+3148 4595 1	3146 4595 1	Jump-to;Pillar;20544
+3146 4595 1	3148 4595 1	Jump-to;Pillar;20543
+3146 4595 1	3144 4595 1	Jump-to;Pillar;20545
+3144 4595 1	3146 4595 1	Jump-to;Pillar;20544
+3144 4595 1	3142 4595 1	Jump-to;Pillar;20546
+3142 4595 1	3144 4595 1	Jump-to;Pillar;20545
+3142 4595 1	3140 4595 1	Jump-to;Ledge;20562
+3140 4595 1	3142 4595 1	Jump-to;Pillar;20546
+3144 4595 1	3144 4597 1	Jump-to;Pillar;20547
+3144 4597 1	3144 4599 1	Jump-to;Pillar;20548
+3144 4599 1	3144 4601 1	Jump-to;Ledge;20563
+3144 4601 1	3144 4599 1	Jump-to;Pillar;20548
+3144 4599 1	3144 4597 1	Jump-to;Pillar;20547
+3144 4597 1	3144 4595 1	Jump-to;Pillar;20545
+3175 4598 1	3179 4598 1	Enter;Passageway;20535
+3179 4598 1	3175 4598 1	Enter;Passageway;20536
+3180 4596 1	3182 4596 1	Jump-to;Pillar;20549
+3182 4596 1	3180 4596 1	Jump-to;Ledge;20564
+3180 4600 1	3182 4600 1	Jump-to;Pillar;20550
+3182 4600 1	3180 4600 1	Jump-to;Ledge;20565
+3184 4600 1	3182 4600 1	Jump-to;Pillar;20550
+3182 4600 1	3184 4600 1	Jump-to;Pillar;20551
+3184 4600 1	3184 4598 1	Jump-to;Pillar;20552
+3184 4598 1	3184 4600 1	Jump-to;Pillar;20551
+3184 4598 1	3186 4598 1	Jump-to;Pillar;20553
+3186 4598 1	3184 4598 1	Jump-to;Pillar;20552
+3186 4598 1	3186 4596 1	Jump-to;Pillar;20554
+3186 4596 1	3186 4598 1	Jump-to;Pillar;20553
+3186 4596 1	3188 4596 1	Jump-to;Pillar;20555
+3188 4596 1	3186 4596 1	Jump-to;Pillar;20554
+3188 4596 1	3190 4596 1	Jump-to;Ledge;20566
+3190 4596 1	3188 4596 1	Jump-to;Pillar;20555
+3190 4600 1	3188 4600 1	Jump-to;Pillar;20556
+3188 4600 1	3190 4600 1	Jump-to;Ledge;20567
+3194 4598 1	3189 4598 0	Climb;Stairs;17098
+3189 4598 0	3194 4598 1	Enter;Passageway;16132
+3185 4601 0	3149 4644 0	Enter;Passageway;20539
+3149 4644 0	3185 4601 0	Enter;Passageway;15771
+
+# Mort Myre
+3440 3331 0	3441 3329 0	Jump;Bridge;3522
+3441 3329 0	3440 3331 0	Jump;Bridge;3522
+3441 3331 0	3441 3329 0	Jump;Bridge;3522
+3440 3329 0	3440 3331 0	Jump;Bridge;3522
+3441 3328 0	3440 3331 0	Jump;Bridge;3522
+3440 3332 0	3441 3329 0	Jump;Bridge;3522
+3440 3328 0	3440 3331 0	Jump;Bridge;3522
+3441 3332 0	3441 3329 0	Jump;Bridge;3522
+3440 3337 0	3442 9734 1	Enter;Grotto;3516
+3442 9734 1	3440 3337 0	Exit;Grotto;3526
+3439 3337 0	3442 9734 1	Enter;Grotto;3516
+3441 3337 0	3442 9734 1	Enter;Grotto;3516
+3444 3458 0	3444 3457 0	Open;Gate;3506
+3443 3458 0	3443 3457 0	Open;Gate;3507
+3444 3457 0	3444 3458 0	Open;Gate;3506
+3443 3457 0	3443 3458 0	Open;Gate;3507
+
+# Paterdomus
+3405 3506 0	3405 9906 0	Climb-down;Trapdoor;1581
+3405 9906 0	3405 3506 0	Climb-up;Ladder;17385								2
+3405 9895 0	3405 9894 0	Open;Gate;3444
+3405 9894 0	3405 9895 0	Open;Gate;3444
+3431 9897 0	3432 9897 0	Open;Gate;3445
+3432 9897 0	3431 9897 0	Open;Gate;3445
+3360 9904 0	3440 9899 0	Climb-up;Ladder;12764								2
+3440 9899 0	3360 9904 0	Climb-down;Trapdoor;12762
+3440 9887 0	3423 3485 0	Pass-through;Holy barrier;3443
+3423 3485 0	3440 9887 0	Climb-down;Trapdoor;3433
+3422 3484 0	3440 9887 0	Climb-down;Trapdoor;3433
+3408 3489 0	3409 3489 0	Open;Large door;3489
+3409 3489 0	3408 3489 0	Open;Large door;3489
+3408 3488 0	3409 3488 0	Open;Large door;3490
+3409 3488 0	3408 3488 0	Open;Large door;3490
+3417 3494 0	3416 3493 1	Climb-up;Staircase;16671								1
+3416 3493 1	3417 3494 0	Climb-down;Staircase;16673								1
+3416 3493 0	3416 3493 1	Climb-up;Staircase;16671								1
+3416 3492 0	3416 3493 1	Climb-up;Staircase;16671								1
+3417 3491 0	3416 3493 1	Climb-up;Staircase;16671								1
+3418 3491 0	3416 3493 1	Climb-up;Staircase;16671								1
+3416 3485 0	3416 3485 1	Climb-up;Staircase;16671								1
+3416 3485 1	3417 3486 0	Climb-down;Staircase;16673								1
+3417 3486 0	3416 3485 1	Climb-up;Staircase;16671								1
+3418 3486 0	3416 3485 1	Climb-up;Staircase;16671								1
+3416 3484 0	3416 3485 1	Climb-up;Staircase;16671								1
+3417 3483 0	3416 3485 1	Climb-up;Staircase;16671								1
+3410 3486 1	3410 3486 2	Climb-up;Ladder;16683								2
+3410 3486 2	3410 3486 1	Climb-down;Ladder;16679								2
+3411 3485 1	3411 3485 2	Climb-up;Ladder;16683								2
+3411 3485 2	3411 3485 1	Climb-down;Ladder;16679								2
+3410 3484 1	3410 3484 2	Climb-up;Ladder;16683								2
+3410 3484 2	3410 3484 1	Climb-down;Ladder;16679								2
+3409 3485 1	3409 3485 2	Climb-up;Ladder;16683								2
+3409 3485 2	3409 3485 1	Climb-down;Ladder;16679								2
+3415 3489 2	3416 3489 2	Open;Cell door;3463
+3416 3489 2	3415 3489 2	Open;Cell door;3463
+
+# Enakhra's Lament
+3194 2926 0	3124 9328 1	Climb-down;Secret entrance;11046
+3124 9328 1	3194 2926 0	Climb;Sand pile;10950
+3195 2925 0	3124 9328 1	Climb-down;Secret entrance;11046
+3125 9328 1	3194 2926 0	Climb;Sand pile;10950
+3193 2925 0	3124 9328 1	Climb-down;Secret entrance;11046
+3126 9329 1	3194 2926 0	Climb;Sand pile;10950
+3194 2924 0	3124 9328 1	Climb-down;Secret entrance;11046
+3126 9330 1	3194 2926 0	Climb;Sand pile;10950
+3127 9328 1	3127 9330 0	Climb-down;Ladder;11042								2
+3127 9330 0	3127 9330 1	Climb-up;Ladder;11041								2
+3127 9330 1	3127 9330 0	Climb-down;Ladder;11042								2
+3128 9329 1	3127 9330 0	Climb-down;Ladder;11042								2
+3126 9329 1	3127 9330 0	Climb-down;Ladder;11042								2
+3129 9290 0	3129 9289 0	Open;Door;11070								1
+3129 9289 0	3129 9290 0	Open;Door;11070								1
+3122 9286 0	3122 9286 1	Climb-up;Ladder;11041								2
+3122 9286 1	3122 9286 0	Climb-down;Ladder;11042								2
+3121 9287 1	3122 9286 0	Climb-down;Ladder;11042								2
+3120 9286 1	3122 9286 0	Climb-down;Ladder;11042								2
+3121 9285 1	3122 9286 0	Climb-down;Ladder;11042								2
+3121 9288 1	3189 2889 0	Climb;Sand pile;10950
+3189 2889 0	3120 9288 1	Climb-down;Secret entrance;11047
+3120 9288 1	3189 2889 0	Climb;Sand pile;10950
+3190 2888 0	3120 9288 1	Climb-down;Secret entrance;11047
+3122 9289 1	3189 2889 0	Climb;Sand pile;10950
+3188 2888 0	3120 9288 1	Climb-down;Secret entrance;11047
+3122 9290 1	3189 2889 0	Climb;Sand pile;10950
+3189 2887 0	3120 9288 1	Climb-down;Secret entrance;11047
+3104 9305 0	3104 9306 0	Open;Door;11051								1
+3104 9306 0	3104 9305 0	Open;Door;11051								1
+3110 9312 0	3111 9312 0	Open;Door;11057								1
+3111 9312 0	3110 9312 0	Open;Door;11057								1
+3104 9318 0	3104 9319 0	Open;Door;11055								1
+3104 9319 0	3104 9318 0	Open;Door;11055								1
+3088 9336 1	3088 9336 0	Climb-down;Ladder;11042								2
+3087 9337 1	3088 9336 0	Climb-down;Ladder;11042								2
+3086 9336 0	3088 9336 1	Climb-up;Ladder;11041								2
+3086 9336 1	3088 9336 0	Climb-down;Ladder;11042								2
+3087 9335 1	3088 9336 0	Climb-down;Ladder;11042								2
+3088 9335 1	3148 2938 0	Climb;Sand pile;10950
+3148 2938 0	3086 9333 1	Climb-down;Secret entrance;11045
+3086 9333 1	3148 2938 0	Climb;Sand pile;10950
+3149 2937 0	3086 9333 1	Climb-down;Secret entrance;11045
+3086 9334 1	3148 2938 0	Climb;Sand pile;10950
+3147 2937 0	3086 9333 1	Climb-down;Secret entrance;11045
+3087 9335 1	3148 2938 0	Climb;Sand pile;10950
+3148 2936 0	3086 9333 1	Climb-down;Secret entrance;11045
+3079 9335 0	3079 9334 0	Open;Door;11068								1
+3079 9334 0	3079 9335 0	Open;Door;11068								1
+3079 9307 1	3079 9307 0	Climb-down;Ladder;11042								2
+3078 9306 1	3079 9307 0	Climb-down;Ladder;11042								2
+3079 9305 0	3079 9307 1	Climb-up;Ladder;11041								2
+3079 9305 1	3079 9307 0	Climb-down;Ladder;11042								2
+3080 9306 1	3079 9307 0	Climb-down;Ladder;11042								2
+3080 9306 1	3146 2909 0	Climb;Sand pile;10950
+3146 2909 0	3080 9306 1	Climb-down;Secret entrance;11048
+3080 9307 1	3146 2909 0	Climb;Sand pile;10950
+3145 2908 0	3080 9306 1	Climb-down;Secret entrance;11048
+3081 9305 1	3146 2909 0	Climb;Sand pile;10950
+3146 2907 0	3080 9306 1	Climb-down;Secret entrance;11048
+3082 9305 1	3146 2909 0	Climb;Sand pile;10950
+3147 2908 0	3080 9306 1	Climb-down;Secret entrance;11048
+3081 9287 0	3082 9287 0	Open;Door;11064								1
+3082 9287 0	3081 9287 0	Open;Door;11064								1
+3097 9312 0	3098 9312 0	Open;Door;11053								1
+3098 9312 0	3097 9312 0	Open;Door;11053								1
+3104 9308 0	3104 9310 1	Climb-up;Ladder;11041								2
+3104 9310 1	3104 9310 0	Climb-down;Ladder;11042								2
+3103 9309 1	3104 9310 0	Climb-down;Ladder;11042								2
+3104 9308 1	3104 9310 0	Climb-down;Ladder;11042								2
+3105 9309 1	3104 9310 0	Climb-down;Ladder;11042								2
+3103 9318 1	3103 9320 1	Pass-through;Magic barrier;11005
+3103 9320 1	3103 9318 1	Pass-through;Magic barrier;11005
+3104 9318 1	3104 9320 1	Pass-through;Magic barrier;11005
+3104 9320 1	3104 9318 1	Pass-through;Magic barrier;11005
+3105 9318 1	3105 9320 1	Pass-through;Magic barrier;11005
+3105 9320 1	3105 9318 1	Pass-through;Magic barrier;11005
+3104 9331 1	3105 9332 2	Climb-up;Ladder;11041								2
+3105 9332 2	3105 9332 1	Climb-down;Ladder;11042								2
+3104 9331 2	3105 9332 1	Climb-down;Ladder;11042								2
+3104 9333 2	3105 9332 1	Climb-down;Ladder;11042								2
+3103 9332 2	3105 9332 1	Climb-down;Ladder;11042								2
+3105 9308 2	3105 9306 2	Climb-over;Pile of rubble;33342
+3105 9306 2	3105 9308 2	Climb-over;Pile of rubble;33342
+3104 9308 2	3104 9306 2	Climb-over;Pile of bones;18342
+3104 9306 2	3104 9308 2	Climb-over;Pile of bones;18342
+3105 9301 2	3105 9299 1	Climb-down;Stone Ladder;11044
+3105 9299 1	3105 9301 2	Climb-up;Stone Ladder;11043
+3104 9301 2	3104 9299 1	Climb-down;Stone Ladder;11044
+3104 9299 1	3104 9301 2	Climb-up;Stone Ladder;11043
+3105 9284 2	3105 9286 1	Climb-down;Stone Ladder;11044
+3105 9286 1	3105 9284 2	Climb-up;Stone Ladder;11043
+3104 9284 2	3104 9286 1	Climb-down;Stone Ladder;11044
+3104 9286 1	3104 9284 2	Climb-up;Stone Ladder;11043
+3127 9337 0	3126 9337 0	Open;Door;11066								1
+3126 9337 0	3127 9337 0	Open;Door;11066								1
+
+# Rellekka
+2666 3694 0	2666 3694 1	Climb-up;Ladder;4187								2
+2666 3694 1	2666 3694 0	Climb-down;Ladder;4189								2
+2621 3694 0	2472 3994 0	Travel;Fremennik Boat;37432								2
+2472 3994 0	2621 3692 0	Travel;Fremennik Boat;37408								2
+2621 3693 0	2472 3994 0	Travel;Fremennik Boat;37432								2
+2473 3994 0	2621 3692 0	Travel;Fremennik Boat;37408								2
+2621 3692 0	2472 3994 0	Travel;Fremennik Boat;37432								2
+2621 3691 0	2472 3994 0	Travel;Fremennik Boat;37432								2
+2621 3690 0	2472 3994 0	Travel;Fremennik Boat;37432								2
+2598 3608 0	2596 3608 0	Cross;Broken bridge;4616								2
+2596 3608 0	2598 3608 0	Cross;Broken bridge;4615								2
+
+# Isle of Stone
+2465 4010 0	2461 10417 0	Enter;Cave;37433
+2461 10417 0	2465 4010 0	Exit;Steps;37411
+2468 10403 0	2471 10403 0	Climb;Steps;37417
+2471 10403 0	2468 10403 0	Climb;Steps;37417
+
+# Pirates' Cove
+2213 3794 0	2213 3796 1	Climb;Ladder;16960
+2213 3796 1	2213 3794 0	Climb;Ladder;16962
+2214 3802 1	2214 3800 2	Climb;Ladder;16959
+2214 3800 2	2214 3802 1	Climb;Ladder;16961
+2221 3795 2	2221 3792 3	Climb;Stairs;16945
+2221 3792 3	2221 3795 2	Climb;Stairs;16947
+2227 3795 2	2227 3792 3	Climb;Stairs;16945
+2227 3792 3	2227 3795 2	Climb;Stairs;16947
+2220 3792 2	2223 3792 1	Climb;Stairs;16947
+2223 3792 1	2220 3792 2	Climb;Stairs;16945
+2225 3792 1	2228 3792 2	Climb;Stairs;16945
+2228 3792 2	2225 3792 1	Climb;Stairs;16947
+2225 3806 1	2225 3809 0	Climb;Stairs;16948
+2225 3809 0	2225 3806 1	Climb;Stairs;16946
+2221 3805 2	2221 3808 3	Climb;Stairs;16945
+2221 3808 3	2221 3805 2	Climb;Stairs;16947
+2227 3805 2	2227 3808 3	Climb;Stairs;16945
+2227 3808 3	2227 3805 2	Climb;Stairs;16947
+2213 3809 1	2211 3809 0	Climb;Ladder;16962
+2211 3809 0	2213 3809 1	Climb;Ladder;16960
+
+# Miscellania
+2509 3847 0	2509 10245 0	Climb-down;Ladder;15116								2
+2509 10245 0	2510 3846 0	Climb-up;Ladder;15115								2
+2505 10280 0	2505 10283 0	Squeeze-through;Crevice;15186
+2505 10283 0	2505 10280 0	Squeeze-through;Crevice;15187
+2507 10288 0	2509 10288 1	Use-Lift;Platform;15239
+2509 10288 1	2507 10288 0	Use-Lift;Lift Platform;15242
+2508 10289 0	2509 10288 1	Use-Lift;Platform;15239
+2510 10287 1	2514 10291 0	Enter;Tunnel;15188
+2514 10291 0	2510 10287 1	Enter;Tunnel;15189
+2539 10299 0	2543 10299 0	Swing-on;Ropeswing;15252
+2540 10296 0	2536 10296 0	Swing-on;Ropeswing;15216
+2549 10288 0	2547 10288 0	Use;Plank -> Rocks;15213
+2547 10288 0	2549 10288 0	Use;Plank -> Rocks;15213
+2546 10287 0	2544 10287 0	Use;Plank -> Rocks;15213
+2544 10287 0	2546 10287 0	Use;Plank -> Rocks;15213
+2543 10287 0	2541 10287 0	Use;Plank -> Rocks;15213
+2541 10287 0	2543 10287 0	Use;Plank -> Rocks;15213
+2540 10286 0	2538 10286 0	Use;Plank -> Rocks;15213
+2538 10286 0	2540 10286 0	Use;Plank -> Rocks;15213
+2585 10259 0	2585 10262 0	Squeeze-through;Crevice;15194
+2585 10262 0	2585 10259 0	Squeeze-through;Crevice;15195
+2618 10266 0	2620 3864 0	Climb-up;Exit;15193
+2620 3864 0	2619 10265 0	Climb-down;Hole;15203
+2619 10265 0	2620 3864 0	Climb-up;Exit;15193
+2619 3865 0	2619 10265 0	Climb-down;Hole;15203
+2618 10264 0	2620 3864 0	Climb-up;Exit;15193
+2617 10265 0	2620 3864 0	Climb-up;Exit;15193
+2621 3865 0	2619 10265 0	Climb-down;Hole;15203
+2614 3866 0	2615 3867 1	Climb-up;Staircase;16671								1
+2615 3867 1	2614 3866 0	Climb-down;Staircase;16673								1
+2613 3866 0	2615 3867 1	Climb-up;Staircase;16671								1
+2612 3867 0	2615 3867 1	Climb-up;Staircase;16671								1
+2612 3868 0	2615 3867 1	Climb-up;Staircase;16671								1
+2613 3869 0	2615 3867 1	Climb-up;Staircase;16671								1
+2614 3869 0	2615 3867 1	Climb-up;Staircase;16671								1
+2615 3868 0	2615 3867 1	Climb-up;Staircase;16671								1
+2615 3867 0	2615 3867 1	Climb-up;Staircase;16671								1
+2506 3870 0	2507 3871 1	Climb-up;Staircase;16675								1
+2507 3871 1	2506 3870 0	Climb-down;Staircase;16676								1
+2505 3870 0	2507 3871 1	Climb-up;Staircase;16675								1
+2506 3870 1	2506 3870 0	Climb-down;Staircase;16676								1
+2504 3871 0	2507 3871 1	Climb-up;Staircase;16675								1
+2507 3871 0	2507 3871 1	Climb-up;Staircase;16675								1
+2507 3872 0	2507 3871 1	Climb-up;Staircase;16675								1
+2504 3872 0	2507 3871 1	Climb-up;Staircase;16675								1
+2506 3870 1	2507 3871 2	Climb-up;Staircase;16676								1
+2507 3871 2	2506 3870 1	Climb-down;Staircase;16676								1
+2507 3871 1	2507 3871 2	Climb-up;Staircase;16676								1
+2506 3870 2	2506 3870 1	Climb-down;Staircase;16676								1
+2507 3871 2	2507 3871 3	Climb-up;Staircase;16676								1
+2507 3871 3	2506 3870 2	Climb-down;Staircase;16677								1
+2506 3870 2	2507 3871 3	Climb-up;Staircase;16676								1
+2506 3856 1	2506 3857 1	Open;Throne Room Door;4672
+2506 3857 1	2506 3856 1	Open;Throne Room Door;4672
+2506 3863 1	2506 3864 1	Open;Throne Room Door;4672
+2506 3864 1	2506 3863 1	Open;Throne Room Door;4672
+2505 3850 1	2505 3850 0	Climb-down;Staircase;16676								1
+2505 3850 0	2504 3849 1	Climb-up;Staircase;16675								1
+2504 3849 1	2505 3850 0	Climb-down;Staircase;16676								1
+2506 3850 0	2504 3849 1	Climb-up;Staircase;16675								1
+2507 3849 0	2504 3849 1	Climb-up;Staircase;16675								1
+2507 3848 0	2504 3849 1	Climb-up;Staircase;16675								1
+2506 3847 0	2504 3849 1	Climb-up;Staircase;16675								1
+2505 3847 0	2504 3849 1	Climb-up;Staircase;16675								1
+2504 3849 0	2504 3849 1	Climb-up;Staircase;16675								1
+2504 3848 0	2504 3849 1	Climb-up;Staircase;16675								1
+2504 3849 2	2505 3850 1	Climb-down;Staircase;16676								1
+2505 3850 1	2504 3849 2	Climb-up;Staircase;16676								1
+2505 3850 2	2505 3850 1	Climb-down;Staircase;16676								1
+2504 3849 1	2504 3849 2	Climb-up;Staircase;16676								1
+2504 3849 2	2504 3849 3	Climb-up;Staircase;16676								1
+2504 3849 3	2505 3850 2	Climb-down;Staircase;16677								1
+2505 3850 2	2504 3849 3	Climb-up;Staircase;16676								1
+
+# Ungael
+2266 4039 0	2264 4039 0	Climb-over;Ice chunks;29868
+2264 4039 0	2266 4039 0	Climb-over;Ice chunks;29868
+2263 4040 0	2263 4048 0	Climb-up;Ice chunks;29870
+2263 4048 0	2263 4040 0	Climb-down;Ice chunks;29869
+2247 4078 0	2259 10482 0	Enter;Cave;31999
+2259 10482 0	2247 4078 0	Enter;Cave Entrance;32047
+
+# Jatizso
+2331 3810 0	2329 3810 1	Climb-up;Ladder;21514								2
+2329 3810 1	2331 3810 0	Climb-down;Ladder;21515								2
+2410 3824 0	2410 3824 2	Climb-up;Ladder;21395								2
+2410 3824 2	2410 3824 0	Climb-down;Ladder;21396								2
+2421 3824 0	2421 3824 2	Climb-up;Ladder;21395								2
+2421 3824 2	2421 3824 0	Climb-down;Ladder;21396								2
+2387 3804 0	2387 3804 2	Climb-up;Ladder;21395								2
+2387 3804 2	2387 3804 0	Climb-down;Ladder;21396								2
+2387 3793 0	2387 3793 2	Climb-up;Ladder;21395								2
+2387 3793 2	2387 3793 0	Climb-down;Ladder;21396								2
+2372 3800 0	2372 3800 2	Climb-up;Ladder;21395								2
+2372 3800 2	2372 3800 0	Climb-down;Ladder;21396								2
+2399 3812 0	2405 10188 0	Climb-down;Staircase;21455								1
+2405 10188 0	2399 3812 0	Climb-up;Staircase;21578								1
+2399 3813 0	2405 10188 0	Climb-down;Staircase;21455								1
+2405 10189 0	2399 3812 0	Climb-up;Staircase;21578								1
+2406 10187 0	2399 3812 0	Climb-up;Staircase;21578								1
+2407 10187 0	2399 3812 0	Climb-up;Staircase;21578								1
+2406 10190 0	2399 3812 0	Climb-up;Staircase;21578								1
+2398 3811 0	2405 10188 0	Climb-down;Staircase;21455								1
+2407 10190 0	2399 3812 0	Climb-up;Staircase;21578								1
+2397 3811 0	2405 10188 0	Climb-down;Staircase;21455								1
+2408 10189 0	2399 3812 0	Climb-up;Staircase;21578								1
+2398 3814 0	2405 10188 0	Climb-down;Staircase;21455								1
+2408 10188 0	2399 3812 0	Climb-up;Staircase;21578								1
+2397 3814 0	2405 10188 0	Climb-down;Staircase;21455								1
+2396 3813 0	2405 10188 0	Climb-down;Staircase;21455								1
+2396 3812 0	2405 10188 0	Climb-down;Staircase;21455								1
+2317 3893 0	2420 10279 1	Open;Cave;21585
+2421 10278 1	2319 3892 0	Climb-up;Stone ladder;21592
+2318 3894 0	2420 10279 1	Open;Cave;21585
+2420 10279 1	2319 3892 0	Climb-up;Stone ladder;21592
+2316 3893 0	2420 10279 1	Open;Cave;21585
+2315 3894 0	2420 10279 1	Open;Cave;21585
+2400 3889 0	2394 10300 1	Open;Cave;21584				The Fremennik Isles
+2401 3888 0	2394 10300 1	Open;Cave;21584				The Fremennik Isles
+2403 3889 0	2394 10300 1	Open;Cave;21584				The Fremennik Isles
+2398 10258 1	2393 10258 1	Walk-across;Rope bridge;21318
+2393 10258 1	2398 10258 1	Walk-across;Rope bridge;21319
+2385 10259 1	2385 10264 1	Walk-across;Rope bridge;21317
+2385 10264 1	2385 10260 1	Walk-across;Rope bridge;21316
+2393 10300 1	2401 3888 0	Exit;Cave opening;21597
+2385 10260 1	2385 10264 1	Walk-across;Rope bridge;21317
+2394 10300 1	2401 3888 0	Exit;Cave opening;21598
+2395 10300 1	2401 3888 0	Exit;Cave opening;21599
+2314 3848 0	2314 3839 0	Walk-across;Rope bridge;21311
+2314 3839 0	2314 3848 0	Walk-across;Rope bridge;21310
+2355 3848 0	2355 3839 0	Walk-across;Rope bridge;21313
+2355 3839 0	2355 3848 0	Walk-across;Rope bridge;21312
+2378 3839 0	2378 3848 0	Cross-bridge;Rope bridge;21314
+2378 3848 0	2378 3839 0	Walk-across;Rope bridge;21315
+2343 3829 0	2343 3820 0	Walk-across;Rope bridge;21309
+2343 3820 0	2343 3829 0	Walk-across;Rope bridge;21308
+2317 3823 0	2317 3832 0	Walk-across;Rope bridge;21306
+2317 3832 0	2317 3823 0	Walk-across;Rope bridge;21307
+2331 3802 0	2329 3802 1	Climb-up;Ladder;21514								2
+2329 3802 1	2331 3802 0	Climb-down;Ladder;21515								2
+2362 3799 0	2364 3799 2	Climb-up;Ladder;21512								2
+2364 3799 2	2362 3799 0	Climb-down;Ladder;21513								2
+
+# Iceberg
+2630 4013 1	2656 10423 0	Use;A crack;21245
+2656 10423 0	2631 4013 1	Use;Chasm;21035
+2631 4013 1	2656 10423 0	Use;A crack;21245
+2638 10424 0	2639 10424 0	Open;Door;21167
+2639 10424 0	2638 10424 0	Open;Door;21167
+
+# Weiss
+2852 3966 0	2852 3964 0	Climb;Rockslide;33184
+2852 3964 0	2852 3966 0	Climb;Rockslide;33184
+2852 3964 0	2855 3964 0	Climb;Rockslide;33185
+2855 3964 0	2852 3964 0	Climb;Rockslide;33185
+2855 3964 0	2853 3961 0	Climb;Rope;33328
+2853 3961 0	2855 3964 0	Climb;Roped tree;33327
+2853 3961 0	2857 3961 0	Cross;Ledge;33190
+2857 3961 0	2853 3961 0	Cross;Ledge;33190
+2859 3962 0	2859 3960 0	Climb;Rockslide;33191
+2859 3960 0	2859 3962 0	Climb;Rockslide;33191
+2857 3957 0	2857 3954 0	Pass;Fallen Tree;33192
+2857 3954 0	2857 3957 0	Pass;Fallen Tree;33192
+2852 3936 0	2850 3936 0	Cross;Little boulder;33312
+2850 3936 0	2852 3936 0	Cross;Little boulder;33312
+2858 3968 0	2854 3941 0	Enter;Cave Entrance;33329
+2855 3941 0	2859 3968 0	Descend;Hole;33227
+2859 3968 0	2854 3941 0	Enter;Cave Entrance;33329
+2854 3941 0	2859 3968 0	Descend;Hole;33227
+2860 3968 0	2854 3941 0	Enter;Cave Entrance;33329
+2853 3941 0	2859 3968 0	Descend;Hole;33227
+2856 3941 0	2859 3968 0	Descend;Hole;33227
+2852 3941 0	2859 3968 0	Descend;Hole;33227
+2869 3941 0	2845 10351 0	Descend;Stairs;33234
+2845 10351 0	2869 3941 0	Climb;Steps;33261
+2844 10351 0	2869 3941 0	Climb;Steps;33261
+2846 10351 0	2869 3941 0	Climb;Steps;33261
+2855 10334 0	2845 3960 0	Enter;Smelly hole;33262
+2856 10335 0	2845 3960 0	Enter;Smelly hole;33262
+
+# Hunter Area
+2716 3798 0	2716 3802 1	Ascend;Steps;19690
+2716 3802 1	2716 3798 0	Descend;Steps;19691
+2715 3798 0	2715 3802 1	Ascend;Steps;19690
+2715 3802 1	2715 3798 0	Descend;Steps;19691
+2726 3805 1	2726 3801 0	Descend;Steps;19691
+2726 3801 0	2726 3805 1	Ascend;Steps;19690
+2727 3805 1	2727 3801 0	Descend;Steps;19691
+2727 3801 0	2727 3805 1	Ascend;Steps;19690
+2740 3830 1	2744 3830 1	Climb;Rocky handholds;19846
+2744 3830 1	2740 3830 1	Climb;Rocky handholds;19847
+2744 3830 1	2707 10205 0	Enter;Cave;19762
+2707 10205 0	2744 3830 1	Exit;Cave;19764
+2707 10206 0	2744 3830 1	Exit;Cave;19764
+2707 10204 0	2744 3830 1	Exit;Cave;19764
+
+# Keldagrim
+2730 3714 0	2773 10162 0	Enter;Tunnel;5008
+2773 10162 0	2730 3713 0	Enter;Tunnel;5014
+2730 3713 0	2773 10162 0	Enter;Tunnel;5008
+2773 10163 0	2730 3713 0	Enter;Tunnel;5014
+2730 3712 0	2773 10162 0	Enter;Tunnel;5008
+2773 10161 0	2730 3713 0	Enter;Tunnel;5014
+2731 3711 0	2773 10162 0	Enter;Tunnel;5008
+2780 10161 0	2838 10124 0	Go-through;Cave Entrance;5973
+2838 10124 0	2778 10161 0	Go-through;Entrance;5998
+2799 10134 0	2797 3719 0	Enter;Tunnel;5013
+2797 3719 0	2799 10134 0	Enter;Tunnel;5012
+2800 10134 0	2797 3719 0	Enter;Tunnel;5013
+2795 3719 0	2799 10134 0	Enter;Tunnel;5012
+2796 3719 0	2799 10134 0	Enter;Tunnel;5012
+2917 10196 0	2914 10196 1	Climb-up;Stairs;6085
+2914 10196 1	2917 10196 0	Climb-down;Stairs;6086
+2914 10187 0	1943 4705 1	Climb-down;Stairs;10288
+1943 4705 1	2914 10187 0	Climb-up;Stairs;10287
+1942 4706 1	1942 4703 0	Climb-down;Stairs;6086
+1942 4703 0	1942 4706 1	Climb-up;Stairs;6085
+2931 10182 0	2930 10179 1	Climb-up;Stairs;6087
+2930 10179 1	2930 10182 0	Climb-down;Stairs;6088
+2930 10182 0	2930 10179 1	Climb-up;Stairs;6087
+2931 10179 1	2930 10182 0	Climb-down;Stairs;6088
+2933 10165 1	2930 10165 0	Climb-down;Stairs;6086
+2930 10165 0	2933 10165 1	Climb-up;Stairs;6085
+2913 10163 1	2910 10163 0	Climb-down;Stairs;6086
+2910 10163 0	2913 10163 1	Climb-up;Stairs;6085
+2904 10208 0	2907 10208 1	Climb-up;Stairs;6085
+2907 10208 1	2904 10208 0	Climb-down;Stairs;6086
+2893 10210 0	2896 10209 1	Climb-up;Stairs;6087
+2896 10209 1	2893 10209 0	Climb-down;Stairs;6088
+2893 10209 0	2896 10209 1	Climb-up;Stairs;6087
+2896 10210 1	2893 10209 0	Climb-down;Stairs;6088
+2896 10189 1	2893 10188 0	Climb-down;Stairs;6088
+2893 10188 0	2896 10188 1	Climb-up;Stairs;6087
+2896 10188 1	2893 10188 0	Climb-down;Stairs;6088
+2893 10189 0	2896 10188 1	Climb-up;Stairs;6087
+2890 10200 1	2893 10198 2	Climb-up;Stairs;6089
+2893 10198 2	2890 10198 1	Climb-down;Stairs;6090
+2890 10198 1	2893 10198 2	Climb-up;Stairs;6089
+2893 10199 2	2890 10198 1	Climb-down;Stairs;6090
+2890 10199 1	2893 10198 2	Climb-up;Stairs;6089
+2893 10200 2	2890 10198 1	Climb-down;Stairs;6090
+2865 10200 2	2868 10198 1	Climb-down;Stairs;6090
+2868 10198 1	2865 10198 2	Climb-up;Stairs;6089
+2865 10198 2	2868 10198 1	Climb-down;Stairs;6090
+2868 10199 1	2865 10198 2	Climb-up;Stairs;6089
+2865 10199 2	2868 10198 1	Climb-down;Stairs;6090
+2868 10200 1	2865 10198 2	Climb-up;Stairs;6089
+2862 10210 1	2865 10209 0	Climb-down;Stairs;6088
+2865 10209 0	2862 10209 1	Climb-up;Stairs;6087
+2862 10209 1	2865 10209 0	Climb-down;Stairs;6088
+2865 10210 0	2862 10209 1	Climb-up;Stairs;6087
+2862 10188 1	2865 10188 0	Climb-down;Stairs;6088
+2865 10188 0	2862 10188 1	Climb-up;Stairs;6087
+2862 10189 1	2865 10188 0	Climb-down;Stairs;6088
+2865 10189 0	2862 10188 1	Climb-up;Stairs;6087
+2865 10221 0	2865 10224 1	Climb-up;Stairs;6085
+2865 10224 1	2865 10221 0	Climb-down;Stairs;6086
+2834 10223 0	2834 10226 1	Climb-up;Stairs;6085
+2834 10226 1	2834 10223 0	Climb-down;Stairs;6086
+2835 10226 1	2835 10223 2	Climb-up;Stairs;6085
+2835 10223 2	2835 10226 1	Climb-down;Stairs;6086
+2828 10217 0	2828 10214 1	Climb-up;Stairs;6085
+2828 10214 1	2828 10217 0	Climb-down;Stairs;6086
+2834 10196 0	2837 10196 1	Climb-up;Stairs;6085
+2837 10196 1	2834 10196 0	Climb-down;Stairs;6086
+2828 10224 0	2828 10227 1	Climb-up;Stairs;6085
+2828 10227 1	2828 10224 0	Climb-down;Stairs;6086
+2930 10185 0	2930 10186 0	Open;Door;6977
+2930 10186 0	2930 10185 0	Open;Door;6977
+2930 10194 0	2930 10195 0	Open;Door;6975
+2930 10195 0	2930 10194 0	Open;Door;6975
+2931 10197 0	1940 4958 0	Climb-down;Stairs;9084
+1940 4958 0	2931 10196 0	Climb-up;Stairs;9138
+2931 10196 0	1940 4958 0	Climb-down;Stairs;9084
+1939 4958 0	2931 10196 0	Climb-up;Stairs;9138
+1937 4969 0	1937 4970 0	Open;Gate;9141
+1937 4970 0	1937 4969 0	Open;Gate;9141
+2941 10179 0	2438 5535 0	Enter;Doorway;23287
+2435 5535 0	2941 10179 0	Enter;Doorway;23286
+2488 5536 0	2696 5277 1	Enter;Doorway;23285
+2696 5277 1	2488 5536 0	Enter;Doorway;23052
+
+# Slayer Cave
+2796 3616 0	2808 10002 0	Enter;Cave Entrance;2123
+2808 10002 0	2796 3615 0	Enter;Tunnel;2141
+2796 3615 0	2808 10002 0	Enter;Cave Entrance;2123
+2808 10003 0	2796 3615 0	Enter;Tunnel;2141
+2796 3614 0	2808 10002 0	Enter;Cave Entrance;2123
+2808 10001 0	2796 3615 0	Enter;Tunnel;2141
+2703 9991 0	2703 9989 0	Climb;Steps;29993
+2703 9989 0	2703 9991 0	Climb;Steps;29993
+2823 3555 0	2822 3555 0	Open;Door;3745								1
+2822 3555 0	2823 3555 0	Open;Door;3745								1
+2820 3557 0	2820 3558 0	Open;Door;3746								1
+2820 3558 0	2820 3557 0	Open;Door;3746								1
+2817 3561 0	2817 3564 0	Climb-over;Stile;3730								6
+2816 3563 0	2817 3561 0	Climb-over;Stile;3730								6
+2818 3562 0	2817 3564 0	Climb-over;Stile;3730								6
+2817 3564 0	2817 3561 0	Climb-over;Stile;3730								6
+2816 3562 0	2817 3564 0	Climb-over;Stile;3730								6
+2880 3596 0	2880 3593 0	Climb;Rocks;3722
+2880 3593 0	2880 3596 0	Climb;Rocks;3723
+2881 3596 0	2881 3593 0	Climb;Rocks;3722
+2881 3593 0	2881 3596 0	Climb;Rocks;3723
+2857 3611 0	2857 3613 0	Climb;Rocks;3748
+2857 3613 0	2857 3611 0	Climb;Rocks;3748
+2856 3611 0	2856 3613 0	Climb;Rocks;3748
+2856 3613 0	2856 3611 0	Climb;Rocks;3748
+2858 3627 0	2861 3627 0	Climb;Rocks;3790
+2861 3627 0	2858 3627 0	Climb;Rocks;3791
+2858 3626 0	2861 3626 0	Climb;Rocks;3790
+2861 3626 0	2858 3626 0	Climb;Rocks;3791
+2877 3623 0	2880 3623 0	Climb;Rocks;3791
+2880 3623 0	2877 3623 0	Climb;Rocks;3790
+2877 3622 0	2880 3622 0	Climb;Rocks;3791
+2880 3622 0	2877 3622 0	Climb;Rocks;3790
+2896 3619 0	2897 3619 0	Open;Arena Entrance;3783
+2897 3619 0	2896 3619 0	Open;Arena Entrance;3783
+2896 3618 0	2897 3618 0	Open;Arena Entrance;3782
+2897 3618 0	2896 3618 0	Open;Arena Entrance;3782
+2917 3628 0	2917 3629 0	Open;Arena Exit;3786
+2917 3629 0	2917 3628 0	Open;Arena Exit;3786
+2916 3628 0	2916 3629 0	Open;Arena Exit;3785
+2916 3629 0	2916 3628 0	Open;Arena Exit;3785
+2905 3643 0	2907 10019 0	Enter;Cave Entrance;3757
+2907 10019 0	2904 3643 0	Exit;Cave Exit;3758
+2904 3643 0	2907 10019 0	Enter;Cave Entrance;3757
+2908 10019 0	2904 3643 0	Exit;Cave Exit;3758
+2903 3643 0	2907 10019 0	Enter;Cave Entrance;3757
+2906 10019 0	2904 3643 0	Exit;Cave Exit;3758
+2908 10035 0	2908 3654 0	Exit;Cave Exit;3758
+2908 3654 0	2907 10035 0	Enter;Cave Entrance;3757
+2907 10035 0	2908 3654 0	Exit;Cave Exit;3758
+2909 3654 0	2907 10035 0	Enter;Cave Entrance;3757
+2906 10035 0	2908 3654 0	Exit;Cave Exit;3758
+2907 3654 0	2907 10035 0	Enter;Cave Entrance;3757
+2834 3627 0	2834 3629 0	Climb;Rocks;3748
+2834 3629 0	2834 3627 0	Climb;Rocks;3748
+2833 3627 0	2833 3629 0	Climb;Rocks;3748
+2833 3629 0	2833 3627 0	Climb;Rocks;3748
+2822 3635 0	2820 3635 0	Climb;Rocks;3748
+2820 3635 0	2822 3635 0	Climb;Rocks;3748
+2827 3646 0	2823 10050 0	Open;Secret Door;3762
+2823 10050 0	2827 3646 0	Open;Exit;3761
+2828 3646 0	2823 10050 0	Open;Secret Door;3762
+2824 10050 0	2827 3646 0	Open;Exit;3761
+2825 10050 0	2827 3646 0	Open;Exit;3761
+2852 10105 0	2852 10109 1	Climb-up;Stone Staircase;3788
+2852 10109 1	2852 10105 0	Climb-down;Stone Staircase;3789
+2853 10105 0	2852 10109 1	Climb-up;Stone Staircase;3788
+2853 10109 1	2852 10105 0	Climb-down;Stone Staircase;3789
+2848 10107 1	2847 10107 1	Unlock;Prison Door;3780
+2847 10107 1	2848 10107 1	Unlock;Prison Door;3780
+2841 10052 1	2845 10051 2	Climb-up;Stone Staircase;3788
+2845 10051 2	2841 10051 1	Climb-down;Stone Staircase;3789
+2841 10051 1	2845 10051 2	Climb-up;Stone Staircase;3788
+2845 10052 2	2841 10051 1	Climb-down;Stone Staircase;3789
+2831 10076 2	2831 3676 0	Climb-up;Troll ladder;18834
+2831 3676 0	2831 10076 2	Climb-down;Troll ladder;18833
+2830 10077 2	2831 3676 0	Climb-up;Troll ladder;18834
+2830 3677 0	2831 10076 2	Climb-down;Troll ladder;18833
+2832 3677 0	2831 10076 2	Climb-down;Troll ladder;18833
+2831 3678 0	2831 10076 2	Climb-down;Troll ladder;18833
+2840 3690 0	2837 10090 2	Enter;Stronghold;3771
+2837 10090 2	2840 3690 0	Leave;Exit;3774
+2837 10089 2	2840 3690 0	Leave;Exit;3773
+2837 10091 2	2840 3690 0	Use;Exit;3772
+2845 10109 2	2841 10108 1	Climb-down;Stone Staircase;3789
+2841 10108 1	2845 10108 2	Climb-up;Stone Staircase;3788
+2845 10108 2	2841 10108 1	Climb-down;Stone Staircase;3789
+2841 10109 1	2845 10108 2	Climb-up;Stone Staircase;3788
+2853 10060 1	2852 10064 0	Climb-down;Stone Staircase;3789
+2852 10064 0	2852 10060 1	Climb-up;Stone Staircase;3788
+2852 10060 1	2852 10064 0	Climb-down;Stone Staircase;3789
+2853 10064 0	2852 10060 1	Climb-up;Stone Staircase;3788
+2869 10084 0	2869 10085 0	Open;Storeroom Door;3810
+2869 10085 0	2869 10084 0	Open;Storeroom Door;3810
+2888 3662 0	2888 3660 0	Climb;Rocks;3803
+2888 3660 0	2888 3662 0	Climb;Rocks;3803
+2887 3662 0	2887 3660 0	Climb;Rocks;3804
+2887 3660 0	2887 3662 0	Climb;Rocks;3804
+2892 3671 0	2893 10074 2	Enter;Cave Entrance;3759
+2893 10074 2	2893 3671 0	Exit;Cave Exit;3760
+2893 3671 0	2893 10074 2	Enter;Cave Entrance;3759
+2892 10074 2	2893 3671 0	Exit;Cave Exit;3760
+2894 3671 0	2893 10074 2	Enter;Cave Entrance;3759
+2894 10074 2	2893 3671 0	Exit;Cave Exit;3760
+2837 3736 0	2839 3739 0	Go-through;Ice gate;5044
+2839 3739 0	2837 3739 0	Go-through;Ice gate;5043
+2837 3739 0	2839 3739 0	Go-through;Ice gate;5043
+2839 3737 0	2837 3739 0	Go-through;Ice gate;5044
+2837 3738 0	2839 3739 0	Go-through;Ice gate;5044
+2839 3738 0	2837 3739 0	Go-through;Ice gate;5044
+2837 3737 0	2839 3739 0	Go-through;Ice gate;5044
+2839 3736 0	2837 3739 0	Go-through;Ice gate;5044
+2837 3740 0	2839 3739 0	Go-through;Ice gate;5043
+2839 3740 0	2837 3739 0	Go-through;Ice gate;5043
+2839 3741 0	2837 3739 0	Go-through;Ice gate;5043
+2867 3720 0	2874 3720 0	Enter;Cave Entrance;6440
+2874 3720 0	2867 3719 0	Enter;Cave Exit;6447
+2867 3719 0	2874 3720 0	Enter;Cave Entrance;6440
+2874 3721 0	2867 3719 0	Enter;Cave Exit;6447
+2867 3718 0	2874 3720 0	Enter;Cave Entrance;6440
+2874 3719 0	2867 3719 0	Enter;Cave Exit;6447
+2868 3721 0	2874 3720 0	Enter;Cave Entrance;6440
+2899 3715 0	2898 3719 0	Move;Boulder;26415
+2898 3719 0	2898 3715 0	Move;Boulder;26415
+2898 3715 0	2898 3719 0	Move;Boulder;26415
+2899 3719 0	2898 3715 0	Move;Boulder;26415
+2900 3719 0	2898 3715 0	Move;Boulder;26415
+2899 3713 0	2904 3720 0	Crawl-through;Little crack;26382
+2904 3720 0	2899 3713 0	Crawl-through;Little crack;26382
+2916 3748 0	2882 5311 2	Climb-down;Hole;26419
+2880 5311 2	2916 3745 0	Climb;Rope;26370
+2916 3745 0	2882 5311 2	Climb-down;Hole;26419
+2882 5311 2	2916 3745 0	Climb;Rope;26370
+2916 3746 0	2882 5311 2	Climb-down;Hole;26419
+2881 5310 2	2916 3745 0	Climb;Rope;26370
+2917 3744 0	2882 5311 2	Climb-down;Hole;26419
+2918 3744 0	2882 5311 2	Climb-down;Hole;26419
+2919 3744 0	2882 5311 2	Climb-down;Hole;26419
+2920 3744 0	2882 5311 2	Climb-down;Hole;26419
+2916 3747 0	2882 5311 2	Climb-down;Hole;26419
+2917 3749 0	2882 5311 2	Climb-down;Hole;26419
+2918 3749 0	2882 5311 2	Climb-down;Hole;26419
+2919 3749 0	2882 5311 2	Climb-down;Hole;26419
+2920 3749 0	2882 5311 2	Climb-down;Hole;26419
+2921 3748 0	2882 5311 2	Climb-down;Hole;26419
+2921 3747 0	2882 5311 2	Climb-down;Hole;26419
+2921 3746 0	2882 5311 2	Climb-down;Hole;26419
+2912 5300 2	2914 5300 1	Climb-down;Rock;26561
+2914 5300 1	2912 5299 2	Climb-up;Rope;26371
+2920 5276 1	2920 5274 0	Climb-down;Rock;26562
+2920 5274 0	2919 5276 1	Climb-up;Rope;26375
+2919 5274 0	2919 5276 1	Climb-up;Rope;26375
+2915 5300 1	2912 5299 2	Climb-up;Rope;26371
+2909 3686 0	2911 3686 0	Climb;Rocks;3748
+2911 3686 0	2909 3686 0	Climb;Rocks;3748
+2909 3687 0	2911 3687 0	Climb;Rocks;3748
+2911 3687 0	2909 3687 0	Climb;Rocks;3748
+2943 3769 0	2950 3767 0	Climb;Rocky handholds;26405
+2943 3769 0	2950 3767 0	Climb;Rocky handholds;26405
+2943 3767 0	2950 3767 0	Climb;Rocky handholds;26405
+2942 3768 0	2950 3767 0	Climb;Rocky handholds;26405
+
+# Hemenster
+2661 3500 0	2662 3500 0	Squeeze-through;Loose Railing;51
+2662 3500 0	2661 3500 0	Squeeze-through;Loose Railing;51
+2612 3476 0	2612 3476 1	Climb-up;Ladder;16683								2
+2612 3476 1	2612 3476 0	Climb-down;Ladder;16679								2
+2611 3475 0	2611 3475 1	Climb-up;Ladder;16683								2
+2611 3475 1	2611 3475 0	Climb-down;Ladder;16679								2
+2612 3474 0	2612 3474 1	Climb-up;Ladder;16683								2
+2612 3474 1	2612 3474 0	Climb-down;Ladder;16679								2
+2613 3475 0	2613 3475 1	Climb-up;Ladder;16683								2
+2613 3475 1	2613 3475 0	Climb-down;Ladder;16679								2
+2642 3429 0	2642 3429 1	Climb-up;Ladder;16683								2
+2642 3429 1	2642 3429 0	Climb-down;Ladder;16679								2
+2641 3428 0	2641 3428 1	Climb-up;Ladder;16683								2
+2641 3428 1	2641 3428 0	Climb-down;Ladder;16679								2
+2657 3438 0	2659 3437 0	Open;Guild door;11665
+2658 3439 0	2659 3437 0	Open;Guild door;11665
+2658 3437 0	2657 3439 0	Open;Guild door;11665
+2659 3438 0	2657 3439 0	Open;Guild door;11665
+2668 3429 0	2668 3429 2	Climb-up;Tower ladder;11661
+2667 3428 0	2668 3429 2	Climb-up;Tower ladder;11661
+2668 3427 0	2668 3429 2	Climb-up;Tower ladder;11661
+2669 3428 0	2668 3429 2	Climb-up;Tower ladder;11661
+2668 3429 2	2667 3429 0	Climb-down;Tower ladder;11662
+2667 3428 2	2667 3429 0	Climb-down;Tower ladder;11662
+2668 3427 2	2667 3429 0	Climb-down;Tower ladder;11662
+2669 3428 2	2667 3429 0	Climb-down;Tower ladder;11662
+2620 9797 0	2623 3391 0	Climb-over;Mud pile;13
+2623 3391 0	2619 9797 0	Enter;Cave Entrance;2
+2620 9796 0	2623 3391 0	Climb-over;Mud pile;13
+2624 3391 0	2619 9797 0	Enter;Cave Entrance;2
+2621 9795 0	2623 3391 0	Climb-over;Mud pile;13
+2625 3391 0	2619 9797 0	Enter;Cave Entrance;2
+2622 3391 0	2619 9797 0	Enter;Cave Entrance;2
+2611 3393 0	2611 3394 0	Open;Door;20925								1
+2611 3394 0	2611 3393 0	Open;Door;20925								1
+2630 3385 0	2630 3385 1	Climb-up;Ladder;16683								2
+2630 3385 1	2630 3385 0	Climb-down;Ladder;16684								2
+2631 3386 0	2631 3386 1	Climb-up;Ladder;16683								2
+2631 3386 1	2631 3386 0	Climb-down;Ladder;16684								2
+2631 3386 1	2631 3386 2	Climb-up;Ladder;16684								2
+2631 3386 2	2631 3386 1	Climb-down;Ladder;16679								2
+2630 3385 1	2630 3385 2	Climb-up;Ladder;16684								2
+2630 3385 2	2630 3385 1	Climb-down;Ladder;16679								2
+2647 3376 0	2649 3375 0	Climb-over;Stile;993								6
+2649 3375 0	2646 3375 0	Climb-over;Stile;993								6
+2646 3375 0	2649 3375 0	Climb-over;Stile;993								6
+2648 3374 0	2646 3375 0	Climb-over;Stile;993								6
+2647 3374 0	2649 3375 0	Climb-over;Stile;993								6
+2648 3376 0	2646 3375 0	Climb-over;Stile;993								6
+2637 3350 0	2640 3350 0	Climb-over;Stile;993								6
+2640 3350 0	2637 3350 0	Climb-over;Stile;993								6
+2638 3351 0	2640 3350 0	Climb-over;Stile;993								6
+2639 3349 0	2637 3350 0	Climb-over;Stile;993								6
+2638 3349 0	2640 3350 0	Climb-over;Stile;993								6
+2639 3351 0	2637 3350 0	Climb-over;Stile;993								6
+2654 3347 0	2657 3347 0	Climb-over;Stile;993								6
+2657 3347 0	2654 3347 0	Climb-over;Stile;993								6
+2655 3348 0	2657 3347 0	Climb-over;Stile;993								6
+2656 3348 0	2654 3347 0	Climb-over;Stile;993								6
+2655 3346 0	2657 3347 0	Climb-over;Stile;993								6
+
+# Entrana
+2834 3335 0	2834 3332 1	Cross;Gangplank;2415								3
+2834 3332 1	2834 3335 0	Cross;Gangplank;2415								3
+
+# Karamja
+2910 3049 0	2906 3049 0	Cross;A wooden log;23644								5
+2906 3049 0	2910 3049 0	Cross;A wooden log;23644								5
+2879 2954 0	2876 2952 0	Climb over;Broken cart;2216				Shilo Village				2
+2880 2953 0	2876 2952 0	Climb over;Broken cart;2216				Shilo Village				2
+2880 2952 0	2876 2952 0	Climb over;Broken cart;2216				Shilo Village				2
+2880 2951 0	2876 2952 0	Climb over;Broken cart;2216	  			Shilo Village				2
+2879 2950 0	2876 2952 0	Climb over;Broken cart;2216				Shilo Village				2
+2877 2954 0	2880 2952 0	Climb over;Broken cart;2216				Shilo Village				2
+2876 2953 0	2880 2952 0	Climb over;Broken cart;2216				Shilo Village				2
+2876 2952 0	2880 2952 0	Climb over;Broken cart;2216				Shilo Village				2
+2876 2951 0	2880 2952 0	Climb over;Broken cart;2216				Shilo Village				2
+2877 2950 0	2880 2952 0	Climb over;Broken cart;2216				Shilo Village				2
+2777 3214 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5
+2778 3214 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5
+2776 3213 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5
+2776 3212 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5
+2776 3211 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5
+2779 3213 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5
+2779 3212 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5
+2779 3211 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5
+2777 3210 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5
+2778 3210 0	2834 2951 0	Board;Travel cart;2230			10 Coins	Shilo Village				5
+2830 2953 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5
+2830 2952 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5
+2831 2954 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5
+2832 2954 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5
+2833 2954 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5
+2831 2951 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5
+2832 2951 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5
+2833 2951 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5
+2834 2953 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5
+2834 2952 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins	Shilo Village				5
+2836 9599 0	2836 9600 0	Open;Wall;2606				Dragon Slayer I				2
+2836 9600 0	2836 9599 0	Open;Wall;2606								2
+2832 9657 0	2834 3258 0	Climb;Climbing rope;25213								1
+2833 9658 0	2834 3258 0	Climb;Climbing rope;25213								1
+2833 9656 0	2834 3258 0	Climb;Climbing rope;25213								1
+2834 9657 0	2834 3258 0	Climb;Climbing rope;25213								1
+2832 3255 0	2833 9658 0	Enter;Hole;25154								1
+2832 3256 0	2833 9658 0	Enter;Hole;25154								1
+2832 3257 0	2833 9658 0	Enter;Hole;25154								1
+2833 3258 0	2833 9658 0	Enter;Hole;25154								1
+2834 3258 0	2833 9658 0	Enter;Hole;25154								1
+2835 3258 0	2833 9658 0	Enter;Hole;25154								1
+2833 3254 0	2833 9658 0	Enter;Hole;25154								1
+2834 3254 0	2833 9658 0	Enter;Hole;25154								1
+2835 3254 0	2833 9658 0	Enter;Hole;25154								1
+2836 3255 0	2833 9658 0	Enter;Hole;25154								1
+2836 3256 0	2833 9658 0	Enter;Hole;25154								1
+2836 3257 0	2833 9658 0	Enter;Hole;25154								1
+2998 3032 1	3001 3032 0	Cross;Gangplank;17397
+3001 3032 0	2998 3032 1	Cross;Gangplank;17396
+2795 2978 0	2791 2978 0	Climb;Rocks;2231								3
+2791 2978 0	2795 2978 0	Climb;Rocks;2231								3
+2795 2979 0	2791 2979 0	Climb;Rocks;2231								3
+2791 2979 0	2795 2979 0	Climb;Rocks;2231								3
+2795 2980 0	2791 2980 0	Climb;Rocks;2231								3
+2791 2980 0	2795 2980 0	Climb;Rocks;2231								3
+2871 2970 0	2871 2970 1	Climb-up;Ladder;16683
+2871 2970 1	2871 2970 0	Climb-down;Ladder;16679
+2871 2972 0	2871 2972 1	Climb-up;Ladder;16683
+2871 2972 1	2871 2972 0	Climb-down;Ladder;16679
+
+# Lunar Isle
+2128 3893 2	2126 3893 1	Climb;Ladder;16961								2
+2126 3893 1	2128 3893 2	Climb;Ladder;16959								2
+2118 3893 1	2118 3895 0	Climb;Ladder;16962								2
+2118 3895 0	2118 3893 1	Climb;Ladder;16960								2
+2451 4645 0	2090 3930 0	Open;Door;16774								2
+
+# Zanaris
+2452 4473 0	3201 3169 0	Use;Fairy ring;12094								6
+3202 3169 0	2452 4473 0	Open;Door;2406								6
+2486 4471 0	3260 3171 0	Use;Fairy ring;12003								6
+
+# Wintertodt
+1630 3968 0	1630 3963 0	Enter;Doors of dinh;29322								1
+1630 3963 0	1630 3968 0	Enter;Doors of dinh;29322								1
+
+# Camdozaal
+2998 3494 0	2952 5762 0	Enter;Ruins Entrance;41357				Below Ice Mountain
+2952 5762 0	2998 3494 0	Exit;Ruins Exit;41446				Below Ice Mountain
+
+# Magic guild
+2590 3088 0	2590 3092 1	Climb-up;Staircase;15645
+2591 3088 0	2591 3092 1	Climb-up;Staircase;15645
+2591 3092 1	2590 3088 0	Climb-down;Staircase;15648
+2590 3092 1	2590 3088 0	Climb-down;Staircase;15648
+
+# Asgarnian ice dungeon
+3009 3150 0	3009 9550 0	Climb-down;Trapdoor;1738
+3007 9550 0	3007 3150 0	Climb-up;Ladder;17385
+3009 9550 0	3009 3150 0	Climb-up;Ladder;17385
+3056 9562 0	3056 9555 0	Enter;Icy Cavern;10596
+3056 9555 0	3056 9562 0	Enter;Icy Cavern;10595
+3060 9555 0	3060 9557 0	Climb;Steps;8729
+3060 9557 0	3060 9555 0	Climb;Steps;8729
+
+# Sawmill
+3310 3508 1	3310 3508 0	Climb-down;Ladder;11795
+3310 3508 0	3310 3508 1	Climb-up;Ladder;11794
+
+# Desert mining camp
+3290 3035 0	3290 3035 1	Climb-up;Ladder;18903
+3290 3037 1	3290 3037 0	Climb-down;Ladder;18904
+
+# Kovac
+3366 11483 0	3361 3148 0	Exit;Exit;44636
+3361 3148 0	3366 11483 0	Enter;Cave;44635
+
+# Hazeel cult
+2567 9680 0	2606 9692 0	Board;Raft;2849
+2606 9692 0	2567 9680 0	Board;Raft;2849
+
+# Murder mystery
+2736 3580 1	2736 3580 0	Climb-down;Staircase;25683
+2736 3580 0	2736 3580 1	Climb-up;Staircase;25682
+
+# Lumbridge basement / cavern
+3219 9618 0	3221 9618 0	Squeeze-through;Hole;6898				The Lost Tribe
+3221 9618 0	3219 9618 0	Squeeze-through;Hole;6899				The Lost Tribe
+3224 9604 0	3224 9600 0	Squeeze-through;Hole;6912
+3224 9600 0	3224 9604 0	Squeeze-through;Hole;6912
+3226 9542 0	3219 9532 2	Enter;Tunnel;6659
+3219 9532 2	3226 9542 0	Enter;Tunnel;6658
+3317 9603 0	2748 5374 0	Open;Door;6919
+2748 5374 0	3317 9603 0	Open;Bone door;22945
+
+# Mountain camp
+2761 3657 0	2761 3660 0	Climb-over;Rockslide;5847
+2761 3660 0	2761 3657 0	Climb-over;Rockslide;5847
+
+# Varrock pub
+3285 3496 0	3285 3492 1	Climb-up;Staircase;11797
+3285 3492 1	3285 3496 0	Climb-down;Staircase;11799
+
+# Dungeon Zogre flesh eaters
+2477 9437 2	2485 3045 0	Climb-up;Stairs;6842
+2457 3048 0	2455 3048 0	Climb-over;Crushed barricade;6878
+2442 9417 0	2446 9417 2	Climb-over;Stairs;6842
+
+# Shayzien Encampent
+1482 3633 0	1482 3633 1	Climb-up;Ladder;42207
+1482 3633 1	1482 3633 0	Climb-down;Ladder;42208
+
+# Chasm of Fire
+1435 3671 0	1435 10077 3	Enter;Chasm;30236
+1435 10077 3	1435 3671 0	Climb-up;Rope;30234
+1437 10093 3	1437 10093 2	Enter;Lift;30258
+1438 10093 3	1438 10093 2	Enter;Lift;30258
+1437 10093 2	1437 10093 3	Enter;Lift;30259
+1438 10093 2	1438 10093 3	Enter;Lift;30259
+1451 10068 3	1451 10068 2	Enter;Lift;30258
+1451 10069 3	1451 10069 2	Enter;Lift;30258
+1451 10068 2	1451 10068 3	Enter;Lift;30259
+1451 10069 2	1451 10069 3	Enter;Lift;30259
+1457 10096 2	1457 10096 1	Enter;Lift;30258
+1457 10095 2	1457 10095 1	Enter;Lift;30258
+1457 10096 1	1457 10096 2	Enter;Lift;30259
+1457 10095 1	1457 10095 2	Enter;Lift;30259
+1457 10075 2	1457 10075 1	Enter;Lift;30258
+1457 10076 2	1457 10076 1	Enter;Lift;30258
+1457 10075 1	1457 10075 2	Enter;Lift;30259
+1457 10076 1	1457 10076 2	Enter;Lift;30259
+
+# dungeon shayzien mountain camp
+1169 9973 0	1171 9946 0	Pass;Magic gate;31967
+9363 1050 0	1214 3557 0	Climb;Rope;32507
+
+# dragon slayer 2
+2458 2860 0	2458 2862 0	Pass;Magical Barrier;31616
+2457 2860 0	2457 2862 0	Pass;Magical Barrier;31616
+2456 2860 0	2456 2862 0	Pass;Magical Barrier;31616
+2458 2862 0	2458 2860 0	Pass;Magical Barrier;31616
+2457 2862 0	2457 2860 0	Pass;Magical Barrier;31616
+2456 2862 0	2456 2860 0	Pass;Magical Barrier;31616
+
+# watchtower
+2933 4712 2	2549 3112 1	Climb-down;Ladder;2797
+2549 3112 1	2933 4712 2	Climb-down;Ladder;2797
+2544 3112 1	2544 3112 0	Climb-down;Ladder;17122
+2544 3112 0	2544 3112 1	Climb-down;Ladder;17122
+
+# kourend
+1618 3680 0	1614 3680 1	Climb-up;Staircase;11807
+1614 3680 1	1618 3680 0	Climb-down;Staircase;11799
+1616 3686 1	1616 3686 2	Climb-up;Staircase;12536
+1616 3686 2	1616 3686 1	Climb-down;Staircase;12538
+1639 3673 0	1666 10050 0	Investigate;Statue;27785
+1666 10050 0	1639 3673 0	Climb-up;Vine ladder;28894
+1562 3791 0	1617 10101 0	Enter;Hole;28921					5090=1
+1617 10101 0	1562 3791 0	Climb-up;Vine;28895
+1469 3653 0	1650 9987 0	Enter;Hole;28919					5080=1
+1650 9987 0	1469 3653 0	Climb-up;Vine;28895
+1696 3864 0	1719 10101 0	Enter;Hole;28920					5070=1
+1719 10101 0	1696 3864 0	Climb-up;Vine;28898
+1727 9993 0	1803 9968 0	Climb-up;Vine;28897
+1803 9968 0	1727 9993 0	Enter;Strange passage;28918	 				5087=1
+1670 3569 0	1800 9968 0	Climb-down;Staircase;34865
+1800 9968 0	1670 3569 0	Climb-up;Staircase;34864
+1830 9973 0	1702 3575 0	Climb-up;Ladder;34863
+1830 9975 0	1702 3575 0	Climb-up;Ladder;34863
+1702 3575 0	1830 9973 0	Climb-down;Ladder;34862								10
+1833 9944 0	1833 9943 0	Slash;Web;733
+1833 9943 0	1833 9944 0	Slash;Web;733
+1841 9934 0	1841 9933 0	Slash;Web;733
+1841 9933 0	1841 9934 0	Slash;Web;733
+1842 9934 0	1842 9933 0	Slash;Web;733
+1842 9933 0	1842 9934 0	Slash;Web;733
+1849 9934 0	1849 9935 0	Slash;Web;733
+1849 9935 0	1849 9934 0	Slash;Web;733
+1850 9934 0	1850 9935 0	Slash;Web;733
+1850 9935 0	1850 9934 0	Slash;Web;733
+1847 9920 0	1847 9919 0	Slash;Web;733
+1847 9919 0	1847 9920 0	Slash;Web;733
+
+# Arceuus Library
+1617 3826 0	1610 3826 1	Climb;Stairs;27853
+1617 3827 0	1610 3827 1	Climb;Stairs;27854
+1610 3826 1	1617 3826 0	Climb;Stairs;27855
+1610 3827 1	1617 3827 0	Climb;Stairs;27856
+1615 3818 1	1608 3818 2	Climb;Stairs;27851
+1615 3819 1	1608 3819 2	Climb;Stairs;27851
+1608 3818 2	1615 3818 1	Climb;Stairs;27852
+1608 3819 2	1615 3819 1	Climb;Stairs;27852
+1639 3810 1	1639 3803 2	Climb;Stairs;27851
+1638 3810 1	1638 3803 2	Climb;Stairs;27851
+1639 3803 2	1639 3810 1	Climb;Stairs;27852
+1638 3803 2	1638 3810 1	Climb;Stairs;27852
+1617 3795 0	1610 3795 1	Climb;Stairs;27853
+1617 3796 0	1610 3796 1	Climb;Stairs;27854
+1610 3795 1	1617 3795 0	Climb;Stairs;27855
+1610 3796 1	1617 3796 0	Climb;Stairs;27856
+1621 3791 1	1621 3798 2	Climb;Stairs;27851
+1622 3791 1	1622 3798 2	Climb;Stairs;27851
+1621 3798 2	1621 3791 1	Climb;Stairs;27852
+1622 3798 2	1622 3791 1	Climb;Stairs;27852
+1644 3818 0	1644 3825 1	Climb;Stairs;27853
+1645 3818 0	1645 3825 1	Climb;Stairs;27854
+1644 3825 1	1644 3818 0	Climb;Stairs;27855
+1645 3825 1	1645 3818 0	Climb;Stairs;27856
+1643 3829 1	1650 3829 2	Climb;Stairs;27851
+1643 3828 1	1650 3828 2	Climb;Stairs;27851
+1650 3829 2	1643 3829 1	Climb;Stairs;27852
+1650 3828 2	1643 3828 1	Climb;Stairs;27852
+# Corsair Cove
+2578 2840 0	2578 2837 1	Cross;Gangplank;31756								1
+2578 2837 1	2578 2840 0	Cross;Gangplank;31756								1
+2523 2860 0	2012 9004 1	Enter;Hole;31791								2
+2012 9004 1	2523 2860 0	Climb;Vine ladder;31790								2
+2483 2889 0	1971 9035 1	Enter;Cave;31766								2
+1971 9035 1	2483 2889 0	Enter;Cave;31806								2
+
+# mining guild
+3021 9739 0	3021 3339 0	Climb-up;Ladder;17385
+3021 3339 0	3021 9739 0	Climb-down;Ladder;30367
+
+# portal to gotr
+3104 9573 0	3615 9470 0	Enter;Portal;43841
+3615 9470 0	3104 9573 0	Enter;Portal;43692
+
+# Necropolis
+3347 2759 0	3349 2759 0	Climb-over;Rubble;44003								4
+3349 2759 0	3347 2759 0	Climb-over;Rubble;44003								4
+
+# Villa entry aldarin
+1425 2933 0	1427 2933 0	Pass-through;Entryway;54707								4
+1427 2933 0	1425 2933 0	Pass-through;Entryway;54707								4
+
+# Fortis Colosseum
+1795 3107 0	1799 9506 0	Enter;Colosseum entrance;50749								8
+1799 9506 0	1795 3107 0	Exit;Stairs;50750								8
+
+# Hunter Guild
+1558 3047 0	1558 9451 0	Climb-down;Stairs;51641								8
+1558 9451 0	1558 3047 0	Climb-up;Stairs;51642								8
+1553 3033 0	1553 3033 1	Climb-up;Ladder;52614
+1553 3033 1	1553 3033 0	Climb-down;Ladder;52620
+1556 3034 1	1556 3034 2	Climb-up;Ladder;52614
+1556 3034 2	1556 3034 1	Climb-down;Ladder;52620
+
+# Piscatoris Hunting Area
+2371 3622 0	2371 3620 0	Climb-over;Stile;19222								8
+2371 3620 0	2371 3622 0	Climb-over;Stile;19222								8
+
+# Taverly dungeon
 2924 9803 0	2923 9803 0	Open;Gate;2623									Taverly gate
-											
-# Fight Caves											
-2493 5174 0	2495 5174 0	Pass;Hot vent door;30266								2	
-2495 5174 0	2493 5174 0	Pass;Hot vent door;30266								2	
-2494 5157 0	2496 5157 0	Pass;Hot vent door;30266								2	
-2496 5157 0	2494 5157 0	Pass;Hot vent door;30266								2	
-2474 5138 0	2474 5136 0	Pass;Hot vent door;30266								2	
-2474 5136 0	2474 5138 0	Pass;Hot vent door;30266								2	
-2457 5120 0	2457 5118 0	Pass;Hot vent door;30266								2	
-2457 5118 0	2457 5120 0	Pass;Hot vent door;30266								2	
-2436 5121 0	2436 5119 0	Pass;Hot vent door;30266								2	
-2436 5119 0	2436 5121 0	Pass;Hot vent door;30266								2	
-2399 5177 0	2399 5175 0	Pass;Hot vent door;30266								2	
-											
-# Sunset Coast											
-1491 2985 1	1495 2985 0	Cross;Gangplank;55335									
-1495 2985 0	1491 2985 1	Cross;Gangplank;55334									
-1514 2968 1	1514 2971 0	Cross;Gangplank;50737									
-1514 2971 0	1514 2968 1	Cross;Gangplank;50736									
-											
-# Aldarin											
-1446 2976 1	1443 2976 0	Cross;Gangplank;55337									
-1443 2976 0	1446 2976 1	Cross;Gangplank;55336									
-1458 2968 1	1455 2968 0	Cross;Gangplank;55333									
-1455 2968 0	1458 2968 1	Cross;Gangplank;55332									
-											
-# Tyras											
-2142 3125 1	2142 3122 0	Cross;Gangplank;17409									
-2142 3122 0	2142 3125 1	Cross;Gangplank;17408									
-											
-# Isafdar Forest											
-2188 3162 0	2188 3165 0	Enter;Dense forest;3999									
-2188 3165 0	2188 3168 0	Enter;Dense forest;3939									
-2188 3168 0	2188 3171 0	Enter;Dense forest;3998									
-2188 3165 0	2188 3162 0	Enter;Dense forest;3999									
-2188 3168 0	2188 3165 0	Enter;Dense forest;3939									
-2188 3171 0	2188 3168 0	Enter;Dense forest;3998									
-2199 3169 0	2202 3169 0	Pass;Sticks;3922									
-2202 3169 0	2199 3169 0	Pass;Sticks;3922									
-2217 3169 0	2217 3166 0	Enter;Dense forest;3939									
-2217 3166 0	2217 3163 0	Enter;Dense forest;3938									
-2217 3163 0	2217 3160 0	Enter;Dense forest;3939									
-2217 3166 0	2217 3169 0	Enter;Dense forest;3939									
-2217 3163 0	2217 3166 0	Enter;Dense forest;3938									
-2217 3160 0	2217 3163 0	Enter;Dense forest;3939									
-2215 3156 0	2215 3153 0	Step-over;Tripwire;3921									
-2220 3155 0	2220 3152 0	Step-over;Tripwire;3921									
-2215 3153 0	2215 3156 0	Step-over;Tripwire;3921									
-2220 3152 0	2220 3155 0	Step-over;Tripwire;3921									
-2231 3149 0	2234 3149 0	Enter;Dense forest;3937									
-2234 3149 0	2237 3149 0	Enter;Dense forest;3938									
-2237 3149 0	2240 3149 0	Enter;Dense forest;3939									
-2234 3149 0	2231 3149 0	Enter;Dense forest;3937									
-2237 3149 0	2234 3149 0	Enter;Dense forest;3938									
-2240 3149 0	2237 3149 0	Enter;Dense forest;3939									
-2274 3172 0	2274 3176 0	Jump;Leaves;3925									
-2274 3176 0	2274 3172 0	Jump;Leaves;3925									
-2234 3181 0	2238 3181 0	Pass;Sticks;3922									
-2238 3181 0	2234 3181 0	Pass;Sticks;3922									
-2238 3219 0	2235 3219 0	Enter;Dense forest;3939									
-2235 3219 0	2232 3219 0	Enter;Dense forest;3937									
-2232 3219 0	2229 3219 0	Enter;Dense forest;3939									
-2229 3219 0	2226 3219 0	Enter;Dense forest;3938									
-2235 3219 0	2238 3219 0	Enter;Dense forest;3939									
-2232 3219 0	2235 3219 0	Enter;Dense forest;3937									
-2229 3219 0	2232 3219 0	Enter;Dense forest;3939									
-2226 3219 0	2229 3219 0	Enter;Dense forest;3938									
-2274 3192 0	2271 3192 0	Enter;Dense forest;3937									
-2271 3192 0	2268 3192 0	Enter;Dense forest;3939									
-2268 3192 0	2265 3192 0	Enter;Dense forest;3938									
-2271 3192 0	2274 3192 0	Enter;Dense forest;3937									
-2268 3192 0	2271 3192 0	Enter;Dense forest;3939									
-2265 3192 0	2268 3192 0	Enter;Dense forest;3938									
-2267 3201 0	2267 3205 0	Jump;Leaves;3925									
-2267 3205 0	2267 3201 0	Jump;Leaves;3925									
-2284 3188 0	2287 3188 0	Step-over;Tripwire;3921									
-2287 3188 0	2284 3188 0	Step-over;Tripwire;3921									
-2306 3194 0	2304 3194 0	Pass;Tree;8742									
-2306 3195 0	2304 3195 0	Pass;Tree;8742									
-2304 3194 0	2306 3195 0	Pass;Tree;8742									
-2304 3195 0	2306 3195 0	Pass;Tree;8742									
-2202 3237 0	2196 3237 0	Cross;Log balance;3931									
-2196 3237 0	2202 3237 0	Cross;Log balance;3931									
-2303 3213 0	2303 3216 0	Enter;Dense forest;3937									
-2303 3216 0	2303 3219 0	Enter;Dense forest;3938									
-2303 3219 0	2303 3222 0	Enter;Dense forest;3939									
-2303 3222 0	2303 3225 0	Enter;Dense forest;3938									
-2303 3216 0	2303 3213 0	Enter;Dense forest;3937									
-2303 3219 0	2303 3216 0	Enter;Dense forest;3938									
-2303 3222 0	2303 3219 0	Enter;Dense forest;3939									
-2303 3225 0	2303 3222 0	Enter;Dense forest;3938									
-2290 3232 0	2290 3239 0	Cross;Log balance;3933									
-2290 3239 0	2290 3232 0	Cross;Log balance;3933									
-2294 3242 0	2294 3245 0	Step-over;Tripwire;3921									
-2294 3245 0	2294 3242 0	Step-over;Tripwire;3921									
-2295 3215 0	2295 3217 0	Pass;Sticks;3922									
-2295 3217 0	2295 3215 0	Pass;Sticks;3922									
-2279 3221 0	2279 3225 0	Enter;Dense forest;3938									
-2279 3225 0	2279 3228 0	Enter;Dense forest;3937									
-2279 3228 0	2279 3231 0	Enter;Dense forest;3939									
-2279 3225 0	2279 3221 0	Enter;Dense forest;3938									
-2279 3228 0	2279 3225 0	Enter;Dense forest;3937									
-2279 3231 0	2279 3228 0	Enter;Dense forest;3939									
-2264 3250 0	2258 3250 0	Cross;Log balance;3932									
-2258 3250 0	2264 3250 0	Cross;Log balance;3932									
-2312 3216 0	2314 9624 0	Enter;Cave entrance;4006									
-2314 9624 0	2312 3216 0	Leave;Cave exit;4007									
-2385 3335 0	2385 3333 0	Enter;Huge Gate;3945									
-2386 3335 0	2386 3333 0	Enter;Huge Gate;3944									
-2385 3333 0	2385 3335 0	Enter;Huge Gate;3945									
-2386 3333 0	2386 3335 0	Enter;Huge Gate;3944									
-											
-# Wilderness Slayer Cave											
+
+# Fight Caves
+2493 5174 0	2495 5174 0	Pass;Hot vent door;30266								2
+2495 5174 0	2493 5174 0	Pass;Hot vent door;30266								2
+2494 5157 0	2496 5157 0	Pass;Hot vent door;30266								2
+2496 5157 0	2494 5157 0	Pass;Hot vent door;30266								2
+2474 5138 0	2474 5136 0	Pass;Hot vent door;30266								2
+2474 5136 0	2474 5138 0	Pass;Hot vent door;30266								2
+2457 5120 0	2457 5118 0	Pass;Hot vent door;30266								2
+2457 5118 0	2457 5120 0	Pass;Hot vent door;30266								2
+2436 5121 0	2436 5119 0	Pass;Hot vent door;30266								2
+2436 5119 0	2436 5121 0	Pass;Hot vent door;30266								2
+2399 5177 0	2399 5175 0	Pass;Hot vent door;30266								2
+
+# Sunset Coast
+1491 2985 1	1495 2985 0	Cross;Gangplank;55335
+1495 2985 0	1491 2985 1	Cross;Gangplank;55334
+1514 2968 1	1514 2971 0	Cross;Gangplank;50737
+1514 2971 0	1514 2968 1	Cross;Gangplank;50736
+
+# Aldarin
+1446 2976 1	1443 2976 0	Cross;Gangplank;55337
+1443 2976 0	1446 2976 1	Cross;Gangplank;55336
+1458 2968 1	1455 2968 0	Cross;Gangplank;55333
+1455 2968 0	1458 2968 1	Cross;Gangplank;55332
+
+# Tyras
+2142 3125 1	2142 3122 0	Cross;Gangplank;17409
+2142 3122 0	2142 3125 1	Cross;Gangplank;17408
+
+# Isafdar Forest
+2188 3162 0	2188 3165 0	Enter;Dense forest;3999
+2188 3165 0	2188 3168 0	Enter;Dense forest;3939
+2188 3168 0	2188 3171 0	Enter;Dense forest;3998
+2188 3165 0	2188 3162 0	Enter;Dense forest;3999
+2188 3168 0	2188 3165 0	Enter;Dense forest;3939
+2188 3171 0	2188 3168 0	Enter;Dense forest;3998
+2199 3169 0	2202 3169 0	Pass;Sticks;3922
+2202 3169 0	2199 3169 0	Pass;Sticks;3922
+2217 3169 0	2217 3166 0	Enter;Dense forest;3939
+2217 3166 0	2217 3163 0	Enter;Dense forest;3938
+2217 3163 0	2217 3160 0	Enter;Dense forest;3939
+2217 3166 0	2217 3169 0	Enter;Dense forest;3939
+2217 3163 0	2217 3166 0	Enter;Dense forest;3938
+2217 3160 0	2217 3163 0	Enter;Dense forest;3939
+2215 3156 0	2215 3153 0	Step-over;Tripwire;3921
+2220 3155 0	2220 3152 0	Step-over;Tripwire;3921
+2215 3153 0	2215 3156 0	Step-over;Tripwire;3921
+2220 3152 0	2220 3155 0	Step-over;Tripwire;3921
+2231 3149 0	2234 3149 0	Enter;Dense forest;3937
+2234 3149 0	2237 3149 0	Enter;Dense forest;3938
+2237 3149 0	2240 3149 0	Enter;Dense forest;3939
+2234 3149 0	2231 3149 0	Enter;Dense forest;3937
+2237 3149 0	2234 3149 0	Enter;Dense forest;3938
+2240 3149 0	2237 3149 0	Enter;Dense forest;3939
+2274 3172 0	2274 3176 0	Jump;Leaves;3925
+2274 3176 0	2274 3172 0	Jump;Leaves;3925
+2234 3181 0	2238 3181 0	Pass;Sticks;3922
+2238 3181 0	2234 3181 0	Pass;Sticks;3922
+2238 3219 0	2235 3219 0	Enter;Dense forest;3939
+2235 3219 0	2232 3219 0	Enter;Dense forest;3937
+2232 3219 0	2229 3219 0	Enter;Dense forest;3939
+2229 3219 0	2226 3219 0	Enter;Dense forest;3938
+2235 3219 0	2238 3219 0	Enter;Dense forest;3939
+2232 3219 0	2235 3219 0	Enter;Dense forest;3937
+2229 3219 0	2232 3219 0	Enter;Dense forest;3939
+2226 3219 0	2229 3219 0	Enter;Dense forest;3938
+2274 3192 0	2271 3192 0	Enter;Dense forest;3937
+2271 3192 0	2268 3192 0	Enter;Dense forest;3939
+2268 3192 0	2265 3192 0	Enter;Dense forest;3938
+2271 3192 0	2274 3192 0	Enter;Dense forest;3937
+2268 3192 0	2271 3192 0	Enter;Dense forest;3939
+2265 3192 0	2268 3192 0	Enter;Dense forest;3938
+2267 3201 0	2267 3205 0	Jump;Leaves;3925
+2267 3205 0	2267 3201 0	Jump;Leaves;3925
+2284 3188 0	2287 3188 0	Step-over;Tripwire;3921
+2287 3188 0	2284 3188 0	Step-over;Tripwire;3921
+2306 3194 0	2304 3194 0	Pass;Tree;8742
+2306 3195 0	2304 3195 0	Pass;Tree;8742
+2304 3194 0	2306 3195 0	Pass;Tree;8742
+2304 3195 0	2306 3195 0	Pass;Tree;8742
+2202 3237 0	2196 3237 0	Cross;Log balance;3931
+2196 3237 0	2202 3237 0	Cross;Log balance;3931
+2303 3213 0	2303 3216 0	Enter;Dense forest;3937
+2303 3216 0	2303 3219 0	Enter;Dense forest;3938
+2303 3219 0	2303 3222 0	Enter;Dense forest;3939
+2303 3222 0	2303 3225 0	Enter;Dense forest;3938
+2303 3216 0	2303 3213 0	Enter;Dense forest;3937
+2303 3219 0	2303 3216 0	Enter;Dense forest;3938
+2303 3222 0	2303 3219 0	Enter;Dense forest;3939
+2303 3225 0	2303 3222 0	Enter;Dense forest;3938
+2290 3232 0	2290 3239 0	Cross;Log balance;3933
+2290 3239 0	2290 3232 0	Cross;Log balance;3933
+2294 3242 0	2294 3245 0	Step-over;Tripwire;3921
+2294 3245 0	2294 3242 0	Step-over;Tripwire;3921
+2295 3215 0	2295 3217 0	Pass;Sticks;3922
+2295 3217 0	2295 3215 0	Pass;Sticks;3922
+2279 3221 0	2279 3225 0	Enter;Dense forest;3938
+2279 3225 0	2279 3228 0	Enter;Dense forest;3937
+2279 3228 0	2279 3231 0	Enter;Dense forest;3939
+2279 3225 0	2279 3221 0	Enter;Dense forest;3938
+2279 3228 0	2279 3225 0	Enter;Dense forest;3937
+2279 3231 0	2279 3228 0	Enter;Dense forest;3939
+2264 3250 0	2258 3250 0	Cross;Log balance;3932
+2258 3250 0	2264 3250 0	Cross;Log balance;3932
+2312 3216 0	2314 9624 0	Enter;Cave entrance;4006
+2314 9624 0	2312 3216 0	Leave;Cave exit;4007
+2385 3335 0	2385 3333 0	Enter;Huge Gate;3945
+2386 3335 0	2386 3333 0	Enter;Huge Gate;3944
+2385 3333 0	2385 3335 0	Enter;Huge Gate;3945
+2386 3333 0	2386 3335 0	Enter;Huge Gate;3944
+
+# Wilderness Slayer Cave
 3259 3663 0	3385 10052 0	Walk-down;Stairs;40388							Y
 3260 3663 0	3385 10052 0	Walk-down;Stairs;40388							Y
 3385 10052 0	3259 3663 0	Exit;Opening;40389							Y
 3294 3749 0	3406 10145 0	Walk-down;Stairs;40390							Y
 3293 3749 0	3406 10145 0	Walk-down;Stairs;40390							Y
 3406 10145 0	3293 3749 0	Exit;Opening;40391							Y
-3434 10090 0	3434 10095 0	Squeeze-through;Crevice;53259									
-3434 10090 0	3434 10095 0	Squeeze-through;Crevice;53259									
-											
-# Ourania Altar											
-2453 3231 0	3015 5629 0	Climb;Ladder;29635									
-3015 5629 0	2453 3231 0	Climb;Ladder;29636									
-											
-# Port Phasmatys											
-3705 3503 1	3702 3503 0	Cross;Gangplank;17393									
-3702 3503 0	3705 3503 1	Cross;Gangplank;17392									
-3659 3509 0	3659 3507 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy					
-3659 3507 0	3659 3509 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy					
-3660 3509 0	3660 3507 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy					
-3660 3507 0	3660 3509 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy					
-3654 3485 0	3651 3485 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy					
-3651 3485 0	3654 3485 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy					
-3654 3486 0	3651 3486 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy					
-3651 3486 0	3654 3486 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy					
-3670 3454 0	3670 3452 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy					
-3670 3452 0	3670 3454 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy					
-3669 3454 0	3669 3452 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy					
-											
-# Port Khazard											
-2674 3141 1	2674 3144 0	Cross;Gangplank;17403									
-2674 3144 0	2674 3141 1	Cross;Gangplank;17402									
-											
-# Civitas illa Fortis											
-1747 3136 1	1743 3136 0	Cross;Gangplank;50735									
-1743 3136 0	1747 3136 1	Cross;Gangplank;50734									
-											
-# Prifddinas											
-2157 3330 0	2157 3333 1	Cross;Gangplank;34948									
-2157 3333 1	2157 3330 0	Cross;Gangplank;34949									
-2181 3327 0	3208 6079 0	Enter;City Gate;36519									
-3208 6079 0	2181 3327 0	Exit;City Gate;36523									
-2181 3328 0	3208 6080 0	Enter;City Gate;36518									
-3208 6080 0	2181 3328 0	Exit;City Gate;36522									
-2239 3386 0	3263 6135 0	Enter;City Gate;36519									
-3263 6135 0	2239 3386 0	Exit;City Gate;36523									
-2240 3386 0	3264 6135 0	Enter;City Gate;36518									
-3264 6135 0	2240 3386 0	Exit;City Gate;36522									
-2298 3328 0	3319 6080 0	Enter;City Gate;36519									
-3319 6080 0	2298 3328 0	Exit;City Gate;36523									
-2298 3327 0	3319 6079 0	Enter;City Gate;36518									
-3319 6079 0	2298 3327 0	Exit;City Gate;36522									
-2240 3269 0	3264 6024 0	Enter;City Gate;36519									
-3264 6024 0	2240 3269 0	Exit;City Gate;36523									
-2239 3269 0	3263 6024 0	Enter;City Gate;36518									
-3263 6024 0	2239 3269 0	Exit;City Gate;36522									
-3225 6046 0	3225 12445 0	Enter;Cave;36690									
-3226 6046 0	3225 12445 0	Enter;Cave;36690									
-3225 12445 0	3225 6046 0	Exit;Steps;36691									
-											
-# Mount Karuulm Dungeon											
-1311 3806 0	1311 10189 0	Activate;Elevator;34359									
-1311 3808 0	1311 10189 0	Activate;Elevator;34359									
-1311 3806 0	1312 10189 0	Activate;Elevator;34359									
-1311 3808 0	1312 10189 0	Activate;Elevator;34359									
-1311 10189 0	1311 3806 0	Exit;Cave exit;34514									
-1311 10189 0	1311 3808 0	Exit;Cave exit;34514									
-1312 10189 0	1311 3806 0	Exit;Cave exit;34514									
-1312 10189 0	1311 3808 0	Exit;Cave exit;34514									
-1311 10214 0	1311 10215 0	Climb;Rocks;34544									
-1312 10214 0	1312 10215 0	Climb;Rocks;34544									
-1311 10215 0	1311 10214 0	Climb;Rocks;34544									
-1312 10215 0	1312 10214 0	Climb;Rocks;34544									
-1320 10205 0	1322 10205 0	Climb;Rocks;34544									
-1320 10206 0	1322 10206 0	Climb;Rocks;34544									
-1322 10205 0	1320 10205 0	Climb;Rocks;34544									
-1322 10206 0	1320 10205 0	Climb;Rocks;34544									
-1329 10205 0	1334 10205 1	Climb;Steps;34530									
-1329 10206 0	1334 10206 1	Climb;Steps;34530									
-1334 10205 1	1329 10205 0	Climb;Steps;34531									
-1334 10206 1	1329 10206 0	Climb;Steps;34531									
-1313 10188 1	1318 10188 2	Climb;Steps;34530									
-1313 10189 1	1318 10189 2	Climb;Steps;34530									
-1318 10188 2	1313 10188 1	Climb;Steps;34531									
-1318 10189 2	1313 10189 1	Climb;Steps;34531									
+3434 10090 0	3434 10095 0	Squeeze-through;Crevice;53259
+3434 10090 0	3434 10095 0	Squeeze-through;Crevice;53259
 
-# Piscatoris Fishing Colony											
-2344 3650 0	2344 3655 0	Enter;Hole;12656				Swan Song					
-2344 3655 0	2344 3650 0	Enter;Hole;12656				Swan Song					
-2343 3661 0	2343 3663 0	Open;Colony gate;12723				Swan Song					
-2343 3663 0	2343 3661 0	Open;Colony gate;12723				Swan Song					
-2344 3661 0	2344 3663 0	Open;Colony gate;12725				Swan Song					
-2344 3663 0	2344 3661 0	Open;Colony gate;12725				Swan Song					
-											
-# Quetzacali Gorge											
-1520 3247 0	1513 3243 0	Pass-through;Gate;55322									
-1517 3250 0	1513 3243 0	Pass-through;Gate;55322									
-1511 3244 0	1518 3248 0	Pass-through;Gate;55323									
-1514 3241 0	1518 3248 0	Pass-through;Gate;55323									
-											
-# Molch											
-1313 3685 0	1312 10086 0	Enter;Lizard dwelling;34405									
-1312 3685 0	1312 10086 0	Enter;Lizard dwelling;34405									
-1294 10077 0	1292 3676 0	Jump-in;Strange hole;34422									
-1294 10078 0	1292 3676 0	Jump-in;Strange hole;34422									
-1293 10076 0	1292 3676 0	Jump-in;Strange hole;34422									
-1292 10076 0	1292 3676 0	Jump-in;Strange hole;34422									
-1291 10077 0	1292 3676 0	Jump-in;Strange hole;34422									
-1291 10078 0	1292 3676 0	Jump-in;Strange hole;34422									
-1292 10079 0	1292 3676 0	Jump-in;Strange hole;34422									
-1293 10079 0	1292 3676 0	Jump-in;Strange hole;34422									
-1293 3659 0	1292 10057 0	Enter;Lizard dwelling;34402									
-1292 3659 0	1292 10057 0	Enter;Lizard dwelling;34402									
-1315 3665 0	1314 10063 0	Enter;Lizard dwelling;34403									
-1314 3665 0	1314 10063 0	Enter;Lizard dwelling;34403									
-1329 3670 0	1330 10069 0	Enter;Lizard dwelling;34403									
-1329 3669 0	1330 10069 0	Enter;Lizard dwelling;34403									
+# Ourania Altar
+2453 3231 0	3015 5629 0	Climb;Ladder;29635
+3015 5629 0	2453 3231 0	Climb;Ladder;29636
+
+# Port Phasmatys
+3705 3503 1	3702 3503 0	Cross;Gangplank;17393
+3702 3503 0	3705 3503 1	Cross;Gangplank;17392
+3659 3509 0	3659 3507 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy
+3659 3507 0	3659 3509 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy
+3660 3509 0	3660 3507 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy
+3660 3507 0	3660 3509 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy
+3654 3485 0	3651 3485 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy
+3651 3485 0	3654 3485 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy
+3654 3486 0	3651 3486 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy
+3651 3486 0	3654 3486 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy
+3670 3454 0	3670 3452 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy
+3670 3452 0	3670 3454 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy
+3669 3454 0	3669 3452 0	Pay-toll(2-Ecto);Energy Barrier;16105				Ghosts Ahoy
+
+# Port Khazard
+2674 3141 1	2674 3144 0	Cross;Gangplank;17403
+2674 3144 0	2674 3141 1	Cross;Gangplank;17402
+
+# Civitas illa Fortis
+1747 3136 1	1743 3136 0	Cross;Gangplank;50735
+1743 3136 0	1747 3136 1	Cross;Gangplank;50734
+
+# Prifddinas
+2157 3330 0	2157 3333 1	Cross;Gangplank;34948
+2157 3333 1	2157 3330 0	Cross;Gangplank;34949
+2181 3327 0	3208 6079 0	Enter;City Gate;36519
+3208 6079 0	2181 3327 0	Exit;City Gate;36523
+2181 3328 0	3208 6080 0	Enter;City Gate;36518
+3208 6080 0	2181 3328 0	Exit;City Gate;36522
+2239 3386 0	3263 6135 0	Enter;City Gate;36519
+3263 6135 0	2239 3386 0	Exit;City Gate;36523
+2240 3386 0	3264 6135 0	Enter;City Gate;36518
+3264 6135 0	2240 3386 0	Exit;City Gate;36522
+2298 3328 0	3319 6080 0	Enter;City Gate;36519
+3319 6080 0	2298 3328 0	Exit;City Gate;36523
+2298 3327 0	3319 6079 0	Enter;City Gate;36518
+3319 6079 0	2298 3327 0	Exit;City Gate;36522
+2240 3269 0	3264 6024 0	Enter;City Gate;36519
+3264 6024 0	2240 3269 0	Exit;City Gate;36523
+2239 3269 0	3263 6024 0	Enter;City Gate;36518
+3263 6024 0	2239 3269 0	Exit;City Gate;36522
+3225 6046 0	3225 12445 0	Enter;Cave;36690
+3226 6046 0	3225 12445 0	Enter;Cave;36690
+3225 12445 0	3225 6046 0	Exit;Steps;36691
+
+# Mount Karuulm Dungeon
+1311 3806 0	1311 10189 0	Activate;Elevator;34359
+1311 3808 0	1311 10189 0	Activate;Elevator;34359
+1311 3806 0	1312 10189 0	Activate;Elevator;34359
+1311 3808 0	1312 10189 0	Activate;Elevator;34359
+1311 10189 0	1311 3806 0	Exit;Cave exit;34514
+1311 10189 0	1311 3808 0	Exit;Cave exit;34514
+1312 10189 0	1311 3806 0	Exit;Cave exit;34514
+1312 10189 0	1311 3808 0	Exit;Cave exit;34514
+1311 10214 0	1311 10215 0	Climb;Rocks;34544
+1312 10214 0	1312 10215 0	Climb;Rocks;34544
+1311 10215 0	1311 10214 0	Climb;Rocks;34544
+1312 10215 0	1312 10214 0	Climb;Rocks;34544
+1320 10205 0	1322 10205 0	Climb;Rocks;34544
+1320 10206 0	1322 10206 0	Climb;Rocks;34544
+1322 10205 0	1320 10205 0	Climb;Rocks;34544
+1322 10206 0	1320 10205 0	Climb;Rocks;34544
+1329 10205 0	1334 10205 1	Climb;Steps;34530
+1329 10206 0	1334 10206 1	Climb;Steps;34530
+1334 10205 1	1329 10205 0	Climb;Steps;34531
+1334 10206 1	1329 10206 0	Climb;Steps;34531
+1313 10188 1	1318 10188 2	Climb;Steps;34530
+1313 10189 1	1318 10189 2	Climb;Steps;34530
+1318 10188 2	1313 10188 1	Climb;Steps;34531
+1318 10189 2	1313 10189 1	Climb;Steps;34531
+
+# Piscatoris Fishing Colony
+2344 3650 0	2344 3655 0	Enter;Hole;12656				Swan Song
+2344 3655 0	2344 3650 0	Enter;Hole;12656				Swan Song
+2343 3661 0	2343 3663 0	Open;Colony gate;12723				Swan Song
+2343 3663 0	2343 3661 0	Open;Colony gate;12723				Swan Song
+2344 3661 0	2344 3663 0	Open;Colony gate;12725				Swan Song
+2344 3663 0	2344 3661 0	Open;Colony gate;12725				Swan Song
+
+# Quetzacali Gorge
+1520 3247 0	1513 3243 0	Pass-through;Gate;55322
+1517 3250 0	1513 3243 0	Pass-through;Gate;55322
+1511 3244 0	1518 3248 0	Pass-through;Gate;55323
+1514 3241 0	1518 3248 0	Pass-through;Gate;55323
+
+# Molch
+1313 3685 0	1312 10086 0	Enter;Lizard dwelling;34405
+1312 3685 0	1312 10086 0	Enter;Lizard dwelling;34405
+1294 10077 0	1292 3676 0	Jump-in;Strange hole;34422
+1294 10078 0	1292 3676 0	Jump-in;Strange hole;34422
+1293 10076 0	1292 3676 0	Jump-in;Strange hole;34422
+1292 10076 0	1292 3676 0	Jump-in;Strange hole;34422
+1291 10077 0	1292 3676 0	Jump-in;Strange hole;34422
+1291 10078 0	1292 3676 0	Jump-in;Strange hole;34422
+1292 10079 0	1292 3676 0	Jump-in;Strange hole;34422
+1293 10079 0	1292 3676 0	Jump-in;Strange hole;34422
+1293 3659 0	1292 10057 0	Enter;Lizard dwelling;34402
+1292 3659 0	1292 10057 0	Enter;Lizard dwelling;34402
+1315 3665 0	1314 10063 0	Enter;Lizard dwelling;34403
+1314 3665 0	1314 10063 0	Enter;Lizard dwelling;34403
+1329 3670 0	1330 10069 0	Enter;Lizard dwelling;34403
+1329 3669 0	1330 10069 0	Enter;Lizard dwelling;34403
 1293 10091 0	1293 10093 0	Pass;Mystical barrier;34542
 1292 10091 0	1292 10093 0	Pass;Mystical barrier;34542
 1293 10093 0	1293 10091 0	Pass;Mystical barrier;34542
@@ -4962,15 +4962,15 @@
 1324 10096 0	1326 10096 0	Pass;Mystical barrier;34646
 1326 10097 0	1324 10097 0	Pass;Mystical barrier;34646
 1326 10096 0	1324 10096 0	Pass;Mystical barrier;34646
-											
-# f2p altars (earth, air, fire, body, water)											
-2793 4828 0	2980 3511 0	Use;Portal;34749									
-2726 4832 0	3182 3162 0	Use;Portal;34750									
-2521 4834 0	3052 3440 0	Use;Portal;34753									
-2575 4850 0	3310 3252 0	Use;Portal;34752									
-2655 4830 0	3302 3477 0	Use;Portal;34751									
-											
-# Moons of Peril											
+
+# f2p altars (earth, air, fire, body, water)
+2793 4828 0	2980 3511 0	Use;Portal;34749
+2726 4832 0	3182 3162 0	Use;Portal;34750
+2521 4834 0	3052 3440 0	Use;Portal;34753
+2575 4850 0	3310 3252 0	Use;Portal;34752
+2655 4830 0	3302 3477 0	Use;Portal;34751
+
+# Moons of Peril
 1374 9667 0	1347 9590 0	Pass-Through;Entrance;51377
 1347 9590 0	1374 9667 0	Pass-Through;Entrance;51375
 1418 9632 0	1387 9591 0	Pass-Through;Entrance;51377
@@ -4995,20 +4995,20 @@
 1439 9599 1	1440 9615 1	Pass-Through;Entrance;51375
 1440 9509 1	1435 3128 0	Pass-Through;Entrance;51375
 1435 3128 0	1440 9509 1	Pass-Through;Entrance;51375
-											
-# Legends Guild											
-2732 3376 0	2732 3380 1	Climb-up;Staircase;15653									
-2733 3376 0	2733 3380 1	Climb-up;Staircase;15653									
-2732 3380 1	2732 3376 0	Climb-down;Staircase;15654									
-2733 3380 1	2733 3376 0	Climb-down;Staircase;15654									
-2732 3376 1	2732 3376 2	Climb-up;Ladder;16683									
-2732 3376 2	2732 3376 1	Climb-down;Ladder;16679									
-2733 3375 1	2733 3375 2	Climb-up;Ladder;16683									
-2733 3375 2	2733 3375 1	Climb-down;Ladder;16679									
-2732 3374 1	2732 3374 2	Climb-up;Ladder;16683									
-2732 3374 2	2732 3374 1	Climb-down;Ladder;16679									
-2731 3375 1	2731 3375 2	Climb-up;Ladder;16683									
-2731 3375 2	2731 3375 1	Climb-down;Ladder;16679									
+
+# Legends Guild
+2732 3376 0	2732 3380 1	Climb-up;Staircase;15653
+2733 3376 0	2733 3380 1	Climb-up;Staircase;15653
+2732 3380 1	2732 3376 0	Climb-down;Staircase;15654
+2733 3380 1	2733 3376 0	Climb-down;Staircase;15654
+2732 3376 1	2732 3376 2	Climb-up;Ladder;16683
+2732 3376 2	2732 3376 1	Climb-down;Ladder;16679
+2733 3375 1	2733 3375 2	Climb-up;Ladder;16683
+2733 3375 2	2733 3375 1	Climb-down;Ladder;16679
+2732 3374 1	2732 3374 2	Climb-up;Ladder;16683
+2732 3374 2	2732 3374 1	Climb-down;Ladder;16679
+2731 3375 1	2731 3375 2	Climb-up;Ladder;16683
+2731 3375 2	2731 3375 1	Climb-down;Ladder;16679
 2725 3376 1	2725 3376 2	Climb-up;Ladder;16683
 2725 3376 2	2725 3376 1	Climb-down;Ladder;16679
 2726 3375 1	2726 3375 2	Climb-up;Ladder;16683
@@ -5017,9 +5017,9 @@
 2725 3374 2	2725 3374 1	Climb-down;Ladder;16679
 2724 3375 1	2724 3375 2	Climb-up;Ladder;16683
 2724 3375 2	2724 3375 1	Climb-down;Ladder;16679
-2723 3374 0	2727 9774 0	Climb-down;Staircase;16664									
-2723 3375 0	2727 9775 0	Climb-down;Staircase;16664									
-2727 9774 0	2723 3374 0	Climb-up;Staircase;16665									
+2723 3374 0	2727 9774 0	Climb-down;Staircase;16664
+2723 3375 0	2727 9775 0	Climb-down;Staircase;16664
+2727 9774 0	2723 3374 0	Climb-up;Staircase;16665
 2727 9775 0	2723 3375 0	Climb-up;Staircase;16664
 
 # MYTH GUILD

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -3875,8 +3875,6 @@
 # Rellekka											
 2666 3694 0	2666 3694 1	Climb-up;Ladder;4187								2	
 2666 3694 1	2666 3694 0	Climb-down;Ladder;4189								2	
-2688 3697	2691 3697 0	Jump;Broken Fence;544	57 Agility							2			
-2691 3697 0	2688 3697 0	Jump;Broken Fence;544	57 Agility							2			
 2621 3694 0	2472 3994 0	Travel;Fremennik Boat;37432								2			
 2472 3994 0	2621 3692 0	Travel;Fremennik Boat;37408								2			
 2621 3693 0	2472 3994 0	Travel;Fremennik Boat;37432								2			

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -3875,6 +3875,17 @@
 # Rellekka											
 2666 3694 0	2666 3694 1	Climb-up;Ladder;4187								2	
 2666 3694 1	2666 3694 0	Climb-down;Ladder;4189								2	
+2688 3697	2691 3697 0	Jump;Broken Fence;544	57 Agility							2			
+2691 3697 0	2688 3697 0	Jump;Broken Fence;544	57 Agility							2			
+2621 3694 0	2472 3994 0	Travel;Fremennik Boat;37432								2			
+2472 3994 0	2621 3692 0	Travel;Fremennik Boat;37408								2			
+2621 3693 0	2472 3994 0	Travel;Fremennik Boat;37432								2			
+2473 3994 0	2621 3692 0	Travel;Fremennik Boat;37408								2			
+2621 3692 0	2472 3994 0	Travel;Fremennik Boat;37432								2			
+2621 3691 0	2472 3994 0	Travel;Fremennik Boat;37432								2			
+2621 3690 0	2472 3994 0	Travel;Fremennik Boat;37432								2			
+2598 3608 0	2596 3608 0	Cross;Broken bridge;4616								2			
+2596 3608 0	2598 3608 0	Cross;Broken bridge;4615								2			                           						
 											
 # Isle of Stone											
 2465 4010 0	2461 10417 0	Enter;Cave;37433									


### PR DESCRIPTION
It's now possible to calculate pathing to Lighthouse without fairy ring and without horror of the deep completed, tested and works.
Added boats though can't test them as I dont meet requirements to use them.