### PR TITLE
fix(GiantSeaweed): fixed dead seaweed varbits, atomic operations, and spore looting coordination

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/GiantSeaweedFarmer/GiantSeaweedFarmerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/GiantSeaweedFarmer/GiantSeaweedFarmerScript.java
@@ -329,14 +329,18 @@ public class GiantSeaweedFarmerScript extends Script {
         };
         var obj = Rs2GameObject.findObject(ids);
         
-        // If not found by ID, look for Dead seaweed specifically
+        // If not found by ID, look for patch objects by name
         if (obj == null) {
             obj = Rs2GameObject.getGameObjects()
                     .stream()
                     .filter(o -> {
                         var objComp = Rs2GameObject.convertToObjectComposition(o, false);
-                        return objComp != null && objComp.getName() != null && 
-                               objComp.getName().equalsIgnoreCase("Dead seaweed");
+                        if (objComp == null || objComp.getName() == null) return false;
+                        String name = objComp.getName();
+                        // Look for seaweed patch objects or dead seaweed
+                        return name.equalsIgnoreCase("Dead seaweed") || 
+                               name.equalsIgnoreCase("Seaweed patch") ||
+                               (name.equalsIgnoreCase("Seaweed") && objComp.getId() == patchId);
                     })
                     .findFirst()
                     .orElse(null);
@@ -354,20 +358,20 @@ public class GiantSeaweedFarmerScript extends Script {
                 Rs2Player.waitForXpDrop(Skill.FARMING);
                 Rs2Inventory.use(" spore");
                 Rs2GameObject.interact(patchObj, "Plant");
-                sleepUntil(() -> getSeaweedPatchState(patchObj).equals("Growing"));
-                return false;
+                sleepUntil(() -> getSeaweedPatchState(patchObj).equals("Growing"), 10000);
+                return true;
             case "Harvestable":
                 Rs2GameObject.interact(patchObj, "Pick");
                 sleepUntil(() -> getSeaweedPatchState(patchObj).equals("Empty") || Rs2Inventory.isFull(), 20000);
-                return false;
+                return true;
             case "Weeds":
                 Rs2GameObject.interact(patchObj);
                 sleepUntil(() -> !getSeaweedPatchState(patchObj).equals("Weeds"), 10000);
-                return false;
+                return true;
             case "Dead":
                 Rs2GameObject.interact(patchObj, "Clear");
-                sleepUntil(() -> getSeaweedPatchState(patchObj).equals("Empty"));
-                return false;
+                sleepUntil(() -> getSeaweedPatchState(patchObj).equals("Empty"), 10000);
+                return true;
             default:
                 currentPatch = null;
                 return true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/GiantSeaweedFarmer/GiantSeaweedFarmerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/GiantSeaweedFarmer/GiantSeaweedFarmerScript.java
@@ -156,6 +156,10 @@ public class GiantSeaweedFarmerScript extends Script {
 
     private void returnToBank() {
         Rs2Walker.walkTo(3731, 10280, 1); // Get to anchor
+        
+        // Brief pause to allow spore detection before climbing
+        sleep(300, 500);
+        
         Rs2GameObject.interact(UNDERWATER_ANCHOR, "Climb");
         sleepUntil(() -> Rs2Player.getWorldLocation().getPlane() == 0, 7000);
         if (Rs2Player.getWorldLocation().getPlane() != 0) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/GiantSeaweedFarmer/GiantSeaweedSporeScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/TaF/GiantSeaweedFarmer/GiantSeaweedSporeScript.java
@@ -19,8 +19,9 @@ public class GiantSeaweedSporeScript extends Script {
                 if (!super.run() || !Microbot.isLoggedIn()) return;
                 if (!config.lootSeaweedSpores()) return;
                 
-                // Check for seaweed spores
-                if (Rs2GroundItem.exists(ItemID.SEAWEED_SPORE, 15)) {
+                // Check for seaweed spores - but respect critical farming operations
+                if (Rs2GroundItem.exists(ItemID.SEAWEED_SPORE, 15) && 
+                    !GiantSeaweedFarmerScript.inCriticalSection) {
                     // Pause all other scripts while we loot
                     Microbot.pauseAllScripts.set(true);
                     try {


### PR DESCRIPTION
## Summary
Fixes issues in the Giant Seaweed Farmer plugin including incorrect patch state detection and race conditions with concurrent spore looting.

## Changes
- **Fixed varbit detection**: Replaced incorrect herb farming varbit ranges with official RuneLite seaweed ranges from `PatchImplementation.java`
- **Added critical section protection**: Made composting+planting atomic to prevent spore looting interruptions
- **Improved patch state handling**:
  - Fixed detection for dead seaweed patches (varbits 14-16)
  - Fixed weed detection (varbits 0-2, 17-255)
  - Special handling for varbit 3 (fully raked, ready for planting)
- **Enhanced recovery logic**: Patches properly replant after raking/clearing/harvesting
- **Thread-safe coordination**: Added `volatile` flag to coordinate between farming and spore scripts

## Testing
- Dead seaweed patches now correctly detected and cleared
- Patches with weeds properly raked and planted
- Composting and planting complete without interruption