### PR TITLE
fix(Moons Of Peril): Break out of blood jaguar phase at correct time

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/moonsOfPeril/handlers/BloodMoonHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/moonsOfPeril/handlers/BloodMoonHandler.java
@@ -193,7 +193,7 @@ public class BloodMoonHandler implements BaseHandler {
 
         while (isSpecialAttack1Sequence() && System.currentTimeMillis() - startMs < TIMEOUT_MS) {
             int bloodPoolTick = moonsOfPerilPlugin.bloodPoolTick;
-            if (targetJaguar.getAnimation() == 10960) {
+            if (targetJaguar.getAnimation() == 12492) {
                 sleep(600);
                 break;
             }


### PR DESCRIPTION
- Corrected the death animation ID of blood jaguar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected animation detection for the Jaguar’s special attack during Blood Moon encounters, resolving inconsistent handling that could cause missed or delayed actions.
  * Improves reliability and timing of the special attack sequence, ensuring interactions proceed as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->