### PR TITLE
burn baking final 2 fixes, portal string's changed for ID's, final IDLE tracker for wildy killer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/MossKillerPlugin.java
@@ -94,15 +94,7 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
     private boolean useMelee = false;
     private boolean useRange = false;
 
-    public boolean firemethod = false;
-
-
     private int consecutiveHitsplatsMain = 0;
-    private int consecutiveHitsplatsSafeSpot1 = 0;
-    private long lastHitsplatTimeMain = 0;
-    private long lastHitsplatTimeSafeSpot1 = 0;
-    private static final long CONSECUTIVE_HITSPLAT_TIMEOUT = 3000; //
-
     private boolean runeScimitar = false;
 
     private final Object targetLock = new Object();
@@ -120,11 +112,12 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
     private boolean superNullTarget = false;
 
     private boolean isJammed;
+    private boolean superJammed;
 
     private boolean hitsplatIsTheirs = false;
 
     private int hitsplatSetTick = -1; // Initialize to an invalid tick value
-
+    private long lastHitsplatTimeMain = 0;
     // Tracks the nearby player condition
     private boolean isPlayerNearby = false;
 
@@ -293,6 +286,10 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
         return isJammed;
     }
 
+    public boolean isSuperJammed() {
+        return superJammed;
+    }
+
     public void resetWorldHopFlag() {
         worldHopFlag = false;
     }
@@ -417,9 +414,14 @@ public class MossKillerPlugin extends Plugin implements SchedulablePlugin {
                         isJammed = true;
                     }
 
+                    if (tickCount >= 500) {
+                        superJammed = true;
+                    }
+
                 } else {
                     tickCount = 0;
                     isJammed = false;
+                    superJammed = false;
                 }
             }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildyKillerScript.java
@@ -2260,7 +2260,10 @@ public class WildyKillerScript extends Script {
         }
         if (playerLocation.getY() > 9000) {
             Microbot.log("attempting to interact with the portal");
-            Rs2GameObject.interact("Portal", "Exit");
+            if (Rs2GameObject.exists(4389)) {Rs2GameObject.interact(4389, "Exit");}
+            else if (Rs2GameObject.exists(4390)) {
+                Rs2GameObject.interact(4390, "Exit");
+            }
             sleep(4000, 5000);
             return;
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bee/MossKiller/WildySaferScript.java
@@ -141,7 +141,7 @@ public class WildySaferScript extends Script {
                 // If you're not at moss giants but have prepared inventory, go to moss giants
                 if (!isInMossGiantArea() && equipmentIsPrepared()) {
                     System.out.println("not in moss giant area but we are prepared");
-                    if (config.attackStyle() == MAGIC && isEquippedWithRequiredItems() && isInventoryPreparedMage()) {walkTo(SAFESPOT);}
+                    if (config.attackStyle() == MAGIC && isEquippedWithRequiredItems() && isInventoryPreparedMage()) {walkTo(SAFESPOT);} else if (config.attackStyle() == MAGIC){doBankingLogic();}
                     if (config.attackStyle() == RANGE && isEquippedWithRequiredItemsRange() && isInventoryPreparedArcher()) {walkTo(SAFESPOT);}
                     // if you're not at moss giants but don't have prepared inventory, prepare inventory
                 }
@@ -258,8 +258,10 @@ public class WildySaferScript extends Script {
                 }
 
                 // Check if any players are near and hop if there are
-                playersCheck();
+                if (SAFE_ZONE_AREA.contains(Rs2Player.getWorldLocation())) playersCheck();
 
+                if (mossKillerPlugin.isSuperJammed()) {if (Rs2Inventory.items() == null) {Microbot.log("Inventory has returned null, doing banking logic");
+                    doBankingLogic();}}
 
                 long endTime = System.currentTimeMillis();
                 long totalTime = endTime - startTime;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/cooking/scripts/BurnBakingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/cooking/scripts/BurnBakingScript.java
@@ -403,8 +403,11 @@ public class BurnBakingScript extends Script {
                 }
             }
             // Step 5: If we already have flour and water in the inventory
-            else if (Rs2Inventory.hasItem("Pot of flour", true) && Rs2Inventory.hasItem("Bucket of water", true)) {
+            else if (Rs2Inventory.hasItem(POT_OF_FLOUR) && Rs2Inventory.hasItem(BUCKET_OF_WATER)) {
                 // Combine flour and water to make bread dough
+                if (Rs2Bank.isOpen()) {
+                    Rs2Bank.closeBank();
+                    sleep(900, 1300);}
 
                 Rs2Inventory.combineClosest("Pot of flour", "Bucket of water");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/cooking/scripts/BurnBakingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/cooking/scripts/BurnBakingScript.java
@@ -400,7 +400,7 @@ public class BurnBakingScript extends Script {
                         System.out.println("Missing ingredients in the bank for bread-making.");
                         Microbot.log("Could not find flour or water in the bank for bread-making.");
                     }
-                }
+                } else if (!Rs2Bank.isOpen() && Rs2Inventory.isEmpty()) {Rs2Bank.openBank();}
             }
             // Step 5: If we already have flour and water in the inventory
             else if (Rs2Inventory.hasItem(POT_OF_FLOUR) && Rs2Inventory.hasItem(BUCKET_OF_WATER)) {


### PR DESCRIPTION
1. added superJammed tracker for when idle for >5 minutes and inventory returns null (was strange glitch where inventory wasn't initialized, and therefore inventory checks wouldn't move the bot)
2. added an area check before checking for players as you only want to check for players and hop when in the safe zone
3. fixed 2 bugs in burn baking to do with preparing bread 
4. speeds up and stops unresponsiveness and null exception when using portal in castle wars in wildy killer by adding ID's rather than string's 
5. cleaning up unused wildy plugin variables 
6. gives an obviousand  final failsafe for magers in wildy safer that if you don't have equipment or inventory, to go do banking logic rather than just be idle