### PR TITLE
fix(AIOFighter): consider loot style configuration

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
 )
 @Slf4j
 public class AIOFighterPlugin extends Plugin {
-    public static final String version = "2.0.1 BETA";
+    public static final String version = "2.0.2 BETA";
     public static boolean needShopping = false;
     private static final String SET = "Set";
     private static final String CENTER_TILE = ColorUtil.wrapWithColorTag("Center Tile", JagexColors.MENU_TARGET);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/loot/LootScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/loot/LootScript.java
@@ -12,12 +12,10 @@ import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2RunePouch;
+import net.runelite.client.plugins.microbot.util.magic.Runes;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -92,7 +90,8 @@ public class LootScript extends Script {
         if (!groundItem.isStackable()) {
             return false;
         }
-        if (Rs2RunePouch.contains(groundItem.getItemId())) {
+        int runePouchRunes = Rs2RunePouch.getQuantity(groundItem.getItemId());
+        if (runePouchRunes > 0 && runePouchRunes <= 16000 - groundItem.getQuantity()) {
             return true;
         }
         //TODO("Coal bag, Herb Sack, Seed pack")
@@ -100,6 +99,8 @@ public class LootScript extends Script {
     }
 
     private boolean shouldLootBasedOnValue(GroundItem groundItem, AIOFighterConfig config) {
+        if (config.looterStyle() != DefaultLooterStyle.GE_PRICE_RANGE && config.looterStyle() != DefaultLooterStyle.MIXED)
+            return false;
         int price = groundItem.getGePrice();
         return config.minPriceOfItemsToLoot() <= price && price / groundItem.getQuantity() <= config.maxPriceOfItemsToLoot();
     }


### PR DESCRIPTION
Script was ignoring loot style configuration and always picked up items based on value. In addition to that it would try to pick up runes that were in your runepouch at full inventory when they wouldn't fit in the rune pouch.