### PR TITLE
Fix enchant logic for lava item and magic level check

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magetrainingarena/enums/Rooms.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/magetrainingarena/enums/Rooms.java
@@ -25,7 +25,7 @@ public enum Rooms {
             () -> {
                 var magicLevel = Microbot.getClient().getBoostedSkillLevel(Skill.MAGIC);
                 MagicAction enchant;
-                if (magicLevel >= 87 && Rs2Inventory.hasItem("lava") || Rs2Equipment.isWearing("lava")) {
+                if (magicLevel >= 87 && Rs2Inventory.hasItem("lava") || (magicLevel >= 87 && Rs2Equipment.isWearing("lava"))) {
                     enchant = MagicAction.ENCHANT_ONYX_JEWELLERY;
                 } else if (magicLevel >= 68) {
                     enchant = MagicAction.ENCHANT_DRAGONSTONE_JEWELLERY;


### PR DESCRIPTION
Corrected the conditional to ensure both magic level and lava item/equipment are checked together for onyx enchantment. This prevents incorrect enchant selection when only one condition is met.