### PR TITLE
fix(breakhandler): allow break countdown to continue during lock state

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
@@ -192,7 +192,7 @@ public class BreakHandlerScript extends Script {
         // Count down to next break
         if (breakIn >= 0 && breakDuration <= 0) {
             if (!(Rs2AntibanSettings.takeMicroBreaks && config.onlyMicroBreaks())) {
-                if(Microbot.isLoggedIn() && !isLockState()) {
+                if(Microbot.isLoggedIn()) {
                     breakIn--;
                 }
             }


### PR DESCRIPTION
**The Problem**: Previously, the break countdown timer (breakIn--) was checking `!isLockState()`, which meant the countdown would pause when in lock state. This caused timing issues because time was effectively not counting towards a break during lock states.

**Solution**: Removed the !isLockState() check from the countdown logic, allowing the timer to continue counting down even when locked. 