### PR TITLE
MotherloadMine 1.8.0

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineConfig.java
@@ -2,63 +2,144 @@ package net.runelite.client.plugins.microbot.mining.motherloadmine;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigInformation;
 import net.runelite.client.config.ConfigItem;
-import net.runelite.client.plugins.microbot.mining.motherloadmine.enums.MLMMiningSpot;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.plugins.microbot.inventorysetups.InventorySetup;
 import net.runelite.client.plugins.microbot.mining.motherloadmine.enums.MLMMiningSpotList;
 
-@ConfigGroup("MotherloadMine")
-public interface MotherloadMineConfig extends Config {
+@ConfigGroup(MotherloadMineConfig.configGroup)
+@ConfigInformation(
+	"• This plugin will automate mining in motherload mine <br />" +
+	"• If using deposit all feature, <b>ensure you lock the slots you wish to keep in inventory</b> <br />" +
+	"• Start near the bank chest in motherload mine <br />"
+)
+public interface MotherloadMineConfig extends Config
+{
+	String configGroup = "micro-motherloadmine";
 
-    @ConfigItem(
-            keyName = "guide",
-            name = "How to use",
-            description = "How to use this plugin",
-            position = 0
-    )
-    default String GUIDE() {
-        return "1. Have a hammer in your inventory or equipped \n2. Start near the bank chest in motherload mine";
-    }
+	String isPickaxeInInventory = "isPickaxeInInventory";
+	String useInventorySetup = "useInventorySetup";
+	String inventorySetup = "inventory-setup";
+	String useDepositAll = "useDepositAll";
+	String antiCrash = "antiCrash";
+	String useUpstairsMine = "useUpstairsMine";
+	String useUpstairsHopper = "useUpstairsHopper";
+	String miningArea = "miningArea";
 
-    @ConfigItem(
-            keyName = "PickAxeInInventory",
-            name = "Pick Axe In Inventory?",
-            description = "Pick Axe in inventory?",
-            position = 1
-    )
-    default boolean pickAxeInInventory() {
-        return false;
-    }
+	@ConfigSection(
+		name = "General",
+		description = "General Plugin Settings",
+		position = 0
+	)
+	String generalSection = "general";
 
-    // Mine upstairs
-    @ConfigItem(
-            keyName = "MineUpstairs",
-            name = "Mine Upstairs?",
-            description = "Mine upstairs?",
-            position = 2
-    )
-    default boolean mineUpstairs() {
-        return false;
-    }
+	@ConfigSection(
+		name = "Features",
+		description = "Feature Settings",
+		position = 1
+	)
+	String featureSection = "features";
 
-    // Upstairs hopper unlocked
-    @ConfigItem(
-            keyName = "UpstairsHopperUnlocked",
-            name = "Upstairs Hopper Unlocked?",
-            description = "Upstairs hopper unlocked?",
-            position = 3
-    )
-    default boolean upstairsHopperUnlocked() {
-        return false;
-    }
+	@ConfigItem(
+		keyName = isPickaxeInInventory,
+		name = "Pickaxe In Inventory",
+		description = "Where should the plugin look for a pickaxe<br>" +
+			"Enabled - looks in inventory<br>" +
+			"Disabled - looks in equipment",
+		position = 0,
+		section = generalSection
+	)
+	default boolean isPickaxeInInventory()
+	{
+		return false;
+	}
 
-    // Mining Area Selection
-    @ConfigItem(
-            keyName = "miningArea",
-            name = "Mining Area",
-            description = "Choose the specific area to mine in Motherload Mine",
-            position = 4
-    )
-    default MLMMiningSpotList miningArea() {
-        return MLMMiningSpotList.ANY;
-    }
+	@ConfigItem(
+		keyName = useInventorySetup,
+		name = "Enable Inventory Setup",
+		description = "Enable this option to use an inventory setup with the plugin",
+		position = 1,
+		section = generalSection
+	)
+	default boolean useInventorySetup()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = inventorySetup,
+		name = "Inventory Setup",
+		description = "Select the inventory setup to use with the plugin",
+		position = 2,
+		section = generalSection
+	)
+	default InventorySetup getInventorySetup()
+	{
+		return null;
+	}
+
+	@ConfigItem(
+		keyName = useDepositAll,
+		name = "Use Deposit All",
+		description = "Uses deposit all button in the deposit box<br>" +
+			"Note: ensure you enable locked slots enabled for the items you want to keep in your inventory",
+		position = 3,
+		section = generalSection
+	)
+	default boolean useDepositAll()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = antiCrash,
+		name = "Anti Crash",
+		description = "Avoids other players when mining in the lower level",
+		position = 4,
+		section = generalSection
+	)
+	default boolean useAntiCrash()
+	{
+		return false;
+	}
+
+	// Mine upstairs
+	@ConfigItem(
+		keyName = useUpstairsMine,
+		name = "Use Mine Upstairs",
+		description = "Should the plugin use the upstairs mining area",
+		position = 0,
+		section = featureSection
+	)
+	default boolean mineUpstairs()
+	{
+		return false;
+	}
+
+	// Upstairs hopper unlocked
+	@ConfigItem(
+		keyName = useUpstairsHopper,
+		name = "Use Upstairs Hopper",
+		description = "Should uthe plugin use the upstairs hopper",
+		position = 1,
+		section = featureSection
+	)
+	default boolean upstairsHopperUnlocked()
+	{
+		return false;
+	}
+
+	// Mining Area Selection
+	@ConfigItem(
+		keyName = miningArea,
+		name = "Mining Area",
+		description = "Choose the specific area to mine in Motherload Mine",
+		position = 2,
+		section = featureSection
+	)
+	default MLMMiningSpotList miningArea()
+	{
+		return MLMMiningSpotList.ANY;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineConfig.java
@@ -18,7 +18,6 @@ public interface MotherloadMineConfig extends Config
 {
 	String configGroup = "micro-motherloadmine";
 
-	String isPickaxeInInventory = "isPickaxeInInventory";
 	String useInventorySetup = "useInventorySetup";
 	String inventorySetup = "inventory-setup";
 	String useDepositAll = "useDepositAll";
@@ -42,24 +41,10 @@ public interface MotherloadMineConfig extends Config
 	String featureSection = "features";
 
 	@ConfigItem(
-		keyName = isPickaxeInInventory,
-		name = "Pickaxe In Inventory",
-		description = "Where should the plugin look for a pickaxe<br>" +
-			"Enabled - looks in inventory<br>" +
-			"Disabled - looks in equipment",
-		position = 0,
-		section = generalSection
-	)
-	default boolean isPickaxeInInventory()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = useInventorySetup,
 		name = "Enable Inventory Setup",
 		description = "Enable this option to use an inventory setup with the plugin",
-		position = 1,
+		position = 0,
 		section = generalSection
 	)
 	default boolean useInventorySetup()
@@ -71,7 +56,7 @@ public interface MotherloadMineConfig extends Config
 		keyName = inventorySetup,
 		name = "Inventory Setup",
 		description = "Select the inventory setup to use with the plugin",
-		position = 2,
+		position = 1,
 		section = generalSection
 	)
 	default InventorySetup getInventorySetup()
