### PR TITLE
Agility Scheduler Conditions & Pickaxe Detection in MLM update

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
@@ -86,14 +86,6 @@ public class AgilityScript extends Script
 					return;
 				}
 
-				// If we're at the start of the course
-				if(config.agilityCourse().getHandler().getCurrentObstacle().equals(config.agilityCourse().getHandler().getObstacles().get(0)))
-				{
-					unlockTheScript(plugin); //unlock the plugin, the bot will click the first obstacle then return, re-locking.
-				} else {
-					lockTheScript(plugin);
-				}
-
 				final WorldPoint playerWorldLocation = Microbot.getClient().getLocalPlayer().getWorldLocation();
 
 				if (handleFood())
@@ -299,19 +291,5 @@ public class AgilityScript extends Script
 			Rs2Inventory.dropAll(ItemID.PIEDISH);
 		}
 		return true;
-	}
-
-	private void lockTheScript(MicroAgilityPlugin plugin)
-	{
-		if (plugin.getLockCondition(plugin.getStopCondition()) != null) {
-			plugin.getLockCondition(plugin.getStopCondition()).lock();
-		}
-	}
-
-	private void unlockTheScript(MicroAgilityPlugin plugin)
-	{
-		if (plugin.getLockCondition(plugin.getStopCondition()) != null) {
-			plugin.getLockCondition(plugin.getStopCondition()).unlock();
-		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/enums/Pickaxe.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mining/motherloadmine/enums/Pickaxe.java
@@ -44,7 +44,7 @@ public enum Pickaxe
 	}
 
 	public static int[] getAccessibleItemIDs() {
-		return Arrays.stream(Pickaxe.values()).filter(p -> p.hasRequirements(false)).mapToInt(Pickaxe::getItemID).toArray();
+		return Arrays.stream(Pickaxe.values()).filter(p -> p.hasRequirements(true)).mapToInt(Pickaxe::getItemID).toArray();
 	}
 
 	public static boolean hasItem() {


### PR DESCRIPTION
## Fixes
Agility
  __Issue__: New scheduler implementation (#1326) was using a simple lock condition, which causes the break handler lock state to be toggled, then leads to the break handler being locked / unlocked during the agility course.
  
  __Resolution__: Create a more prominent stop condition, such as a predicate condition and a supplier to provide game data to the scheduler to determine if we are at the course start. This approach requires no script interaction just suppling the scheduler with the needed information to determine if we can stop the plugin

Note: There are other things that would prevent this script from truly being schedulable, such as proper pre-post tasks in-order to withdraw alchable items & means to cast High Alch, equip graceful set or withdrawing summer pies are just a few examples.
  
 MLM
   __Issue__: Previous Pickaxe Enum did not fully encompass the differences in requirements when equipped vs inventory
   
   __Resolution__: Simplify conditions for `Pickaxe#hasItem`