### PR TITLE
fix(aiofighter): Fix 'Eat food for space' feature in AIO Fighter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
@@ -20,6 +20,7 @@ import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.aiofighter.bank.BankerScript;
 import net.runelite.client.plugins.microbot.aiofighter.cannon.CannonScript;
 import net.runelite.client.plugins.microbot.aiofighter.combat.*;
+import net.runelite.client.plugins.microbot.aiofighter.loot.EatForSpaceScript;
 import net.runelite.client.plugins.microbot.aiofighter.enums.PrayerStyle;
 import net.runelite.client.plugins.microbot.aiofighter.enums.State;
 import net.runelite.client.plugins.microbot.aiofighter.loot.LootScript;
@@ -72,6 +73,7 @@ public class AIOFighterPlugin extends Plugin {
     private final AttackNpcScript attackNpc = new AttackNpcScript();
 
     private final FoodScript foodScript = new FoodScript();
+    private final EatForSpaceScript eatForSpaceScript = new EatForSpaceScript();
     private final LootScript lootScript = new LootScript();
     private final SafeSpot safeSpotScript = new SafeSpot();
     private final FlickerScript flickerScript = new FlickerScript();
@@ -150,6 +152,7 @@ public class AIOFighterPlugin extends Plugin {
         Microbot.getSpecialAttackConfigs()
                 .setSpecialAttack(true);
         Rs2Slayer.blacklistedSlayerMonsters = getBlacklistedSlayerNpcs();
+        eatForSpaceScript.run(config);  // Run eat for space BEFORE banking decisions
         bankerScript.run(config);
         shopScript.run(config);
     }
@@ -160,6 +163,7 @@ public class AIOFighterPlugin extends Plugin {
         cannonScript.shutdown();
         attackNpc.shutdown();
         foodScript.shutdown();
+        eatForSpaceScript.shutdown();
         safeSpotScript.shutdown();
         flickerScript.shutdown();
         useSpecialAttackScript.shutdown();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/bank/BankerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/bank/BankerScript.java
@@ -54,11 +54,21 @@ public class BankerScript extends Script {
             try {
                 if (!Microbot.isLoggedIn()) return;
                 if(!super.run()) return;
-                if (config.bank() && needBanking() && ! AIOFighterPlugin.needShopping) {
-                    if (config.eatFoodForSpace() && Rs2Inventory.isFull() && !Rs2Inventory.getInventoryFood().isEmpty())
-                        if (Rs2Player.eatAt(100))
-                            return;
-
+                
+                // Handle eat food for space before checking if we need banking
+                if (config.eatFoodForSpace() && config.bank()) {
+                    // Check if we have too few empty slots (but have food to eat)
+                    if (Rs2Inventory.getEmptySlots() <= config.minFreeSlots() && !Rs2Inventory.getInventoryFood().isEmpty()) {
+                        Microbot.log("Eating food for space - Empty slots: " + Rs2Inventory.getEmptySlots() + " <= Min slots: " + config.minFreeSlots());
+                        // Eat food to make space
+                        if (Rs2Player.eatAt(100)) {
+                            return; // Successfully ate food, wait for next cycle
+                        }
+                    }
+                }
+                
+                // Now check if we need banking
+                if (config.bank() && needBanking() && !AIOFighterPlugin.needShopping) {
                     if(handleBanking()){
                         Microbot.log("Banking handled successfully.");
                     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/bank/BankerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/bank/BankerScript.java
@@ -54,20 +54,6 @@ public class BankerScript extends Script {
             try {
                 if (!Microbot.isLoggedIn()) return;
                 if(!super.run()) return;
-                
-                // Handle eat food for space before checking if we need banking
-                if (config.eatFoodForSpace() && config.bank()) {
-                    // Check if we have too few empty slots (but have food to eat)
-                    if (Rs2Inventory.getEmptySlots() <= config.minFreeSlots() && !Rs2Inventory.getInventoryFood().isEmpty()) {
-                        Microbot.log("Eating food for space - Empty slots: " + Rs2Inventory.getEmptySlots() + " <= Min slots: " + config.minFreeSlots());
-                        // Eat food to make space
-                        if (Rs2Player.eatAt(100)) {
-                            return; // Successfully ate food, wait for next cycle
-                        }
-                    }
-                }
-                
-                // Now check if we need banking
                 if (config.bank() && needBanking() && !AIOFighterPlugin.needShopping) {
                     if(handleBanking()){
                         Microbot.log("Banking handled successfully.");
@@ -120,6 +106,14 @@ public class BankerScript extends Script {
             AIOFighterPlugin.setCurrentSlayerInventorySetup(config.defaultInventorySetup());
         }        
         if(!config.bank()){
+            return false;
+        }
+
+        // Don't bank if we can eat food for space instead
+        if (config.eatFoodForSpace() && 
+            Rs2Inventory.getEmptySlots() <= config.minFreeSlots() && 
+            !Rs2Inventory.getInventoryFood().isEmpty()) {
+            // Food available to make space - let EatForSpaceScript handle it
             return false;
         }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/loot/EatForSpaceScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/loot/EatForSpaceScript.java
@@ -1,0 +1,71 @@
+package net.runelite.client.plugins.microbot.aiofighter.loot;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.aiofighter.AIOFighterConfig;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Script that handles eating food to make inventory space.
+ * This runs before banking decisions to prevent unnecessary banking trips.
+ */
+public class EatForSpaceScript extends Script {
+
+    private AIOFighterConfig config;
+
+    public boolean run(AIOFighterConfig config) {
+        this.config = config;
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) return;
+                if (!super.run()) return;
+                if (!config.eatFoodForSpace()) return;
+                
+                checkAndEatForSpace();
+                
+            } catch (Exception ex) {
+                Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
+            }
+        }, 0, 1000, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    /**
+     * Check if we need to eat food for space and do so if needed.
+     * @return true if food was eaten, false otherwise
+     */
+    public boolean checkAndEatForSpace() {
+        if (!config.eatFoodForSpace()) {
+            return false;
+        }
+
+        // Check if we have food to eat
+        if (Rs2Inventory.getInventoryFood().isEmpty()) {
+            return false;
+        }
+
+        // Determine threshold: use minFreeSlots if banking enabled, otherwise only when full
+        int threshold = config.bank() ? config.minFreeSlots() : 0;
+        
+        // Check if we need to eat food for space
+        if (Rs2Inventory.getEmptySlots() <= threshold) {
+            Microbot.log("Eating food for space - Empty slots: " + Rs2Inventory.getEmptySlots() + " <= threshold: " + threshold);
+            // Eat food to make space
+            if (Rs2Player.eatAt(100)) {
+                // Wait a bit for the eating action to complete
+                sleep(600, 1200);
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the broken "Eat food for space" feature in the AIO Fighter plugin that was not working as intended.

## Problem
The "Eat food for space" setting was supposed to eat food when inventory space dropped below the configured minimum free slots threshold, preventing unnecessary banking trips. However, it was completely
broken due to:

1. **Incorrect execution order** - The eating logic was inside the banking check, so it only ran after already deciding to bank
2. **Wrong trigger condition** - It only activated when inventory was completely full rather than at `Min. free slots`
3. **No coordination between scripts** - Banking could trigger before the eat food logic had a chance to run
4. **Didn't work with banking disabled** - Feature only worked when banking was enabled

## Solution
- Created a dedicated `EatForSpaceScript` that runs independently every second to handle eating food for space
- Added coordination logic to `BankerScript.needBanking()` to prevent premature banking when food is available to eat
- Fixed the threshold logic to:
  - When banking enabled: eat at `minFreeSlots` threshold
  - When banking disabled: eat when inventory is full
- Ensures proper execution order - banking decisions now check if food can be eaten first
- Added debug logging to track when the feature activates

## Testing
- ✅ Plugin now correctly eats food when inventory slots drop to or below the configured threshold
- ✅ Works with both banking enabled and disabled modes
- ✅ Banking is deferred when food is available to eat for space
- ✅ Feature properly prevents unnecessary banking trips when food is available