### PR TITLE
feat(sandminer): drop empty waterskins when humidify disabled

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/gabplugs/sandminer/GabulhasSandMinerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/gabplugs/sandminer/GabulhasSandMinerScript.java
@@ -83,6 +83,11 @@ public class GabulhasSandMinerScript extends Script {
             sleep(100, 4000);
         }
         while (!Rs2Inventory.isFull() && super.isRunning()) {
+            // Drop empty waterskins if not using humidify
+            if (!config.useHumidify()) {
+                dropEmptyWaterskins();
+            }
+            
             while (Rs2Player.hopIfPlayerDetected(1, 3000, 100) && super.isRunning()) {
                 sleepUntil(() -> Microbot.getClient().getGameState() == GameState.HOPPING);
                 sleepUntil(() -> Microbot.getClient().getGameState() == GameState.LOGGED_IN);
@@ -128,6 +133,12 @@ public class GabulhasSandMinerScript extends Script {
             Rs2Antiban.actionCooldown();
             Rs2Antiban.takeMicroBreakByChance();
             sleep(1000, 2000);
+        }
+    }
+
+    private void dropEmptyWaterskins() {
+        if (Rs2Inventory.hasItem(ItemID.WATER_SKIN0)) {
+            Rs2Inventory.drop(ItemID.WATER_SKIN0);
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/gabplugs/sandminer/GabulhasSandMinerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/gabplugs/sandminer/GabulhasSandMinerScript.java
@@ -83,8 +83,8 @@ public class GabulhasSandMinerScript extends Script {
             sleep(100, 4000);
         }
         while (!Rs2Inventory.isFull() && super.isRunning()) {
-            // Drop empty waterskins if not using humidify
-            if (!config.useHumidify()) {
+            // Drop empty waterskins if not using humidify (only when idle)
+            if (!config.useHumidify() && !Rs2Player.isAnimating()) {
                 dropEmptyWaterskins();
             }
             
@@ -137,7 +137,7 @@ public class GabulhasSandMinerScript extends Script {
     }
 
     private void dropEmptyWaterskins() {
-        if (Rs2Inventory.hasItem(ItemID.WATER_SKIN0)) {
+        while (Rs2Inventory.hasItem(ItemID.WATER_SKIN0)) {
             Rs2Inventory.drop(ItemID.WATER_SKIN0);
         }
     }


### PR DESCRIPTION
## Description
  Added automatic dropping of empty waterskins (Waterskin(0)) to the Sandstone Miner plugin when the "Use Humidify" option is disabled. This prevents inventory clutter from depleted waterskins during mining sessions without the humidify spell.

  ## Changes
  - Added `dropEmptyWaterskins()` method to check and drop empty waterskins
  - Integrated dropping logic into the mining loop when humidify is disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sand Miner now automatically drops empty waterskins while mining when Humidify is disabled, freeing inventory space and reducing manual cleanup.
  - Humidify-enabled behavior is unchanged, preserving existing hydration workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->