### PR TITLE
Fix for dodgy necklace only withdrawing correctly once and added new feature Automatically detection and wearing of rogue set - Thieving 1.6.5

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
@@ -31,7 +31,7 @@ import static net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment.i
 
 public class ThievingScript extends Script {
 
-    public static String version = "1.6.4";
+    public static String version = "1.6.5";
     ThievingConfig config;
 
     public boolean run(ThievingConfig config) {
@@ -257,34 +257,34 @@ public class ThievingScript extends Script {
         Rs2Bank.depositAll();
 
         if (config.shadowVeil()) {
-            Rs2Inventory.waitForInventoryChanges(5000);
             if (!isEquipped("Lava battlestaff", EquipmentInventorySlot.WEAPON)) {
                 if (Rs2Bank.hasBankItem("Lava battlestaff")) {
                     Rs2Bank.withdrawItem("Lava battlestaff");
-                    Rs2Inventory.waitForInventoryChanges(5000);
+                    Rs2Inventory.waitForInventoryChanges(3000);
                     if (Rs2Inventory.contains("Lava battlestaff")) {
                         Rs2Inventory.wear("Lava battlestaff");
-                        Rs2Inventory.waitForInventoryChanges(5000);
+                        Rs2Inventory.waitForInventoryChanges(3000);
                     } else {
                         Rs2Bank.withdrawAll(true, "Fire rune", true);
-                        Rs2Inventory.waitForInventoryChanges(5000);
+                        Rs2Inventory.waitForInventoryChanges(3000);
                         Rs2Bank.withdrawAll(true, "Earth rune", true);
-                        Rs2Inventory.waitForInventoryChanges(5000);
+                        Rs2Inventory.waitForInventoryChanges(3000);
                     }
                 }
             }
             Rs2Bank.withdrawAll(true, "Cosmic rune", true);
-            Rs2Inventory.waitForInventoryChanges(5000);
+            Rs2Inventory.waitForInventoryChanges(3000);
         }
 
         boolean successfullyWithdrawFood = Rs2Bank.withdrawX(true, config.food().getName(), config.foodAmount(), true);
         if (!successfullyWithdrawFood) {
             Microbot.showMessage(config.food().getName() + " not found in bank");
-            sleep(5000);
+            sleep(3000);
             return;
         }
 
-        Rs2Bank.withdrawDeficit("dodgy necklace", config.dodgyNecklaceAmount());
+        Rs2Inventory.waitForInventoryChanges(3000);
+        Rs2Bank.withdrawX("dodgy necklace", config.dodgyNecklaceAmount(), true);
 
         Rs2Bank.closeBank();
         sleepUntil(() -> !Rs2Bank.isOpen());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
@@ -238,13 +238,12 @@ public class ThievingScript extends Script {
         }
 
     private void handleShadowVeil() {
-        if (!Rs2Magic.isShadowVeilActive() &&
-                Rs2Magic.isArceeus() &&
-                Rs2Player.getBoostedSkillLevel(Skill.MAGIC) >= MagicAction.SHADOW_VEIL.getLevel() &&
-                Microbot.getVarbitValue(Varbits.SHADOW_VEIL_COOLDOWN) == 0 &&
-                Rs2Inventory.contains(ItemID.COSMIC_RUNE)
-        ) {
-            Rs2Magic.cast(MagicAction.SHADOW_VEIL);
+        if (!Rs2Magic.isShadowVeilActive() && config.shadowVeil()) {
+            if (Rs2Magic.canCast(MagicAction.SHADOW_VEIL)) {
+                Rs2Magic.cast(MagicAction.SHADOW_VEIL);
+            } else {
+                Microbot.showMessage("Please check, unable to cast Shadow Veil");
+            }
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
@@ -2,9 +2,6 @@ package net.runelite.client.plugins.microbot.thieving;
 
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.NPC;
-import net.runelite.api.Skill;
-import net.runelite.api.Varbits;
-import net.runelite.api.ItemID;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.client.game.npcoverlay.HighlightedNpc;
 import net.runelite.client.plugins.microbot.Microbot;
@@ -298,7 +295,7 @@ public class ThievingScript extends Script {
         }
 
         Rs2Inventory.waitForInventoryChanges(3000);
-        Rs2Bank.withdrawX("dodgy necklace", config.dodgyNecklaceAmount(), true);
+        Rs2Bank.withdrawDeficit("dodgy necklace", config.dodgyNecklaceAmount());
 
         Rs2Bank.closeBank();
         sleepUntil(() -> !Rs2Bank.isOpen());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
@@ -256,6 +256,22 @@ public class ThievingScript extends Script {
         if (!isBankOpen || !Rs2Bank.isOpen()) return;
         Rs2Bank.depositAll();
 
+        Map<String, EquipmentInventorySlot> rogueEquipment = new HashMap<>();
+        rogueEquipment.put("Rogue mask", EquipmentInventorySlot.HEAD);
+        rogueEquipment.put("Rogue top", EquipmentInventorySlot.BODY);
+        rogueEquipment.put("Rogue trousers", EquipmentInventorySlot.LEGS);
+        rogueEquipment.put("Rogue boots", EquipmentInventorySlot.BOOTS);
+        rogueEquipment.put("Rogue gloves", EquipmentInventorySlot.GLOVES);
+
+        for (Map.Entry<String, EquipmentInventorySlot> entry : rogueEquipment.entrySet()) {
+            String itemName = entry.getKey();
+            EquipmentInventorySlot slot = entry.getValue();
+            if (!isEquipped(itemName, slot) && Rs2Bank.hasBankItem(itemName)) {
+                Rs2Bank.withdrawAndEquip(itemName);
+                Rs2Inventory.waitForInventoryChanges(1200);
+            }
+        }
+
         if (config.shadowVeil()) {
             if (!isEquipped("Lava battlestaff", EquipmentInventorySlot.WEAPON)) {
                 if (Rs2Bank.hasBankItem("Lava battlestaff")) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
@@ -294,8 +294,7 @@ public class ThievingScript extends Script {
         boolean successfullyWithdrawFood = Rs2Bank.withdrawX(true, config.food().getName(), config.foodAmount(), true);
         if (!successfullyWithdrawFood) {
             Microbot.showMessage(config.food().getName() + " not found in bank");
-            sleep(3000);
-            return;
+            shutdown();
         }
 
         Rs2Inventory.waitForInventoryChanges(3000);


### PR DESCRIPTION

1. The issue should be because:

If Rs2Inventory.waitForInventoryChanges(3000); is not added before withdrawing dodgy necklace it withdraws the same amount of food with it adding this fixes the issue based on my testing

Also , withdraw deficit was not working properly hence changed to withdrawX to implement the appropiate withdrawal functionality and lowered the inventorychanges wait timings too

2. Added New feature : Automatically detection and wearing of rogue set