### PR TITLE
feat(AIOFighter): Add custom spec weapon switching

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
@@ -137,10 +137,33 @@ public interface AIOFighterConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "Custom spec weapon",
+            name = "Custom spec weapon",
+            description = "Name of weapon to switch to for special attack (leave empty to use current weapon)",
+            position = 4,
+            section = combatSection
+    )
+    default String customSpecWeapon() {
+        return "";
+    }
+
+    @Range(min = 1, max = 100)
+    @ConfigItem(
+            keyName = "Spec attack cost",
+            name = "Spec attack cost %",
+            description = "Special attack energy cost percentage (1-100)",
+            position = 5,
+            section = combatSection
+    )
+    default int specAttackCost() {
+        return 100;
+    }
+
+    @ConfigItem(
             keyName = "Cannon",
             name = "Auto reload cannon",
             description = "Automatically reloads cannon",
-            position = 4,
+            position = 6,
             section = combatSection
     )
     default boolean toggleCannon() {
@@ -152,7 +175,7 @@ public interface AIOFighterConfig extends Config {
             keyName = "Safe Spot",
             name = "Safe Spot",
             description = "Shift Right-click the ground to select the safe spot tile",
-            position = 5,
+            position = 7,
             section = combatSection
     )
     default boolean toggleSafeSpot() {
@@ -164,7 +187,7 @@ public interface AIOFighterConfig extends Config {
             keyName = "PlayStyle",
             name = "Play Style",
             description = "Play Style",
-            position = 6,
+            position = 8,
             section = combatSection
     )
     default PlayStyle playStyle() {
@@ -175,7 +198,7 @@ public interface AIOFighterConfig extends Config {
             keyName = "ReachableNpcs",
             name = "Only attack reachable npcs",
             description = "Only attack npcs that we can reach with melee",
-            position = 7,
+            position = 9,
             section = combatSection
     )
     default boolean attackReachableNpcs() {
@@ -380,7 +403,7 @@ public interface AIOFighterConfig extends Config {
             keyName = "Center Tile",
             name = "Manual Center Tile",
             description = "Shift Right-click the ground to select the center tile",
-            position = 6,
+            position = 10,
             section = combatSection
     )
     default boolean toggleCenterTile() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
@@ -8,6 +8,7 @@ import net.runelite.client.plugins.microbot.aiofighter.enums.PrayerStyle;
 import net.runelite.client.plugins.microbot.aiofighter.enums.State;
 import net.runelite.client.plugins.microbot.inventorysetups.InventorySetup;
 import net.runelite.client.plugins.microbot.util.magic.Rs2CombatSpells;
+import net.runelite.client.plugins.microbot.util.misc.SpecialAttackWeaponEnum;
 import net.runelite.client.plugins.microbot.util.slayer.enums.SlayerMaster;
 
 @ConfigGroup(AIOFighterConfig.GROUP)
@@ -137,33 +138,21 @@ public interface AIOFighterConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "Custom spec weapon",
-            name = "Custom spec weapon",
-            description = "Name of weapon to switch to for special attack (leave empty to use current weapon)",
+            keyName = "Spec weapon",
+            name = "Spec weapon",
+            description = "Special attack weapon to use",
             position = 4,
             section = combatSection
     )
-    default String customSpecWeapon() {
-        return "";
-    }
-
-    @Range(min = 1, max = 100)
-    @ConfigItem(
-            keyName = "Spec attack cost",
-            name = "Spec attack cost %",
-            description = "Special attack energy cost percentage (1-100)",
-            position = 5,
-            section = combatSection
-    )
-    default int specAttackCost() {
-        return 100;
+    default SpecialAttackWeaponEnum specWeapon() {
+        return null;
     }
 
     @ConfigItem(
             keyName = "Cannon",
             name = "Auto reload cannon",
             description = "Automatically reloads cannon",
-            position = 6,
+            position = 5,
             section = combatSection
     )
     default boolean toggleCannon() {
@@ -175,7 +164,7 @@ public interface AIOFighterConfig extends Config {
             keyName = "Safe Spot",
             name = "Safe Spot",
             description = "Shift Right-click the ground to select the safe spot tile",
-            position = 7,
+            position = 6,
             section = combatSection
     )
     default boolean toggleSafeSpot() {
@@ -187,7 +176,7 @@ public interface AIOFighterConfig extends Config {
             keyName = "PlayStyle",
             name = "Play Style",
             description = "Play Style",
-            position = 8,
+            position = 7,
             section = combatSection
     )
     default PlayStyle playStyle() {
@@ -198,7 +187,7 @@ public interface AIOFighterConfig extends Config {
             keyName = "ReachableNpcs",
             name = "Only attack reachable npcs",
             description = "Only attack npcs that we can reach with melee",
-            position = 9,
+            position = 8,
             section = combatSection
     )
     default boolean attackReachableNpcs() {
@@ -403,7 +392,7 @@ public interface AIOFighterConfig extends Config {
             keyName = "Center Tile",
             name = "Manual Center Tile",
             description = "Shift Right-click the ground to select the center tile",
-            position = 10,
+            position = 9,
             section = combatSection
     )
     default boolean toggleCenterTile() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
@@ -147,8 +147,18 @@ public class AIOFighterPlugin extends Plugin {
         potionManagerScript.run(config);
         safetyScript.run(config);
         slayerScript.run(config);
-        Microbot.getSpecialAttackConfigs()
-                .setSpecialAttack(true);
+        
+        // Configure special attack settings
+        if (config.useSpecialAttack() && config.specWeapon() != null) {
+            Microbot.getSpecialAttackConfigs()
+                    .setSpecialAttack(true)
+                    .setSpecialAttackWeapon(config.specWeapon())
+                    .setMinimumSpecEnergy(config.specWeapon().getEnergyRequired());
+        } else {
+            Microbot.getSpecialAttackConfigs()
+                    .setSpecialAttack(config.useSpecialAttack());
+        }
+        
         Rs2Slayer.blacklistedSlayerMonsters = getBlacklistedSlayerNpcs();
         bankerScript.run(config);
         shopScript.run(config);
@@ -172,6 +182,7 @@ public class AIOFighterPlugin extends Plugin {
         slayerScript.shutdown();
         shopScript.shutdown();
         resetLocation();
+        Microbot.getSpecialAttackConfigs().reset();
         overlayManager.remove(playerAssistOverlay);
         overlayManager.remove(playerAssistInfoOverlay);
         playerAssistInfoOverlay.myButton.unhookMouseListener();
@@ -383,6 +394,17 @@ public class AIOFighterPlugin extends Plugin {
                 setCenter(Rs2Player.getWorldLocation());
             }
 
+        }
+        // Handle special attack weapon config changes
+        if (event.getKey().equals("Use special attack") || event.getKey().equals("Spec weapon")) {
+            if (config.useSpecialAttack() && config.specWeapon() != null) {
+                Microbot.getSpecialAttackConfigs()
+                        .setSpecialAttack(true)
+                        .setSpecialAttackWeapon(config.specWeapon())
+                        .setMinimumSpecEnergy(config.specWeapon().getEnergyRequired());
+            } else {
+                Microbot.getSpecialAttackConfigs().reset();
+            }
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/combat/UseSpecialAttackScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/combat/UseSpecialAttackScript.java
@@ -1,25 +1,14 @@
 package net.runelite.client.plugins.microbot.aiofighter.combat;
 
-import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.aiofighter.AIOFighterConfig;
-import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
-import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
-import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
-import net.runelite.client.plugins.microbot.util.misc.SpecialAttackWeaponEnum;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static net.runelite.client.plugins.microbot.util.Global.sleep;
-
 public class UseSpecialAttackScript extends Script {
-
-    private List<Rs2ItemModel> savedEquipment = null;
 
     public boolean run(AIOFighterConfig config) {
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
@@ -28,104 +17,17 @@ public class UseSpecialAttackScript extends Script {
                 if (!super.run()) return;
                 if (!config.useSpecialAttack()) return;
                 if (Rs2Equipment.isWearingFullGuthan()) return;
-                
-                String customSpecWeapon = config.customSpecWeapon().trim();
-                
-                // If no custom spec weapon configured, use default behavior
-                if (customSpecWeapon.isEmpty()) {
-                    if (Rs2Player.isInteracting()) {
-                        Microbot.getSpecialAttackConfigs().useSpecWeapon();
-                    }
-                    return;
-                }
-                
-                // Only proceed if we're in combat
-                if (!Rs2Combat.inCombat() && !Rs2Player.isInteracting()) return;
-                
-                int specCost = config.specAttackCost() * 10;
-                int currentSpecEnergy = Rs2Combat.getSpecEnergy();
-                
-                // Check if spec weapon exists in inventory or equipped
-                boolean hasSpecWeapon = Rs2Inventory.hasItem(customSpecWeapon) || 
-                                       Rs2Equipment.isWearing(customSpecWeapon);
-                if (!hasSpecWeapon) return;
-                
-                boolean isSpecWeaponEquipped = Rs2Equipment.isWearing(customSpecWeapon);
-                
-                if (currentSpecEnergy >= specCost && !isSpecWeaponEquipped) {
-                    // Switch to spec weapon
-                    
-                    // Check 2H constraints first - need at least 1 free slot for shield
-                    boolean is2H = isSpecWeapon2H(customSpecWeapon);
-                    if (is2H && Rs2Equipment.isWearingShield() && Rs2Inventory.emptySlotCount() < 1) {
-                        return; // Cannot equip 2H weapon without space for shield
-                    }
-                    
-                    // Save equipment only after we know we can switch
-                    if (savedEquipment == null) {
-                        savedEquipment = new ArrayList<>(Rs2Equipment.items());
-                    }
-                    
-                    Rs2Inventory.wear(customSpecWeapon);
-                    sleep(600);
-                    
-                } else if (currentSpecEnergy < specCost && isSpecWeaponEquipped && savedEquipment != null) {
-                    // Switch back to original equipment
-                    restoreOriginalEquipment();
-                }
-                
-                // Use special attack if conditions are met
-                if (isSpecWeaponEquipped && currentSpecEnergy >= specCost) {
-                    Rs2Combat.setSpecState(true, specCost);
-                }
-                
+                if (Rs2Player.isInteracting())
+                    Microbot.getSpecialAttackConfigs().useSpecWeapon();
             } catch (Exception ex) {
                 Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
             }
         }, 0, 1000, TimeUnit.MILLISECONDS);
         return true;
     }
-    
-    private boolean isSpecWeapon2H(String weaponName) {
-        String lowerName = weaponName.toLowerCase();
-        for (SpecialAttackWeaponEnum weapon : SpecialAttackWeaponEnum.values()) {
-            if (lowerName.contains(weapon.getName())) {
-                return weapon.is2H();
-            }
-        }
-        // Default to checking common 2H patterns if not in enum
-        return lowerName.contains("2h") || lowerName.contains("godsword") || 
-               lowerName.contains("halberd") || lowerName.contains("bow");
-    }
-    
-    private void restoreOriginalEquipment() {
-        if (savedEquipment == null) return;
-        
-        Rs2ItemModel originalWeapon = savedEquipment.stream()
-                .filter(item -> item.getSlot() == EquipmentInventorySlot.WEAPON.getSlotIdx())
-                .findFirst().orElse(null);
-        
-        Rs2ItemModel originalShield = savedEquipment.stream()
-                .filter(item -> item.getSlot() == EquipmentInventorySlot.SHIELD.getSlotIdx())
-                .findFirst().orElse(null);
-        
-        // Re-equip weapon first (important for 2H -> 1H+Shield transitions)
-        if (originalWeapon != null && Rs2Inventory.hasItem(originalWeapon.getName())) {
-            Rs2Inventory.wear(originalWeapon.getName());
-            sleep(600);
-        }
-        
-        // Then re-equip shield if we had one (2H spec weapon would have unequipped it)
-        if (originalShield != null && Rs2Inventory.hasItem(originalShield.getName())) {
-            Rs2Inventory.wear(originalShield.getName());
-            sleep(600);
-        }
-        
-        savedEquipment = null;
-    }
 
     public void shutdown() {
-        savedEquipment = null;
         super.shutdown();
     }
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/combat/UseSpecialAttackScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/combat/UseSpecialAttackScript.java
@@ -1,14 +1,25 @@
 package net.runelite.client.plugins.microbot.aiofighter.combat;
 
+import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.aiofighter.AIOFighterConfig;
+import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+import net.runelite.client.plugins.microbot.util.misc.SpecialAttackWeaponEnum;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static net.runelite.client.plugins.microbot.util.Global.sleep;
+
 public class UseSpecialAttackScript extends Script {
+
+    private List<Rs2ItemModel> savedEquipment = null;
 
     public boolean run(AIOFighterConfig config) {
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
@@ -17,17 +28,104 @@ public class UseSpecialAttackScript extends Script {
                 if (!super.run()) return;
                 if (!config.useSpecialAttack()) return;
                 if (Rs2Equipment.isWearingFullGuthan()) return;
-                if (Rs2Player.isInteracting())
-                    Microbot.getSpecialAttackConfigs().useSpecWeapon();
+                
+                String customSpecWeapon = config.customSpecWeapon().trim();
+                
+                // If no custom spec weapon configured, use default behavior
+                if (customSpecWeapon.isEmpty()) {
+                    if (Rs2Player.isInteracting()) {
+                        Microbot.getSpecialAttackConfigs().useSpecWeapon();
+                    }
+                    return;
+                }
+                
+                // Only proceed if we're in combat
+                if (!Rs2Combat.inCombat() && !Rs2Player.isInteracting()) return;
+                
+                int specCost = config.specAttackCost() * 10;
+                int currentSpecEnergy = Rs2Combat.getSpecEnergy();
+                
+                // Check if spec weapon exists in inventory or equipped
+                boolean hasSpecWeapon = Rs2Inventory.hasItem(customSpecWeapon) || 
+                                       Rs2Equipment.isWearing(customSpecWeapon);
+                if (!hasSpecWeapon) return;
+                
+                boolean isSpecWeaponEquipped = Rs2Equipment.isWearing(customSpecWeapon);
+                
+                if (currentSpecEnergy >= specCost && !isSpecWeaponEquipped) {
+                    // Switch to spec weapon
+                    
+                    // Check 2H constraints first - need at least 1 free slot for shield
+                    boolean is2H = isSpecWeapon2H(customSpecWeapon);
+                    if (is2H && Rs2Equipment.isWearingShield() && Rs2Inventory.emptySlotCount() < 1) {
+                        return; // Cannot equip 2H weapon without space for shield
+                    }
+                    
+                    // Save equipment only after we know we can switch
+                    if (savedEquipment == null) {
+                        savedEquipment = new ArrayList<>(Rs2Equipment.items());
+                    }
+                    
+                    Rs2Inventory.wear(customSpecWeapon);
+                    sleep(600);
+                    
+                } else if (currentSpecEnergy < specCost && isSpecWeaponEquipped && savedEquipment != null) {
+                    // Switch back to original equipment
+                    restoreOriginalEquipment();
+                }
+                
+                // Use special attack if conditions are met
+                if (isSpecWeaponEquipped && currentSpecEnergy >= specCost) {
+                    Rs2Combat.setSpecState(true, specCost);
+                }
+                
             } catch (Exception ex) {
                 Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
             }
         }, 0, 1000, TimeUnit.MILLISECONDS);
         return true;
     }
-
-    public void shutdown() {
-        super.shutdown();
+    
+    private boolean isSpecWeapon2H(String weaponName) {
+        String lowerName = weaponName.toLowerCase();
+        for (SpecialAttackWeaponEnum weapon : SpecialAttackWeaponEnum.values()) {
+            if (lowerName.contains(weapon.getName())) {
+                return weapon.is2H();
+            }
+        }
+        // Default to checking common 2H patterns if not in enum
+        return lowerName.contains("2h") || lowerName.contains("godsword") || 
+               lowerName.contains("halberd") || lowerName.contains("bow");
+    }
+    
+    private void restoreOriginalEquipment() {
+        if (savedEquipment == null) return;
+        
+        Rs2ItemModel originalWeapon = savedEquipment.stream()
+                .filter(item -> item.getSlot() == EquipmentInventorySlot.WEAPON.getSlotIdx())
+                .findFirst().orElse(null);
+        
+        Rs2ItemModel originalShield = savedEquipment.stream()
+                .filter(item -> item.getSlot() == EquipmentInventorySlot.SHIELD.getSlotIdx())
+                .findFirst().orElse(null);
+        
+        // Re-equip weapon first (important for 2H -> 1H+Shield transitions)
+        if (originalWeapon != null && Rs2Inventory.hasItem(originalWeapon.getName())) {
+            Rs2Inventory.wear(originalWeapon.getName());
+            sleep(600);
+        }
+        
+        // Then re-equip shield if we had one (2H spec weapon would have unequipped it)
+        if (originalShield != null && Rs2Inventory.hasItem(originalShield.getName())) {
+            Rs2Inventory.wear(originalShield.getName());
+            sleep(600);
+        }
+        
+        savedEquipment = null;
     }
 
+    public void shutdown() {
+        savedEquipment = null;
+        super.shutdown();
+    }
 }


### PR DESCRIPTION
## Summary
Adds intelligent special attack weapon switching to the AIO Fighter plugin, allowing players to automatically swap to a designated spec weapon when energy is available.

## Features
- **Spec Weapon Selection**: Dropdown menu to select from all supported special attack weapons
- **Automatic Energy Management**: Uses each weapon's built-in energy requirement (no manual configuration needed)
- **Smart Switching Logic**:
  - Automatically equips spec weapon when energy >= weapon's requirement
  - Keeps spec weapon equipped for multiple specs while energy permits
  - Only switches back to original gear when energy drops below threshold
- **2H Weapon Support**: Properly handles shield unequipping/re-equipping for 2-handed weapons
- **Inventory Safety**: Prevents equipment loss by checking for required inventory space

## Configuration
Located in Combat section under "Use special attack":
1. **Spec weapon**: Select from dropdown of supported weapons (Dragon Dagger, AGS, BGS, etc.)
   - Leave unselected to use currently equipped weapon (default behavior)
2. Energy thresholds are automatic based on weapon selection:

## Technical Details
- Leverages existing `SpecialAttackConfigs` framework for battle-tested weapon switching
- Uses `SpecialAttackWeaponEnum` for type-safe weapon selection and automatic energy costs
- Proper lifecycle management with configuration on startup and cleanup on shutdown
- Dynamic config updates without requiring plugin restart
- Consistent with QoL plugin's implementation for familiar behavior