### PR TITLE
Unjamming wildy killer and safer scripts

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
@@ -402,19 +402,21 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
             } else {
                 superNullTarget = false;
             }
-
-            if (!Rs2Player.isMoving()) {
-                tickCount++;
-
-                if (tickCount >= 50) {
-                    isJammed = true;
-                }
-
-            } else {
-                tickCount = 0;
-                isJammed = false;
-            }
         }
+
+            if (config.wildy() || config.wildySafer()) {
+                if (!Rs2Player.isMoving()) {
+                    tickCount++;
+
+                    if (tickCount >= 50) {
+                        isJammed = true;
+                    }
+
+                } else {
+                    tickCount = 0;
+                    isJammed = false;
+                }
+            }
 
         if (!config.wildy() && !config.wildySafer()) {
             NPC bryophyta = findBryophyta();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
@@ -93,6 +93,8 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
     private boolean useMelee = false;
     private boolean useRange = false;
 
+    public boolean firemethod = false;
+
 
     private int consecutiveHitsplatsMain = 0;
     private int consecutiveHitsplatsSafeSpot1 = 0;
@@ -423,10 +425,16 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
             }
         }
 
-        if (config.wildySafer() && !wildySaferScript.fired) {
+        /// reserved for wildysafer anti-pk logic ///
+
+        /*if (config.wildySafer()
+                && !wildySaferScript.fired
+                && Rs2Player.getWorldLocation().getY() > 3700
+                && Rs2Player.getPlayersInCombatLevelRange() != null) {
             wildySaferScript.checkCombatAndRunToBank();
-        }
+        }*/
     }
+
 
     public NPC findBryophyta() {
         return client.getNpcs().stream()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
@@ -385,7 +385,7 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
                 }
             }
 
-            if (config.combatMode() == CombatMode.FIGHT) {
+            if (config.combatMode() == CombatMode.FIGHT && currentTarget != null) {
                 trackAttackers();
             }
 
@@ -508,7 +508,7 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
                         && !WildyKillerScript.CORRIDOR.contains(Rs2Player.getWorldLocation()))) {
 
                     int currentCount = attackerTickMap.getOrDefault(player, 0);
-                    attackerTickMap.put(player, currentCount + 1);
+                    attackerTickMap.put(player, currentCount + 3);
                     System.out.println("Player " + player.getName() + " tick count increased to: " + (currentCount + 1));
                 }
             }
@@ -517,7 +517,7 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
         // Create a copy of the entry set to avoid concurrent modification
         List<Map.Entry<Rs2PlayerModel, Integer>> entries = new ArrayList<>(attackerTickMap.entrySet());
 
