### PR TITLE
Replace Rs2Inventory.size() with count() across scripts

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/DeadFallTrapHunter/DeadFallTrapHunterScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/DeadFallTrapHunter/DeadFallTrapHunterScript.java
@@ -336,7 +336,7 @@ public class DeadFallTrapHunterScript extends Script {
         if (!Rs2Player.isAnimating() && !Rs2Player.isMoving()) {
             var gameObject = Rs2GameObject.getGameObject(location);
             if (gameObject != null) {
-                if (Rs2Inventory.size() > 24) {
+                if (Rs2Inventory.count() > 24) {
                     forceDrop = true;
                     Rs2Inventory.waitForInventoryChanges(8000);
                 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/DeadFallTrapHunter/DeadFallTrapInventoryHandlerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/DeadFallTrapHunter/DeadFallTrapInventoryHandlerScript.java
@@ -25,7 +25,7 @@ public class DeadFallTrapInventoryHandlerScript extends Script {
                 if (!script.forceDrop) {
                     if (Rs2Player.isMoving()) return;
                     if (Rs2Player.isAnimating()) return;
-                    if (Rs2Inventory.size() > Rs2Random.between(8, 28)) {
+                    if (Rs2Inventory.count() > Rs2Random.between(8, 28)) {
                         cleanInventory(config);
                     }
                     return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/salamanders/SalamanderGroundItemLooter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/salamanders/SalamanderGroundItemLooter.java
@@ -28,7 +28,7 @@ public class SalamanderGroundItemLooter extends Script {
                 if (Rs2Player.isMoving()) return;
                 if (Rs2Player.isAnimating()) return;
                 lootRobeAndNets();
-                if (Rs2Inventory.size() > 20) {
+                if (Rs2Inventory.count() > 20) {
                     cleanInventory();
                 }
             } catch (Exception ex) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
@@ -225,7 +225,7 @@ public class MotherloadMineScript extends Script
 
         while (Microbot.getVarbitValue(Varbits.SACK_NUMBER) > 0)
         {
-            if (Rs2Inventory.size() <= 2)
+            if (Rs2Inventory.count() <= 2)
             {
                 Rs2GameObject.interact(SACK_ID);
                 sleepUntil(this::hasOreInInventory);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
@@ -332,7 +332,7 @@ public class GotrScript extends Script {
     }
 
     private boolean usePortal() {
-        if (!isInHugeMine() && Microbot.getClient().hasHintArrow() && Rs2Inventory.size() < config.maxAmountEssence()) {
+        if (!isInHugeMine() && Microbot.getClient().hasHintArrow() && Rs2Inventory.count() < config.maxAmountEssence()) {
             if (leaveLargeMine()) return true;
             Rs2Walker.walkFastCanvas(Microbot.getClient().getHintArrowPoint());
             sleepUntil(Rs2Player::isMoving);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
@@ -549,9 +549,9 @@ public class Rs2Bank {
         }
 
         if (hasX && configuredX == amount) {
-            int before = Rs2Inventory.size();
+            int before = Rs2Inventory.count();
             invokeMenu(xSetOffset, rs2Item);
-            if (safe) return sleepUntilTrue(() -> Rs2Inventory.size() != before, 100, 2500);
+            if (safe) return sleepUntilTrue(() -> Rs2Inventory.count() != before, 100, 2500);
             return true;
         }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItem.java
@@ -266,7 +266,7 @@ public class Rs2GroundItem {
         RS2Item[] groundItems = Microbot.getClientThread().runOnClientThreadOptional(() ->
                 Rs2GroundItem.getAll(range)
         ).orElse(new RS2Item[] {});
-        final int invSize = Rs2Inventory.size();
+        final int invSize = Rs2Inventory.count();
         for (RS2Item rs2Item : groundItems) {
             if (!hasLineOfSight(rs2Item.getTile())) continue;
             long totalPrice = (long) Microbot.getClientThread().runOnClientThreadOptional(() ->
@@ -277,14 +277,14 @@ public class Rs2GroundItem {
                         Rs2Player.waitForAnimation();
                         boolean result = interact(rs2Item);
                         if (result) {
-                            sleepUntil(() -> invSize != Rs2Inventory.size());
+                            sleepUntil(() -> invSize != Rs2Inventory.count());
                         }
                         return result;
                     }
                 }
                 boolean result = interact(rs2Item);
                 if (result) {
-                    sleepUntil(() -> invSize != Rs2Inventory.size());
+                    sleepUntil(() -> invSize != Rs2Inventory.count());
                 }
                 return result;
             }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/vorkath/VorkathScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/vorkath/VorkathScript.java
@@ -399,16 +399,16 @@ public class VorkathScript extends Script {
                                     leaveVorkath();
                                     return;
                                 }
-                                final int invSize = Rs2Inventory.size();
+                                final int invSize = Rs2Inventory.count();
                                 Rs2Widget.clickWidget(39452678);
                                 sleep(600);
                                 Rs2Widget.clickWidget(39452678);
-                                sleepUntil(() -> Rs2Inventory.size() != invSize);
+                                sleepUntil(() -> Rs2Inventory.count() != invSize);
                                 boolean isWearingOriginalEquipment = rs2InventorySetup.wearEquipment();
                                 if (!isWearingOriginalEquipment) {
-                                    int finalInvSize = Rs2Inventory.size();
+                                    int finalInvSize = Rs2Inventory.count();
                                     Rs2Widget.clickWidget(39452678);
-                                    sleepUntil(() -> Rs2Inventory.size() != finalInvSize);
+                                    sleepUntil(() -> Rs2Inventory.count() != finalInvSize);
                                     rs2InventorySetup.wearEquipment();
                                 }
                             }


### PR DESCRIPTION
Updated multiple scripts to use Rs2Inventory.count() instead of size() for inventory checks. This change ensures consistency and may address potential issues with inventory size calculations.