### PR TITLE
Rs2Player - Combat Potion Logic Enhancements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/scripts/PotionManagerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/scripts/PotionManagerScript.java
@@ -12,13 +12,11 @@ import java.util.concurrent.TimeUnit;
 
 public class PotionManagerScript extends Script {
     public boolean run(QoLConfig config) {
-        if (!config.enablePotionManager()) {
-            return false;
-        }
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
                 if (!Microbot.isLoggedIn()) return;
                 if (!super.run()) return;
+                if (!config.enablePotionManager()) return;
 
                 // Always attempt to drink anti-poison
                 if (Rs2Player.drinkAntiPoisonPotion()) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -1240,9 +1240,16 @@ public class Rs2Player {
      * @return {@code true} if a potion was successfully consumed, {@code false} otherwise.
      */
     public static boolean drinkCombatPotionAt(Skill skill, boolean superCombat) {
-        // If the current boosted level is already 5 or more above the real level, don't drink
-        if (Microbot.getClient().getBoostedSkillLevel(skill)
-                - Microbot.getClient().getRealSkillLevel(skill) > 5) {
+        int real = Microbot.getClient().getRealSkillLevel(skill);
+        int boosted = Microbot.getClient().getBoostedSkillLevel(skill);
+
+        // max boost per wiki: RealLevel * (15/100) + 5
+        double maxBoost = real * 0.15 + 5;
+
+        // threshold is 20% of that max
+        double threshold = maxBoost * 0.20;
+
+        if ((boosted - real) > threshold) {
             return false;
         }
 


### PR DESCRIPTION

### Potion Management Updates:
* [`PotionManagerScript.java`](diffhunk://#diff-f3a33d6753d52dd6fd0ba0be26481b06e9821b56365bb5d7df7ed9a211ec1566L15-R19): Moved the check for `config.enablePotionManager()` inside the scheduled task to ensure it is evaluated dynamically during execution rather than upfront.

### Combat Potion Logic Enhancements:
* [`Rs2Player.java`](diffhunk://#diff-c8d91e0689ac63a80e21760dbd0d3498ad0a82426223fc3d933d6be700a2f0ffL1243-R1252): Updated the logic for determining whether to drink a combat potion. The threshold for drinking is now based on a percentage (20%) of the maximum possible boost, calculated as `RealLevel * (15/100) + 5`, instead of a fixed value of 5 levels above the real level. This change aligns potion usage with more nuanced boost thresholds.