### PR TITLE
fix(CombatHotkeys): fixed dance functionality in combat hotkeys plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysPlugin.java
@@ -152,7 +152,7 @@ public class CombatHotkeysPlugin extends Plugin implements KeyListener {
     @Subscribe
     public void onMenuEntryAdded(MenuEntryAdded event)
     {
-        if (event.getOption().equals("Walk here"))
+        if (event.getOption().equals("Walk here") && config.yesDance())
         {
             Microbot.getClient().getMenu().createMenuEntry(-1)
                     .setOption("Dancing -> mark tile 2")


### PR DESCRIPTION
Currently when combat hotkeys is running, the right click context menu always shows the two dance tile options even when the dance option is not ticked in the plugin config. This small change fixes functionality so that it only works when the tickbox has been activated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * “Dancing → mark tile” context menu entries now appear only when “Walk here” is selected and the Dance setting is enabled, aligning behavior with user preferences.
  * Reduces unexpected menu clutter by respecting the Dance configuration toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->