### PR TITLE
feat(Rs2Tile): Add method to mark dangerous tiles from GameObjects

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/tile/Rs2Tile.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/tile/Rs2Tile.java
@@ -75,6 +75,29 @@ public abstract class Rs2Tile implements Tile {
     }
 
     /**
+     * Adds a dangerous tile from a gameobject, to the list of dangerous tiles
+     * @param gameObject the gameobject object
+     * @param time the time a tile is dangerous in milliseconds
+     */
+    public static void addDangerousGameObjectTile(GameObject gameObject, int time) {
+        if (gameObject == null) return;
+
+        WorldPoint worldPoint = gameObject.getWorldLocation();
+        if (worldPoint == null) return;
+
+        dangerousGraphicsObjectTilesInternal.merge(worldPoint, time, Math::max);
+
+        if (Rs2Player.getWorldLocation().equals(worldPoint)) {
+            Microbot.getClientThread().runOnSeperateThread(() -> {
+                final WorldPoint safeTile = Rs2Tile.getSafeTile();
+                System.out.println(safeTile);
+                Rs2Walker.walkFastCanvas(safeTile);
+                return true;
+            });
+        }
+    }
+
+    /**
      * Returns a safe tile based on dangerous tiles
      *
      * @return list of safe tile, sorted on the closest tile to the player


### PR DESCRIPTION
Introduces addDangerousGameObjectTile to track dangerous tiles based on GameObject locations and trigger movement to a safe tile if the player is on a dangerous tile. This enhances safety logic by integrating GameObject-based hazards.


Note: Needed for future PluginHub plugin