### PR TITLE
Walker Changes - kharedst's memoirs identifier offset

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -2273,10 +2273,11 @@ public class Rs2Walker {
                 lowerCaseItemName.contains("slayer ring") ||
 				lowerCaseItemName.contains("construct. cape")) {
             return 4;
-        } else if (lowerCaseItemName.contains("kharedst's memoirs") ||
+        } else if (lowerCaseItemName.contains("book of the dead") ||
                    lowerCaseItemName.contains("giantsoul amulet")) {
             return 3;
-        } else if (lowerCaseItemName.contains("enchanted lyre")) {
+        } else if (lowerCaseItemName.contains("kharedst's memoirs") ||
+			       lowerCaseItemName.contains("enchanted lyre")) {
             return 2;
         } else {
             return 4; // Default offset if no match is found

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
@@ -290,11 +290,16 @@
 2336 3802 0		23458		4494=1		Y	F	19	4	4. Enchanted lyre(i): Neitiznot
 3105 9315 2		6707		1574>0		Y	F	19	4	1. Camulet: Enakhra's Temple
 3191 2924 0		6707		4485=1;1574>0		Y	F	19	4	2. Camulet: Enakhra's Temple Entrance
-1713 3612 0		21760;25818	The Depths of Despair	6028=1;6035>1		Y	T	19	4	1. Kharedst's memoirs: Lunch by the Lancalliums
-1802 3748 0		21760;25818	The Queen of Thieves	6038=1;6035>1		Y	T	19	4	2. Kharedst's memoirs: The Fisher's Flute
-1478 3576 0		21760;25818	Tale of the Righteous	6359=1;6035>1		Y	T	19	4	3. Kharedst's memoirs: History and Hearsay
-1544 3762 0		21760;25818	The Forsaken Tower	7801=1;6035>1		Y	T	19	4	4. Kharedst's memoirs: Jewellery of Jubilation
-1680 3746 0		21760;25818	The Ascent of Arceuus	7857=1;6035>1		Y	T	19	4	5. Kharedst's memoirs: A Dark Disposition
+1713 3612 0		21760	The Depths of Despair	6028=1;6035>1		Y	T	19	4	1. Kharedst's memoirs: Lunch by the Lancalliums
+1802 3748 0		21760	The Queen of Thieves	6038=1;6035>1		Y	T	19	4	2. Kharedst's memoirs: The Fisher's Flute
+1478 3576 0		21760	Tale of the Righteous	6359=1;6035>1		Y	T	19	4	3. Kharedst's memoirs: History and Hearsay
+1544 3762 0		21760	The Forsaken Tower	7801=1;6035>1		Y	T	19	4	4. Kharedst's memoirs: Jewellery of Jubilation
+1680 3746 0		21760	The Ascent of Arceuus	7857=1;6035>1		Y	T	19	4	5. Kharedst's memoirs: A Dark Disposition
+1713 3612 0		25818	The Depths of Despair	6028=1;6035>1		Y	T	19	4	1. Book of the dead: Lunch by the Lancalliums
+1802 3748 0		25818	The Queen of Thieves	6038=1;6035>1		Y	T	19	4	2. Book of the dead: The Fisher's Flute
+1478 3576 0		25818	Tale of the Righteous	6359=1;6035>1		Y	T	19	4	3. Book of the dead: History and Hearsay
+1544 3762 0		25818	The Forsaken Tower	7801=1;6035>1		Y	T	19	4	4. Book of the dead: Jewellery of Jubilation
+1680 3746 0		25818	The Ascent of Arceuus	7857=1;6035>1		Y	T	19	4	5. Book of the dead: A Dark Disposition
 3649 3230 0		22400				Y	F	19	4	Drakan's medallion: Ver Sinhaza
 3592 3337 0		22400	Sins of the Father			Y	F	19	4	Drakan's medallion: Darkmeyer
 # todo: this only works if you've used a Slepey tablet on the medallion										


### PR DESCRIPTION
This pull request breaks up the kharedst's memoirs & book of the dead transports

These are separated due to the identifier offset being different for the two items.

