### PR TITLE
Added "Turbo Mode" for Sandstone Miner plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/gabplugs/sandminer/GabulhasSandMinerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/gabplugs/sandminer/GabulhasSandMinerConfig.java
@@ -4,9 +4,44 @@ import net.runelite.client.config.*;
 
 @ConfigGroup("GabulhasSandMiner")
 @ConfigInformation(
-        "Mines sandstone and deposits it in the Quarry. Just start next to the grinder with a pickaxe. The scripts supports handling the heat using waterskins + humidify spell (Lunar spells) or using the circlet of water. If you get below 25% health, it will bank for safety.\n\n Updated by TaF"
+        "Mines sandstone and deposits it in the Quarry.<br/><br/>"+
+        "Just start next to the grinder with a pickaxe. <br/><br/>"+
+        "The scripts supports handling the heat using waterskins +"+
+        "humidify spell (Lunar spells) or using the circlet of water.<br/><br/>"+
+        "<b>Turbo mode enables the plugin to mine and deposit faster, without clicking on minimap to walk, "+
+        "clicking directly on the ideal ore or grinder instead and also removes long pauses between actions. "+
+        "Use at your own risk, some may see 'turbo' mode as how a normal player would mine sandstone, some don't.</b><br/><br/>"+
+        "If you get below 25% health, it will bank and logout for safety.<br/><br/>Updated by TaF and Bolado"
 )
 public interface GabulhasSandMinerConfig extends Config {
+    @ConfigSection(
+            name = "Settings",
+            description = "Settings for the Sand Miner plugin.",
+            position = 0
+    )
+    String settingsSection = "settingsSection";
+
+    @ConfigItem(
+            keyName = "turboMode",
+            name = "Turbo Mode",
+            description = "Enables Turbo Mode for faster mining and depositing. Can look more like how someone would sand mine.",
+            position = 0,
+            section = settingsSection
+    )
+    default boolean turboMode() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "useHumidify",
+            name = "Use Humidify",
+            description = "Enables the use of the Humidify spell to keep your waterskins full. Requires the Lunar spellbook to be active.",
+            position = 1,
+            section = settingsSection
+    )
+    default boolean useHumidify() {
+        return false;
+    }
 
     @ConfigSection(
             name = "Starting State",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/gabplugs/sandminer/GabulhasSandMinerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/gabplugs/sandminer/GabulhasSandMinerScript.java
@@ -1,17 +1,19 @@
 package net.runelite.client.plugins.microbot.gabplugs.sandminer;
 
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.GameObject;
-import net.runelite.api.GameState;
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.ItemID;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
+import net.runelite.client.plugins.microbot.util.magic.Rs2Spellbook;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
@@ -24,32 +26,37 @@ import static net.runelite.client.plugins.microbot.gabplugs.sandminer.GabulhasSa
 
 @Slf4j
 public class GabulhasSandMinerScript extends Script {
-    public static String version = "1.1";
-    private final WorldPoint miningPoint = new WorldPoint(3165, 2906, 0);
+    public static String version = "1.2";
+    private final WorldPoint miningPoint = new WorldPoint(3165, 2905, 0);
     private final WorldPoint grinder = new WorldPoint(3150, 2908, 0);
 
     public boolean run(GabulhasSandMinerConfig config) {
         Microbot.enableAutoRunOn = false;
+        if (config.turboMode()){
+            Rs2Camera.setZoom(Rs2Random.randomGaussian(100, 20));
+            Rs2Camera.setYaw((Rs2Random.dicePercentage(50)? Rs2Random.randomGaussian(750, 50) : Rs2Random.randomGaussian(1700, 50)));
+            Rs2Camera.setPitch(Rs2Random.betweenInclusive(418, 512));
+        }
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
                 if (!Microbot.isLoggedIn()) return;
                 if (!super.run()) return;
                 switch (botStatus) {
                     case Mining:
-                        humidifyIfNeeded();
-                        miningLoop();
+                        if (config.useHumidify()) humidifyIfNeeded();
+                        miningLoop(config);
                         handleSafety();
                         botStatus = states.Depositing;
                         break;
                     case Depositing:
-                        deposit();
+                        deposit(config);
                         botStatus = states.Mining;
                         break;
                 }
             } catch (Exception ex) {
                 Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
             }
-        }, 0, 1000, TimeUnit.MILLISECONDS);
+        }, 0, 600, TimeUnit.MILLISECONDS);
         return true;
     }
 
@@ -59,7 +66,7 @@ public class GabulhasSandMinerScript extends Script {
             Microbot.log("Health is low: " + health + "%, banking for safety.");
             Rs2Bank.walkToBank();
             Rs2Player.logout();
-            shutdown();
+            Microbot.stopPlugin(GabulhasSandMinerPlugin.class);
         }
     }
 
@@ -69,22 +76,41 @@ public class GabulhasSandMinerScript extends Script {
     }
 
 
