### PR TITLE
fix(bluedragons): add dragon ID 267 and improve bot functionality

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsConfig.java
@@ -26,8 +26,11 @@ public interface BlueDragonsConfig extends Config {
     @ConfigItem(keyName = "lootEnsouledHead", name = "Loot Ensouled heads", description = "LootEnsouled heads dropped by the dragon", section = lootSection)
     default boolean lootEnsouledHead() { return true; }
 
-    @ConfigItem(keyName = "lootMiscItems", name = "Loot items over 3.5k?", description = "Should we loot items worth more than 3.5k?", section = lootSection)
+    @ConfigItem(keyName = "lootMiscItems", name = "Loot items above value", description = "Should we loot items above the specified value threshold?", section = lootSection)
     default boolean lootMiscItems() { return true; }
+
+    @ConfigItem(keyName = "lootValueThreshold", name = "Loot value threshold", description = "Minimum value in GP for items to be looted", section = lootSection)
+    default int lootValueThreshold() { return 3500; }
 
     @ConfigSection(name = "Food Options", description = "Settings for selecting food and health threshold", position = 2)
     String foodSection = "foodSection";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsScript.java
@@ -353,7 +353,7 @@ public class BlueDragonsScript extends Script {
             lootedAnything |= lootItem("Scaly blue dragonhide");
         }
         if (config.lootMiscItems() && !isInventoryFull()) {
-            Rs2GroundItem.lootItemBasedOnValue(new LootingParameters(3500, 100000, 8, 1, 1, false, true));
+            Rs2GroundItem.lootItemBasedOnValue(new LootingParameters(config.lootValueThreshold(), 100000, 8, 1, 1, false, true));
         }
 
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsScript.java
@@ -139,18 +139,62 @@ public class BlueDragonsScript extends Script {
 
         if (Rs2Bank.walkToBankAndUseBank(BankLocation.FALADOR_WEST)) {
             logOnceToChat("Opened bank. Depositing loot.", true, config);
+            // Core drops
+            Rs2Bank.depositAll("Blue dragonhide");
             Rs2Bank.depositAll("Dragon bones");
-            Rs2Bank.depositAll("Dragon spear");
-            Rs2Bank.depositAll("Shield left half");
             Rs2Bank.depositAll("Scaly blue dragonhide");
-
-            if (config.lootEnsouledHead()) {
-                Rs2Bank.depositAll("Ensouled dragon head");
-            }
-
-            if (config.lootDragonhide()) {
-                Rs2Bank.depositAll("Blue dragonhide");
-            }
+            Rs2Bank.depositAll("Ensouled dragon head");
+            
+            // Equipment drops
+            Rs2Bank.depositAll("Steel platelegs");
+            Rs2Bank.depositAll("Mithril axe");
+            Rs2Bank.depositAll("Steel battleaxe");
+            Rs2Bank.depositAll("Mithril spear");
+            Rs2Bank.depositAll("Adamant full helm");
+            Rs2Bank.depositAll("Mithril kiteshield");
+            Rs2Bank.depositAll("Rune dagger");
+            Rs2Bank.depositAll("Rune javelin");
+            Rs2Bank.depositAll("Rune spear");
+            Rs2Bank.depositAll("Shield left half");
+            Rs2Bank.depositAll("Dragon spear");
+            
+            // Runes
+            Rs2Bank.depositAll("Nature rune");
+            Rs2Bank.depositAll("Fire rune");
+            
+            // Herbs
+            Rs2Bank.depositAll("Grimy guam leaf");
+            Rs2Bank.depositAll("Grimy marrentill");
+            Rs2Bank.depositAll("Grimy tarromin");
+            Rs2Bank.depositAll("Grimy harralander");
+            Rs2Bank.depositAll("Grimy ranarr weed");
+            Rs2Bank.depositAll("Grimy irit leaf");
+            Rs2Bank.depositAll("Grimy avantoe");
+            Rs2Bank.depositAll("Grimy kwuarm");
+            Rs2Bank.depositAll("Grimy cadantine");
+            Rs2Bank.depositAll("Grimy lantadyme");
+            Rs2Bank.depositAll("Grimy dwarf weed");
+            
+            // Resources and gems
+            Rs2Bank.depositAll("Coins");
+            Rs2Bank.depositAll("Adamantite ore");
+            Rs2Bank.depositAll("Bass");
+            Rs2Bank.depositAll("Uncut sapphire");
+            Rs2Bank.depositAll("Uncut emerald");
+            Rs2Bank.depositAll("Uncut ruby");
+            Rs2Bank.depositAll("Uncut diamond");
+            
+            // Talismans and keys
+            Rs2Bank.depositAll("Chaos talisman");
+            Rs2Bank.depositAll("Nature talisman");
+            Rs2Bank.depositAll("Loop half of key");
+            Rs2Bank.depositAll("Tooth half of key");
+            Rs2Bank.depositAll("Tooth half of key (moon key)");
+            Rs2Bank.depositAll("Brimstone key");
+            Rs2Bank.depositAll("Frozen tear");
+            
+            // Clue scrolls
+            Rs2Bank.depositAll("Clue scroll (hard)");
             logOnceToChat("Withdrawing food for combat.", true, config);
             withdrawFood(config);
             Rs2Bank.closeBank();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/bluedragons/BlueDragonsScript.java
@@ -45,6 +45,7 @@ public class BlueDragonsScript extends Script {
 
     private static final int BLUE_DRAGON_ID_1 = 265;
     private static final int BLUE_DRAGON_ID_2 = 266;
+    private static final int BLUE_DRAGON_ID_3 = 267;
     private static final int MIN_WORLD = 302;
     private static final int MAX_WORLD = 580;
 
@@ -227,7 +228,7 @@ public class BlueDragonsScript extends Script {
             return;
         }
 
-        boolean walkAttemptSuccessful = Rs2Walker.walkTo(SAFE_SPOT);
+        boolean walkAttemptSuccessful = Rs2Walker.walkTo(SAFE_SPOT, 0);
         
         if (!walkAttemptSuccessful) {
             logOnceToChat("Failed to start walking to safe spot. Will retry next tick.", true, config);
@@ -461,8 +462,8 @@ public class BlueDragonsScript extends Script {
         logOnceToChat("Found dragon: " + (dragon != null ? "Yes (ID: " + dragon.getId() + ")" : "No"), true, config);
         
         if (dragon != null) {
-            boolean correctId = (dragon.getId() == BLUE_DRAGON_ID_1 || dragon.getId() == BLUE_DRAGON_ID_2);
-            logOnceToChat("Dragon has correct ID (265 or 266): " + correctId, true, config);
+            boolean correctId = (dragon.getId() == BLUE_DRAGON_ID_1 || dragon.getId() == BLUE_DRAGON_ID_2 || dragon.getId() == BLUE_DRAGON_ID_3);
+            logOnceToChat("Dragon has correct ID (265, 266, or 267): " + correctId, true, config);
             
             boolean hasLineOfSight = Rs2Npc.hasLineOfSight(new Rs2NpcModel(dragon));
             logOnceToChat("Has line of sight to dragon: " + hasLineOfSight, true, config);
@@ -511,7 +512,7 @@ public class BlueDragonsScript extends Script {
         
         if (distance > 15) {
             logOnceToChat("Using walkTo to approach safe spot", true, config);
-            Rs2Walker.walkTo(SAFE_SPOT);
+            Rs2Walker.walkTo(SAFE_SPOT, 0);
             
             sleepUntil(() -> Rs2Player.distanceTo(SAFE_SPOT) <= 5, 30000);
         }


### PR DESCRIPTION
## Summary
- Fix bot waiting for respawn instead of attacking available dragon by adding missing ID 267
- Add configurable loot value threshold to replace hardcoded 3500 GP
- Expand bank deposit list to include all blue dragon drops
- Ensure exact safespot positioning with distance 0

## Changes
- Add blue dragon ID 267 to constants (fixes second dragon detection)
- Replace hardcoded loot threshold with user-configurable value
- Add comprehensive bank deposit list organized by category
- Use Rs2Walker with distance 0 for precise safespot positioning

## Testing
- Bot now correctly attacks both dragons from safespot
- Loot threshold is configurable in plugin settings
- All valuable drops are properly banked