### PR TITLE
Removal of hardcoded microbreak setting and return for microbreak

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/tempoross/TemporossScript.java
@@ -72,13 +72,12 @@ public class TemporossScript extends Script {
         Rs2Antiban.resetAntibanSettings();
         Rs2AntibanSettings.naturalMouse = true;
         Rs2AntibanSettings.simulateMistakes = false;
-        Rs2AntibanSettings.takeMicroBreaks = true;
-        Rs2AntibanSettings.microBreakChance = 0.2;
+
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() ->{
             try {
                 if (!Microbot.isLoggedIn()) return;
                 if (!super.run()) return;
-                if (BreakHandlerScript.isBreakActive()) return;
+                if (BreakHandlerScript.isBreakActive() || BreakHandlerScript.isMicroBreakActive()) return;
 
                 if (!isInMinigame()) {
                     handleEnterMinigame();


### PR DESCRIPTION
It's not healthy to enable and set break chances in behalf of user as it may see the character idle there or logged out without knowing exactly why.

This pull request makes a small update to the Tempoross plugin's script logic, specifically related to how microbreaks are handled. The main change is to improve how the script checks for active breaks, now including both regular and microbreaks, and to remove the direct enabling of microbreak settings in the antiban configuration.

- Updated the scheduled task in `TemporossScript.java` to check for both regular breaks and microbreaks by using `BreakHandlerScript.isBreakActive()` and `BreakHandlerScript.isMicroBreakActive()`, preventing the script from running during either type of break.
- Removed direct assignment of `Rs2AntibanSettings.takeMicroBreaks` and `Rs2AntibanSettings.microBreakChance`, delegating microbreak management to the break handler logic.