### PR TITLE
fix(GiantSeaweedFarmer): Fix banking issues + Add flipper support

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/GiantSeaweedFarmer/GiantSeaweedFarmerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/GiantSeaweedFarmer/GiantSeaweedFarmerScript.java
@@ -4,7 +4,6 @@ import net.runelite.api.Skill;
 import net.runelite.api.TileObject;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
-import net.runelite.client.plugins.microbot.pluginscheduler.api.SchedulablePlugin;
 import net.runelite.client.plugins.microbot.pluginscheduler.condition.logical.LockCondition;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
@@ -19,11 +18,10 @@ import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import javax.inject.Inject;
 
 import static net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity.VERY_LOW;
 
@@ -32,11 +30,12 @@ public class GiantSeaweedFarmerScript extends Script {
     public static final int UNDERWATER_ANCHOR = 30948;
     public static final int BOAT = 30919;
     private final GiantSeaweedFarmerPlugin giantSeaweedPlugin;
-    private TileObject currentPatch;
-    public GiantSeaweedFarmerStatus BOT_STATE = GiantSeaweedFarmerStatus.BANKING;
-    private List<Integer> handledPatches = new ArrayList<>();
-    private List<Integer> patches = List.of(30500,30501);
     private final LockCondition lookCondition;
+    public GiantSeaweedFarmerStatus BOT_STATE = GiantSeaweedFarmerStatus.BANKING;
+    private TileObject currentPatch;
+    private List<Integer> handledPatches = new ArrayList<>();
+    private List<Integer> patches = List.of(30500, 30501);
+
     {
         Microbot.enableAutoRunOn = false;
         Rs2Antiban.resetAntibanSettings();
@@ -54,217 +53,25 @@ public class GiantSeaweedFarmerScript extends Script {
         Rs2AntibanSettings.moveMouseRandomlyChance = 0.04;
         Rs2Antiban.setActivityIntensity(VERY_LOW);
     }
+
     @Inject
     public GiantSeaweedFarmerScript(GiantSeaweedFarmerPlugin giantSeaweedPlugin) {
-       this.giantSeaweedPlugin = giantSeaweedPlugin;
-       this.lookCondition = giantSeaweedPlugin.getLockCondition(giantSeaweedPlugin.getStopCondition());
-    }
-    public boolean run(GiantSeaweedFarmerConfig config) {
-        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
-            try {
-                if (!super.run()) return;
-                if (!Microbot.isLoggedIn()) return;
-                
-                switch (BOT_STATE) {
-                    case BANKING:
-                        if (handleBanking(config)) {
-                            BOT_STATE = GiantSeaweedFarmerStatus.WALKING_TO_PATCH;
-                        }
-                        break;
-                    case WALKING_TO_PATCH:
-                        handleDiving();
-                        break;
-                    case FARMING:
-                        handleFarming(config);
-                        break;
-                    case RETURN_TO_BANK:
-                        returnToBank();
-                        break;
-                }
-            } catch (Exception ex) {
-                System.out.println("Exception message: " + ex.getMessage());
-                ex.printStackTrace();
-            }
-        }, 0, 600, TimeUnit.MILLISECONDS);
-        return true;
+        this.giantSeaweedPlugin = giantSeaweedPlugin;
+        this.lookCondition = giantSeaweedPlugin.getLockCondition(giantSeaweedPlugin.getStopCondition());
     }
 
