### PR TITLE
feat(MicrobotMouseOverlay): overlay set as naughty to not appear on screenshots

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/MicrobotClickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/MicrobotClickOverlay.java
@@ -21,6 +21,7 @@ public class MicrobotClickOverlay extends Overlay {
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ABOVE_WIDGETS);
         setPriority(Overlay.PRIORITY_LOW);
+        setNaughty();
     }
 
     @Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/MicrobotMouseOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/MicrobotMouseOverlay.java
@@ -28,6 +28,7 @@ public class MicrobotMouseOverlay extends Overlay {
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ABOVE_WIDGETS);
         setPriority(Overlay.PRIORITY_LOW);
+        setNaughty();
         // Increase the angle
         new Thread(() -> {
             try {


### PR DESCRIPTION
To avoid this happening on certain achievements:

<img width="425" height="144" alt="image" src="https://github.com/user-attachments/assets/43963f51-bead-4ce3-af38-ac1f37f06a27" />