-    private void miningLoop() {
-        Rs2Walker.walkTo(miningPoint, 0);
-        sleep(100, 4000);
+    private void miningLoop(GabulhasSandMinerConfig config) {
+        boolean firstRock = true;
+        if (!config.turboMode()){
+            Rs2Walker.walkTo(miningPoint, 0);
+            sleep(100, 4000);
+        }
         while (!Rs2Inventory.isFull() && super.isRunning()) {
-            while (Rs2Player.hopIfPlayerDetected(1, 3000, 100)) {
+            while (Rs2Player.hopIfPlayerDetected(1, 3000, 100) && super.isRunning()) {
                 sleepUntil(() -> Microbot.getClient().getGameState() == GameState.HOPPING);
                 sleepUntil(() -> Microbot.getClient().getGameState() == GameState.LOGGED_IN);
                 sleep(1200, 2000);
             }
 
-            sleep(Rs2Random.nextInt(300, 5000, 0.1, true));
+            if (!config.turboMode()) sleep(Rs2Random.nextInt(300, 5000, 0.1, true));
             if (!Rs2Player.isInteracting() || !Rs2Player.isAnimating()) {
+                if (config.turboMode()) {
+                    if (firstRock) {
+                        WorldPoint innerMiningPoint = (Rs2Random.dicePercentage(50)) ?
+                                new WorldPoint(3164, 2905, 0) : new WorldPoint(3166, 2905, 0);
+                        GameObject innerSandstoneRock = Rs2GameObject.getGameObject("Sandstone rocks", true, innerMiningPoint);
+                        Rs2GameObject.interact(innerSandstoneRock, "Mine");
+                        Rs2Player.waitForXpDrop(Skill.MINING, 15000);
+                        Rs2Antiban.actionCooldown();
+                        firstRock = false;
+                        continue;
+                    }
+                }
                 GameObject sandstoneRock = Rs2GameObject.getGameObject("Sandstone rocks", true, miningPoint, 5);
                 if (sandstoneRock != null) {
                     Rs2GameObject.interact(sandstoneRock, "Mine");
-                    Rs2Player.waitForAnimation();
+                    if(config.turboMode()) {
+                        Rs2Player.waitForXpDrop(Skill.MINING, 15000);
+                    } else {
+                        Rs2Player.waitForAnimation();
+                    }
                     Rs2Antiban.actionCooldown();
                 }
             }
@@ -95,12 +121,7 @@ public class GabulhasSandMinerScript extends Script {
         if (Rs2Equipment.isWearing("Circlet of water")) {
             return;
         }
-        String[] waterskinNames = {"Waterskin(4)", "Waterskin(3)", "Waterskin(2)", "Waterskin(1)"};
-        boolean containsAnyWaterskin = false;
-        for (int i = 0; i < waterskinNames.length; i++) {
-            containsAnyWaterskin = Rs2Inventory.contains(waterskinNames[i]);
-        }
-        if (!containsAnyWaterskin) {
+        if (Rs2Magic.isSpellbook(Rs2Spellbook.LUNAR) && !Rs2Inventory.hasItem(ItemID.WATER_SKIN1, ItemID.WATER_SKIN2, ItemID.WATER_SKIN3, ItemID.WATER_SKIN4)) {
             System.out.println("Humidified");
             Rs2Magic.cast(MagicAction.HUMIDIFY);
             sleepUntilOnClientThread(() -> Rs2Inventory.hasItem("Waterskin(4)"));
@@ -110,12 +131,16 @@ public class GabulhasSandMinerScript extends Script {
         }
     }
 
-    private void deposit() {
-        Rs2Walker.walkTo(grinder);
+    private void deposit(GabulhasSandMinerConfig config) {
+        if (!config.turboMode()) Rs2Walker.walkTo(grinder);
         GameObject sandstoneRock = Rs2GameObject.findObject(26199, grinder);
         Rs2GameObject.interact(sandstoneRock, "Deposit");
-        while (Rs2Inventory.contains("Sandstone (1kg)", "Sandstone (2kg)", "Sandstone (5kg)", "Sandstone (10kg)") && this.isRunning()) {
-            sleep(100, 3000);
+        while (Rs2Inventory.contains("Sandstone (1kg)", "Sandstone (2kg)", "Sandstone (5kg)", "Sandstone (10kg)") && super.isRunning()) {
+            if (!config.turboMode()) {
+                sleep(100, 3000);
+            }else{
+                sleepGaussian(300, 200);
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request adds a new "Turbo Mode" feature and improves the configuration options for the Gabulhas Sand Miner plugin, allowing users to customize mining speed and spell usage. It also refines the mining and depositing logic to support these new options, updates the safety handling, and improves the humidify spell logic for waterskins.

**New Features and Configuration:**

* Added a "Turbo Mode" option to `GabulhasSandMinerConfig`, enabling faster mining and depositing by reducing delays and optimizing interactions. Also added a "Use Humidify" option to automate waterskin refilling with the Lunar spellbook.

**Mining and Depositing Logic Updates:**

* Updated the mining loop and deposit logic in `GabulhasSandMinerScript` to respect the new "Turbo Mode" and "Use Humidify" settings, including bypassing certain waits and optimizing actions for speed when enabled. [[1]](diffhunk://#diff-9dbf6e6f23ed62711477e030b34c94bd5043a13c2aeab7c4038dcad41bac732aL27-R59) [[2]](diffhunk://#diff-9dbf6e6f23ed62711477e030b34c94bd5043a13c2aeab7c4038dcad41bac732aL72-R113) [[3]](diffhunk://#diff-9dbf6e6f23ed62711477e030b34c94bd5043a13c2aeab7c4038dcad41bac732aL113-R143)

**Safety and Spell Handling:**

* Improved safety handling so that the plugin stops and logs out when health is low, using a more robust method to stop the plugin.
* Refined the humidify logic to more accurately detect when waterskins need to be refilled and to use item IDs for detection.

**Other Improvements:**

* Updated version number and improved configuration documentation, including a more detailed description of Turbo Mode and plugin authorship. [[1]](diffhunk://#diff-9dbf6e6f23ed62711477e030b34c94bd5043a13c2aeab7c4038dcad41bac732aL27-R59) [[2]](diffhunk://#diff-d9dc28475eaefc9fc163ece6d1e533dceeb6d9c0a75c939515c27528a3f98717L7-R44)
* Refactored imports for clarity and maintainability.