### PR TITLE
fix: Changed the Breakhandlers future delay to 1 second.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
@@ -46,7 +46,7 @@ public class BreakHandlerScript extends Script {
     public static String version = "2.0.0";
     
     // Constants for configuration and timing
-    private static final int SCHEDULER_INTERVAL_MS = Constants.GAME_TICK_LENGTH;
+    private static final int SCHEDULER_INTERVAL_MS = 1000;
     private static final int MINUTES_TO_SECONDS = 60;
     
     // Configuration-dependent timing values (accessed through helper methods)


### PR DESCRIPTION
The BreakHandlers future delay was set to 1 gametick (0.6s) which made the plugin tick down the time too quickly, as the the timing is reduced at the same rate as the scheduled delay.
Changed to 1 second (1000ms) to accurately count down time.