### PR TITLE
Exclude combat potion for Defence skill in superCombat

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -1255,7 +1255,12 @@ public class Rs2Player {
 
         // If superCombat is specified and the skill is Attack, Strength, or Defence, try super combat potions first
         if (superCombat && (skill == Skill.ATTACK || skill == Skill.STRENGTH || skill == Skill.DEFENCE)) {
-            if (usePotion(Rs2Potion.getCombatPotionsVariants().toArray(new String[0]))) {
+            // for Defence, exclude the basic "combat potion"
+            List<String> combatVariants = new ArrayList<>(Rs2Potion.getCombatPotionsVariants());
+            if (skill == Skill.DEFENCE) {
+                combatVariants.remove("combat potion");
+            }
+            if (usePotion(combatVariants.toArray(new String[0]))) {
                 return true;
             }
         }


### PR DESCRIPTION
When boosting Defence with superCombat, the basic 'combat potion' is now excluded from the list of usable potions. This ensures only appropriate potions are used for Defence boosts.