### PR TITLE
More Moss + Burn Baking - misc improvements + restored targetting/anti-pk

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
@@ -3,6 +3,7 @@ package net.runelite.client.plugins.microbot.bee.MossKiller;
 import com.google.inject.Provides;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Deque;
 import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
@@ -111,6 +112,9 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
     public boolean dead = false;
     @Getter
     private boolean defensive;
+
+    private int projectileCount = 0;
+    public boolean windStrikeflag = false;
 
     @Getter
     private boolean superNullTarget = false;
@@ -418,6 +422,10 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
                 }
             }
 
+            if (config.wildySafer() && !windStrikeflag) {
+                checkProjectiles();
+            }
+
         if (!config.wildy() && !config.wildySafer()) {
             NPC bryophyta = findBryophyta();
 
@@ -435,6 +443,43 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
                 && Rs2Player.getPlayersInCombatLevelRange() != null) {
             wildySaferScript.checkCombatAndRunToBank();
         }*/
+    }
+
+    public void checkProjectiles()
+    {
+        if (projectileCount > 10)
+        {
+            // Stop processing after 10 detections
+            return;
+        }
+
+        Player localPlayer = Rs2Player.getLocalPlayer();
+        if (localPlayer == null)
+            return;
+
+        WorldView worldView = Microbot.getClient().getWorldView(-1);
+        if (worldView == null)
+            return;
+
+        LocalPoint playerPos = localPlayer.getLocalLocation();
+
+        Deque<Projectile> projectiles = worldView.getProjectiles();
+        for (Projectile projectile : projectiles)
+        {
+            if (projectile == null)
+                continue;
+
+            if (projectile.getId() == 91)
+            {
+                LocalPoint start = new LocalPoint(projectile.getX1(), projectile.getY1());
+                if (start.equals(playerPos))
+                {
+                    windStrikeflag = true;
+                    projectileCount++;
+                    break;
+                }
+            }
+        }
     }
 
 
@@ -457,6 +502,7 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
             return bryophyta.getWorldLocation();
         }
     }
+
 
     private void trackAttackers() {
         Player localPlayer = Microbot.getClient().getLocalPlayer();
@@ -830,6 +876,7 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
         wildySaferScript.shutdown();
         startedFromScheduler = false;
         preparingForShutdown = false;
+        projectileCount = 0;
         overlayManager.remove(mossKillerOverlay);
         }
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
@@ -389,7 +389,8 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
                 }
             }
 
