### PR TITLE
Small Tempoross and Fishing Trawler plugin fixes and improvements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/fishing/FishingTrawler/FishingTrawlerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/fishing/FishingTrawler/FishingTrawlerOverlay.java
@@ -23,7 +23,7 @@ public class FishingTrawlerOverlay extends OverlayPanel {
         try {
             panelComponent.setPreferredSize(new Dimension(200, 300));
             panelComponent.getChildren().add(TitleComponent.builder()
-                    .text("Micro Example V1.0.0")
+                    .text("Fishing Trawler V1.0.0")
                     .color(Color.GREEN)
                     .build());
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossOverlay.java
@@ -52,7 +52,9 @@ public class TemporossOverlay extends Overlay {
 
     @Override
     public Dimension render(Graphics2D graphics) {
-
+        if (!TemporossScript.isInMinigame()){
+            return null;
+        }
         // Render NPC overlays if the list is not null
         if (npcList != null) {
             for (Rs2NpcModel npc : npcList) {


### PR DESCRIPTION
**Tempoross Plugin**

- Fixed a occasional freeze near endgame (mass world) when inventory was full of raw fish by adjusting ordering and adding checks in handleStateLoop. Now, after filling inventory, the character stays near the pool if energy is too low instead of fishing again.
- Fixed BreakHandler lock being released at incorrect times, which caused the character to go AFK inside the minigame.
- Added null checks to prevent occasional null exceptions.
- Stopped the overlay from trying to render outside the minigame, preventing errors that were popping before going inside the minigame again.

State logic changes were made so it doesn't affect the solo logic as I wouldn't be able to test it.

**Fishing Trawler**

- Added BreakHandler support
- Small changes on the tentacle attacking logic 
- Camera now tries looking to the tentacle when it spawns
- Small typo correction on the overlay