### PR TITLE
Winemaker bugfix & GotR logic improvement

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/skilling/natewinemaker/WineOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/skilling/natewinemaker/WineOverlay.java
@@ -30,6 +30,7 @@ public class WineOverlay extends OverlayPanel {
 
             panelComponent.getChildren().add(LineComponent.builder()
                     .left(Microbot.status)
+                    .right("version: " + WineScript.version)
                     .build());
 
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/skilling/natewinemaker/WineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/skilling/natewinemaker/WineScript.java
@@ -1,16 +1,18 @@
 package net.runelite.client.plugins.microbot.nateplugins.skilling.natewinemaker;
 
+import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
 import java.util.concurrent.TimeUnit;
 
 public class WineScript extends Script {
 
-    public static double version = 1.1;
+    public static String version = "1.1.1";
 
     public boolean run(WineConfig config) {
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
@@ -37,17 +39,29 @@ public class WineScript extends Script {
         Rs2Bank.openBank();
         if(Rs2Bank.isOpen()){
             Rs2Bank.depositAll();
-            if(Rs2Bank.hasItem("jug of water") &&  Rs2Bank.hasItem("grapes")) {
+            if(Rs2Bank.hasBankItem("jug of water",14) &&  Rs2Bank.hasBankItem("grapes",14)) {
                 Rs2Bank.withdrawX(true, "jug of water", 14);
                 sleepUntil(() -> Rs2Inventory.hasItem("jug of water"));
                 Rs2Bank.withdrawX(true, "grapes", 14);
                 sleepUntil(() -> Rs2Inventory.hasItem("grapes"));
             } else {
                 Microbot.getNotifier().notify("Run out of Materials");
+                Rs2Bank.closeBank();
+                Rs2Player.logout();
+                Plugin wineMakerPlugin = Microbot.getPluginManager().getPlugins().stream()
+                        .filter(x -> x.getClass().getName().equals(WinePlugin.class.getName()))
+                        .findFirst()
+                        .orElse(null);
+                Microbot.stopPlugin(wineMakerPlugin);
                 shutdown();
             }
         }
         Rs2Bank.closeBank();
         sleepUntil(() -> !Rs2Bank.isOpen());
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
     }
 }


### PR DESCRIPTION
This pull request introduces updates to two scripts, `WineScript` and `GotrScript`, to enhance functionality, improve logic, and fix minor issues. The most notable changes include version updates, adjustments to inventory and banking logic in `WineScript`, and the introduction of an `optimizedEssenceLoop` flag alongside restructured logic in `GotrScript`.

### Updates to `WineScript`:
* **Version Update**: Updated `WineScript.version` from `1.1` to `1.1.1` and changed its type from `double` to `String`.
* **Banking Logic Enhancements**:
  - Replaced `hasItem` with `hasBankItem` to verify specific quantities of items in the bank.
  - Added logic to close the bank, log out the player, stop the plugin, and shut down the script when materials are insufficient.

### Updates to `GotrScript`:
* **Version Update**: Incremented `GotrScript.version` from `1.2.0` to `1.2.1`.
* **Optimized Essence Loop**:
  - Introduced a new `optimizedEssenceLoop` flag to streamline essence handling during mining and crafting.
  - Adjusted logic to prevent redundant actions when the flag is active, such as depositing runes or mining unnecessary resources. 
  
* **Inventory and Resource Management**:
  - Improved guardian fragment handling by dynamically calculating required quantities based on inventory and pouch capacity.
  - Modified mining behavior to skip certain actions if `GUARDIAN_ESSENCE` is already present in the inventory.