-    private void returnToBank() {
-        Rs2Walker.walkTo(3731,10280,1); // Get to anchor
-        Rs2GameObject.interact(UNDERWATER_ANCHOR, "Climb");
-        sleepUntil(() -> Rs2Player.getWorldLocation().getPlane() == 0, 7000);
-        if (Rs2Player.getWorldLocation().getPlane() != 0) {
-            Microbot.log("We failed to get back to the surface");
+    private static void getToFossilIsland() {
+        if (Rs2Player.isNearArea(BankLocation.FOSSIL_ISLAND_WRECK.getWorldPoint(), 25)) {
             return;
         }
-        lookCondition.unlock();
-        Microbot.log("We're back at the bank, stopping the script");
-        if (giantSeaweedPlugin != null){
-            giantSeaweedPlugin.reportFinished("Giant Seaweed Farming script finished successfully." , true);
-        }
-        this.shutdown();
-    }
-
-    private void handleDiving() {
-        Rs2GameObject.interact(BOAT, "Dive");
-        sleepUntil(() -> Rs2Player.getWorldLocation().getPlane() == 1, 5000);
-        if (Rs2Player.getWorldLocation().getPlane() != 1) {
-            Microbot.log("We failed to get underwater - Make sure to handle the warning dialog manually once");
-            lookCondition.unlock();
-            giantSeaweedPlugin.reportFinished("Giant Seaweed Farming script error. We failed to get underwater" , false);            
-            this.shutdown();
-            return;
-        }
-        lookCondition.lock();
-        Rs2Walker.walkTo(3731,10273,1); // Patch
-        BOT_STATE = GiantSeaweedFarmerStatus.FARMING;
-    }
-
-    private boolean handleBanking(GiantSeaweedFarmerConfig config) {
-        lookCondition.unlock();
-        Rs2Bank.walkToBank(BankLocation.FOSSIL_ISLAND_WRECK);
-        if (!Rs2Bank.openBank()) {
-            return false;
-        }
-
-        // Just deposit all items to ensure low weight when under water
-        Rs2Bank.depositAll();
-        Rs2Bank.depositEquipment();
-
-        // Essential farming equipment
-        Rs2Bank.withdrawX("seaweed spore", 2);
-        Rs2Bank.withdrawAndEquip("Fishbowl helmet");
-        Rs2Bank.withdrawAndEquip("Diving apparatus");
-        Rs2Bank.withdrawOne("secateurs"); // Loot is not affected by type of secateurs, so just take whatever
-        Rs2Bank.withdrawOne("seed dibber");
-        Rs2Bank.withdrawOne("rake");
-        Rs2Bank.withdrawOne("spade");
-
-        // Handle compost based on configuration
-        if (config.compostType() != GiantSeaweedFarmerConfig.CompostType.NONE) {
-            switch (config.compostType()) {
-                case COMPOST:
-                    Rs2Bank.withdrawX("Compost", 2);
-                    break;
-                case SUPERCOMPOST:
-                    Rs2Bank.withdrawX("Supercompost", 2);
-                    break;
-                case ULTRACOMPOST:
-                    Rs2Bank.withdrawX("Ultracompost", 2);
-                    break;
-                case BOTTOMLESS_COMPOST_BUCKET:
-                    Rs2Bank.withdrawOne("Bottomless compost bucket");
-                    break;
-            }
-        }
-
-        Rs2Bank.closeBank();
-
-        // Validate inventory and equipment
-        boolean hasHelmet = Rs2Equipment.isWearing("Fishbowl helmet");
-        boolean hasApparatus = Rs2Equipment.isWearing("Diving apparatus");
-        boolean hasSpores = Rs2Inventory.contains("seaweed spore");
-        boolean hasTools = Rs2Inventory.contains("secateurs") &&
-                Rs2Inventory.contains("seed dibber") &&
-                Rs2Inventory.contains("rake") &&
-                Rs2Inventory.contains("spade");
-
-        boolean readyToFarm = hasHelmet && hasApparatus && hasSpores && hasTools;
-        if (!readyToFarm) {
-            StringBuilder missingItems = new StringBuilder("Missing required items: ");
-
-            if (!hasHelmet) missingItems.append("Fishbowl helmet, ");
-            if (!hasApparatus) missingItems.append("Diving apparatus, ");
-            if (!hasSpores) missingItems.append("Seaweed spores, ");
-
-            if (!hasTools) {
-                if (!Rs2Inventory.contains("secateurs")) missingItems.append("Secateurs, ");
-                if (!Rs2Inventory.contains("seed dibber")) missingItems.append("Seed dibber, ");
-                if (!Rs2Inventory.contains("rake")) missingItems.append("Rake, ");
-                if (!Rs2Inventory.contains("spade")) missingItems.append("Spade, ");
-            }
-
-            // Remove trailing comma and space if present
-            String missingItemsStr = missingItems.toString();
-            if (missingItemsStr.endsWith(", ")) {
-                missingItemsStr = missingItemsStr.substring(0, missingItemsStr.length() - 2);
-            }
-
-            Microbot.log(missingItemsStr + " - shutting down");
-            giantSeaweedPlugin.reportFinished("Giant Seaweed Farming script error.\nWe failed to get items from the bank:\n\t"+missingItemsStr , false);                 
-            this.shutdown();
-        }
-
-        return readyToFarm;
-    }
-
-    private void handleFarming(GiantSeaweedFarmerConfig config) {
-        Integer patchToFarm = patches.stream()
-                .filter(patch -> !handledPatches.contains(patch))
-                .findFirst()
-                .orElse(null);
-
-        if (patchToFarm == null) {
-            if (config.returnToBank()) {
-                BOT_STATE = GiantSeaweedFarmerStatus.RETURN_TO_BANK;
-                Microbot.log("Finished farming, returning to wreck");
-                return;
-            }
-            Microbot.log("Finished farming, stopping...");
-            lookCondition.unlock();
-            giantSeaweedPlugin.reportFinished("Giant Seaweed Farming script, finished farming not returning to bank", true);            
-            shutdown();
-            return;
-        }
-
-        var handledPatch = handlePatch(patchToFarm);
-        if (handledPatch) {
-            handledPatches.add(patchToFarm);
-        }
-    }
-
-    private boolean handlePatch(int patchId) {
-        if (Rs2Inventory.isFull()) {
-            Rs2NpcModel leprechaun = Rs2Npc.getNpc("Tool leprechaun");
-            if (leprechaun != null) {
-                Rs2ItemModel unNoted = Rs2Inventory.getUnNotedItem("Giant seaweed", true);
-                Rs2Inventory.use(unNoted);
-                Rs2Npc.interact(leprechaun, "Talk-to");
-                Rs2Inventory.waitForInventoryChanges(10000);
-            }
-            return false;
-        }
-
-        Integer[] ids = {
-                patchId
-        };
-        var obj = Rs2GameObject.findObject(ids);
-        if (obj == null) return false;
-        var state = getSeaweedPatchState(obj);
-        switch (state) {
-            case "Empty":
-                Rs2Inventory.use("compost");
-                Rs2GameObject.interact(obj, "Compost");
-                Rs2Player.waitForXpDrop(Skill.FARMING);
-                Rs2Inventory.use(" spore");
-                Rs2GameObject.interact(obj, "Plant");
-                sleepUntil(() -> getSeaweedPatchState(obj).equals("Growing"));
-                return false;
-            case "Harvestable":
-                Rs2GameObject.interact(obj, "Pick");
-                sleepUntil(() -> getSeaweedPatchState(obj).equals("Empty") || Rs2Inventory.isFull(), 20000);
-                return false;
-            case "Weeds":
-                Rs2GameObject.interact(obj);
-                Rs2Player.waitForAnimation(10000);
-                return false;
-            case "Dead":
-                Rs2GameObject.interact(obj, "Clear");
-                sleepUntil(() -> getSeaweedPatchState(obj).equals("Empty"));
-                return false;
-            default:
-                currentPatch = null;
-                return true;
+        if (!Rs2Inventory.hasItem("Digsite pendant", false)) {
+            Rs2Bank.walkToBankAndUseBank();
+            sleepUntil(Rs2Bank::isOpen);
+            sleep(100, 200);
+            Rs2Bank.withdrawOne("Digsite pendant", false);
+            Rs2Bank.closeBank();
+            sleepUntil(() -> !Rs2Bank.isOpen());
+            sleep(100, 200);
         }
     }
 
@@ -328,6 +135,221 @@ public class GiantSeaweedFarmerScript extends Script {
         }
 
         return "Empty";
+    }
+
+    public boolean run(GiantSeaweedFarmerConfig config) {
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!super.run()) return;
+                if (!Microbot.isLoggedIn()) return;
+
+                switch (BOT_STATE) {
+                    case BANKING:
+                        getToFossilIsland();
+                        if (handleBanking(config)) {
+                            BOT_STATE = GiantSeaweedFarmerStatus.WALKING_TO_PATCH;
+                        }
+                        break;
+                    case WALKING_TO_PATCH:
+                        handleDiving();
+                        break;
+                    case FARMING:
+                        handleFarming(config);
+                        break;
+                    case RETURN_TO_BANK:
+                        returnToBank();
+                        break;
+                }
+            } catch (Exception ex) {
+                System.out.println("Exception message: " + ex.getMessage());
+                ex.printStackTrace();
+            }
+        }, 0, 600, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    private void returnToBank() {
+        Rs2Walker.walkTo(3731, 10280, 1); // Get to anchor
+        Rs2GameObject.interact(UNDERWATER_ANCHOR, "Climb");
+        sleepUntil(() -> Rs2Player.getWorldLocation().getPlane() == 0, 7000);
+        if (Rs2Player.getWorldLocation().getPlane() != 0) {
+            Microbot.log("We failed to get back to the surface");
+            return;
+        }
+        lookCondition.unlock();
+        Microbot.log("We're back at the bank, stopping the script");
+        if (giantSeaweedPlugin != null) {
+            giantSeaweedPlugin.reportFinished("Giant Seaweed Farming script finished successfully.", true);
+        }
+        this.shutdown();
+    }
+
+    private void handleDiving() {
+        Rs2GameObject.interact(BOAT, "Dive");
+        sleepUntil(() -> Rs2Player.getWorldLocation().getPlane() == 1, 5000);
+        if (Rs2Player.getWorldLocation().getPlane() != 1) {
+            Microbot.log("We failed to get underwater - Make sure to handle the warning dialog manually once");
+            lookCondition.unlock();
+            giantSeaweedPlugin.reportFinished("Giant Seaweed Farming script error. We failed to get underwater", false);
+            this.shutdown();
+            return;
+        }
+        lookCondition.lock();
+        Rs2Walker.walkTo(3731, 10273, 1); // Patch
+        BOT_STATE = GiantSeaweedFarmerStatus.FARMING;
+    }
+
+    private boolean handleBanking(GiantSeaweedFarmerConfig config) {
+        lookCondition.unlock();
+        Rs2Bank.walkToBank(BankLocation.FOSSIL_ISLAND_WRECK);
+        if (!Rs2Bank.openBank()) {
+            return false;
+        }
+
+        // Just deposit all items to ensure low weight when under water
+        Rs2Bank.depositAll();
+        Rs2Bank.depositEquipment();
+
+        // Essential farming equipment
+        Rs2Bank.withdrawX("seaweed spore", 2);
+        Rs2Inventory.waitForInventoryChanges(600);
+        Rs2Bank.withdrawAndEquip("Fishbowl helmet");
+        Rs2Inventory.waitForInventoryChanges(600);
+        Rs2Bank.withdrawAndEquip("Diving apparatus");
+        Rs2Inventory.waitForInventoryChanges(600);
+        Rs2Bank.withdrawAndEquip("Flippers");
+        Rs2Inventory.waitForInventoryChanges(600);
+        Rs2Bank.withdrawOne("seed dibber", true);
+        Rs2Inventory.waitForInventoryChanges(600);
+        Rs2Bank.withdrawOne("rake", true);
+        Rs2Inventory.waitForInventoryChanges(600);
+        Rs2Bank.withdrawOne("spade", true);
+        Rs2Inventory.waitForInventoryChanges(600);
+
+        // Handle compost based on configuration
+        if (config.compostType() != GiantSeaweedFarmerConfig.CompostType.NONE) {
+            switch (config.compostType()) {
+                case COMPOST:
+                    Rs2Bank.withdrawX("Compost", 2);
+                    break;
+                case SUPERCOMPOST:
+                    Rs2Bank.withdrawX("Supercompost", 2);
+                    break;
+                case ULTRACOMPOST:
+                    Rs2Bank.withdrawX("Ultracompost", 2);
+                    break;
+                case BOTTOMLESS_COMPOST_BUCKET:
+                    Rs2Bank.withdrawOne("Bottomless compost bucket");
+                    break;
+            }
+        }
+
+        Rs2Bank.closeBank();
+
+        // Validate inventory and equipment
+        boolean hasHelmet = Rs2Equipment.isWearing("Fishbowl helmet");
+        boolean hasApparatus = Rs2Equipment.isWearing("Diving apparatus");
+        boolean hasSpores = Rs2Inventory.contains("seaweed spore");
+        boolean hasTools = Rs2Inventory.contains("seed dibber") &&
+                Rs2Inventory.contains("rake") &&
+                Rs2Inventory.contains("spade");
+
+        boolean readyToFarm = hasHelmet && hasApparatus && hasSpores && hasTools;
+        if (!readyToFarm) {
+            StringBuilder missingItems = new StringBuilder("Missing required items: ");
+
+            if (!hasHelmet) missingItems.append("Fishbowl helmet, ");
+            if (!hasApparatus) missingItems.append("Diving apparatus, ");
+            if (!hasSpores) missingItems.append("Seaweed spores, ");
+
+            if (!hasTools) {
+                if (!Rs2Inventory.contains("seed dibber")) missingItems.append("Seed dibber, ");
+                if (!Rs2Inventory.contains("rake")) missingItems.append("Rake, ");
+                if (!Rs2Inventory.contains("spade")) missingItems.append("Spade, ");
+            }
+
+            // Remove trailing comma and space if present
+            String missingItemsStr = missingItems.toString();
+            if (missingItemsStr.endsWith(", ")) {
+                missingItemsStr = missingItemsStr.substring(0, missingItemsStr.length() - 2);
+            }
+
+            Microbot.log(missingItemsStr + " - shutting down");
+            giantSeaweedPlugin.reportFinished("Giant Seaweed Farming script error.\nWe failed to get items from the bank:\n\t" + missingItemsStr, false);
+            this.shutdown();
+        }
+
+        return readyToFarm;
+    }
+
+    private void handleFarming(GiantSeaweedFarmerConfig config) {
+        Integer patchToFarm = patches.stream()
+                .filter(patch -> !handledPatches.contains(patch))
+                .findFirst()
+                .orElse(null);
+
+        if (patchToFarm == null) {
+            if (config.returnToBank()) {
+                BOT_STATE = GiantSeaweedFarmerStatus.RETURN_TO_BANK;
+                Microbot.log("Finished farming, returning to wreck");
+                return;
+            }
+            Microbot.log("Finished farming, stopping...");
+            lookCondition.unlock();
+            giantSeaweedPlugin.reportFinished("Giant Seaweed Farming script, finished farming not returning to bank", true);
+            shutdown();
+            return;
+        }
+
+        var handledPatch = handlePatch(patchToFarm);
+        if (handledPatch) {
+            handledPatches.add(patchToFarm);
+        }
+    }
+
+    private boolean handlePatch(int patchId) {
+        if (Rs2Inventory.isFull()) {
+            Rs2NpcModel leprechaun = Rs2Npc.getNpc("Tool leprechaun");
+            if (leprechaun != null) {
+                Rs2ItemModel unNoted = Rs2Inventory.getUnNotedItem("Giant seaweed", true);
+                Rs2Inventory.use(unNoted);
+                Rs2Npc.interact(leprechaun, "Talk-to");
+                Rs2Inventory.waitForInventoryChanges(10000);
+            }
+            return false;
+        }
+
+        Integer[] ids = {
+                patchId
+        };
+        var obj = Rs2GameObject.findObject(ids);
+        if (obj == null) return false;
+        var state = getSeaweedPatchState(obj);
+        switch (state) {
+            case "Empty":
+                Rs2Inventory.use("compost");
+                Rs2GameObject.interact(obj, "Compost");
+                Rs2Player.waitForXpDrop(Skill.FARMING);
+                Rs2Inventory.use(" spore");
+                Rs2GameObject.interact(obj, "Plant");
+                sleepUntil(() -> getSeaweedPatchState(obj).equals("Growing"));
+                return false;
+            case "Harvestable":
+                Rs2GameObject.interact(obj, "Pick");
+                sleepUntil(() -> getSeaweedPatchState(obj).equals("Empty") || Rs2Inventory.isFull(), 20000);
+                return false;
+            case "Weeds":
+                Rs2GameObject.interact(obj);
+                Rs2Player.waitForAnimation(10000);
+                return false;
+            case "Dead":
+                Rs2GameObject.interact(obj, "Clear");
+                sleepUntil(() -> getSeaweedPatchState(obj).equals("Empty"));
+                return false;
+            default:
+                currentPatch = null;
+                return true;
+        }
     }
 
     @Override