@@ -84,7 +69,7 @@ public interface MotherloadMineConfig extends Config
 		name = "Use Deposit All",
 		description = "Uses deposit all button in the deposit box<br>" +
 			"Note: ensure you enable locked slots enabled for the items you want to keep in your inventory",
-		position = 3,
+		position = 2,
 		section = generalSection
 	)
 	default boolean useDepositAll()
@@ -96,7 +81,7 @@ public interface MotherloadMineConfig extends Config
 		keyName = antiCrash,
 		name = "Anti Crash",
 		description = "Avoids other players when mining in the lower level",
-		position = 4,
+		position = 3,
 		section = generalSection
 	)
 	default boolean useAntiCrash()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import net.runelite.client.plugins.mining.MiningAnimation;
 
 @Slf4j
 public class MotherloadMineScript extends Script
@@ -381,18 +382,21 @@ public class MotherloadMineScript extends Script
             else {
                 int randomChoice = Math.toIntExact(Arrays.stream(MLMMiningSpot.values()).filter(s -> s.getWorldPoint() != null && s.isDownstairs()).count());
                 switch (randomChoice) {
-                    case 0:
+                    case 1:
                         miningSpot = MLMMiningSpot.WEST_LOWER;
                         break;
-                    case 1:
+                    case 2:
                         miningSpot = MLMMiningSpot.WEST_MID;
                         break;
-                    case 2:
+                    case 3:
                         miningSpot = MLMMiningSpot.SOUTH_WEST;
                         break;
-                    case 3:
+                    case 4:
                         miningSpot = MLMMiningSpot.SOUTH_EAST;
                         break;
+					default:
+						miningSpot = MLMMiningSpot.WEST_LOWER;
+						break;
                 }
             }
         } else {
@@ -444,12 +448,13 @@ public class MotherloadMineScript extends Script
             repositionCameraAndMove();
             return;
         }
-        // once a vein is found and ready to be interacted (mined), trigger the pickaxe special attack function
+
         handlePickaxeSpec();
+
         if (Rs2GameObject.interact(vein))
         {
             oreVein = vein;
-            sleepUntil(() -> Rs2Player.isAnimating() && oreVein.getWorldLocation().distanceTo(Microbot.getClient().getLocalPlayer().getWorldLocation()) <= 2, 10_000);
+            sleepUntil(() -> AntibanPlugin.isMining() && oreVein.getWorldLocation().distanceTo(Microbot.getClient().getLocalPlayer().getWorldLocation()) <= 2, 10_000);
             if (!Rs2Player.isAnimating()) {
 				oreVein = null;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
@@ -1,7 +1,9 @@
 package net.runelite.client.plugins.microbot.mining.motherloadmine;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.GameObject;
@@ -347,12 +349,21 @@ public class MotherloadMineScript extends Script
 			}
 		} else {
 			Rs2InventorySetup mlmInventorySetup = new Rs2InventorySetup(config.getInventorySetup(), mainScheduledFuture);
+			boolean doesEquipmentMatch = true;
+			boolean doesInventoryMatch = true;
+
 			if (!mlmInventorySetup.doesEquipmentMatch()) {
-				mlmInventorySetup.loadEquipment();
+				doesEquipmentMatch = mlmInventorySetup.loadEquipment();
 			}
 
 			if (!mlmInventorySetup.doesInventoryMatch()) {
-				mlmInventorySetup.loadInventory();
+				doesInventoryMatch = mlmInventorySetup.loadInventory();
+			}
+
+			if (!doesEquipmentMatch || !doesInventoryMatch) {
+				Microbot.showMessage("Failed to load inventory setup. Please check your settings.");
+				Microbot.stopPlugin(plugin);
+				return;
 			}
 		}
 
