### PR TITLE
Revert "Motherload mine, Barrows, and Rev killer changes."

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/barrows/BarrowsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/barrows/BarrowsOverlay.java
@@ -42,11 +42,6 @@ public class BarrowsOverlay extends OverlayPanel {
                     .build());
 
             panelComponent.getChildren().add(LineComponent.builder()
-                    .left("Tunnel:")
-                    .right(BarrowsScript.WhoisTun.split(" ")[0])
-                    .build());
-
-            panelComponent.getChildren().add(LineComponent.builder()
                     .left("Pieces found:")
                     .build());
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/barrows/BarrowsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/barrows/BarrowsPlugin.java
@@ -37,9 +37,9 @@ import java.util.regex.Matcher;
 @Slf4j
 public class BarrowsPlugin extends Plugin {
     @Inject
-    private BarrowsConfig config;
+    private net.runelite.client.plugins.microbot.barrows.BarrowsConfig config;
     @Provides
-    BarrowsConfig provideConfig(ConfigManager configManager) {
+    net.runelite.client.plugins.microbot.barrows.BarrowsConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(BarrowsConfig.class);
     }
 
@@ -69,18 +69,15 @@ public class BarrowsPlugin extends Plugin {
 
     @Subscribe
     public void onChatMessage(ChatMessage chatMessage) {
-        if (chatMessage.getType() != ChatMessageType.GAMEMESSAGE) {
+        if (chatMessage.getType() != ChatMessageType.SPAM && chatMessage.getType() != ChatMessageType.GAMEMESSAGE) {
             return;
         }
 
         String msg = chatMessage.getMessage();
+
         //need to add the chat message we get when we try to attack an NPC with an empty staff.
 
-        if (msg.contains("out of charges")) {
-            BarrowsScript.outOfPoweredStaffCharges = true;
-        }
-
-        if (msg.contains("no charges")) {
+        if (msg.contains("has run out of charges.")) {
             BarrowsScript.outOfPoweredStaffCharges = true;
         }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/barrows/BarrowsScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/barrows/BarrowsScript.java
@@ -35,7 +35,7 @@ public class BarrowsScript extends Script {
 
     public static boolean test = false;
     public static boolean inTunnels = false;
-    public static String WhoisTun = "Unknown";
+    public String WhoisTun = "Unknown";
     private String neededRune = "unknown";
     private boolean shouldBank = false;
     private boolean shouldAttackSkeleton = false;
@@ -123,12 +123,13 @@ public class BarrowsScript extends Script {
                     super.shutdown();
                 }
 
-                outOfSupplies();
+                suppliesCheck();
 
                 if(!inTunnels && shouldBank == false) {
                     for (BarrowsBrothers brother : BarrowsBrothers.values()) {
                         Rs2WorldArea mound = brother.getHumpWP();
                         NeededPrayer = brother.whatToPray;
+                        suppliesCheck();
                         outOfSupplies();
                         if(shouldBank){
                             return;
@@ -414,22 +415,21 @@ public class BarrowsScript extends Script {
                             }
                             //we looted the chest time to reset
 
-                            suppliesCheck();
-
-                            if(shouldBank){
+                            if (Rs2Inventory.get("Barrows teleport") == null || Rs2Inventory.get("Barrows teleport").getQuantity() < 1 || (Rs2Inventory.count("Prayer potion(3)") + Rs2Inventory.count("Prayer potion(4)")) <= 2 || Rs2Inventory.getInventoryFood().isEmpty() || Rs2Inventory.count(Rs2Inventory.getInventoryFood().get(0).getName()) <= 3 || Rs2Player.getRunEnergy() <= 35 || Rs2Inventory.count("Forgotten brew(4)") + Rs2Inventory.count("Forgotten brew(3)") < config.minForgottenBrew()) {
                                 Microbot.log("We should bank.");
+                                shouldBank = true;
                                 ChestsOpened++;
                                 WhoisTun = "Unknown";
                                 inTunnels = false;
                             } else {
+                                shouldBank = false;
                                 Rs2Inventory.interact("Barrows teleport", "Break");
-                                sleepUntil(() -> Rs2Player.getAnimation() == 4069, Rs2Random.between(2000, 4000));
+                                sleepUntil(() -> Rs2Player.isAnimating(), Rs2Random.between(2000, 4000));
                                 sleepUntil(() -> !Rs2Player.isAnimating(), Rs2Random.between(6000, 10000));
                                 ChestsOpened++;
                                 WhoisTun = "Unknown";
                                 inTunnels = false;
                             }
-
                         }
                     }
                     tunnelLoopCount++;
@@ -615,27 +615,44 @@ public class BarrowsScript extends Script {
                             }
                         }
 
-                        suppliesCheck();
-
-                        if(!shouldBank){
-                            if(Rs2Bank.isOpen()){
-                                if(Rs2Bank.closeBank()){
-                                    sleepUntil(()-> Rs2Bank.isOpen(), Rs2Random.between(2000,4000));
-                                }
-                            }
-                            if(!Rs2Bank.isOpen()){
+                        if(!usingPoweredStaffs) {
+                            if (Rs2Equipment.get(EquipmentInventorySlot.RING) != null && Rs2Inventory.contains("Spade") &&
+                                    Rs2Inventory.count(Rs2Inventory.getInventoryFood().get(0).getName()) >= config.minFood() &&
+                                    Rs2Inventory.get("Barrows teleport").getQuantity() >= config.minBarrowsTeleports() &&
+                                    Rs2Inventory.count("Forgotten brew(4)") + Rs2Inventory.count("Forgotten brew(3)") >= config.minForgottenBrew() &&
+                                    Rs2Inventory.count("Prayer potion(4)") + Rs2Inventory.count("Prayer potion(3)") >= config.minPrayerPots() &&
+                                    Rs2Inventory.get(neededRune).getQuantity() >= config.minRuneAmount()) {
+                                Microbot.log("We have everything we need. Going back to barrows.");
                                 reJfount();
-                            }
-                        } else {
-                            if(Rs2Player.getRunEnergy() <= 5){
-                                if(Rs2Bank.isOpen()){
-                                    if(Rs2Bank.closeBank()){
-                                        sleepUntil(()-> Rs2Bank.isOpen(), Rs2Random.between(2000,4000));
+                                if (Rs2Bank.isOpen()) {
+                                    if (Rs2Bank.closeBank()) {
+                                        sleepUntil(() -> !Rs2Bank.isOpen(), Rs2Random.between(2000, 4000));
+                                        shouldBank = false;
                                     }
+                                } else {
+                                    shouldBank = false;
                                 }
-                                if(!Rs2Bank.isOpen()){
-                                    reJfount();
+
+                            }
+                        }
+
+                        if(usingPoweredStaffs) {
+                            if (Rs2Equipment.get(EquipmentInventorySlot.RING) != null && Rs2Inventory.contains("Spade") &&
+                                    Rs2Inventory.count(Rs2Inventory.getInventoryFood().get(0).getName()) >= config.minFood() &&
+                                    Rs2Inventory.get("Barrows teleport").getQuantity() >= config.minBarrowsTeleports() &&
+                                    Rs2Inventory.count("Forgotten brew(4)") + Rs2Inventory.count("Forgotten brew(3)") >= config.minForgottenBrew() &&
+                                    Rs2Inventory.count("Prayer potion(4)") + Rs2Inventory.count("Prayer potion(3)") >= config.minPrayerPots()) {
+                                Microbot.log("We have everything we need. Going back to barrows.");
+                                reJfount();
+                                if (Rs2Bank.isOpen()) {
+                                    if (Rs2Bank.closeBank()) {
+                                        sleepUntil(() -> !Rs2Bank.isOpen(), Rs2Random.between(2000, 4000));
+                                        shouldBank = false;
+                                    }
+                                } else {
+                                    shouldBank = false;
                                 }
+
                             }
                         }
 
@@ -822,6 +839,7 @@ public class BarrowsScript extends Script {
                         }
                         sleep(750,1500);
                         eatFood();
+                        suppliesCheck();
                         outOfSupplies();
                         antiPatternDropVials();
 
@@ -868,10 +886,10 @@ public class BarrowsScript extends Script {
     public void suppliesCheck(){
         if(!usingPoweredStaffs) {
             if (Rs2Equipment.get(EquipmentInventorySlot.RING) == null || !Rs2Inventory.contains("Spade") ||
-                    Rs2Inventory.count(Rs2Inventory.getInventoryFood().get(0).getName()) < 2 || (Rs2Inventory.get("Barrows teleport") == null)
-                    || Rs2Inventory.count(it->it!=null&&it.getName().contains("Forgotten brew(")) < minForgottenBrews ||
+                    Rs2Inventory.count(Rs2Inventory.getInventoryFood().get(0).getName()) < 2 || (Rs2Inventory.get("Barrows teleport") != null && Rs2Inventory.get("Barrows teleport").getQuantity() < 1)
+                    || Rs2Inventory.count("Forgotten brew(4)") + Rs2Inventory.count("Forgotten brew(3)") < minForgottenBrews ||
                     Rs2Inventory.count("Prayer potion(4)") + Rs2Inventory.count("Prayer potion(3)") < 1 ||
-                    Rs2Inventory.get(neededRune).getQuantity() <= minRuneAmt || Rs2Player.getRunEnergy() <= 5) {
+                    Rs2Inventory.get(neededRune).getQuantity() <= minRuneAmt) {
                 Microbot.log("We need to bank.");
                 if (Rs2Equipment.get(EquipmentInventorySlot.RING) == null) {
                     Microbot.log("We don't have a ring of dueling equipped.");
@@ -882,10 +900,10 @@ public class BarrowsScript extends Script {
                 if (Rs2Inventory.count(Rs2Inventory.getInventoryFood().get(0).getName()) < 2) {
                     Microbot.log("We have less than 2 food.");
                 }
-                if ((Rs2Inventory.get("Barrows teleport") == null)) {
+                if ((Rs2Inventory.get("Barrows teleport") != null && Rs2Inventory.get("Barrows teleport").getQuantity() < 1)) {
                     Microbot.log("We don't have a barrows teleport.");
                 }
-                if (Rs2Inventory.count(it->it!=null&&it.getName().contains("Forgotten brew(")) < minForgottenBrews) {
+                if (Rs2Inventory.count("Forgotten brew(4)") + Rs2Inventory.count("Forgotten brew(3)") < minForgottenBrews) {
                     Microbot.log("We forgot our Forgotten brew.");
                 }
                 if (Rs2Inventory.count("Prayer potion(4)") + Rs2Inventory.count("Prayer potion(3)") < 1) {
@@ -894,20 +912,19 @@ public class BarrowsScript extends Script {
                 if (Rs2Inventory.get(neededRune).getQuantity() <= minRuneAmt) {
                     Microbot.log("We have less than 180 " + neededRune);
                 }
-                if(Rs2Player.getRunEnergy() <= 5){
-                    Microbot.log("We need more run energy ");
-                }
                 shouldBank = true;
             } else {
-                shouldBank = false;
+                //if we're not all ready at the bank. This is needed because it could swap shouldBank to false while standing at the bank with 1 prayer potion
+                if (Rs2Player.getWorldLocation().distanceTo(BankLocation.FEROX_ENCLAVE.getWorldPoint()) > 40) {
+                    shouldBank = false;
+                }
             }
         }
         if(usingPoweredStaffs){
             if(Rs2Equipment.get(EquipmentInventorySlot.RING)==null || !Rs2Inventory.contains("Spade") ||
-                    Rs2Inventory.count(Rs2Inventory.getInventoryFood().get(0).getName())<2 || (Rs2Inventory.get("Barrows teleport") == null)
-                    || Rs2Inventory.count(it->it!=null&&it.getName().contains("Forgotten brew(")) < minForgottenBrews ||
-                    Rs2Inventory.count("Prayer potion(4)") + Rs2Inventory.count("Prayer potion(3)") < 1 || outOfPoweredStaffCharges
-                    || Rs2Player.getRunEnergy() <= 5){
+                    Rs2Inventory.count(Rs2Inventory.getInventoryFood().get(0).getName())<2 || (Rs2Inventory.get("Barrows teleport") !=null && Rs2Inventory.get("Barrows teleport").getQuantity() < 1)
+                    || Rs2Inventory.count("Forgotten brew(4)") + Rs2Inventory.count("Forgotten brew(3)") < minForgottenBrews ||
+                    Rs2Inventory.count("Prayer potion(4)") + Rs2Inventory.count("Prayer potion(3)") < 1){
                 Microbot.log("We need to bank.");
                 if(Rs2Equipment.get(EquipmentInventorySlot.RING)==null){
                     Microbot.log("We don't have a ring of dueling equipped.");
@@ -918,10 +935,10 @@ public class BarrowsScript extends Script {
                 if(Rs2Inventory.count(Rs2Inventory.getInventoryFood().get(0).getName())<2){
                     Microbot.log("We have less than 2 food.");
                 }
-                if((Rs2Inventory.get("Barrows teleport") ==null)){
+                if((Rs2Inventory.get("Barrows teleport") !=null && Rs2Inventory.get("Barrows teleport").getQuantity() < 1)){
                     Microbot.log("We don't have a barrows teleport.");
                 }
-                if(Rs2Inventory.count(it->it!=null&&it.getName().contains("Forgotten brew(")) < minForgottenBrews){
+                if(Rs2Inventory.count("Forgotten brew(4)") + Rs2Inventory.count("Forgotten brew(3)") < minForgottenBrews){
                     Microbot.log("We forgot our Forgotten brew.");
                 }
                 if(Rs2Inventory.count("Prayer potion(4)") + Rs2Inventory.count("Prayer potion(3)") < 1){
@@ -930,12 +947,12 @@ public class BarrowsScript extends Script {
                 if(outOfPoweredStaffCharges){
                     Microbot.log("We're out of staff charges.");
                 }
-                if(Rs2Player.getRunEnergy() <= 5){
-                    Microbot.log("We need more run energy ");
-                }
                 shouldBank = true;
             } else {
-                shouldBank = false;
+                //if we're not all ready at the bank. This is needed because it could swap shouldBank to false while standing at the bank with 1 prayer potion
+                if(Rs2Player.getWorldLocation().distanceTo(BankLocation.FEROX_ENCLAVE.getWorldPoint()) > 40){
+                    shouldBank = false;
+                }
             }
         }
     }
@@ -950,7 +967,6 @@ public class BarrowsScript extends Script {
                 if(currentTile.equals(FirstLoopTile)){
                     Microbot.log("We seem to be stuck. Resetting the walker");
                     stopFutureWalker();
-                    tunnelLoopCount = 0;
                 }
             }
         }
@@ -1029,7 +1045,6 @@ public class BarrowsScript extends Script {
         }
     }
     public void outOfSupplies(){
-        suppliesCheck();
         // Needed because the walker won't teleport to the enclave while in the tunnels or in a barrow
         if(shouldBank && (inTunnels || Rs2Player.getWorldLocation().getPlane() == 3)){
             if(Rs2Equipment.useRingAction(JewelleryLocationEnum.FEROX_ENCLAVE)){
@@ -1138,7 +1153,6 @@ public class BarrowsScript extends Script {
                         eatFood();
                         outOfSupplies();
                         antiPatternDropVials();
-                        drinkforgottonbrew();
 
                         if(!Rs2Prayer.isPrayerActive(neededprayer)){
                             Microbot.log("Turning on Prayer.");
@@ -1220,6 +1234,7 @@ public class BarrowsScript extends Script {
                     if(Rs2Inventory.contains("Forgotten brew(4)")) {
                         Rs2Inventory.interact("Forgotten brew(4)", "Drink");
                         sleep(300,1000);
+                        return;
                     }
                 }
             }
@@ -1303,6 +1318,23 @@ public class BarrowsScript extends Script {
         public Rs2WorldArea getHumpWP() { return humpWP; }
         public Rs2PrayerEnum getWhatToPray() { return whatToPray; }
 
+    }
+
+    public enum PoweredStaffs {
+        TRIDENT_OF_THE_SEAS_E ("Trident of the seas (e)", 10);
+
+        private String name;
+
+        private int ChargesLeft;
+
+        PoweredStaffs(String name, int chargesLeft){
+            this.name = name;
+            this.ChargesLeft = chargesLeft;
+        }
+
+        public String getName() { return name; }
+
+        public int getChargesLeft() { return ChargesLeft; }
     }
 
     @Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
@@ -21,7 +21,6 @@ import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
-import net.runelite.client.plugins.microbot.util.player.Rs2PlayerModel;
 import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Gembag;
@@ -30,8 +29,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Slf4j
 public class MotherloadMineScript extends Script
@@ -391,9 +388,6 @@ public class MotherloadMineScript extends Script
         int id = wallObject.getId();
         boolean isVein = (id == 26661 || id == 26662 || id == 26663 || id == 26664);
         if (!isVein) return false;
-
-        Stream<Rs2PlayerModel> players = Rs2Player.getPlayers(it -> it!=null && it.getWorldLocation().distanceTo(wallObject.getWorldLocation()) <= 2);
-        if (players.findAny().isPresent()) return false;
 
         if (config.mineUpstairs())
         {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/revKiller/revKillerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/revKiller/revKillerConfig.java
@@ -14,7 +14,7 @@ public interface revKillerConfig extends Config {
             description = "Select a Rev",
             position = 0
     )
-    default RevSelections selectedRev() {
+    default revKillerConfig.RevSelections selectedRev() {
         return RevSelections.IMP; // Default selection
     }
 
@@ -55,7 +55,7 @@ public interface revKillerConfig extends Config {
             description = "Select an arrow type",
             position = 0
     )
-    default ArrowSelections selectedArrow() {
+    default revKillerConfig.ArrowSelections selectedArrow() {
         return ArrowSelections.RUNE; // Default selection
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/revKiller/revKillerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/revKiller/revKillerPlugin.java
@@ -2,14 +2,12 @@ package net.runelite.client.plugins.microbot.revKiller;
 
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.MicrobotApi;
 import net.runelite.client.plugins.microbot.example.ExampleConfig;
 import net.runelite.client.plugins.microbot.example.ExampleOverlay;
@@ -28,9 +26,9 @@ import java.awt.*;
 @Slf4j
 public class revKillerPlugin extends Plugin {
     @Inject
-    private revKillerConfig config;
+    private net.runelite.client.plugins.microbot.revKiller.revKillerConfig config;
     @Provides
-    revKillerConfig provideConfig(ConfigManager configManager) {
+    net.runelite.client.plugins.microbot.revKiller.revKillerConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(revKillerConfig.class);
     }
 
@@ -56,7 +54,7 @@ public class revKillerPlugin extends Plugin {
         revKillerScript.startHealthCheck();
         revKillerScript.weDied = false;
         revKillerScript.shouldFlee = false;
-        eventBus.register(this);
+        eventBus.register(revKillerScript);
 
         revKillerScript.selectedWP = config.selectedRev().getWorldPoint();
         revKillerScript.selectedArrow = config.selectedArrow().getArrowID();
@@ -68,18 +66,9 @@ public class revKillerPlugin extends Plugin {
         revKillerScript.shouldFlee = false;
         revKillerScript.stopFutures();
         revKillerScript.shutdown();
-        eventBus.unregister(this);
+        eventBus.unregister(revKillerScript);
         overlayManager.remove(revKillerOverlay);
     }
-
-    @Subscribe
-    public void onActorDeath(ActorDeath event) {
-        //Thank you george!
-        if (event.getActor() == Microbot.getClient().getLocalPlayer()) {
-            revKillerScript.weDied = true;
-        }
-    }
-
     int ticks = 10;
     @Subscribe
     public void onGameTick(GameTick tick)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/revKiller/revKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/revKiller/revKillerScript.java
@@ -66,7 +66,7 @@ public class revKillerScript extends Script {
     long randomdelay = generateRandomNumber(350,1000);
     protected ScheduledFuture<?> checkForPKerFuture;
     protected ScheduledFuture<?> healthCheckFuture;
-    public static boolean weDied = false;
+    public boolean weDied = false;
     private boolean useTimedWorldHopper = false;
     private long howLongUntilHop = 0;
     public volatile boolean shouldFlee = false;
@@ -864,6 +864,14 @@ public class revKillerScript extends Script {
                     sleepUntil(()-> !Rs2Player.isMoving(), Rs2Random.between(4000,8000));
                 }
             }
+        }
+    }
+
+    @Subscribe
+    public void onActorDeath(ActorDeath event) {
+        //Thank you george!
+        if (event.getActor() == Microbot.getClient().getLocalPlayer()) {
+            weDied = true;
         }
     }
 


### PR DESCRIPTION
Reverts chsami/Microbot#992

No comments on changes made to plugins other than MLM. 

This MLM pull request has ruined the script for upper level mining. Worlds are too busy & there are too many players that use the upper level to include a players.findAny() check like this. My character frequently gets stuck in one position clicking the ground.

I added a log message to these MLM changes:

    Stream<Rs2PlayerModel> players = Rs2Player.getPlayers(it -> it!=null && it.getWorldLocation().distanceTo(wallObject.getWorldLocation()) <= 2);
    if (players.findAny().isPresent()) {
        Microbot.log("Script found another player too close - choosing another vein");
        return false;
    }

And now the subsequent screenshot

![image](https://github.com/user-attachments/assets/836465e3-447e-4f4e-9e94-056249d41423)
