### PR TITLE
Added check for Event dismiss plugin to disallow starting if Agility plugin is active as it causes occassional bugging

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissScript.java
@@ -17,7 +17,6 @@ public class EventDismissScript extends Script {
     public boolean run(EventDismissConfig config) {
         List<Plugin> activePlugins = Microbot.getActiveMicrobotPlugins();
         for (Plugin plugin : activePlugins) {
-            Microbot.log(plugin.getName());
             if (plugin.getName().equals("<html>[<font color=#b8f704M>M</font>] Agility")) {
                 Microbot.log("Event Dismiss Start Failed : Cannot use event dismiss with Agility Plugin");
                 return false;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissScript.java
@@ -1,27 +1,16 @@
 package net.runelite.client.plugins.microbot.eventdismiss;
 
 import net.runelite.api.NPC;
-import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
-
-
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class EventDismissScript extends Script {
     public static double version = 1.0;
     public boolean run(EventDismissConfig config) {
-        List<Plugin> activePlugins = Microbot.getActiveMicrobotPlugins();
-        for (Plugin plugin : activePlugins) {
-            if (plugin.getName().equals("<html>[<font color=#b8f704M>M</font>] Agility")) {
-                Microbot.log("Event Dismiss Start Failed : Cannot use event dismiss with Agility Plugin");
-                return false;
-            }
-        }
         Microbot.enableAutoRunOn = false;
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissScript.java
@@ -30,7 +30,7 @@ public class EventDismissScript extends Script {
 
                 NPC npc = Rs2Npc.getRandomEventNPC();
 
-                if (npc != null) {
+                if (Rs2Npc.getNpcsInLineOfSight(npc.getName()) != null) {
                     if (shouldDismissNpc(npc, config)) {
                         Microbot.pauseAllScripts = true;
                         dismissNpc(npc);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissScript.java
@@ -1,19 +1,28 @@
 package net.runelite.client.plugins.microbot.eventdismiss;
 
 import net.runelite.api.NPC;
+import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 
-import java.util.Arrays;
+
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class EventDismissScript extends Script {
     public static double version = 1.0;
-
     public boolean run(EventDismissConfig config) {
+        List<Plugin> activePlugins = Microbot.getActiveMicrobotPlugins();
+        for (Plugin plugin : activePlugins) {
+            Microbot.log(plugin.getName());
+            if (plugin.getName().equals("<html>[<font color=#b8f704M>M</font>] Agility")) {
+                Microbot.log("Event Dismiss Start Failed : Cannot use event dismiss with Agility Plugin");
+                return false;
+            }
+        }
         Microbot.enableAutoRunOn = false;
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {


### PR DESCRIPTION
Bug found is :

When NPC is stuck behind another agility platform the player keeps trying to click it which forms a loop until the event is dismissed by itself i.e. a timeout. This happens a few times a day, therefore i added a check for Event dismiss plugin to disallow starting if Agility plugin is active.



