### PR TITLE
fix(PluginManager): ensure plugin is stopped before removal

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -559,6 +559,14 @@ public class PluginManager {
     }
 
     public void remove(Plugin plugin) {
+        try
+        {
+            Microbot.stopPlugin(plugin);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
         plugins.remove(plugin);
     }
 


### PR DESCRIPTION
This pull request updates the plugin removal process in `PluginManager` to ensure that plugins are properly stopped before being removed. The main change is the addition of a call to `Microbot.stopPlugin(plugin)` inside the `remove` method, with exception handling to wrap any errors in a `RuntimeException`.

Plugin lifecycle management:

* Updated the `remove` method in `PluginManager` (`PluginManager.java`) to call `Microbot.stopPlugin(plugin)` before removing a plugin, ensuring proper shutdown of plugin resources and handling any exceptions by rethrowing them as `RuntimeException`s.