### PR TITLE
fix(InventorySetup): Determine isStackable based on InventorySetup instead of inventory.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/Rs2InventorySetup.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/Rs2InventorySetup.java
@@ -186,9 +186,6 @@ public class Rs2InventorySetup {
 		String itemName = setupItem.getName().toLowerCase();
 		boolean isFuzzy = setupItem.isFuzzy();
 
-		Rs2ItemModel rs2Item = Rs2Inventory.get(itemId);
-		boolean isStackable = rs2Item != null && rs2Item.isStackable();
-
 		int desiredQuantity = setupItems.stream()
 			.mapToInt(InventorySetupsItem::getQuantity)
 			.sum();
@@ -200,6 +197,8 @@ public class Rs2InventorySetup {
 		if (currentQuantity >= desiredQuantity) {
 			return 0;
 		}
+
+		boolean isStackable = (setupItems.size() == 1) && (desiredQuantity > 1);
 
 		if (!isStackable) {
 			long alreadyPresent = isFuzzy


### PR DESCRIPTION
If we don't have any of the item in our inventory already, only 1 will be withdrawn, regardless of the desired stack size.

This bug can be reproduced by creating a setup with any stackable (e.g. seeds) and trying to load it with none of that item in your inventory already.