-        // Process each entry - similar to your original logic
+        // Process each entry
         for (Map.Entry<Rs2PlayerModel, Integer> entry : entries) {
             Rs2PlayerModel player = entry.getKey();
             int tickCount = entry.getValue();
@@ -526,14 +526,14 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
 
             // Increment tick count if the player is interacting and performing combat animation
             if (player.getInteracting() == localPlayer && !isNonCombatAnimation(player)) {
-                tickCount += 1;
+                tickCount += 3;
                 attackerTickMap.put(player, tickCount);
                 System.out.println(player.getName() + " in combat with us, ticks now: " + tickCount);
             }
 
             // Increment tick count if the player is interacting and their hitsplat is applied to you
             if (player.getInteracting() == localPlayer && hitsplatIsTheirs()) {
-                tickCount += 1;
+                tickCount += 3;
                 attackerTickMap.put(player, tickCount);
                 System.out.println(player.getName() + " hitsplat applied, ticks now: " + tickCount);
             }
@@ -557,7 +557,7 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
             // If tick count is >= MIN_TICKS_TO_TRACK, they become your target
             if (tickCount >= MIN_TICKS_TO_TRACK) {
                 currentTarget = player;
-                System.out.println("Setting target to: " + player.getName() + " with ticks: " + tickCount);
+                Microbot.log("Setting target to: " + player.getName() + " with ticks: " + tickCount);
                 break;
             }
 
@@ -565,7 +565,7 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
             if (tickCount == 0) {
                 attackerTickMap.remove(player);
                 Microbot.log("Removing " + player.getName() + " from map due to 0 ticks");
-                if (currentTarget == player) {
+                if (currentTarget == player.getPlayer()) {
                     resetTarget();
                     if (Rs2Player.getWorldLocation().getY() > 3675) wildyKillerScript.handleAsynchWalk("Twenty Wild"); Microbot.log("target has been reset, going twenty wild for safety");
                     Microbot.log("Resetting target since it was " + player.getName());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerScript.java
@@ -46,6 +46,7 @@ import static net.runelite.api.Skill.MAGIC;
 import static net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity.HIGH;
 import static net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity.LOW;
 import static net.runelite.client.plugins.microbot.util.player.Rs2Player.eatAt;
+import static net.runelite.client.plugins.microbot.util.player.Rs2Player.getWorldLocation;
 import static net.runelite.client.plugins.skillcalculator.skills.MagicAction.HIGH_LEVEL_ALCHEMY;
 
 
@@ -306,7 +307,7 @@ public class MossKillerScript extends Script {
                 sleep(1000, 3000);
             }
             Rs2Bank.walkToBank(BankLocation.VARROCK_EAST);
-        } else if (Rs2Player.getWorldLocation().getY() > 3520) {
+        } else if (getWorldLocation().getY() > 3520) {
             Rs2Bank.walkToBank(BankLocation.FEROX_ENCLAVE);
         }
 
@@ -418,7 +419,7 @@ public class MossKillerScript extends Script {
 
     public void handleMossGiants() {
 
-        WorldPoint playerLocation = Rs2Player.getWorldLocation();
+        WorldPoint playerLocation = getWorldLocation();
 
         if (!Rs2Inventory.contains(FOOD) || BreakHandlerScript.breakIn <= 30){
             Microbot.log("Inventory does not contains FOOD or break in less than 30");
@@ -541,7 +542,7 @@ public class MossKillerScript extends Script {
     }
 
     public List<Rs2PlayerModel> getNearbyPlayers(int distance) {
-        WorldPoint playerLocation = Rs2Player.getWorldLocation();
+        WorldPoint playerLocation = getWorldLocation();
 
         // Use the predicate-based getPlayers method directly
         return Rs2Player.getPlayers(p -> p != null &&
@@ -661,7 +662,7 @@ public class MossKillerScript extends Script {
             return;
         }
 
-        if (Rs2Walker.getDistanceBetween(Rs2Player.getWorldLocation(), VARROCK_SQUARE) < 10 && Rs2Player.getWorldLocation().getPlane() == 0) {
+        if (Rs2Walker.getDistanceBetween(getWorldLocation(), VARROCK_SQUARE) < 10 && getWorldLocation().getPlane() == 0) {
             if (!Rs2Inventory.hasItemAmount(SWORDFISH, 15)) {
                 Microbot.log("you're at varrock square and could restock food, let's do that");
                 state = MossKillerState.BANK;
@@ -687,7 +688,7 @@ public class MossKillerScript extends Script {
             bossMode = true;
         }
 
-        WorldPoint playerLocation = Rs2Player.getWorldLocation();
+        WorldPoint playerLocation = getWorldLocation();
 
         if(!Rs2Inventory.contains(FOOD)) {
             state = MossKillerState.WALK_TO_BANK;
@@ -776,7 +777,7 @@ public class MossKillerScript extends Script {
 
 
     public void handleBanking(){
-        if(bossMode && !Rs2Inventory.contains(MOSSY_KEY) && Rs2Walker.getDistanceBetween(Rs2Player.getWorldLocation(), VARROCK_WEST_BANK) > 6) {
+        if(bossMode && !Rs2Inventory.contains(MOSSY_KEY) && Rs2Walker.getDistanceBetween(getWorldLocation(), VARROCK_WEST_BANK) > 6) {
             state = MossKillerState.WALK_TO_BANK;
             return;
         }
@@ -903,7 +904,7 @@ public class MossKillerScript extends Script {
     public void walkToVarrockWestBank(){
         BreakHandlerScript.setLockState(false);
         plugin.lockCondition.unlock();
-        WorldPoint playerLocation = Rs2Player.getWorldLocation();
+        WorldPoint playerLocation = getWorldLocation();
         toggleRunEnergy();
         if(!bossMode && Rs2Inventory.containsAll(new int[]{AIR_RUNE, FIRE_RUNE, LAW_RUNE, FOOD})){
             state = MossKillerState.WALK_TO_MOSS_GIANTS;
@@ -919,7 +920,7 @@ public class MossKillerScript extends Script {
     }
 
     public void varrockTeleport(){
-        WorldPoint playerLocation = Rs2Player.getWorldLocation();
+        WorldPoint playerLocation = getWorldLocation();
         Microbot.log(String.valueOf(Rs2Walker.getDistanceBetween(playerLocation, VARROCK_SQUARE)));
         sleep(1000, 2000);
         if(Rs2Walker.getDistanceBetween(playerLocation, VARROCK_SQUARE) <= 10 && playerLocation.getY() < 5000){
@@ -946,7 +947,7 @@ public class MossKillerScript extends Script {
 
 
     public void getInitiailState(){
-        WorldPoint playerLocation = Rs2Player.getWorldLocation();
+        WorldPoint playerLocation = getWorldLocation();
         if(Rs2Walker.getDistanceBetween(playerLocation, VARROCK_SQUARE) < 10 || Rs2Walker.getDistanceBetween(playerLocation, VARROCK_WEST_BANK) < 10){
             state = MossKillerState.WALK_TO_BANK;
             return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -1936,6 +1936,10 @@ public class WildyKillerScript extends Script {
                         return;
                     }
                 }
+                if (!Rs2Inventory.hasItem(FOOD)) {
+                    Microbot.log("you might have missed banking for food at castle wars");
+                    state = MossKillerState.BANK;
+                }
             }
         }
         if (Rs2Inventory.hasItemAmount(MIND_RUNE, 1500)) {
@@ -2002,6 +2006,10 @@ public class WildyKillerScript extends Script {
         if (Rs2Inventory.hasItemAmount(MIND_RUNE, 1500) &&
                 Rs2Walker.getDistanceBetween(playerLocation, VARROCK_WEST_BANK) > 6) {
             state = MossKillerState.WALK_TO_BANK;
+        }
+
+        if (TOTAL_FEROX_ENCLAVE.contains(Rs2Player.getWorldLocation())) {
+            Rs2Bank.walkToBankAndUseBank(BankLocation.FEROX_ENCLAVE);
         }
 
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -62,6 +62,7 @@ import static net.runelite.client.plugins.microbot.util.player.Rs2Pvp.getWildern
 import static net.runelite.client.plugins.microbot.util.prayer.Rs2Prayer.isPrayerActive;
 import static net.runelite.client.plugins.microbot.util.prayer.Rs2Prayer.toggle;
 import static net.runelite.client.plugins.microbot.util.prayer.Rs2PrayerEnum.*;
+import static net.runelite.client.plugins.microbot.util.walker.Rs2Walker.setTarget;
 import static net.runelite.client.plugins.skillcalculator.skills.MagicAction.HIGH_LEVEL_ALCHEMY;
 import static net.runelite.client.plugins.skillcalculator.skills.MagicAction.WIND_BLAST;
 
@@ -2356,6 +2357,8 @@ public class WildyKillerScript extends Script {
 
         Microbot.log(String.valueOf(state));
 
+        if (mossKillerPlugin.playerJammed() && ShortestPathPlugin.isStartPointSet()) {setTarget(null);}
+
         WorldPoint playerLocation = Rs2Player.getWorldLocation();
 
         if (!scheduledFuture.isDone()) {
@@ -2553,12 +2556,6 @@ public class WildyKillerScript extends Script {
             }
         }
         return true;
-    }
-
-    public void toggleRunEnergyOff() {
-        if (Rs2Player.isRunEnabled() && Rs2Player.getRunEnergy() > 0) {
-            Rs2Player.toggleRunEnergy(false);
-        }
     }
 
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -193,7 +193,12 @@ public class WildySaferScript extends Script {
                 if (isAtSafeSpot() && move) {
                     walkFastCanvas(SAFESPOT1);
                     sleep(900,1400);
-                    Rs2Npc.interact(MOSS_GIANT_2093,"attack");
+                    Rs2Npc.interact(MOSS_GIANT_2093,"Attack");
+                    sleepUntil(() -> Rs2Player.getInteracting() != null);
+                    if (Rs2Player.getInteracting() == null) {
+                        Microbot.log("We are not interacting with anything, trying to attack again");
+                        Rs2Npc.interact(MOSS_GIANT_2093,"Attack");
+                    }
                     move = false;
                     iveMoved = true;
                 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -222,7 +222,7 @@ public class WildySaferScript extends Script {
                     iveMoved = false;
                 }
 
-                if (config.buryBones()) {
+                if (config.buryBones() && !Rs2Player.isInteracting()) {
                     if (Rs2Inventory.contains(BIG_BONES)) {
                         sleep(100, 1750);
                         Rs2Inventory.interact(BIG_BONES, "Bury");
@@ -236,7 +236,7 @@ public class WildySaferScript extends Script {
 
                 long endTime = System.currentTimeMillis();
                 long totalTime = endTime - startTime;
-                System.out.println("Total time for loop " + totalTime);
+                Microbot.log("Total time for loop " + totalTime);
 
             } catch (Exception ex) {
                 System.out.println(ex.getMessage());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -236,7 +236,7 @@ public class WildySaferScript extends Script {
 
                 long endTime = System.currentTimeMillis();
                 long totalTime = endTime - startTime;
-                Microbot.log("Total time for loop " + totalTime);
+                System.out.println("Total time for loop " + totalTime);
 
             } catch (Exception ex) {
                 System.out.println(ex.getMessage());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -553,21 +553,22 @@ public class WildySaferScript extends Script {
                 sleepUntil(Rs2Bank::isOpen, 15000);
                 if (!Rs2Bank.isOpen()) {
                     Rs2Bank.openBank();
-                    System.out.println("called to open bank twice");
+                    Microbot.log("called to open bank twice");
                     sleepUntil(Rs2Bank::isOpen);
                 }// Check if required consumables exist in the bank with the correct amounts
-                if (Rs2Bank.isOpen() && Rs2Bank.count(APPLE_PIE) < 16 ||
-                        Rs2Bank.count(MIND_RUNE) < 750 ||
-                        Rs2Bank.count(AIR_RUNE) < 1550 ||
-                        !Rs2Bank.hasItem(STAFF_OF_FIRE)) {
+                if (Rs2Bank.isOpen()) {
+                    if (Rs2Bank.count(APPLE_PIE) < 16 ||
+                            Rs2Bank.count(MIND_RUNE) < 750 ||
+                            Rs2Bank.count(AIR_RUNE) < 1550 ||
+                            !Rs2Bank.hasItem(STAFF_OF_FIRE)) {
 
-                    Microbot.log("Missing required consumables in the bank. Shutting down script.");
-                    shutdown(); // Stop script
-                    return;
+                        Microbot.log("Missing required consumables in the bank. Shutting down script.");
+                        shutdown(); // Stop script
+                        return;
+                    }
                 }
             }
         }
-
         sleepUntil(Rs2Bank::isOpen);
         Rs2Bank.depositAll();
         sleep(600);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -1,17 +1,16 @@
 package net.runelite.client.plugins.microbot.bee.MossKiller;
 
 import net.runelite.api.Client;
-import net.runelite.api.Player;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.shortestpath.ShortestPathPlugin;
-import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
-import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.bank.enums.BankLocation;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
@@ -24,7 +23,6 @@ import net.runelite.client.plugins.microbot.util.models.RS2Item;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
-import net.runelite.client.plugins.microbot.util.player.Rs2PlayerModel;
 import net.runelite.client.plugins.microbot.util.security.Login;
 
 import javax.inject.Inject;
@@ -38,10 +36,10 @@ import static net.runelite.api.EquipmentInventorySlot.WEAPON;
 import static net.runelite.api.ItemID.*;
 import static net.runelite.api.NpcID.MOSS_GIANT_2093;
 import static net.runelite.api.Skill.DEFENCE;
+import static net.runelite.api.Skill.WOODCUTTING;
 import static net.runelite.client.plugins.microbot.bee.MossKiller.Enums.AttackStyle.MAGIC;
 import static net.runelite.client.plugins.microbot.bee.MossKiller.Enums.AttackStyle.RANGE;
 import static net.runelite.client.plugins.microbot.util.npc.Rs2Npc.getNpcs;
-import static net.runelite.api.Skill.WOODCUTTING;
 import static net.runelite.client.plugins.microbot.util.walker.Rs2Walker.*;
 
 public class WildySaferScript extends Script {
@@ -113,6 +111,12 @@ public class WildySaferScript extends Script {
 
                 if (Rs2Inventory.contains(MOSSY_KEY)) {
                     doBankingLogic();
+                }
+
+                if (fired) {
+                    Rs2Bank.walkToBank();
+                    Rs2Player.logout();
+                    fired = false;
                 }
 
                 //if you're at moss giants and your inventory is not prepared, prepare inventory
@@ -249,10 +253,13 @@ public class WildySaferScript extends Script {
         return config.attackStyle() == RANGE && Rs2Equipment.isEquipped(MAPLE_SHORTBOW, WEAPON) && Rs2Equipment.isEquipped(MITHRIL_ARROW, AMMO);
     }
 
-    int interactingTicks = 0;
+    /// /// reserved for anti-pk logic /// ///
 
-    public void checkCombatAndRunToBank() {
-        if (Rs2Player.isInCombat()) {
+    //int interactingTicks = 0;
+
+    /*public void dealWithPker() {
+        if (Rs2Npc.getNpcsForPlayer() == null
+                && Rs2Player.getPlayersInCombatLevelRange() != null) {
             Player localPlayer = Rs2Player.getLocalPlayer();
             for (Rs2PlayerModel p : Rs2Player.getPlayersInCombatLevelRange()) {
                 if (p != null && p != localPlayer && p.getInteracting() == localPlayer) {
@@ -262,13 +269,12 @@ public class WildySaferScript extends Script {
             }
 
             if (interactingTicks > 3) {
-                Rs2Bank.walkToBank();
                 fired = true;
             }
         } else {
             interactingTicks = 0; // reset if not in combat
         }
-    }
+    }*/
 
 
     private boolean isInMossGiantArea() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/cooking/scripts/BurnBakingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/cooking/scripts/BurnBakingScript.java
@@ -387,8 +387,8 @@ public class BurnBakingScript extends Script {
                         if (!Rs2Inventory.hasItem(POT_OF_FLOUR) || !Rs2Inventory.hasItem(BUCKET_OF_WATER)) {
                             Microbot.log("trying to withdrawX didn't populate inventory, so withdrawing all");
                             Rs2Bank.openBank();
-                            Rs2Bank.withdrawAll(POT_OF_FLOUR);
-                            Rs2Bank.withdrawAll(BUCKET_OF_WATER);
+                            if (!Rs2Inventory.hasItem(POT_OF_FLOUR)) {Rs2Bank.withdrawAll(POT_OF_FLOUR);}
+                            if (!Rs2Inventory.hasItem(BUCKET_OF_WATER)) {Rs2Bank.withdrawAll(BUCKET_OF_WATER);}
                         }
                     } else {
                         Rs2Bank.depositAll(); //if inventory is not empty deposit all


### PR DESCRIPTION
For some reason after teleporting Varrock, these scripts were finding themselves becoming jammed, where pathfinder would form a route but they wouldn't move. There is already a method which tracks if the player is jammed or not in moss killer plugin, it just wasn't applied for these routes so it was applied. 

Also in wildy Safer noticed that sometimes due to lag or low fps, if the bot did not attack the moss giant in time it would idle until logout, and reset itself on login, so added logic to deal with that case. 

Removed by commenting out unfinished and potentially resource-heavy and script-crashing anti-pk logic to be preserved for context and improved on at a later date in wildy safer.