@@ -368,7 +379,7 @@ public class MotherloadMineScript extends Script
                 miningSpot = Rs2Random.between(0, 1) == 0 ? MLMMiningSpot.WEST_UPPER : MLMMiningSpot.EAST_UPPER;
             }
             else {
-                int randomChoice = Rs2Random.between(0, 3);
+                int randomChoice = Math.toIntExact(Arrays.stream(MLMMiningSpot.values()).filter(s -> s.getWorldPoint() != null && s.isDownstairs()).count());
                 switch (randomChoice) {
                     case 0:
                         miningSpot = MLMMiningSpot.WEST_LOWER;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
@@ -1,15 +1,26 @@
 package net.runelite.client.plugins.microbot.mining.motherloadmine;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.*;
+import net.runelite.api.GameObject;
+import net.runelite.api.Perspective;
+import net.runelite.api.Skill;
+import net.runelite.api.WallObject;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.ObjectID;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.mining.motherloadmine.enums.MLMMiningSpot;
-import net.runelite.client.plugins.microbot.mining.motherloadmine.enums.MLMMiningSpotList;
 import net.runelite.client.plugins.microbot.mining.motherloadmine.enums.MLMStatus;
+import net.runelite.client.plugins.microbot.mining.motherloadmine.enums.Pickaxe;
+import net.runelite.client.plugins.microbot.util.Rs2InventorySetup;
 import net.runelite.client.plugins.microbot.util.antiban.AntibanPlugin;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
@@ -17,6 +28,7 @@ import net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
+import net.runelite.client.plugins.microbot.util.depositbox.Rs2DepositBox;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
@@ -32,13 +44,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Slf4j
 public class MotherloadMineScript extends Script
 {
-    public static final String VERSION = "1.7.2";
+    public static final String VERSION = "1.8.0";
 
     private static final WorldArea WEST_UPPER_AREA = new WorldArea(3748, 5676, 7, 9, 0);
     private static final WorldArea EAST_UPPER_AREA = new WorldArea(3756, 5667, 8, 8, 0);
@@ -49,25 +59,39 @@ public class MotherloadMineScript extends Script
     private static final WorldPoint HOPPER_DEPOSIT_DOWN = new WorldPoint(3748, 5672, 0);
     private static final WorldPoint HOPPER_DEPOSIT_UP = new WorldPoint(3755, 5677, 0);
 
+	private static final WorldArea CRATE_AREA = new WorldArea(new WorldPoint(3750, 5659, 0), 10, 16);
+
+	private static final WorldPoint[] CRATE_WALKPOINTS = new WorldPoint[]
+	{
+		new WorldPoint(3755, 5671, 0),
+		new WorldPoint(3756, 5662, 0),
+		new WorldPoint(3751, 5662, 0),
+	};
+
     private static final int UPPER_FLOOR_HEIGHT = -490;
-    private static final int SACK_LARGE_SIZE = 162;
-    private static final int SACK_SIZE = 81;
-    private static final int SACK_ID = 26688;
+    private static final int SACK_LARGE_SIZE = 189;
+    private static final int SACK_SIZE = 108;
 
     public static MLMStatus status = MLMStatus.IDLE;
     public static WallObject oreVein;
     public static MLMMiningSpot miningSpot = MLMMiningSpot.IDLE;
     private int maxSackSize;
-    private MotherloadMineConfig config;
+	private final MotherloadMinePlugin plugin;
+    private final MotherloadMineConfig config;
 
-    private String pickaxeName = "";
     private boolean shouldEmptySack = false;
-    private boolean gemBagEmptiedThisCycle = false;
+	private boolean shouldRepairWaterwheel = false;
+	private boolean pickedUpHammer = false;
 
+	@Inject
+	public MotherloadMineScript(MotherloadMinePlugin plugin, MotherloadMineConfig config)
+	{
+		this.plugin = plugin;
+		this.config = config;
+	}
 
-    public boolean run(MotherloadMineConfig config)
+    public boolean run()
     {
-        this.config = config;
         initialize();
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(this::executeTask, 0, 600, TimeUnit.MILLISECONDS);
         return true;
@@ -79,13 +103,7 @@ public class MotherloadMineScript extends Script
         miningSpot = MLMMiningSpot.IDLE;
         status = MLMStatus.IDLE;
         shouldEmptySack = false;
-
-        if (config.pickAxeInInventory())
-        {
-            pickaxeName = Optional.ofNullable(Rs2Inventory.get("pickaxe"))
-                    .map(Rs2ItemModel::getName)
-                    .orElse("");
-        }
+		shouldRepairWaterwheel = false;
     }
 
     private void executeTask()
@@ -93,13 +111,6 @@ public class MotherloadMineScript extends Script
         if (!super.run() || !Microbot.isLoggedIn())
         {
             resetMiningState();
-            return;
-        }
-
-        if (config.pickAxeInInventory() && pickaxeName.isEmpty())
-        {
-            Microbot.showMessage("Pickaxe not found in your inventory");
-            shutdown();
             return;
         }
 
@@ -126,9 +137,6 @@ public class MotherloadMineScript extends Script
             case DEPOSIT_HOPPER:
                 depositHopper();
                 break;
-            case BANKING:
-                bankItems();
-                break;
         }
     }
 
@@ -145,63 +153,52 @@ public class MotherloadMineScript extends Script
         updateSackSize();
         if (!hasRequiredTools())
         {
-            bankItems();
+            setupInventory();
             return;
         }
 
-        int sackCount = Microbot.getVarbitValue(Varbits.SACK_NUMBER);
+        if (shouldRepairWaterwheel && Rs2GameObject.getGameObjects(o -> o.getId() == ObjectID.MOTHERLODE_WHEEL_STRUT_BROKEN).size() > 1) {
+            status = MLMStatus.FIXING_WATERWHEEL;
+            return;
+        }
 
-        if (sackCount > maxSackSize || (shouldEmptySack && !Rs2Inventory.contains("pay-dirt")))
+		int sackCount = Microbot.getVarbitValue(VarbitID.MOTHERLODE_SACK_TRANSMIT);
+        if (sackCount >= maxSackSize || (shouldEmptySack && !Rs2Inventory.contains(ItemID.PAYDIRT)))
         {
             resetMiningState();
             status = MLMStatus.EMPTY_SACK;
-        }
-        else if (!Rs2Inventory.isFull())
-        {
-            status = MLMStatus.MINING;
-        }
-        else // Inventory is full
-        {
-            resetMiningState();
-            if (Rs2Inventory.hasItem(ItemID.PAYDIRT))
-            {
-                if (Rs2GameObject.getGameObjects(o -> o.getId() == ObjectID.BROKEN_STRUT).size() > 1 && (Rs2Inventory.hasItem("hammer") || Rs2Equipment.isWearing("hammer")))
-                {
-                    status = MLMStatus.FIXING_WATERWHEEL;
-                }
-                else
-                {
-                    status = MLMStatus.DEPOSIT_HOPPER;
-                }
-            }
-            else
-            {
-                status = MLMStatus.BANKING;
-            }
+            return;
         }
 
-        if (Rs2Inventory.hasItem("coal") && Rs2Inventory.isFull())
+        if (Rs2Inventory.isFull() && Rs2Inventory.hasItem(ItemID.PAYDIRT))
         {
-            status = MLMStatus.BANKING;
+            resetMiningState();
+			status = MLMStatus.DEPOSIT_HOPPER;
+            return;
         }
+        status = MLMStatus.MINING;
     }
 
     private boolean hasRequiredTools()
     {
-        boolean hasHammer = Rs2Inventory.hasItem("hammer") || Rs2Equipment.isWearing("hammer");
-        boolean hasPickaxe = !config.pickAxeInInventory() || Rs2Inventory.hasItem(pickaxeName);
-        return hasHammer && hasPickaxe;
+		return Pickaxe.hasItem();
     }
 
     private void updateSackSize()
     {
-        boolean sackUpgraded = Microbot.getVarbitValue(Varbits.SACK_UPGRADED) == 1;
+        boolean sackUpgraded = Microbot.getVarbitValue(VarbitID.MOTHERLODE_BIGGERSACK) == 1;
         maxSackSize = sackUpgraded ? SACK_LARGE_SIZE : SACK_SIZE;
     }
 
     private void handleMining()
     {
         if (oreVein != null && AntibanPlugin.isMining()) return;
+
+		if (Rs2Gembag.isUnknown()) {
+			Rs2Gembag.checkGemBag();
+		}
+
+		shouldRepairWaterwheel = false;
 
         if (miningSpot == MLMMiningSpot.IDLE)
         {
@@ -223,16 +220,16 @@ public class MotherloadMineScript extends Script
     {
         ensureLowerFloor();
 
-        while (Microbot.getVarbitValue(Varbits.SACK_NUMBER) > 0)
+        while (Microbot.getVarbitValue(VarbitID.MOTHERLODE_SACK_TRANSMIT) > 0 && isRunning())
         {
             if (Rs2Inventory.count() <= 2)
             {
-                Rs2GameObject.interact(SACK_ID);
+                Rs2GameObject.interact(ObjectID.MOTHERLODE_SACK);
                 sleepUntil(this::hasOreInInventory);
             }
             if (hasOreInInventory())
             {
-                bankItems();
+                useDepositBox();
             }
         }
 
@@ -245,32 +242,39 @@ public class MotherloadMineScript extends Script
     {
         return Rs2Inventory.contains(
                 ItemID.RUNITE_ORE, ItemID.ADAMANTITE_ORE, ItemID.MITHRIL_ORE,
-                ItemID.GOLD_ORE, ItemID.COAL, ItemID.UNCUT_SAPPHIRE,
-                ItemID.UNCUT_EMERALD, ItemID.UNCUT_RUBY, ItemID.UNCUT_DIAMOND,
-                ItemID.UNCUT_DRAGONSTONE
+                ItemID.GOLD_ORE, ItemID.COAL
         );
     }
 
     private void fixWaterwheel()
     {
         ensureLowerFloor();
-        if (Rs2Walker.walkTo(new WorldPoint(3741, 5666, 0), 15))
-        {
-            Microbot.isGainingExp = false;
-            if (Rs2GameObject.interact(ObjectID.BROKEN_STRUT))
-            {
-                sleepUntil(() -> Microbot.isGainingExp);
-            }
-        }
+
+		if (!hasHammer()) {
+			if (!obtainHammer()) return;
+		}
+
+		if (Rs2GameObject.interact(ObjectID.MOTHERLODE_WHEEL_STRUT_BROKEN))
+		{
+			Rs2Player.waitForXpDrop(Skill.SMITHING, 10_000);
+
+			dropHammerIfNeeded();
+			shouldRepairWaterwheel = false;
+			if (Microbot.getVarbitValue(VarbitID.MOTHERLODE_SACK_TRANSMIT) > maxSackSize - 28)
+			{
+				shouldEmptySack = true;
+			}
+		}
     }
 
     private void depositHopper()
     {
         // if using a gem bag, fill the gem bag and return to mining if the inventory is no longer full
-        if (Rs2Inventory.isFull() && Rs2Gembag.hasGemBag())
+        if (Rs2Inventory.isFull() && (Rs2Gembag.hasGemBag() && !Rs2Gembag.isGemBagOpen()))
         {
-            Rs2Inventory.interact("gem bag", "Fill");
-            gemBagEmptiedThisCycle = false;
+			Rs2Inventory.interact("gem bag", "open");
+			sleepUntil(Rs2Gembag::isGemBagOpen);
+            Rs2Inventory.interact("gem bag", "fill");
             if (!Rs2Inventory.isFull())
             {
                 return;
@@ -278,7 +282,7 @@ public class MotherloadMineScript extends Script
         }
 
         WorldPoint hopperDeposit = (isUpperFloor() && config.upstairsHopperUnlocked()) ? HOPPER_DEPOSIT_UP : HOPPER_DEPOSIT_DOWN;
-        Optional<GameObject> hopper = Optional.ofNullable(Rs2GameObject.findObject(ObjectID.HOPPER_26674, hopperDeposit));
+        Optional<GameObject> hopper = Optional.ofNullable(Rs2GameObject.getGameObject(ObjectID.MOTHERLODE_HOPPER, hopperDeposit));
 
         if(isUpperFloor() && !config.upstairsHopperUnlocked())
         {
@@ -286,8 +290,11 @@ public class MotherloadMineScript extends Script
         }
         if (hopper.isPresent() && Rs2GameObject.interact(hopper.get()))
         {
-            sleepUntil(() -> !Rs2Inventory.isFull());
-            if (Microbot.getVarbitValue(Varbits.SACK_NUMBER) > maxSackSize - 28)
+			sleepUntil(() -> !Rs2Inventory.isFull() && !Rs2Player.isAnimating(), 10_000);
+
+			shouldRepairWaterwheel = true;
+
+            if (Microbot.getVarbitValue(VarbitID.MOTHERLODE_SACK_TRANSMIT) > maxSackSize - 28)
             {
                 shouldEmptySack = true;
             }
@@ -298,46 +305,71 @@ public class MotherloadMineScript extends Script
         }
     }
 
-    private void bankItems()
+    private void useDepositBox()
     {
-        if (Rs2Bank.useBank())
+        if (Rs2DepositBox.openDepositBox())
         {
-            sleepUntil(Rs2Bank::isOpen);
+            sleepUntil(Rs2DepositBox::isOpen);
 
             // if using the gem sack, empty its contents directly into the bank
-            if (Rs2Gembag.hasGemBag() && !gemBagEmptiedThisCycle)
+            if (Rs2Gembag.hasGemBag() && Rs2Gembag.getGemBagContents().stream().anyMatch(s -> s.getQuantity() > 30))
             {
-                Rs2Gembag.checkGemBag();
-                if (Rs2Gembag.getTotalGemCount() > 0)
-                {
-                    Rs2Inventory.interact("gem bag", "Empty");
-                    sleep(100, 300);
-                }
-                gemBagEmptiedThisCycle = true;
+				Rs2Bank.emptyGemBag();
+				sleep(100, 300);
             }
 
-            Rs2Bank.depositAllExcept("hammer", pickaxeName, "gem bag");
-            sleep(100, 300);
-
-            if (!Rs2Inventory.hasItem("hammer") && !Rs2Equipment.isWearing("hammer"))
-            {
-                if (!Rs2Bank.hasItem("hammer"))
-                {
-                    Microbot.showMessage("No hammer found in the bank.");
-                    sleep(5000);
-                    return;
-                }
-                Rs2Bank.withdrawOne("hammer", true);
-            }
-
-            if (config.pickAxeInInventory() && !Rs2Inventory.hasItem(pickaxeName))
-            {
-                Rs2Bank.withdrawOne(pickaxeName);
-            }
-            sleep(600);
+			if (config.useDepositAll()) {
+				Rs2DepositBox.depositAll();
+			} else {
+				Rs2DepositBox.depositAllExcept("hammer", "pickaxe", "gem bag");
+				Rs2Inventory.waitForInventoryChanges(5000);
+			}
         }
         status = MLMStatus.IDLE;
     }
+
+	private void setupInventory() {
+		if (!config.useInventorySetup()) {
+			Rs2ItemModel pickaxe = Pickaxe.getBestPickaxe(config.isPickaxeInInventory());
+			if (pickaxe == null) {
+				Rs2Bank.openBank();
+				sleepUntil(Rs2Bank::isOpen);
+				pickaxe = Pickaxe.getBestBankedPickaxe(config.isPickaxeInInventory());
+				if (pickaxe == null) {
+					Microbot.showMessage("No pickaxe found in bank or inventory. Please bank a pickaxe.");
+					Microbot.stopPlugin(plugin);
+					return;
+				}
+
+				if (config.isPickaxeInInventory()) {
+					Rs2Bank.withdrawOne(pickaxe.getId());
+					Rs2Inventory.waitForInventoryChanges(5000);
+				}
+				else {
+					final Rs2ItemModel _pickaxe = pickaxe;
+					Rs2Bank.withdrawAndEquip(_pickaxe.getId());
+					sleepUntil(() -> Rs2Equipment.isWearing(_pickaxe.getId()));
+				}
+			}
+			if (!config.isPickaxeInInventory() && Rs2Inventory.hasItem(pickaxe.getId())) {
+				final Rs2ItemModel _pickaxe = pickaxe;
+				Rs2Inventory.equip(_pickaxe.getId());
+				sleepUntil(() -> Rs2Equipment.isWearing(_pickaxe.getId()));
+			}
+		} else {
+			Rs2InventorySetup mlmInventorySetup = new Rs2InventorySetup(config.getInventorySetup(), mainScheduledFuture);
+			if (!mlmInventorySetup.doesEquipmentMatch()) {
+				mlmInventorySetup.loadEquipment();
+			}
+
+			if (!mlmInventorySetup.doesInventoryMatch()) {
+				mlmInventorySetup.loadInventory();
+			}
+		}
+
+		Rs2Bank.closeBank();
+		sleepUntil(() -> !Rs2Bank.isOpen());
+	}
 
     private void selectMiningSpotFromConfig() {
         MLMMiningSpot selected = MLMMiningSpot.valueOf(config.miningArea().name());
@@ -347,8 +379,21 @@ public class MotherloadMineScript extends Script
                 miningSpot = Rs2Random.between(0, 1) == 0 ? MLMMiningSpot.WEST_UPPER : MLMMiningSpot.EAST_UPPER;
             }
             else {
-                miningSpot = Rs2Random.between(0, 1) == 0 ? MLMMiningSpot.WEST_LOWER : MLMMiningSpot.WEST_MID;
-                miningSpot = Rs2Random.between(0, 1) == 0 ? MLMMiningSpot.SOUTH_WEST : MLMMiningSpot.SOUTH_EAST;
+                int randomChoice = Rs2Random.between(0, 3);
+                switch (randomChoice) {
+                    case 0:
+                        miningSpot = MLMMiningSpot.WEST_LOWER;
+                        break;
+                    case 1:
+                        miningSpot = MLMMiningSpot.WEST_MID;
+                        break;
+                    case 2:
+                        miningSpot = MLMMiningSpot.SOUTH_WEST;
+                        break;
+                    case 3:
+                        miningSpot = MLMMiningSpot.SOUTH_EAST;
+                        break;
+                }
             }
         } else {
             switch (selected) {
@@ -362,7 +407,7 @@ public class MotherloadMineScript extends Script
                     break;
                 default:
                     Microbot.showMessage("Invalid mining area selected.");
-                    shutdown();
+                    Microbot.stopPlugin(plugin);
                     return;
             }
         }
@@ -404,12 +449,10 @@ public class MotherloadMineScript extends Script
         if (Rs2GameObject.interact(vein))
         {
             oreVein = vein;
-            //sleepUntil(Rs2Player::isAnimating, 5000);
-            //if (!Rs2Player.isAnimating())
-            if (vein == null)
-            {
-                oreVein = null;
-            }
+            sleepUntil(Rs2Player::isAnimating, 5_000);
+            if (!Rs2Player.isAnimating()) {
+				oreVein = null;
+			}
         }
     }
 
@@ -429,11 +472,11 @@ public class MotherloadMineScript extends Script
 
         WorldPoint location = wallObject.getWorldLocation();
 
-        if (!config.mineUpstairs())
-        {
-            Stream<Rs2PlayerModel> players = Rs2Player.getPlayers(it -> it != null && it.getWorldLocation().distanceTo(wallObject.getWorldLocation()) <= 2);
-            if (players.findAny().isPresent()) return false;
-        }
+		if (!config.mineUpstairs() && config.useAntiCrash())
+		{
+			boolean isPlayerNearBy = Rs2Player.getPlayers(p -> p != null && p.getWorldLocation().distanceTo(wallObject.getWorldLocation()) <= 2).findAny().isPresent();
+			if (isPlayerNearBy) return false;
+		}
 
         if (config.mineUpstairs())
         {
@@ -475,14 +518,14 @@ public class MotherloadMineScript extends Script
     private void goUp()
     {
         if (isUpperFloor()) return;
-        Rs2GameObject.interact(NullObjectID.NULL_19044);
+        Rs2GameObject.interact(ObjectID.MOTHERLODE_LADDER_BOTTOM);
         sleepUntil(this::isUpperFloor);
     }
 
     private void goDown()
     {
         if (!isUpperFloor()) return;
-        Rs2GameObject.interact(NullObjectID.NULL_19045);
+        Rs2GameObject.interact(ObjectID.MOTHERLODE_LADDER_TOP);
         sleepUntil(() -> !isUpperFloor());
     }
 
@@ -507,11 +550,62 @@ public class MotherloadMineScript extends Script
         miningSpot = MLMMiningSpot.IDLE;
     }
 
+	private boolean hasHammer() {
+		return Rs2Equipment.isWearing("hammer") || Rs2Inventory.hasItem("hammer");
+	}
+
+	private boolean obtainHammer() {
+		/*
+
+			Typically, the hammer is located near the hopper on the lower floor OR near the sack,
+			so we should be close enough to directly interact with it.
+
+			WorldPoint nearestCratePoint = Arrays.stream(CRATE_WALKPOINTS)
+				.min(WorldPoint::distanceTo)
+				.orElse(CRATE_WALKPOINTS[0]);
+			if (!Rs2Walker.walkTo(nearestCratePoint)) return false;
+		 */
+
+		while (!Rs2Inventory.hasItem("hammer") && isRunning()) {
+			List<GameObject> crates = Rs2GameObject.getGameObjects(o -> !plugin.getBlacklistedCrates().contains(o.getWorldLocation()) && o.getId() == ObjectID.CRATE2_OLD);
+			Optional<GameObject> closestCrate = Rs2GameObject.pickClosest(crates, GameObject::getWorldLocation, Microbot.getClient().getLocalPlayer().getWorldLocation());
+
+			if (closestCrate.isEmpty()) {
+				log.error("Unable to find any crates to search for a hammer.");
+				break;
+			}
+
+			GameObject crate = closestCrate.get();
+
+			Rs2GameObject.interact(crate);
+			Rs2Inventory.waitForInventoryChanges(5_000);
+			if (!Rs2Inventory.hasItem("hammer")) {
+				plugin.getBlacklistedCrates().add(crate.getWorldLocation());
+				Rs2Inventory.drop("bronze pickaxe");
+				Rs2Inventory.waitForInventoryChanges(5_000);
+			} else {
+				pickedUpHammer = true;
+				break;
+			}
+
+			sleep(50, 100);
+		}
+
+		return pickedUpHammer;
+	}
+
+	private void dropHammerIfNeeded() {
+		if (pickedUpHammer) {
+			Rs2Inventory.drop("hammer");
+			sleepUntil(() -> !Rs2Inventory.hasItem("hammer"));
+			pickedUpHammer = false;
+		}
+	}
+
     @Override
     public void shutdown()
     {
         Rs2Antiban.resetAntibanSettings();
-        resetMiningState();
         Rs2Walker.setTarget(null);
         super.shutdown();
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/MotherloadMineScript.java
@@ -81,7 +81,6 @@ public class MotherloadMineScript extends Script
     public static WallObject oreVein;
     public static MLMMiningSpot miningSpot = MLMMiningSpot.IDLE;
     private int maxSackSize;
-	private Rectangle motherloadSackBounds;
 	private Set<String> itemsToKeep;
 
 	private final MotherloadMinePlugin plugin;
@@ -336,8 +335,7 @@ public class MotherloadMineScript extends Script
 
 			Rectangle gameObjectBounds = getMotherloadSackBounds();
 			Rectangle depositBoxBounds = Rs2DepositBox.getDepositBoxBounds();
-			if (gameObjectBounds != null && depositBoxBounds != null &&
-				(!Rs2UiHelper.isRectangleWithinViewport(gameObjectBounds) || Rs2UiHelper.isRectangleWithinRectangle(depositBoxBounds, gameObjectBounds))) {
+			if (depositBoxBounds != null && (!Rs2UiHelper.isRectangleWithinViewport(gameObjectBounds) || depositBoxBounds.intersects(gameObjectBounds))) {
 				Rs2DepositBox.closeDepositBox();
 			}
         }
@@ -655,15 +653,9 @@ public class MotherloadMineScript extends Script
 		}
 	}
 
-	/*
-		TODO: this needs to be further tested.
-	 */
 	private Rectangle getMotherloadSackBounds() {
-		if (motherloadSackBounds == null) {
-			TileObject sack = Rs2GameObject.getAll(o -> o.getId() == ObjectID.MOTHERLODE_SACK).stream().findFirst().orElse(null);
-			motherloadSackBounds = Rs2UiHelper.getObjectClickbox(sack);
-		}
-		return motherloadSackBounds;
+		TileObject sack = Rs2GameObject.getAll(o -> o.getId() == ObjectID.MOTHERLODE_SACK).stream().findFirst().orElse(null);
+		return Rs2UiHelper.getObjectClickbox(sack);
 	}
 
 	private int getBrokenStrutCount() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/enums/Pickaxe.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/enums/Pickaxe.java
@@ -77,4 +77,12 @@ public enum Pickaxe
 					.findFirst().orElse(0)))
                 .orElse(null);
     }
