### PR TITLE
fix(frosty-rc): fix agility level boundary conditions for blood altar pathfinding

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -645,7 +645,7 @@ public class RcScript extends Script {
             }
 
             if (plugin.getMyWorldPoint().equals(firstCaveExit) &&
-                    Rs2Player.getRealSkillLevel(Skill.AGILITY) > 93) {
+                    Rs2Player.getRealSkillLevel(Skill.AGILITY) >= 93) {
                 Microbot.log("Walking to blood ruins " +
                         outsideBloodRuins93);
                 Rs2Walker.walkTo(outsideBloodRuins93);
@@ -653,7 +653,7 @@ public class RcScript extends Script {
             }
 
             if (plugin.getMyWorldPoint().equals(firstCaveExit) &&
-                    Rs2Player.getRealSkillLevel(Skill.AGILITY) < 93 && Rs2Player.getRealSkillLevel(Skill.AGILITY) > 74) {
+                    Rs2Player.getRealSkillLevel(Skill.AGILITY) < 93 && Rs2Player.getRealSkillLevel(Skill.AGILITY) >= 74) {
                 Microbot.log("Walking to ruins: " + outsideBloodRuins74);
                 Rs2Walker.walkTo(outsideBloodRuins74);
                 sleepUntil(() -> plugin.getMyWorldPoint().equals(outsideBloodRuins74), 1200);


### PR DESCRIPTION
Fixed agility level checks to include exact level matches:
- Changed level 93 check from > to >= to include players with exactly 93 agility
- Changed level 74 check from > to >= to include players with exactly 74 agility

This ensures all players can access the appropriate blood altar paths without falling through condition gaps.