### PR TITLE
fix(Tithe Farm): Lane_1_2 now correctly planting & harvesting 20 fruit

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tithefarm/TitheFarmingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tithefarm/TitheFarmingConfig.java
@@ -45,7 +45,7 @@ public interface TitheFarmingConfig extends Config {
             section = scriptSettings
     )
     default TitheFarmLanes Lanes() {
-        return TitheFarmLanes.LANE_2_3;
+        return TitheFarmLanes.LANE_1_2;
     }
 
     @ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tithefarm/TitheFarmingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tithefarm/TitheFarmingScript.java
@@ -91,9 +91,8 @@ public class TitheFarmingScript extends Script {
                         new TitheFarmPlant(40, 49, 16),
                         new TitheFarmPlant(45, 49, 17),
                         new TitheFarmPlant(45, 46, 18),
-                        new TitheFarmPlant(45, 49, 19),
-                        new TitheFarmPlant(45, 46, 20),
-                        new TitheFarmPlant(45, 43, 21)));
+                        new TitheFarmPlant(45, 43, 19),
+                        new TitheFarmPlant(45, 40, 20)));
                 break;
             case LANE_2_3:
                 plants = new ArrayList<>(Arrays.asList(


### PR DESCRIPTION
Adjusted Lane_1_2 coordinate list to include correct positions for lanes 1, 2, and half of lane 3. This resolves an issue where only 19 plants were placed per cycle, improving efficiency and ensuring optimal planting/harvesting throughput when using low-ping, lag-free conditions.

Tested successfully using antiban settings enabled on a low ping, lag-free world.