### PR TITLE
fix(mixology): add missing sleep after bank open

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mixology/MixologyScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mixology/MixologyScript.java
@@ -137,6 +137,7 @@ public class MixologyScript extends Script {
                     case BANK:
                         if (Rs2Inventory.hasItem("paste")) {
                             if (Rs2Bank.openBank()) {
+                                sleepUntil(Rs2Bank::isOpen);
                                 Rs2Bank.depositAll();
                             }
                             return;


### PR DESCRIPTION
### Problem
The Mixology plugin was missing a critical `sleepUntil()` call after attempting to open the bank in the BANK state, causing it to spam-click the bank interface repeatedly when a PIN was required. This prevented the bank PIN handler from
functioning and created several serious issues:

- **Client freezes** from excessive click spam (10+ clicks/second)
- **Character gets stuck** unable to enter PIN or continue
- **Blocks other plugins** from handling the bank PIN properly

### Solution
Added `sleepUntil(Rs2Bank::isOpen)` after the `Rs2Bank.openBank()` call to properly wait for the bank to open or PIN to be handled, matching the existing pattern used in the REFINER state.

### Changes
- Added missing sleep in BANK state after `openBank()` call (line 140)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bank interactions now wait for the bank to fully open (with a timeout) before depositing or withdrawing, reducing failed deposits and interruptions.
  * Added timeout handling and user-visible logs when banking fails to open, preventing hangs.

* **Reliability**
  * Guarded bank flows and early returns improve stability of mixology runs and reduce unexpected stoppages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->