### PR TITLE
Remove syncPlugins method from MicrobotPluginManager

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -352,7 +352,7 @@ public class PluginManager {
             try {
                 plugin = instantiate(this.plugins, (Class<Plugin>) pluginClazz);
                 newPlugins.add(plugin);
-                this.plugins.add(plugin);
+                add(plugin);
             } catch (PluginInstantiationException ex) {
                 log.error("Error instantiating plugin!", ex);
             }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/externalplugins/MicrobotPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/externalplugins/MicrobotPluginManager.java
@@ -394,31 +394,6 @@ public class MicrobotPluginManager
         return MICROBOT_PLUGINS.listFiles();
     }
 
-	public void syncPlugins()
-	{
-		List<String> installed = getInstalledPlugins();
-		Map<String, Plugin> loadedByInternalName = pluginManager.getPlugins().stream()
-			.filter(p -> p.getClass().isAnnotationPresent(PluginDescriptor.class))
-			.filter(p -> {
-				PluginDescriptor d = p.getClass().getAnnotation(PluginDescriptor.class);
-				return d != null && d.isExternal();
-			})
-			.collect(Collectors.toMap(
-				p -> p.getClass().getAnnotation(PluginDescriptor.class).name(),
-				p -> p,
-				(a, b) -> a
-			));
-
-		// Remove plugins that are loaded but not installed
-		for (Map.Entry<String, Plugin> entry : loadedByInternalName.entrySet())
-		{
-			if (!installed.contains(entry.getKey()))
-			{
-				remove(entry.getKey());
-			}
-		}
-	}
-
     /**
      * Loads a single plugin from the sideload folder if not already loaded.
      */
@@ -490,7 +465,6 @@ public class MicrobotPluginManager
 
 	public void loadSideLoadPlugins()
 	{
-		syncPlugins();
 		File[] files = createSideloadingFolder();
 		if (files == null)
 		{


### PR DESCRIPTION
This method is no longer required considering plugins that are downloaded & installed from the Microbot Plugin Hub are loaded individually.

This resolves the issue where plugins that were from the plugin hub were trying to be loaded using the sideloaded-plugins folder did not show.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized plugin registration through a public API, with no expected user-facing change.
- **Bug Fixes**
  - Adjusted sideloaded external plugin handling: plugins that are no longer installed are no longer automatically removed during sideload operations.
- **Chores**
  - Removed legacy cleanup step from the sideload flow to streamline external plugin loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->