### PR DESCRIPTION
This pull request refactors and enhances the `GiantSeaweedFarmerScript` class to improve functionality and maintainability. Key changes include the addition of new methods for better modularity, adjustments to inventory management, and cleanup of redundant code.

### Refactoring and New Functionality:
- **Added `getToFossilIsland` Method**: Introduced a new method to handle navigation to Fossil Island, ensuring the required item (`Digsite pendant`) is retrieved from the bank if not already in the inventory. [[1]](diffhunk://#diff-cac2fcea696ddb3129d0e8ed3544513382019ad8f108bca35e39f63f5e30b77dR56-R139) [[2]](diffhunk://#diff-cac2fcea696ddb3129d0e8ed3544513382019ad8f108bca35e39f63f5e30b77dR148)

### Inventory Management Enhancements:
- **Improved Banking Logic**: Added `Rs2Inventory.waitForInventoryChanges` calls to ensure proper handling of inventory updates when withdrawing or equipping items. This includes adding flippers and ensuring essential farming tools are properly managed.
- **Removed Redundant Tool Check**: Eliminated the check for "secateurs" from the required tools list, as it is unnecessary for the script's functionality. [[1]](diffhunk://#diff-cac2fcea696ddb3129d0e8ed3544513382019ad8f108bca35e39f63f5e30b77dL167-R253) [[2]](diffhunk://#diff-cac2fcea696ddb3129d0e8ed3544513382019ad8f108bca35e39f63f5e30b77dL181)

### Code Cleanup:
- **Reorganized Field Declarations**: Adjusted the order of field declarations for better readability and logical grouping (e.g., moving `currentPatch` after `lookCondition`).