### PR TITLE
Tempoross - Harpoon Spec and Cloud logic

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossConfig.java
@@ -117,4 +117,14 @@ public interface TemporossConfig extends Config {
         return HarpoonType.INFERNAL_HARPOON;
     }
 
+    @ConfigItem(
+            keyName = "enableHarpoonSpec",
+            name = "Use Harpoon Special",
+            description = "Use the harpoon's special attack when attacking Tempoross.",
+            position = 2,
+            section = harpoonSection
+    )
+    default boolean enableHarpoonSpec() {
+        return true;
+    }
 }


### PR DESCRIPTION
**Added** complete support for Dragon, Infernal and Crystal Harpoon specs to activate when you are fishing from the Spirit Pool for the first time. 

**Changed** - When a cloud is blocking a fishing spot you normally only walk 1 tile outside of the cloud and then wait. Its now been changed to after you walk 1 tile outside the cloud you will immediately look for a new pool to fish from. If the pool that was blocked was a double fishing spot, it will go back to it after the cloud is gone. 

**Changed Tether priority** - Slightly better than it was before but might still have more work to go. 
If it would trigger travel to safe spot and then a wave would go off you would be caught without tethering. I changed it (still needs a little more work) to were if it catches it fast enough when this happens it will stop the move to location action and try to find the closest tether location. 