### PR TITLE
Walker Transports

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2RunePouch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2RunePouch.java
@@ -475,7 +475,7 @@ public class Rs2RunePouch
 	public static Map<Runes, Integer> getRunes() {
 		return slots.stream()
 			.filter(s -> s.getRune() != null && s.getQuantity() > 0)
-			.collect(Collectors.toMap(PouchSlot::getRune, PouchSlot::getQuantity));
+			.collect(Collectors.toMap(PouchSlot::getRune, PouchSlot::getQuantity, Integer::sum));
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2RunePouch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2RunePouch.java
@@ -297,12 +297,7 @@ public class Rs2RunePouch
 	 */
 	public static boolean contains(Map<Runes, Integer> requiredRunes, boolean allowCombinationRunes)
 	{
-		Map<Runes, Integer> availableRunes = slots.stream()
-			.filter(s -> s.getRune() != null && s.getQuantity() > 0)
-			.collect(Collectors.toMap(
-				PouchSlot::getRune,
-				PouchSlot::getQuantity
-			));
+		Map<Runes, Integer> availableRunes = getRunes();
 
 		return contains(requiredRunes, availableRunes, allowCombinationRunes ? COMBO_SUPPORT : STRICT_ONLY);
 	}

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -69,20 +69,29 @@
 3138 3078 1	3138 3078 0	Climb-down;Ladder;16679								2	
 											
 # Lumbridge											
-3205 3228 0	3206 3229 1	Climb-up;Staircase;56230								1	
-3206 3229 1	3205 3228 0	Climb-down;Staircase;16672								1	
-3206 3229 0	3206 3229 1	Climb-up;Staircase;56230								1	
-3205 3228 1	3205 3228 0	Climb-down;Staircase;16672								1	
-3206 3229 1	3206 3229 2	Climb-up;Staircase;16672								1	
-3206 3229 2	3205 3228 1	Climb-down;Staircase;56231								1	
-3205 3228 1	3206 3229 2	Climb-up;Staircase;16672								1	
-3205 3209 1	3206 3208 0	Climb-down;Staircase;16672								1	
-3206 3208 0	3205 3209 1	Climb-up;Staircase;56230								1	
-3206 3208 1	3206 3208 0	Climb-down;Staircase;16672								1	
-3205 3209 0	3205 3209 1	Climb-up;Staircase;56230								1	
-3205 3209 1	3205 3209 2	Climb-up;Staircase;16672								1	
-3205 3209 2	3206 3208 1	Climb-down;Staircase;56231								1	
-3206 3208 1	3205 3209 2	Climb-up;Staircase;16672								1	
+# North Staircase
+3205 3228 0	3206 3229 1	Climb-up;Staircase;56230								1
+3206 3229 0	3206 3229 1	Climb-up;Staircase;56230								1
+3206 3229 1	3205 3228 0	Climb-down;Staircase;16672								1
+3205 3228 1	3205 3228 0	Climb-down;Staircase;16672								1
+3206 3229 1	3206 3229 2	Climb-up;Staircase;16672								1
+3205 3228 1	3206 3229 2	Climb-up;Staircase;16672								1
+3206 3229 2	3205 3228 1	Climb-down;Staircase;56231								1
+3205 3228 0	3205 3228 2	Top-floor;Staircase;56230								1
+3206 3229 0	3206 3229 2	Top-floor;Staircase;56230								1
+3205 3228 2	3205 3228 0	Bottom-floor;Staircase;56231								1
+# South Staircase
+3206 3208 0	3205 3209 1	Climb-up;Staircase;56230								1
+3205 3209 0	3205 3209 1	Climb-up;Staircase;56230								1
+3206 3208 1	3206 3208 0	Climb-down;Staircase;16672								1
+3205 3209 1	3205 3209 0	Climb-down;Staircase;16672								1
+3205 3209 1	3205 3209 2	Climb-up;Staircase;16672								1
+3205 3209 2	3206 3208 1	Climb-down;Staircase;56231								1
+3206 3208 1	3205 3209 2	Climb-up;Staircase;16672								1
+3206 3208 0	3205 3209 2	Top-floor;Staircase;56230								1
+3205 3209 0	3205 3209 2	Top-floor;Staircase;56230								1
+3205 3209 2	3205 3209 0	Bottom-floor;Staircase;56231								1
+
 3210 3216 0	3210 9616 0	Climb-down;Trapdoor;14880									
 3210 9616 0	3210 3216 0	Climb-up;Ladder;17385								2	
 3209 9617 0	3209 3217 0	Climb-up;Ladder;17385								2	
@@ -1008,11 +1017,7 @@
 3097 3432 1	3097 3432 2	Climb-up;Ladder;17026									
 3097 3432 2	3097 3432 1	Climb-down;Ladder;16685									
 											
-# Al Kharid											
-3267 3228 0	3268 3228 0	Pay-toll(10gp);Gate;44599								1	
-3268 3228 0	3267 3228 0	Pay-toll(10gp);Gate;44599								1	
-3267 3227 0	3268 3227 0	Pay-toll(10gp);Gate;44598								1	
-3268 3227 0	3267 3227 0	Pay-toll(10gp);Gate;44598								1	
+# Al Kharid
 3298 3124 0	3297 3124 0	Open;Prison door;2692									
 3297 3124 0	3298 3124 0	Open;Prison door;2692									
 3303 3117 0	3304 3115 0	Go-through;Shantay pass;4031		1854						2	


### PR DESCRIPTION
### Fixes
- Merge keys in runepouch data, this is a temporary fix for now
- Add Bottom Floor -> Top Floor & vice versa transports for lumbridge stairs (this gives slight more preference but still needs further debugging)