### PR TITLE
Adds "Defence Pure Mode" to AIO Fighter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
@@ -987,6 +987,16 @@ public interface AIOFighterConfig extends Config {
         return new WorldPoint(0, 0, 0);
     }
 
+    @ConfigItem(
+            keyName = "monk_killer",
+            name = "Monk killer",
+            description = "Enable defence pure mode, goes to monestary and attacks monks",
+            position = 993
+    )
+    default boolean defencePureMode() {
+        return false;
+    }
+
 }
 
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
@@ -68,7 +68,7 @@ public class AIOFighterPlugin extends Plugin {
     public static int cooldown = 0;
     private final CannonScript cannonScript = new CannonScript();
     private final AttackNpcScript attackNpc = new AttackNpcScript();
-
+    private final MonkKillerScript defencePure = new MonkKillerScript();
     private final FoodScript foodScript = new FoodScript();
     private final LootScript lootScript = new LootScript();
     private final SafeSpot safeSpotScript = new SafeSpot();
@@ -148,6 +148,7 @@ public class AIOFighterPlugin extends Plugin {
         highAlchScript.run(config);
         potionManagerScript.run(config);
         safetyScript.run(config);
+        defencePure.run(config);
         //slayerScript.run(config);
         Microbot.getSpecialAttackConfigs()
                 .setSpecialAttack(true);
@@ -171,6 +172,7 @@ public class AIOFighterPlugin extends Plugin {
         highAlchScript.shutdown();
         potionManagerScript.shutdown();
         safetyScript.shutdown();
+        defencePure.shutdown();
         //slayerScript.shutdown();
         resetLocation();
         overlayManager.remove(playerAssistOverlay);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/MonkKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/MonkKillerScript.java
@@ -1,0 +1,218 @@
+package net.runelite.client.plugins.microbot.aiofighter;
+
+import net.runelite.api.Player;
+import net.runelite.api.coords.WorldArea;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.aiofighter.enums.State;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
+import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
+import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.player.Rs2PlayerModel;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+import javax.inject.Inject;
+import javax.swing.*;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static net.runelite.api.Skill.DEFENCE;
+import static net.runelite.client.plugins.microbot.util.walker.Rs2Walker.walkTo;
+
+public class MonkKillerScript extends Script {
+
+    @Inject
+    public MonkKillerScript() {
+
+    }
+
+    private final WorldArea monkArea = new WorldArea(3040, 3475, 23, 36, 0);
+    private final WorldPoint monkPoint = new WorldPoint(3052, 3491, 0);
+
+    public boolean run(AIOFighterConfig config) {
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!config.defencePureMode()) return;
+                if (config.state().equals(State.BANKING) || config.state().equals(State.WALKING))
+                    return;
+                if (!Microbot.isLoggedIn()) {
+                    Microbot.log("Not logged in, skipping tick.");
+                    return;}
+                if (!super.run()) {Microbot.log("super.run() returned false, skipping tick.");
+                    return;}
+                if (Microbot.getClient() == null || Microbot.getClient().getLocalPlayer() == null) {
+                    Microbot.log("Client or local player not ready. Skipping tick.");
+                    return;
+                }
+                if (BreakHandlerScript.breakIn <= 60) {
+                    Microbot.log("Break in less than 60 seconds, walking outside of monk's sanctuary");
+                    walkTo(3051,3470,0);
+                    Microbot.log("Turn on breakhandler if this is not desired behaviour");
+                    sleep(60000);} //sleep until break
+
+                if (Rs2Player.getRealSkillLevel(DEFENCE) >= config.defenceSkillTarget()) {
+                    JOptionPane.showMessageDialog(null, "The Script has Shut Down due to Defence Level reached");
+                    shutdown();
+                }
+
+                if (isInMonkArea() && !underAttack()) {
+                    Rs2NpcModel monk = findAvailableMonk();
+                    if (monk != null) {
+                        Microbot.log("monk is not null, entering attackMonk");
+                        if (!attackMonk(monk)) {
+                            Microbot.log("Failed to attack monk. Waiting...");
+                        }
+                    } else {
+                        Microbot.log("monk is null, sleeping a bit then if not under attack, logging out");
+                        sleep(5000,15000);
+                        if (!underAttack()) {hopWorld();}
+                    }
+                } else if (!isInMonkArea()){
+                    walkToMonkArea();
+                } else if (underAttack() && !Rs2Player.waitForXpDrop(DEFENCE, 30000)){
+                    Rs2NpcModel attackingMonk = findAttackingMonk();
+                    if (attackingMonk != null) {
+                        Microbot.log("attacking monk is not null");
+                        boolean noHealthBar = attackingMonk.getHealthRatio() == -1;
+                        Microbot.log("noHealthBar " + noHealthBar);
+                        if (noHealthBar) {
+                            Rs2Npc.interact(attackingMonk, "attack");
+                        }
+                        if (!Rs2Player.waitForXpDrop(DEFENCE, 30000) && noHealthBar) {Rs2Keyboard.enter();
+                            Microbot.log("pressed enter as fall-back to stimulate auto-retaliate");};
+                    } else {Microbot.log("attacking Monk is null");}
+                }
+                Rs2Player.eatAt(50);
+            } catch (Exception ex) {
+                Microbot.log("Fatal error in scheduled task: " + ex.getClass().getSimpleName() + ": " + ex.getMessage());
+                System.out.println(ex.getMessage());
+            }
+        }, 0, 2000, TimeUnit.MILLISECONDS); // Executes every 1000 milliseconds (1 second)
+        return true;
+    }
+
+    private boolean isInMonkArea() {
+        Rs2PlayerModel localPlayer = Rs2Player.getLocalPlayer();
+        if (localPlayer == null) {
+            Microbot.log("Local player is null in isInMonkArea");
+            return false;
+        }
+        return monkArea.contains(localPlayer.getWorldLocation());
+    }
+
+    private void walkToMonkArea() {
+        walkTo(monkPoint);  // Walk to a specific point in the monk area
+    }
+
+    private Rs2NpcModel findAttackingMonk() {
+        List<Rs2NpcModel> monks = Rs2Npc.getNpcsForPlayer("Monk", false);
+        return monks.isEmpty() ? null : monks.get(0);
+    }
+
+
+    private Rs2NpcModel findAvailableMonk() {
+        List<Rs2NpcModel> monks;
+        Rs2PlayerModel localPlayer = Rs2Player.getLocalPlayer();
+
+        if (localPlayer == null) {
+            Microbot.log("Local player is null in findAvailableMonk.");
+            return null;
+        }
+
+        try {
+            Stream<Rs2NpcModel> npcStream = Rs2Npc.getNpcs("Monk");
+
+            if (npcStream == null) {
+                Microbot.log("NPC stream is null, skipping this check.");
+                return null;
+            }
+
+            monks = npcStream.collect(Collectors.toList());
+        } catch (Exception e) {
+            Microbot.log("Error while getting monks: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            return null;
+        }
+
+        for (Rs2NpcModel monk : monks) {
+            if (!monk.isDead()
+                    && (!monk.isInteracting() || Objects.equals(monk.getInteracting(), localPlayer)
+                    && monk.getAnimation() == -1)) {
+                return monk;
+            }
+        }
+
+        return null; // No monk found
+    }
+
+
+    private boolean attackMonk(Rs2NpcModel monk) {
+        Player localPlayer = getLocalPlayer();
+
+        if (monk == null) {
+            Microbot.log("No monk found.");
+            return false;
+        }
+
+    if (underAttack() || (monk.isInteracting() && !Objects.equals(monk.getInteracting(),localPlayer))) {
+            Microbot.log("Monk is already in combat or we're under attack.");
+            return false;
+        }
+
+        WorldPoint monkLocation = monk.getWorldLocation();
+        WorldPoint playerLocation = localPlayer.getWorldLocation();
+        int distance = monkLocation.distanceTo(playerLocation);
+
+        // ✅ Only turn camera if monk is not visible
+        if (!Rs2Camera.isTileOnScreen(monk.getLocalLocation())) {
+            Rs2Camera.turnTo(monk);
+        }
+
+        if (distance > 3) {
+            Microbot.log("Monk is far, walking using minimap...");
+            Rs2Walker.walkMiniMap(monkLocation);
+        }
+
+        // Optional: wait until close before attacking
+        sleepUntil(() -> localPlayer.getWorldLocation().distanceTo(monk.getWorldLocation()) <= 3, 3000);
+
+        if (Rs2Npc.attack(monk)) {
+            Microbot.log("Attacking monk...");
+            return true;
+        }
+
+        Microbot.log("Failed to attack monk.");
+        return false;
+    }
+
+
+
+    private boolean underAttack() {
+        // Check if the player is interacting with any NPC
+        return Rs2Player.isInCombat();
+    }
+
+    private void hopWorld() {
+        Rs2Player.logout();
+    }
+
+    public Player getLocalPlayer() {
+        Player localPlayer = Microbot.getClient().getLocalPlayer();
+        if (localPlayer == null) {
+            throw new IllegalStateException("Local player is not available.");
+        }
+        return localPlayer;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/bank/BankerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/bank/BankerScript.java
@@ -64,6 +64,7 @@ public class BankerScript extends Script {
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
                 if (!Microbot.isLoggedIn()) return;
+                if (config.defencePureMode()) return;
                 if (config.bank() && needsBanking()) {
                     if (config.eatFoodForSpace())
                         if (Rs2Player.eatAt(100))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/combat/AttackNpcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/combat/AttackNpcScript.java
@@ -47,7 +47,7 @@ public class AttackNpcScript extends Script {
 
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                if (!Microbot.isLoggedIn() || !super.run() || !config.toggleCombat())
+                if (!Microbot.isLoggedIn() || !super.run() || !config.toggleCombat() || config.defencePureMode())
                     return;
 
                 if(config.centerLocation().distanceTo(Rs2Player.getWorldLocation()) < config.attackRadius() &&

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/loot/LootScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/loot/LootScript.java
@@ -30,7 +30,7 @@ public class LootScript extends Script {
                 minFreeSlots = config.bank() ? config.minFreeSlots() : 0;
                 if (!super.run()) return;
                 if (!Microbot.isLoggedIn()) return;
-                if (AIOFighterPlugin.getState().equals(State.BANKING) || AIOFighterPlugin.getState().equals(State.WALKING)) return;
+                if (AIOFighterPlugin.getState().equals(State.BANKING) || AIOFighterPlugin.getState().equals(State.WALKING) || config.defencePureMode()) return;
                 if (Rs2Inventory.isFull() || Rs2Inventory.getEmptySlots() <= minFreeSlots || (Rs2Combat.inCombat() && !config.toggleForceLoot()))
                     return;
 


### PR DESCRIPTION
1. When Monk Killer config is selected uses the same logic that's in the Monk Killer Plugin #944 
2. Disables banking and looting logic of aio fighter to stop "wrestling" of the bot, particularly if it starts in an area that isn't the monastery 
3. Disables NpcAttackScript