### PR TITLE
Revert #1440

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/gabplugs/sandminer/GabulhasSandMinerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/gabplugs/sandminer/GabulhasSandMinerScript.java
@@ -83,11 +83,6 @@ public class GabulhasSandMinerScript extends Script {
             sleep(100, 4000);
         }
         while (!Rs2Inventory.isFull() && super.isRunning()) {
-            // Drop empty waterskins if not using humidify (only when idle)
-            if (!config.useHumidify() && !Rs2Player.isAnimating()) {
-                dropEmptyWaterskins();
-            }
-            
             while (Rs2Player.hopIfPlayerDetected(1, 3000, 100) && super.isRunning()) {
                 sleepUntil(() -> Microbot.getClient().getGameState() == GameState.HOPPING);
                 sleepUntil(() -> Microbot.getClient().getGameState() == GameState.LOGGED_IN);
@@ -133,12 +128,6 @@ public class GabulhasSandMinerScript extends Script {
             Rs2Antiban.actionCooldown();
             Rs2Antiban.takeMicroBreakByChance();
             sleep(1000, 2000);
-        }
-    }
-
-    private void dropEmptyWaterskins() {
-        while (Rs2Inventory.hasItem(ItemID.WATER_SKIN0)) {
-            Rs2Inventory.drop(ItemID.WATER_SKIN0);
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped automatic dropping of empty waterskins during sand mining. Empty waterskins are now retained instead of being discarded mid-run.
  * Improves inventory predictability and prevents unintended item loss.

* **Notes**
  * No changes to humidify or banking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->