### PR TITLE
Solo royal titans mode + Dodgy necklace bugfix for Thieving script

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansConfig.java
@@ -93,11 +93,22 @@ public interface RoyalTitansConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "soloMode",
+            name = "Enable solo mode?",
+            description = "If enabled, the bot will fight the boss alone - Requires you to have the Twinflame staff",
+            section = generalSection,
+            position = 3
+    )
+    default boolean soloMode() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "waitingTimeForTeammate",
             name = "The amount of time (in seconds) to wait for your teammate at the entrance",
             description = "The amount of time (in seconds) to wait for your teammate before shutting down the script.",
             section = generalSection,
-            position = 3
+            position = 4
     )
     default int waitingTimeForTeammate() {
         return 600;
@@ -329,7 +340,7 @@ public interface RoyalTitansConfig extends Config {
 
     enum RoyalTitan {ICE_TITAN, FIRE_TITAN}
 
-    enum Minions {ICE_MINIONS, FIRE_MINIONS}
+    enum Minions {ICE_MINIONS, FIRE_MINIONS, NONE}
 
     enum LootingTitan {ICE_TITAN, FIRE_TITAN, ALTERNATE, RANDOM}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansLooterScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansLooterScript.java
@@ -9,6 +9,7 @@ import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2Prayer;
 
 import javax.inject.Inject;
 import java.time.Instant;
@@ -46,6 +47,8 @@ public class RoyalTitansLooterScript extends Script {
                 if (iceTitan != null && !iceTitan.isDead() || fireTitan != null && !fireTitan.isDead()) {
                     return;
                 }
+                // Both titans are dead, ensure prayer is off
+                Rs2Prayer.disableAllPrayers();
                 // Both titans are dead and we have looted - Check ground for items
                 if (fireTitanDead != null && iceTitanDead != null) {
                     royalTitansScript.subState = "Looting ground items";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansLooterScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansLooterScript.java
@@ -2,8 +2,10 @@ package net.runelite.client.plugins.microbot.TaF.RoyalTitans;
 
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.Rs2InventorySetup;
 import net.runelite.client.plugins.microbot.util.grounditem.LootingParameters;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
@@ -53,7 +55,7 @@ public class RoyalTitansLooterScript extends Script {
                     lootUntradeableItems(config);
                 }
                 if (LootedTitanLastIteration) {
-                    if (lastLootTime.plusSeconds(30).isBefore(Instant.now())) {
+                    if (lastLootTime.plusSeconds(15).isBefore(Instant.now())) {
                         // If 30 seconds have passed, reset the flag and try looting again
                         LootedTitanLastIteration = false;
                         Microbot.log("30 seconds passed since last loot - trying again");
@@ -94,7 +96,7 @@ public class RoyalTitansLooterScript extends Script {
                         break;
                 }
                 if (looted && !LootedTitanLastIteration) {
-                    Rs2Player.waitForAnimation(2400);
+                    Rs2Inventory.waitForInventoryChanges(2400);
                     royalTitansScript.kills++;
                     LootedTitanLastIteration = true;
                     lastLootTime = Instant.now();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansScript.java
@@ -170,6 +170,13 @@ public class RoyalTitansScript extends Script {
     }
 
     private void handleWaiting(RoyalTitansConfig config) {
+        if (config.soloMode() && config.teammateName().isEmpty()) {
+            state = RoyalTitansBotStatus.TRAVELLING;
+            travelStatus = RoyalTitansTravelStatus.TO_INSTANCE;
+            evaluateAndConsumePotions(config);
+            sleep(1200, 2400);
+            return;
+        }
         var teammate = Rs2Player.getPlayers(x -> Objects.equals(x.getName(), config.teammateName())).findFirst().orElse(null);
         if (waitingTimeStart == null && teammate == null && !waitedLastIteration) {
             waitingTimeStart = Instant.now();
@@ -249,6 +256,7 @@ public class RoyalTitansScript extends Script {
             } else {
                 enrageTile = null;
                 Rs2GameObject.interact(TUNNEL_ID_ESCAPE, "Quick-escape");
+                Rs2Bank.walkToBank();
             }
             state = RoyalTitansBotStatus.TRAVELLING;
             travelStatus = RoyalTitansTravelStatus.TO_BANK;
@@ -309,6 +317,9 @@ public class RoyalTitansScript extends Script {
     }
 
     private void handleSpecialAttacks(RoyalTitansConfig config, Rs2NpcModel titan) {
+        if (!config.useSpecialAttacks()) {
+            return;
+        }
         var specEnergy = Rs2Combat.getSpecEnergy() / 10;
         if (specEnergy < config.specEnergyConsumed()) {
             return;
@@ -342,14 +353,13 @@ public class RoyalTitansScript extends Script {
     }
 
     private void handleBossFocus(RoyalTitansConfig config, Rs2NpcModel iceTitan, Rs2NpcModel fireTitan) {
+        // Handle enrage tile first
         if (enrageTile != null) {
             subState = "Handling enrage tile";
-            if (Rs2Player.getWorldLocation().equals(enrageTile.getWorldLocation())) {
-                equipArmor(rangedInventorySetup);
-            } else {
+            if (!Rs2Player.getWorldLocation().equals(enrageTile.getWorldLocation())) {
                 Rs2Walker.walkFastCanvas(enrageTile.getWorldLocation());
-                equipArmor(rangedInventorySetup);
             }
+            equipArmor(rangedInventorySetup);
 
             if (fireTitan != null && !fireTitan.isDead()) {
                 Rs2Npc.attack(fireTitan);
@@ -361,6 +371,48 @@ public class RoyalTitansScript extends Script {
                 return;
             }
         }
+
+        // Solo mode - balance titan health
+        if (config.soloMode()) {
+            subState = "Solo mode - balancing titan health";
+            Rs2NpcModel targetTitan = selectTitanForSoloMode(iceTitan, fireTitan);
+            if (targetTitan != null && !targetTitan.isDead()) {
+                int titanX = targetTitan.getWorldLocation().getRegionX();
+
+                // Select appropriate gear based on titan position
+                if (enrageTile == null && (
+                        (targetTitan.getId() == FIRE_TITAN_ID && titanX == MELEE_TITAN_FIRE_REGION_X) ||
+                                (targetTitan.getId() == ICE_TITAN_ID && titanX == MELEE_TITAN_ICE_REGION_X) ||
+                                (titanX > MELEE_TITAN_FIRE_REGION_X && titanX < MELEE_TITAN_ICE_REGION_X))) {
+                    equipArmor(meleeInventorySetup);
+                } else {
+                    equipArmor(rangedInventorySetup);
+                }
+
+                // Don't try to attack a Titan if enragetile is active and we are wearing melee armor
+                if (!(enrageTile != null && meleeInventorySetup.doesEquipmentMatch())) {
+                    Rs2Npc.attack(targetTitan);
+                    handleSpecialAttacks(config, targetTitan);
+                }
+            }
+            return;
+        }
+
+        // Both bosses alive - Handle focus
+        if (config.royalTitanToFocus() == RoyalTitansConfig.RoyalTitan.FIRE_TITAN && fireTitan != null && !fireTitan.isDead()) {
+            subState = "Attacking fire titan";
+            int fireX = fireTitan.getWorldLocation().getRegionX();
+            if (enrageTile == null && (fireX == MELEE_TITAN_FIRE_REGION_X ||
+                    (fireX > MELEE_TITAN_FIRE_REGION_X && fireX < MELEE_TITAN_ICE_REGION_X))) {
+                equipArmor(meleeInventorySetup);
+            } else {
+                equipArmor(rangedInventorySetup);
+            }
+            Rs2Npc.attack(fireTitan);
+            handleSpecialAttacks(config, fireTitan);
+            return;
+        }
+
         // Both bosses alive - Handle focus
         if (config.royalTitanToFocus() == RoyalTitansConfig.RoyalTitan.FIRE_TITAN && fireTitan != null && !fireTitan.isDead()) {
             subState = "Attacking fire titan";
@@ -420,18 +472,33 @@ public class RoyalTitansScript extends Script {
     }
 
     private boolean handleWalls(RoyalTitansConfig config) {
+        if (config.minionResponsibility() == RoyalTitansConfig.Minions.NONE) {
+            return false;
+        }
         subState = "Handling walls";
-        var walls = Rs2Npc.getNpcs(config.minionResponsibility() == RoyalTitansConfig.Minions.FIRE_MINIONS ? FIRE_WALL : ICE_WALL).collect(Collectors.toList());
-        if (walls.isEmpty()) {
+
+        // For solo mode, handle both types of walls
+        List<Rs2NpcModel> walls;
+        if (config.soloMode()) {
+            List<Rs2NpcModel> fireWalls = Rs2Npc.getNpcs(FIRE_WALL).collect(Collectors.toList());
+            List<Rs2NpcModel> iceWalls = Rs2Npc.getNpcs(ICE_WALL).collect(Collectors.toList());
+            walls = new ArrayList<>();
+            walls.addAll(fireWalls);
+            walls.addAll(iceWalls);
+        } else {
+            walls = Rs2Npc.getNpcs(config.minionResponsibility() == RoyalTitansConfig.Minions.FIRE_MINIONS ? FIRE_WALL : ICE_WALL)
+                    .collect(Collectors.toList());
+        }
+
+        if (walls.isEmpty() || walls.size() < 8) {
             return false;
         }
-        if (walls.size() < 8) {
-            return false;
-        }
+
         equipArmor(magicInventorySetup);
         for (var wall : walls) {
             if (wall != null && wall.getId() != -1 && !wall.isDead()) {
-                Rs2Npc.interact(wall, config.minionResponsibility() == RoyalTitansConfig.Minions.FIRE_MINIONS ? "Douse" : "Melt");
+                String action = wall.getId() == FIRE_WALL ? "Douse" : "Melt";
+                Rs2Npc.interact(wall, action);
             }
         }
 
@@ -439,18 +506,64 @@ public class RoyalTitansScript extends Script {
     }
 
     private boolean handleMinions(RoyalTitansConfig config) {
+        if (config.minionResponsibility() == RoyalTitansConfig.Minions.NONE) {
+            return false;
+        }
         subState = "Handling minions";
-        var minions = Rs2Npc.getNpcs(config.minionResponsibility() == RoyalTitansConfig.Minions.FIRE_MINIONS ? FIRE_MINION_ID : ICE_MINION_ID).collect(Collectors.toList());
+
+        // For solo mode, handle both types of minions
+        List<Rs2NpcModel> minions;
+        if (config.soloMode()) {
+            List<Rs2NpcModel> fireMinions = Rs2Npc.getNpcs(FIRE_MINION_ID).collect(Collectors.toList());
+            List<Rs2NpcModel> iceMinions = Rs2Npc.getNpcs(ICE_MINION_ID).collect(Collectors.toList());
+            minions = new ArrayList<>();
+            minions.addAll(fireMinions);
+            minions.addAll(iceMinions);
+        } else {
+            minions = Rs2Npc.getNpcs(config.minionResponsibility() == RoyalTitansConfig.Minions.FIRE_MINIONS ? FIRE_MINION_ID : ICE_MINION_ID)
+                    .collect(Collectors.toList());
+        }
+
         if (minions.isEmpty()) {
             return false;
         }
+
         equipArmor(magicInventorySetup);
         for (var minion : minions) {
             if (minion != null && !minion.isDead()) {
                 Rs2Npc.attack(minion);
             }
         }
+
         return true;
+    }
+
+    private Rs2NpcModel selectTitanForSoloMode(Rs2NpcModel iceTitan, Rs2NpcModel fireTitan) {
+        if (iceTitan == null || iceTitan.isDead()) return fireTitan;
+        if (fireTitan == null || fireTitan.isDead()) return iceTitan;
+
+        // Get health ratios
+        double iceHealthRatio = iceTitan.getHealthRatio();
+        double fireHealthRatio = fireTitan.getHealthRatio();
+
+        // If one titan has significantly more health, attack that one
+        // Using a 20% threshold to prevent frequent switching
+        if (iceHealthRatio > fireHealthRatio + 20) {
+            return iceTitan;
+        } else if (fireHealthRatio > iceHealthRatio + 20) {
+            return fireTitan;
+        }
+
+        // If we're already in combat, don't switch targets
+        if (Rs2Player.isInCombat()) {
+            var interacting = Microbot.getClient().getLocalPlayer().getInteracting();
+
+            if (interacting == iceTitan) return iceTitan;
+            if (interacting == fireTitan) return fireTitan;
+        }
+
+        // Default: attack the one with slightly higher health
+        return iceHealthRatio >= fireHealthRatio ? iceTitan : fireTitan;
     }
 
     private void handleDangerousTiles() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansScript.java
@@ -360,7 +360,18 @@ public class RoyalTitansScript extends Script {
                 Rs2Walker.walkFastCanvas(enrageTile.getWorldLocation());
             }
             equipArmor(rangedInventorySetup);
-
+            // Handle focus properly based on config
+            if (config.royalTitanToFocus() == RoyalTitansConfig.RoyalTitan.FIRE_TITAN && fireTitan != null && fireTitan.isDead()) {
+                Rs2Npc.attack(fireTitan);
+                handleSpecialAttacks(config, fireTitan);
+                return;
+            }
+            if (config.royalTitanToFocus() == RoyalTitansConfig.RoyalTitan.ICE_TITAN && iceTitan != null && iceTitan.isDead()) {
+                Rs2Npc.attack(iceTitan);
+                handleSpecialAttacks(config, iceTitan);
+                return;
+            }
+            // Fallback if focused titan is dead
             if (fireTitan != null && !fireTitan.isDead()) {
                 Rs2Npc.attack(fireTitan);
                 handleSpecialAttacks(config, fireTitan);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansScript.java
@@ -340,6 +340,7 @@ public class RoyalTitansScript extends Script {
         if (meleeInventorySetup.doesEquipmentMatch() && config.specialAttackWeaponStyle() == RoyalTitansConfig.SpecialAttackWeaponStyle.MELEE) {
             specialAttackInventorySetup.wearEquipment();
             Rs2Combat.setSpecState(true, config.specEnergyConsumed() * 10);
+            sleepUntil(Rs2Combat::getSpecState);
             Rs2Npc.attack(titan);
             Rs2Player.waitForAnimation(600);
             return;
@@ -347,6 +348,7 @@ public class RoyalTitansScript extends Script {
         if ((magicInventorySetup.doesEquipmentMatch() || rangedInventorySetup.doesEquipmentMatch()) && config.specialAttackWeaponStyle() == RoyalTitansConfig.SpecialAttackWeaponStyle.RANGED) {
             specialAttackInventorySetup.wearEquipment();
             Rs2Combat.setSpecState(true, config.specEnergyConsumed() * 10);
+            sleepUntil(Rs2Combat::getSpecState);
             Rs2Npc.attack(titan);
             Rs2Player.waitForAnimation(600);
         }
@@ -744,11 +746,13 @@ public class RoyalTitansScript extends Script {
                 inventorySetup.loadInventory();
             }
 			if (!inventorySetup.getAdditionalItems().isEmpty()) {
+                Microbot.log("Pre-potting with additional items");
 				inventorySetup.prePot();
 			}
             Rs2Bank.closeBank();
             travelStatus = RoyalTitansTravelStatus.TO_TITANS;
             state = RoyalTitansBotStatus.TRAVELLING;
+            subState = "Walking to titans";
         } else {
             var items = inventorySetup.getEquipmentItems();
             var inventory = inventorySetup.getInventoryItems();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansScript.java
@@ -664,14 +664,16 @@ public class RoyalTitansScript extends Script {
                     return;
                 }
                 subState = "Walking to bank";
-                var isAtBank = Rs2Bank.walkToBank();
+                Rs2Bank.walkToBank();
+                var isAtBank = Rs2Bank.isNearBank(5);
                 if (isAtBank) {
                     state = RoyalTitansBotStatus.BANKING;
                 }
                 break;
             case TO_TITANS:
                 subState = "Walking to titans";
-                var gotToTitans = Rs2Walker.walkTo(BOSS_LOCATION, 1);
+                Rs2Walker.walkTo(BOSS_LOCATION, 1);
+                var gotToTitans = Rs2Player.distanceTo(BOSS_LOCATION) < 3;
                 if (gotToTitans) {
                     state = RoyalTitansBotStatus.WAITING;
                     travelStatus = RoyalTitansTravelStatus.TO_BANK;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansShared.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/RoyalTitans/RoyalTitansShared.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.TaF.RoyalTitans;
 
+import net.runelite.api.Skill;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.misc.Rs2Potion;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
@@ -20,6 +21,15 @@ public class RoyalTitansShared {
 
         if (!isCombatPotionActive(threshold)) {
             consumePotion(Rs2Potion.getCombatPotionsVariants());
+            if (Rs2Player.drinkCombatPotionAt(Skill.STRENGTH)) {
+                Rs2Player.waitForAnimation();
+            }
+            if (Rs2Player.drinkCombatPotionAt(Skill.ATTACK)) {
+                Rs2Player.waitForAnimation();
+            }
+            if (Rs2Player.drinkCombatPotionAt(Skill.DEFENCE)) {
+                Rs2Player.waitForAnimation();
+            }
         }
 
         if (!isRangingPotionActive(threshold)) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/thieving/ThievingScript.java
@@ -134,7 +134,7 @@ public class ThievingScript extends Script {
 
     private boolean hasReqs() {
         boolean hasFood = Rs2Inventory.getInventoryFood().size() >= config.foodAmount();
-        boolean hasDodgy = Rs2Inventory.hasItem("Dodgy necklace");
+        boolean hasDodgy = Rs2Inventory.hasItem("Dodgy necklace") || config.dodgyNecklaceAmount() == 0;
 
         if (config.shadowVeil()) {
             boolean hasCosmic = Rs2Inventory.hasItem("Cosmic rune");


### PR DESCRIPTION
This pull request introduces a new "solo mode" feature for the Royal Titans bot, refines boss and minion handling logic, and includes minor adjustments to other scripts. The most significant changes involve adding configuration options and logic for solo play, improving the handling of special attacks, and enhancing the bot's adaptability during combat.

### Royal Titans Bot Enhancements:

* **Solo Mode Configuration and Logic**:
  - Added a new `soloMode` configuration option to enable solo play, allowing the bot to fight bosses alone. This includes logic to balance titan health and handle both minions and walls in solo mode. (`RoyalTitansConfig.java`, `RoyalTitansScript.java`) [[1]](diffhunk://#diff-d455a0e4cd3fe1f22edf0b0a7be5c1c885d0a32158bf263fb8ef9c24aa982761R95-R111) [[2]](diffhunk://#diff-581692b3f8e53baf94ab2769db5d24afc832712f4d0f4577147ac9b892500aa5R385-R426) [[3]](diffhunk://#diff-581692b3f8e53baf94ab2769db5d24afc832712f4d0f4577147ac9b892500aa5L423-R579)
  - Introduced a `NONE` option for `Minions` to disable minion handling. (`RoyalTitansConfig.java`)

* **Combat and Focus Improvements**:
  - Updated `handleBossFocus` to prioritize titan selection based on health ratios. (`RoyalTitansScript.java`) [[1]](diffhunk://#diff-581692b3f8e53baf94ab2769db5d24afc832712f4d0f4577147ac9b892500aa5R356-R374) [[2]](diffhunk://#diff-581692b3f8e53baf94ab2769db5d24afc832712f4d0f4577147ac9b892500aa5R385-R426)
  - Bugfix for `handleSpecialAttacks` to skip special attacks if disabled in the configuration. (`RoyalTitansScript.java`)

* **Escape and Travel Logic**:
  - Bugfix for walking to the bank after escaping the boss area. (`RoyalTitansScript.java`)

### Minor Adjustments:

* **Thieving Script Update**:
  - Modified the check for the "Dodgy necklace" to allow bypassing if the configured amount is zero. (`ThievingScript.java`)