### PR TITLE
Web Walker Changes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1415,13 +1415,7 @@ public class Rs2Walker {
                             if (Rs2Npc.canWalkTo(npc, 20) && Rs2Npc.interact(npc, transport.getAction())) {
                                 Rs2Player.waitForWalking();
                                 sleepUntil(Rs2Dialogue::isInDialogue,600*2);
-                                if (Rs2Dialogue.hasDialogueText("will cost you")){
-                                    Rs2Dialogue.clickContinue();
-                                    sleepUntil(Rs2Dialogue::hasSelectAnOption,600*3);
-                                    Rs2Dialogue.clickOption("Yes please.");
-                                    sleepUntil(Rs2Dialogue::hasContinue,600*3);
-                                    Rs2Dialogue.clickContinue();
-                                } else if (Rs2Dialogue.clickOption("I'm just going to Pirates' cove")){
+								if (Rs2Dialogue.clickOption("I'm just going to Pirates' cove")){
 									sleep(600 * 2);
 									Rs2Dialogue.clickContinue();
                                 } else if (Objects.equals(transport.getName(), "Mountain Guide")) {

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
@@ -117,11 +117,11 @@
 2965 3378 0		8009				Y	T	19	4	Falador tablet
 3221 3218 0		8008				Y	T	19	4	Lumbridge tablet
 2757 3478 0		8010				Y	T	19	4	Camelot tablet
-2661 3302 0		8011	Plague City		165=30	Y	T	19	4	Ardougne tablet
-2549 3112 0		8012	Watchtower		212=14	Y	T	19	4	Watchtower tablet
+2661 3302 0		8011	Plague City			Y	T	19	4	Ardougne tablet
+2549 3112 0		8012	Watchtower			Y	T	19	4	Watchtower tablet
 										
 # Varbit 4460 is DIARY_ARDOUGNE_HARD										
-2584 3097 0		8012	Watchtower	4460=1	212=14	Y	T	19	4	Watchtower tablet: Yanille
+2584 3097 0		8012	Watchtower	4460=1		Y	T	19	4	Watchtower tablet: Yanille
 2953 3224 0		11741				Y	T	19	4	Rimmington tablet
 2893 3465 0		11742				Y	T	19	4	Taverley tablet
 3340 3004 0		11743				Y	T	19	4	Pollnivneach tablet

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_spells.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_spells.tsv
@@ -42,9 +42,9 @@
 1680 3134 0	54 Magic	Twilight's Promise	19	4070=0		Y	4	Civitas illa Fortis Teleport
 								
 # Watchtower Teleport								
-2549 3112 2	58 Magic	Watchtower Quest	19	4070=0;4548=0		Y	10	Watchtower Teleport
+2549 3112 2	58 Magic	Watchtower	19	4070=0;4548=0	212=14	Y	10	Watchtower Teleport
 # Varbit 4460 is DIARY_ARDOUGNE_HARD								
-2584 3097 0	58 Magic	Watchtower Quest	19	4070=0;4460=1;4548=1		Y	10	Watchtower Teleport: Yanille
+2584 3097 0	58 Magic	Watchtower	19	4070=0;4460=1;4548=1	212=14	Y	10	Watchtower Teleport: Yanille
 								
 # Trollheim Teleport								
 2890 3679 0	61 Magic	Eadgar's Ruse	19	4070=0		Y	10	Trollheim Teleport

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -4519,16 +4519,16 @@
 2876 2952 0	2880 2952 0	Climb over;Broken cart;2216								2
 2876 2951 0	2880 2952 0	Climb over;Broken cart;2216								2
 2877 2950 0	2880 2952 0	Climb over;Broken cart;2216								2
-2777 3214 0	2834 2951 0	Board;Travel cart;2230			10 Coins			116>14		5
-2778 3214 0	2834 2951 0	Board;Travel cart;2230			10 Coins			116>14		5
-2776 3213 0	2834 2951 0	Board;Travel cart;2230			10 Coins			116>14		5
-2776 3212 0	2834 2951 0	Board;Travel cart;2230			10 Coins			116>14		5
-2776 3211 0	2834 2951 0	Board;Travel cart;2230			10 Coins			116>14		5
-2779 3213 0	2834 2951 0	Board;Travel cart;2230			10 Coins			116>14		5
-2779 3212 0	2834 2951 0	Board;Travel cart;2230			10 Coins			116>14		5
-2779 3211 0	2834 2951 0	Board;Travel cart;2230			10 Coins			116>14		5
-2777 3210 0	2834 2951 0	Board;Travel cart;2230			10 Coins			116>14		5
-2778 3210 0	2834 2951 0	Board;Travel cart;2230			10 Coins			116>14		5
+2777 3214 0	2834 2951 0	Pay-fare;Travel cart;2230			200 Coins			116>14		5
+2778 3214 0	2834 2951 0	Pay-fare;Travel cart;2230			200 Coins			116>14		5
+2776 3213 0	2834 2951 0	Pay-fare;Travel cart;2230			200 Coins			116>14		5
+2776 3212 0	2834 2951 0	Pay-fare;Travel cart;2230			200 Coins			116>14		5
+2776 3211 0	2834 2951 0	Pay-fare;Travel cart;2230			200 Coins			116>14		5
+2779 3213 0	2834 2951 0	Pay-fare;Travel cart;2230			200 Coins			116>14		5
+2779 3212 0	2834 2951 0	Pay-fare;Travel cart;2230			200 Coins			116>14		5
+2779 3211 0	2834 2951 0	Pay-fare;Travel cart;2230			200 Coins			116>14		5
+2777 3210 0	2834 2951 0	Pay-fare;Travel cart;2230			200 Coins			116>14		5
+2778 3210 0	2834 2951 0	Pay-fare;Travel cart;2230			200 Coins			116>14		5
 2830 2953 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins			116>14		5
 2830 2952 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins			116>14		5
 2831 2954 0	2776 3214 0	Pay-fare;Travel cart;2265			200 Coins			116>14		5


### PR DESCRIPTION
### Fixes
- Remove scroll requirement from Ardounge Tablet & Watchtower tablet as this requirement is strictly used for the teleport spell for these locations, not tablets.
- Shilo Village Cart now uses the Pay fare option to streamline getting to Shilo Village & Brimhaven