+
+	public static boolean hasAttackLevelRequirement(int itemId) {
+		return Arrays.stream(Pickaxe.values())
+			.filter(p -> p.getItemID() == itemId)
+			.findFirst()
+			.map(p -> Rs2Player.getSkillRequirement(Skill.ATTACK, p.getAttackLevel()))
+			.orElse(false);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/enums/Pickaxe.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/enums/Pickaxe.java
@@ -1,0 +1,80 @@
+package net.runelite.client.plugins.microbot.mining.motherloadmine.enums;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.runelite.api.Skill;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+@Getter
+@AllArgsConstructor
+public enum Pickaxe
+{
+
+	BRONZE_PICKAXE("bronze pickaxe", ItemID.BRONZE_PICKAXE, 1, 1),
+	IRON_PICKAXE("iron pickaxe", ItemID.IRON_PICKAXE, 1, 1),
+	STEEL_PICKAXE("steel pickaxe", ItemID.STEEL_PICKAXE, 6, 5),
+	BLACK_PICKAXE("black pickaxe", ItemID.BLACK_PICKAXE, 11, 10),
+	MITHRIL_PICKAXE("mithril pickaxe", ItemID.MITHRIL_PICKAXE, 21, 20),
+	ADAMANT_PICKAXE("adamant pickaxe", ItemID.ADAMANT_PICKAXE, 31, 30),
+	RUNE_PICKAXE("rune pickaxe", ItemID.RUNE_PICKAXE, 41, 40),
+	DRAGON_PICKAXE("dragon pickaxe", ItemID.DRAGON_PICKAXE, 61, 60),
+	CRYSTAL_PICKAXE("crystal pickaxe", ItemID.CRYSTAL_PICKAXE, 71, 70);
+
+	private final String itemName;
+	private final int itemID;
+	private final int miningLevel;
+	private final int attackLevel;
+
+	public boolean hasRequirements(boolean inventory) {
+		if (inventory) {
+			return Rs2Player.getSkillRequirement(Skill.MINING, miningLevel);
+		} else {
+			return Rs2Player.getSkillRequirement(Skill.MINING, miningLevel) && Rs2Player.getSkillRequirement(Skill.ATTACK, attackLevel);
+		}
+	}
+
+	public static int[] getAccessibleItemIDs() {
+		return Arrays.stream(Pickaxe.values()).filter(p -> p.hasRequirements(false)).mapToInt(Pickaxe::getItemID).toArray();
+	}
+
+	public static boolean hasItem() {
+		boolean hasPickaxeEquipped = Rs2Equipment.isWearing(getAccessibleItemIDs());
+		boolean hasPickaxeInInventory = Rs2Inventory.hasItem(getAccessibleItemIDs());
+		return hasPickaxeEquipped || hasPickaxeInInventory;
+	}
+	
+	private static Predicate<Rs2ItemModel> usablePickaxePredicate(boolean inventory) {
+        return item -> Arrays.stream(Pickaxe.values())
+                .filter(p -> p.getItemID() == item.getId())
+                .anyMatch(p -> p.hasRequirements(inventory));
+    }
+
+    public static Rs2ItemModel getBestPickaxe(boolean inventory) {
+        Stream<Rs2ItemModel> items = inventory ? Rs2Inventory.items() : Rs2Equipment.all();
+        return items.filter(usablePickaxePredicate(inventory))
+                .max(Comparator.comparingInt(item -> Arrays.stream(Pickaxe.values())
+					.filter(p -> p.getItemID() == item.getId())
+					.mapToInt(Pickaxe::getMiningLevel)
+					.findFirst().orElse(0)))
+                .orElse(null);
+    }
+
+    public static Rs2ItemModel getBestBankedPickaxe(boolean inventory) {
+        return Rs2Bank.getAll(usablePickaxePredicate(inventory))
+                .max(Comparator.comparingInt(item -> Arrays.stream(Pickaxe.values())
+					.filter(p -> p.getItemID() == item.getId())
+					.mapToInt(Pickaxe::getMiningLevel)
+					.findFirst().orElse(0)))
+                .orElse(null);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/depositbox/Rs2DepositBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/depositbox/Rs2DepositBox.java
@@ -49,10 +49,21 @@ public class Rs2DepositBox {
      *
      * @return the deposit box widget, or {@code null} if the deposit box is not open
      */
-    private static Widget getDepositBoxWidget() {
+    public static Widget getDepositBoxWidget() {
         if (!isOpen()) return null;
         return Rs2Widget.getWidget(DEPOSITBOX_PARENT_WIDGET_ID, 0);
     }
+
+	/**
+	 * Retrieves the bounding rectangle of the deposit box widget.
+	 *
+	 * @return the bounding rectangle of the deposit box widget, or {@code null} if the deposit box is not open or has no bounds
+	 */
+	public static Rectangle getDepositBoxBounds() {
+		Widget widget = getDepositBoxWidget();
+		if (widget == null || widget.getBounds() == null) return null;
+		return widget.getBounds();
+	}
 
     /**
      * Closes the deposit box interface.
@@ -64,8 +75,7 @@ public class Rs2DepositBox {
         Widget closeDepositBox = Rs2Widget.findWidget("Close", List.of(getDepositBoxWidget()), false);
         if (closeDepositBox == null) return false;
         Rs2Widget.clickWidget(closeDepositBox);
-        sleepUntilOnClientThread(() -> !isOpen());
-        return true;
+        return sleepUntil(() -> !isOpen());
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/depositbox/Rs2DepositBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/depositbox/Rs2DepositBox.java
@@ -106,7 +106,7 @@ public class Rs2DepositBox {
         if (depositAllWidget == null) return;
 
         Rs2Widget.clickWidget(depositAllWidget);
-        sleepUntil(Rs2Inventory::isEmpty);
+        Rs2Inventory.waitForInventoryChanges(5000);
     }
 
     /**


### PR DESCRIPTION
### Features
- Remove hammer dependency, the plugin will intelligently search for a hammer in the gears near Prospector Percey, these crates can provide a bronze pickaxe as well, if one provides a bronze pickaxe - we blacklist the crate until the player hops worlds & logouts
- Add Inventory Setup support
- Improve pickaxe selection & eliminate pickaxeInInventory config option
- Leverages Deposit box over bank chest for emptying sack, will also close the deposit box interface if blocking view


### Fixes
- Make Anti-Crash optional, this feature is only available when mining on the lower floor
- Improve sleeps/flow of walking to a mining spot & sleeping until we are mining 
- Improve mining spot randomization, this will not switch each time