### PR TITLE
Fixed issue where GEcooker is stuck at Cooldown Active

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/sticktothescript/gecooker/GECookerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/sticktothescript/gecooker/GECookerScript.java
@@ -70,11 +70,6 @@ public class GECookerScript extends Script {
                 return;
             }
 
-            if (Rs2AntibanSettings.actionCooldownActive) {
-                debug("Cooldown active");
-                return;
-            }
-
             determineState(cookingItem, logType);
 
             // If the state is not cooking, then let's reset the variable as we are not expecting an XP drop


### PR DESCRIPTION
Fixed issue where its stuck at Cooldown Active after bank and 1st inventory cooked.
Removing the antiban check fixed the issue