### PR TITLE
Add gem bag functionality

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
@@ -24,6 +24,7 @@ import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.player.Rs2PlayerModel;
 import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Gembag;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -264,10 +265,9 @@ public class MotherloadMineScript extends Script
     private void depositHopper()
     {
         // if using a gem bag, fill the gem bag and return to mining if the inventory is no longer full
-        if (Rs2Inventory.isFull() && Rs2Inventory.hasItem("gem bag"))
+        if (Rs2Inventory.isFull() && Rs2Gembag.hasGemBag())
         {
             Rs2Inventory.interact("gem bag", "Fill");
-            sleepUntil(() -> !Rs2Inventory.contains("Uncut sapphire", "Uncut emerald", "Uncut ruby", "Uncut diamond"), 2000);
             gemBagEmptiedThisCycle = false;
             if (!Rs2Inventory.isFull())
             {
@@ -303,11 +303,15 @@ public class MotherloadMineScript extends Script
             sleepUntil(Rs2Bank::isOpen);
 
             // if using the gem sack, empty its contents directly into the bank
-            if (!gemBagEmptiedThisCycle && Rs2Inventory.hasItem("gem bag")) 
+            if (Rs2Gembag.hasGemBag() && !gemBagEmptiedThisCycle) 
             {
-                Rs2Inventory.interact("gem bag", "Empty");
+                Rs2Gembag.checkGemBag();
+                if Rs2Gembag.getTotalGemCount() > 0
+                {
+                    Rs2Inventory.interact("gem bag", "Empty");
+                    sleep(100, 300);
+                }
                 gemBagEmptiedThisCycle = true;
-                sleep(100, 300);
             }
             
             Rs2Bank.depositAllExcept("hammer", pickaxeName, "gem bag");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
@@ -306,7 +306,7 @@ public class MotherloadMineScript extends Script
             if (Rs2Gembag.hasGemBag() && !gemBagEmptiedThisCycle) 
             {
                 Rs2Gembag.checkGemBag();
-                if Rs2Gembag.getTotalGemCount() > 0
+                if (Rs2Gembag.getTotalGemCount() > 0)
                 {
                     Rs2Inventory.interact("gem bag", "Empty");
                     sleep(100, 300);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
@@ -263,6 +263,17 @@ public class MotherloadMineScript extends Script
 
     private void depositHopper()
     {
+        // if using a gem bag, fill the gem bag and return to mining if the inventory is no longer full
+        if (Rs2Inventory.isFull() && Rs2Inventory.hasItem("gem bag"))
+        {
+            Rs2Inventory.interact("gem bag", "Fill");
+            sleepUntil(() -> !Rs2Inventory.containsAny("Uncut sapphire", "Uncut emerald", "Uncut ruby", "Uncut diamond"), 2000);
+            if (!Rs2Inventory.isFull())
+            {
+                return;
+            }
+        }
+        
         WorldPoint hopperDeposit = (isUpperFloor() && config.upstairsHopperUnlocked()) ? HOPPER_DEPOSIT_UP : HOPPER_DEPOSIT_DOWN;
         Optional<GameObject> hopper = Optional.ofNullable(Rs2GameObject.findObject(ObjectID.HOPPER_26674, hopperDeposit));
 
@@ -289,7 +300,15 @@ public class MotherloadMineScript extends Script
         if (Rs2Bank.useBank())
         {
             sleepUntil(Rs2Bank::isOpen);
-            Rs2Bank.depositAllExcept("hammer", pickaxeName);
+
+            // if using the gem sack, empty its contents directly into the bank
+            if (!gemBagEmptiedThisCycle && Rs2Inventory.hasItem("gem bag")) 
+            {
+                Rs2Inventory.interact("gem bag", "Empty");
+                sleep(100, 300);
+            }
+            
+            Rs2Bank.depositAllExcept("hammer", pickaxeName, "gem bag");
             sleep(100, 300);
 
             if (!Rs2Inventory.hasItem("hammer") && !Rs2Equipment.isWearing("hammer"))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
@@ -268,7 +268,7 @@ public class MotherloadMineScript extends Script
         {
             Rs2Inventory.interact("gem bag", "Fill");
             sleepUntil(() -> !Rs2Inventory.contains("Uncut sapphire", "Uncut emerald", "Uncut ruby", "Uncut diamond"), 2000);
-            private boolean gemBagEmptiedThisCycle = false;
+            gemBagEmptiedThisCycle = false;
             if (!Rs2Inventory.isFull())
             {
                 return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
@@ -59,7 +59,7 @@ public class MotherloadMineScript extends Script
 
     private String pickaxeName = "";
     private boolean shouldEmptySack = false;
-
+    private boolean gemBagEmptiedThisCycle = false;
 
 
     public boolean run(MotherloadMineConfig config)
@@ -267,7 +267,8 @@ public class MotherloadMineScript extends Script
         if (Rs2Inventory.isFull() && Rs2Inventory.hasItem("gem bag"))
         {
             Rs2Inventory.interact("gem bag", "Fill");
-            sleepUntil(() -> !Rs2Inventory.containsAny("Uncut sapphire", "Uncut emerald", "Uncut ruby", "Uncut diamond"), 2000);
+            sleepUntil(() -> !Rs2Inventory.contains("Uncut sapphire", "Uncut emerald", "Uncut ruby", "Uncut diamond"), 2000);
+            private boolean gemBagEmptiedThisCycle = false;
             if (!Rs2Inventory.isFull())
             {
                 return;
@@ -305,6 +306,7 @@ public class MotherloadMineScript extends Script
             if (!gemBagEmptiedThisCycle && Rs2Inventory.hasItem("gem bag")) 
             {
                 Rs2Inventory.interact("gem bag", "Empty");
+                gemBagEmptiedThisCycle = true;
                 sleep(100, 300);
             }
             


### PR DESCRIPTION
- Prior to the hopper deposit sequence, fill the gem bag. If inventory space was created by filling the gem bag, then return to mining, or else complete the hopper deposit sequence
- While banking, empty the gem bag directly to bank
- Do not deposit the gem bag while banking