### PR TITLE
Add Pendant of Ates & Fix Quetzal in Tal Teklan

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -2150,7 +2150,7 @@ public class Rs2Walker {
 
         Rs2NpcModel renu = Rs2Npc.getNpc(NpcID.QUETZAL_CHILD_GREEN);
 
-        if (Rs2Npc.canWalkTo(renu, 20) && Rs2Npc.interact(renu, "travel")) {
+        if (Rs2Tile.isTileReachable(transport.getOrigin()) && Rs2Npc.interact(renu, "travel")) {
             Rs2Player.waitForWalking();
             boolean isVarlamoreMapVisible = sleepUntilTrue(() -> Rs2Widget.isWidgetVisible(VARLAMORE_QUETZAL_MAP), 100, 10000);
             
@@ -2274,7 +2274,8 @@ public class Rs2Walker {
             return 6;
         } else if (lowerCaseItemName.contains("xeric's talisman") ||
                 lowerCaseItemName.contains("slayer ring") ||
-				lowerCaseItemName.contains("construct. cape")) {
+				lowerCaseItemName.contains("construct. cape") ||
+				lowerCaseItemName.contains("pendant of ates")) {
             return 4;
         } else if (lowerCaseItemName.contains("book of the dead") ||
                    lowerCaseItemName.contains("giantsoul amulet")) {

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
@@ -23,7 +23,7 @@
 2339 3649 0		13143;13144				Y	F	19	4	Western banner
 # Explorer's Ring (2 has 3 teleports per day, 3 and 4 are unlimited)										
 3052 3291 0		13126		4552<3		Y	T	19	4	Explorer's ring: Teleport
-3052 3291 0		13127;13128				Y	F	19	4	Explorer's ring
+3052 3291 0		13127;13128				Y	F	19	4	Explorer's ring: Teleport
 # Rada's Blessing (Kourend Woodland, 1 has 3 teleports, 2 has 5 teleports, 3 and 4 have unlimited. For Mount Karuulum, 3 has 3 teleports and 4 has unlimited)										
 1554 3457 0		22941		7937<3		Y	T	19	4	Rada's blessing: Kourend Woodland
 1554 3457 0		22943		7937<5		Y	T	19	4	Rada's blessing: Kourend Woodland
@@ -336,6 +336,12 @@
 2019 6434 0		28327				Y	T	19	4	Ring of shadows: The Scar
 2588 6435 0		28327				Y	T	19	4	Ring of shadows: Lassar Undercity
 1175 3424 0		28327				Y	T	19	4	Ring of shadows: The Stranglewood
+1491 3283 0		29893		11175=1		Y	T	19	4	1. Pendant of ates: Darkfrost
+1668 3223 0		29893		11176=1		Y	T	19	4	2. Pendant of ates: Twilight Temple
+1459 3138 0		29893		11177=1		Y	T	19	4	3. Pendant of ates: Ralos' Rise
+1426 2995 0		29893		11178=1		Y	T	19	4	4. Pendant of ates: North Aldarin
+1367 3087 0		29893		16752=1		Y	T	19	4	5. Pendant of ates: Kastori
+1364 3275 0		29893		16757=1		Y	T	19	4	6. Pendant of ates: Nemus Retreat
 										
 #Quetzal Whistle										
 1585 3053 0		29271;29273;29275	Children of the Sun			Y	T	19	4	Quetzal whistle


### PR DESCRIPTION
### Features
- Add teleports for pendant of ates, this respects the varbits assoicated with unlocking each teleport when interacting with the respective statues

### Fixes
- Fix quetzal handling by replacing `getReachableTilesFromTile()` to `isTileReachable()`, this allows using transport origin, which we know is reachable vs searching around npc area, which can be covered in collision.
- Fix Equipment Action for Explorers Ring 3 & Explorers Ring 4