### PR TITLE
fix(Walker): Thread visibility issues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/PathMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/PathMinimapOverlay.java
@@ -6,6 +6,7 @@ import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.shortestpath.pathfinder.Pathfinder;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -37,14 +38,15 @@ public class PathMinimapOverlay extends Overlay {
 		if (!plugin.drawMinimap) {
 			return null;
 		}
-        if (ShortestPathPlugin.getPathfinder() == null)
-            return null;
+
+        final Pathfinder pathfinder = ShortestPathPlugin.getPathfinder();
+        if (pathfinder == null || !pathfinder.isDone()) return null;
 
         graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
         graphics.setClip(plugin.getMinimapClipArea());
 
-        List<WorldPoint> pathPoints = ShortestPathPlugin.getPathfinder().getPath();
-        Color pathColor = ShortestPathPlugin.getPathfinder().isDone() ? plugin.colourPath : plugin.colourPathCalculating;
+        List<WorldPoint> pathPoints = pathfinder.getPath();
+        Color pathColor = pathfinder.isDone() ? plugin.colourPath : plugin.colourPathCalculating;
         for (WorldPoint pathPoint : pathPoints) {
             if (pathPoint.getPlane() != client.getPlane()) {
                 continue;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/PathTileOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/PathTileOverlay.java
@@ -8,6 +8,7 @@ import net.runelite.api.Tile;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.shortestpath.pathfinder.CollisionMap;
+import net.runelite.client.plugins.microbot.shortestpath.pathfinder.Pathfinder;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -116,23 +117,10 @@ public class PathTileOverlay extends Overlay {
             this.renderCollisionMap(graphics);
         }
 
-        if (plugin.drawTiles && plugin.getPathfinder() != null && plugin.getPathfinder().getPath() != null) {
-            Color color;
-            if (plugin.getPathfinder().isDone()) {
-                color = new Color(
-                        plugin.colourPath.getRed(),
-						plugin.colourPath.getGreen(),
-						plugin.colourPath.getBlue(),
-					 plugin.colourPath.getAlpha() / 2);
-            } else {
-                color = new Color(
-                        plugin.colourPathCalculating.getRed(),
-						plugin.colourPathCalculating.getGreen(),
-						plugin.colourPathCalculating.getBlue(),
-					 plugin.colourPathCalculating.getAlpha() / 2);
-            }
+        final Pathfinder pathfinder = ShortestPathPlugin.getPathfinder();
+        if (plugin.drawTiles && pathfinder != null && pathfinder.isDone()) {
+            final List<WorldPoint> path = pathfinder.getPath();
 
-            List<WorldPoint> path = plugin.getPathfinder().getPath();
             int counter = 0;
             if (TileStyle.LINES.equals(plugin.pathStyle)) {
                 for (int i = 1; i < path.size(); i++) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/WorldPointUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/WorldPointUtil.java
@@ -17,7 +17,7 @@ public class WorldPointUtil {
 
     public static int packWorldPoint(WorldPoint point) {
         if (point == null) {
-            return -1;
+            return UNDEFINED;
         }
         return packWorldPoint(point.getX(), point.getY(), point.getPlane());
     }
@@ -83,9 +83,7 @@ public class WorldPointUtil {
 
     public static int distanceBetween(int previousX, int previousY, int previousZ,
                                       int currentX, int currentY, int currentZ, int diagonal) {
-        final int dz = Math.abs(previousZ - currentZ);
-
-        if (dz != 0) {
+        if (previousZ != currentZ) {
             return Integer.MAX_VALUE;
         }
 
@@ -257,5 +255,20 @@ public class WorldPointUtil {
                 (unpackWorldX(packedPoint) - worldView.getBaseX() << LOCAL_COORD_BITS) + (1 << LOCAL_COORD_BITS - 1),
                 (unpackWorldY(packedPoint) - worldView.getBaseY() << LOCAL_COORD_BITS) + (1 << LOCAL_COORD_BITS - 1),
                 worldView.getId());
+    }
+
+    public static String toString(int packedPoint) {
+        final int x = unpackWorldX(packedPoint);
+        final int y = unpackWorldY(packedPoint);
+        final int z = unpackWorldPlane(packedPoint);
+        return "(" + x + "," + y + "," + z + ")";
+    }
+
+    public static String toString(Collection<Integer> packedPoints) {
+        StringBuilder s = new StringBuilder();
+        if (packedPoints.size() != 1) s.append("[");
+        for (int packedPoint : packedPoints) s.append(toString(packedPoint));
+        if (packedPoints.size() != 1) s.append("]");
+        return s.toString();
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/TransportNode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/TransportNode.java
@@ -1,7 +1,6 @@
 package net.runelite.client.plugins.microbot.shortestpath.pathfinder;
 
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.client.plugins.microbot.shortestpath.TransportType;
 
 public class TransportNode extends Node implements Comparable<TransportNode> {
     public TransportNode(WorldPoint point, Node previous, int travelTime) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -86,7 +86,7 @@ public class Rs2Walker {
     public static ShortestPathConfig config;
     static int stuckCount = 0;
     static WorldPoint lastPosition;
-    static WorldPoint currentTarget;
+    static volatile WorldPoint currentTarget;
     static int nextWalkingDistance = 10;
 
     static final int OFFSET = 10; // max offset of the exact area we teleport to
@@ -172,14 +172,17 @@ public class Rs2Walker {
     }
 
     /**
-     * Core walk method contains all the logic to succesfully walk to the destination
-     * this contains doors, gameobjects, teleports, spells etc...
+     * Core walk method contains all the logic to successfully walk to the destination
+     * this contains doors, game objects, teleports, spells etc...
      *
      * @param target
      * @param distance
      */
     private static WalkerState processWalk(WorldPoint target, int distance) {
-        if (debug) return WalkerState.EXIT;
+        if (debug) {
+            log.info("Pathfinder in debug, exiting");
+            return WalkerState.EXIT;
+        }
         try {
             if (!Microbot.isLoggedIn()) {
                 setTarget(null);
@@ -214,23 +217,26 @@ public class Rs2Walker {
                 return WalkerState.EXIT;
             }
 
-            if ((pathfinder = ShortestPathPlugin.getPathfinder()) == null) {
-                log.error("pathfinder is null, exiting: 162");
-                setTarget(null);
-                return WalkerState.EXIT;
+            final List<WorldPoint> path = pathfinder.getPath();
+            final WorldPoint dst;
+            if (path == null || path.isEmpty()) {
+                log.debug("Path is {}, using current location as destination", path == null ? "null" : "empty");
+                dst = Rs2Player.getWorldLocation();
+            } else {
+                dst = path.get(path.size()-1);
             }
 
-            List<WorldPoint> path = pathfinder.getPath();
-            int pathSize = path.size();
-
-
-            if (path.get(pathSize - 1).distanceTo(target) > config.reachedDistance()) {
-                log.warn("Location impossible to reach");
+            if (dst == null || dst.distanceTo(target) > distance) {
+                log.warn("Location {} impossible to reach", dst);
                 setTarget(null);
                 return WalkerState.UNREACHABLE;
             }
 
-            if (!path.isEmpty() && isNear(path.get(pathSize - 1))) {
+            if (path == null || path.isEmpty()) {
+                return WalkerState.ARRIVED;
+            }
+
+            if (isNear(dst)) {
                 setTarget(null);
             }
 
@@ -248,6 +254,7 @@ public class Rs2Walker {
             if (indexOfStartPoint == -1) {
                 log.error("The walker is confused, unable to find our starting point in the web, exiting.");
                 setTarget(null);
+                log.error("pathfinder is null, exiting: 255");
                 return WalkerState.EXIT;
             }
 
@@ -382,11 +389,13 @@ public class Rs2Walker {
             }
         } catch (Exception ex) {
             if (ex instanceof InterruptedException) {
+                log.info("Pathfinder was interrupted, exiting: 397");
                 setTarget(null);
                 return WalkerState.EXIT;
             }
-            log.trace("Exception in Rs2Walker: {} - ", ex.getMessage(), ex);
+            log.error("Exception in Rs2Walker:", ex);
         }
+        log.info("Exiting walker: 403");
         return WalkerState.EXIT;
     }
 
@@ -1261,9 +1270,13 @@ public class Rs2Walker {
      * @param target
      */
     public static void setTarget(WorldPoint target) {
-        if (target != null && !Microbot.isLoggedIn()) return;
+        if (target != null && !Microbot.isLoggedIn()) {
+            log.warn("Unable to set target: not logged in");
+            return;
+        }
         Player localPlayer = Microbot.getClient().getLocalPlayer();
         if (!ShortestPathPlugin.isStartPointSet() && localPlayer == null) {
+            log.warn("Start point is not set and player is null");
             return;
         }
 


### PR DESCRIPTION
I had some issues where transports (stairs) would sometimes not be used. As far as I could track it down this was related to the PrimitiveIntMap not being Thread Safe, this replaces all calls to it to instead use the ConcurrentHashMap. There are other fields I additionally marked as volatile which should probably be visible across Threads instantly.
This might also fix the arceuus rc shortcut problem.