-            if (config.combatMode() == CombatMode.FIGHT && currentTarget != null) {
+            if (config.combatMode() == CombatMode.FIGHT) {
+                //note to self - this is where target is set
                 trackAttackers();
             }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -216,9 +216,9 @@ public class WildyKillerScript extends Script {
                 if (mossKillerPlugin.shouldHopWorld()) {
                     Microbot.log("Player is dead! Hopping worlds...");
                     sleepUntil(() -> !Rs2Player.isInCombat());
-                    sleep(4900);
-                    performWorldHop();
-                    sleep(2900);
+                    Rs2Player.logout();
+                    sleepUntil(() -> !Microbot.isLoggedIn());
+                    sleepUntil(Microbot::isLoggedIn);
                     mossKillerPlugin.resetWorldHopFlag(); // Reset after hopping
                 }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -171,6 +171,7 @@ public class WildyKillerScript extends Script {
                     Microbot.log("Not logged in, skipping tick.");
                     return;}
                 if (!super.run()) {Microbot.log("super.run() returned false, skipping tick.");
+                    if (Microbot.isLoggedIn() && !Rs2Player.isInCombat() && BreakHandlerScript.breakIn <= 1) {Rs2Player.logout();}
                     return;}
                 if (Microbot.getClient() == null || Microbot.getClient().getLocalPlayer() == null) {
                     Microbot.log("Client or local player not ready. Skipping tick.");
@@ -216,9 +217,9 @@ public class WildyKillerScript extends Script {
                 if (mossKillerPlugin.shouldHopWorld()) {
                     Microbot.log("Player is dead! Hopping worlds...");
                     sleepUntil(() -> !Rs2Player.isInCombat());
-                    Rs2Player.logout();
-                    sleepUntil(() -> !Microbot.isLoggedIn());
-                    sleepUntil(Microbot::isLoggedIn);
+                    sleep(4900);
+                    performWorldHop();
+                    sleep(2900);
                     mossKillerPlugin.resetWorldHopFlag(); // Reset after hopping
                 }
 
@@ -1753,18 +1754,8 @@ public class WildyKillerScript extends Script {
         if (mossKillerPlugin.currentTarget == null) {
             if (!getNearbyPlayers(7).isEmpty()) {
                 if (playerCounter > 5) {
-                    sleep(600, 1200);
-                    int world = Login.getRandomWorld(false, null);
-                    if (world == 301 || world == 308) {
-                        return;
-                    }
-                    boolean isHopped = Microbot.hopToWorld(world);
-                    sleepUntil(() -> isHopped, 5000);
-                    if (!isHopped) return;
-                    playerCounter = 0;
-                    int randomThreshold = (int) Rs2Random.truncatedGauss(0, 5, 1.5); // Adjust mean and deviation as needed
-                    if (randomThreshold > 3) {
-                        Rs2Inventory.open();
+                    if (!Rs2Player.isInCombat()) {
+                        Rs2Player.logout();
                     }
                     return;
                 }
@@ -2268,6 +2259,7 @@ public class WildyKillerScript extends Script {
             return;
         }
         if (playerLocation.getY() > 9000) {
+            Microbot.log("attempting to interact with the portal");
             Rs2GameObject.interact("Portal", "Exit");
             sleep(4000, 5000);
             return;
@@ -2365,7 +2357,9 @@ public class WildyKillerScript extends Script {
 
         Microbot.log(String.valueOf(state));
 
-        if (mossKillerPlugin.playerJammed() && ShortestPathPlugin.isStartPointSet()) {setTarget(null);}
+        if (mossKillerPlugin.playerJammed()) {Microbot.log("player registered as Jammed");
+            if(ShortestPathPlugin.isStartPointSet()) {setTarget(null);}
+        }
 
         WorldPoint playerLocation = Rs2Player.getWorldLocation();
 
@@ -2402,6 +2396,8 @@ public class WildyKillerScript extends Script {
             if (Rs2Walker.getDistanceBetween(playerLocation, VARROCK_WEST_BANK) > 6
                     || Rs2Player.isTeleBlocked()
                     || getWildernessLevelFrom(Rs2Player.getWorldLocation()) <= 20) {
+                Rs2Walker.setTarget(null);
+                sleep(2000);
                 Rs2Bank.walkToBank(BankLocation.VARROCK_WEST);
             }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -265,7 +265,7 @@ public class WildySaferScript extends Script {
 
                 long endTime = System.currentTimeMillis();
                 long totalTime = endTime - startTime;
-                Microbot.log("Total time for loop " + totalTime);
+                System.out.println("Total time for loop " + totalTime);
 
             } catch (Exception ex) {
                 System.out.println(ex.getMessage());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -20,12 +20,10 @@ import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.magic.Rs2CombatSpells;
 import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
-import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.models.RS2Item;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
-import net.runelite.client.plugins.microbot.util.security.Login;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -345,19 +343,9 @@ public class WildySaferScript extends Script {
         if(!mossKillerScript.getNearbyPlayers(14).isEmpty()){
             if (ShortestPathPlugin.isStartPointSet()) {setTarget(null);}
             if(playerCounter > 15) {
-                sleep(10000, 15000);
-                int world = Login.getRandomWorld(false, null);
-                if(world == 301){
-                    return;
-                }
-                boolean isHopped = Microbot.hopToWorld(world);
-                sleepUntil(() -> isHopped, 5000);
-                if (!isHopped) return;
-                playerCounter = 0;
-                int randomThreshold = (int) Rs2Random.truncatedGauss(0, 5, 1.5); // Adjust mean and deviation as needed
-                if (randomThreshold > 3) {
-                    Rs2Inventory.open();
-                }
+                Rs2Player.logout();
+                sleepUntil(() -> !Microbot.isLoggedIn());
+                sleepUntil(Microbot::isLoggedIn);
                 return;
             }
             playerCounter++;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -19,6 +19,7 @@ import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.magic.Rs2CombatSpells;
+import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.models.RS2Item;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
@@ -42,6 +43,7 @@ import static net.runelite.client.plugins.microbot.bee.MossKiller.Enums.AttackSt
 import static net.runelite.client.plugins.microbot.bee.MossKiller.Enums.AttackStyle.RANGE;
 import static net.runelite.client.plugins.microbot.util.npc.Rs2Npc.getNpcs;
 import static net.runelite.client.plugins.microbot.util.walker.Rs2Walker.*;
+import static net.runelite.client.plugins.skillcalculator.skills.MagicAction.HIGH_LEVEL_ALCHEMY;
 
 public class WildySaferScript extends Script {
     
@@ -196,6 +198,26 @@ public class WildySaferScript extends Script {
 
                 Rs2Player.eatAt(70);
 
+                if (Rs2Inventory.contains(NATURE_RUNE) &&
+                        !Rs2Inventory.contains(STAFF_OF_FIRE) &&
+                        Rs2Inventory.contains(ALCHABLES) &&
+                        config.alchLoot()) {
+
+                    if (config.attackStyle() == RANGE && !Rs2Inventory.contains(FIRE_RUNE, 5)) return;
+
+                    if (Rs2Player.getRealSkillLevel(Skill.MAGIC) > 54 && Rs2Magic.canCast(HIGH_LEVEL_ALCHEMY)) {
+
+                        if (Rs2Inventory.contains(STEEL_KITESHIELD)) {
+                            Rs2Magic.alch("Steel kiteshield");
+                        } else if (Rs2Inventory.contains(BLACK_SQ_SHIELD)) {
+                            Rs2Magic.alch("Black sq shield");
+                        } else if (Rs2Inventory.contains(MITHRIL_SWORD)) {
+                            Rs2Magic.alch("Mithril sword");
+                        }
+
+                        Rs2Player.waitForXpDrop(Skill.MAGIC, 10000, false);
+                    }
+                }
                 // if at the safe spot attack the moss giant and run to the safespot
                 if (isAtSafeSpot() && !Rs2Player.isInteracting() && desired2093Exists()) {
                     attackMossGiant();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -6,6 +6,7 @@ import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
 import net.runelite.client.plugins.microbot.shortestpath.ShortestPathPlugin;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
@@ -96,6 +97,7 @@ public class WildySaferScript extends Script {
                     Microbot.log("Not logged in, skipping tick.");
                     return;}
                 if (!super.run()) {Microbot.log("super.run() returned false, skipping tick.");
+                    if (Microbot.isLoggedIn() && !Rs2Player.isInCombat() && BreakHandlerScript.breakIn <= 1) {Rs2Player.logout();}
                     return;}
                 if (Microbot.getClient() == null || Microbot.getClient().getLocalPlayer() == null) {
                     Microbot.log("Client or local player not ready. Skipping tick.");
@@ -236,7 +238,7 @@ public class WildySaferScript extends Script {
 
                 long endTime = System.currentTimeMillis();
                 long totalTime = endTime - startTime;
-                System.out.println("Total time for loop " + totalTime);
+                Microbot.log("Total time for loop " + totalTime);
 
             } catch (Exception ex) {
                 System.out.println(ex.getMessage());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -111,6 +111,11 @@ public class WildySaferScript extends Script {
                 if (mossKillerPlugin.preparingForShutdown) {
                     MossKillerScript.prepareSoftStop();}
 
+                if (mossKillerPlugin.windStrikeflag) {
+                    Rs2Combat.setAutoCastSpell(Rs2CombatSpells.FIRE_STRIKE, config.forceDefensive());
+                    mossKillerPlugin.windStrikeflag = false;
+                }
+
                 if (Rs2Inventory.contains(MOSSY_KEY)) {
                     doBankingLogic();
                 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/cooking/scripts/BurnBakingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/cooking/scripts/BurnBakingScript.java
@@ -205,12 +205,16 @@ public class BurnBakingScript extends Script {
     }
 
     private void withdrawAndCheck(String itemName) {
-        Rs2Bank.withdrawAll(itemName);
-        sleep(1200, 1800);
-        if (!Rs2Inventory.contains(itemName)) {
-            System.out.println(itemName + " was not withdrawn, retrying...");
+        for (int attempt = 0; attempt < 5 && !Rs2Inventory.contains(itemName); attempt++) {
+            if (attempt > 0) {
+                Microbot.log(itemName + " was not withdrawn, retrying... (Attempt " + (attempt + 1) + ")");
+            }
             Rs2Bank.withdrawAll(itemName);
             sleep(1200, 1800);
+        }
+
+        if (!Rs2Inventory.contains(itemName)) {
+            Microbot.log("Failed to withdraw " + itemName + " after multiple attempts!");
         }
     }
 
@@ -792,7 +796,7 @@ public class BurnBakingScript extends Script {
 
             if (!Rs2Inventory.isFull()) {
                 Microbot.log("inventory not full after attempted withdrawing of 4x of 7 items (28 items)");
-                Microbot.log("Withdrawing ALL of X item IF inventory doesn't X item");
+                Microbot.log("Withdrawing ALL of X item(s) IF inventory doesn't have X item");
                 Microbot.log("If you are looping here make sure to have an EVEN NUMBER of EACH ingredient at the start");
                 if (!Rs2Inventory.contains(CAKE_TIN)) Rs2Bank.withdrawAll("Cake tin");
                 sleep(500, 800);


### PR DESCRIPTION
Improved the Wildy safer script by fixing spell selection issue and added missing alchemy logic,
Restored Wildy killer targeting functionality and addressed bot freezing while WALK_TO_BANK state is active.
Refined logout and hopworld logic for both scripts. 
Burn Baking enhanced item withdrawal reliability at end of baking session. 

