### PR TITLE
Small Chores

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -41,7 +41,7 @@
 		<git.commit.id.abbrev>nogit</git.commit.id.abbrev>
 		<git.dirty>false</git.dirty>
 		<shade.skip>false</shade.skip>
-		<microbot.version>1.9.8.1</microbot.version>
+		<microbot.version>1.9.8.2</microbot.version>
 		<microbot.commit.sha>nogit</microbot.commit.sha>
 	</properties>
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginListPanel.java
@@ -130,7 +130,7 @@ public class MicrobotPluginListPanel extends PluginPanel {
 
         searchBar = new IconTextField();
         searchBar.setIcon(IconTextField.Icon.SEARCH);
-        searchBar.setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH - 20, 50));
+        searchBar.setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH - 20, 30));
         searchBar.setBackground(ColorScheme.DARKER_GRAY_COLOR);
         searchBar.setHoverBackgroundColor(ColorScheme.DARK_GRAY_HOVER_COLOR);
         searchBar.getDocument().addDocumentListener(new DocumentListener() {


### PR DESCRIPTION
### Chores
- Revert search bar to 30 from 50, this matches the runelite plugin panel search bar. Keeps things consistent.
- Bump version number