### PR TITLE
Update Prayer Helper for Chivalry unlock

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/zeroprayer/AttackTimerMetronomePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/zeroprayer/AttackTimerMetronomePlugin.java
@@ -656,7 +656,8 @@ public class AttackTimerMetronomePlugin extends Plugin
                         Rs2Player.getRealSkillLevel(Skill.PRAYER) >= Rs2PrayerEnum.PIETY.getLevel()) {
                     return Rs2PrayerEnum.PIETY;
                 }
-                if (Rs2Player.getRealSkillLevel(Skill.PRAYER) >= Rs2PrayerEnum.CHIVALRY.getLevel()) {
+                if (Microbot.getVarbitValue(CAMELOT_TRAINING_ROOM_STATUS) == 8 &&
+                        Rs2Player.getRealSkillLevel(Skill.PRAYER) >= Rs2PrayerEnum.CHIVALRY.getLevel()) {
                     return Rs2PrayerEnum.CHIVALRY;
                 }
                 if (Rs2Player.getRealSkillLevel(Skill.PRAYER) >= Rs2PrayerEnum.ULTIMATE_STRENGTH.getLevel()) {


### PR DESCRIPTION
Updating the the prayer picker logic for Chilvary to follow the same test for the Piety prayer. That is, King's Ransom quest must be finished and Knight Waves miniquest completed.

This fixes a minor bug encountered on my account :)