### PR TITLE
Update "Wiki" plugin's popup option to properly redirect to it's page

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotConfigPanel.java
@@ -185,7 +185,7 @@ class MicrobotConfigPanel extends PluginPanel
 			uninstallItem.addActionListener(ev -> externalPluginManager.remove(iname));
 		}
 
-		MicrobotPluginListItem.addLabelPopupMenu(title, pluginConfig.createSupportMenuItem(), uninstallItem);
+		MicrobotPluginListItem.addLabelPopupMenu(title, pluginConfig.createSupportMenuItem(pluginConfig.getPlugin()), uninstallItem);
 
 		if (pluginConfig.getPlugin() != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginConfigurationDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginConfigurationDescriptor.java
@@ -69,18 +69,18 @@ public class MicrobotPluginConfigurationDescriptor
 	 * @return A {@link JMenuItem} which opens the plugin's wiki page URL in the browser when clicked
 	 */
 	@Nullable
-	JMenuItem createSupportMenuItem()
+	JMenuItem createSupportMenuItem(Plugin plugin)
 	{
 		String iname = getInternalPluginHubName();
 		if (iname != null)
 		{
-			JMenuItem menuItem = new JMenuItem("Support");
-			menuItem.addActionListener(e -> LinkBrowser.browse("https://runelite.net/plugin-hub/show/" + iname));
+			JMenuItem menuItem = new JMenuItem("Wiki");
+			menuItem.addActionListener(e -> LinkBrowser.browse("https://chsami.github.io/Microbot-Hub/" + iname));
 			return menuItem;
 		}
 
 		JMenuItem menuItem = new JMenuItem("Wiki");
-		menuItem.addActionListener(e -> LinkBrowser.browse("https://github.com/runelite/runelite/wiki/" + name.replace(' ', '-')));
+		menuItem.addActionListener(e -> LinkBrowser.browse("https://chsami.github.io/Microbot-Hub/" + (plugin != null ? plugin.getClass().getSimpleName() : "")));
 		return menuItem;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginListItem.java
@@ -141,7 +141,7 @@ class MicrobotPluginListItem extends JPanel implements SearchablePlugin
 			uninstallItem.addActionListener(ev -> pluginListPanel.getExternalPluginManager().remove(internalName));
 		}
 
-		addLabelPopupMenu(nameLabel, configMenuItem, pluginConfig.createSupportMenuItem(), uninstallItem);
+		addLabelPopupMenu(nameLabel, configMenuItem, pluginConfig.createSupportMenuItem(pluginConfig.getPlugin()), uninstallItem);
 		add(nameLabel, BorderLayout.CENTER);
 
 		onOffToggle = new MicrobotPluginToggleButton();


### PR DESCRIPTION
This pull request updates how the support/wiki menu item is created for plugins in the Microbot plugins UI. The main change is that the menu now consistently links to the Microbot Hub wiki for each plugin, and the logic for generating the menu item now requires the plugin instance as a parameter.

**Improvements to plugin support/wiki menu:**

* Changed `createSupportMenuItem` in `MicrobotPluginConfigurationDescriptor` to accept a `Plugin` parameter and updated its logic to always link to the Microbot Hub wiki, using either the internal name or the plugin class name. The menu item is now labeled "Wiki" instead of "Support".
* Updated calls to `createSupportMenuItem` in both `MicrobotConfigPanel` and `MicrobotPluginListItem` to pass the plugin instance as an argument. [[1]](diffhunk://#diff-db44c8150c6465de022128f225f9babb250d20825b98346eeb899dd7b6a77babL188-R188) [[2]](diffhunk://#diff-2233673cb7e292f87fb55d08b41175a189f76e6efdd9ecad5fd530315f152356L144-R144)