### PR TITLE
feat(AutoLoginScript): support break handling during login

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/accountselector/AutoLoginScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/accountselector/AutoLoginScript.java
@@ -3,7 +3,9 @@ package net.runelite.client.plugins.microbot.accountselector;
 import net.runelite.api.GameState;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
 import net.runelite.client.plugins.microbot.util.security.Login;
+import org.slf4j.event.Level;
 
 import java.util.concurrent.TimeUnit;
 
@@ -13,16 +15,18 @@ public class AutoLoginScript extends Script {
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
                 if (!super.run()) return;
+                if (BreakHandlerScript.isBreakActive() || BreakHandlerScript.isMicroBreakActive()) return;
 
                 if (Microbot.getClient().getGameState() == GameState.LOGIN_SCREEN) {
                     if (autoLoginConfig.useRandomWorld()) {
+                        Microbot.log(Level.INFO, "Auto logging in into random world. Member: " + autoLoginConfig.isMember());
                         new Login(Login.getRandomWorld(autoLoginConfig.isMember()));
                     } else {
+                        Microbot.log(Level.INFO, "Auto logging in into world: " + autoLoginConfig.world());
                         new Login(autoLoginConfig.world());
                     }
                     sleep(5000);
                 }
-
 
             } catch (Exception ex) {
                 Microbot.logStackTrace(this.getClass().getSimpleName(), ex);


### PR DESCRIPTION
This pull request updates the `AutoLoginScript` to improve its integration with break handling and logging. The main changes ensure that auto-login actions are paused during breaks and provide clearer logging for debugging and monitoring.

**Break handling integration:**
* The script now checks if a break is active using `BreakHandlerScript.isBreakActive()` or `BreakHandlerScript.isMicroBreakActive()` and skips auto-login if so.

**Logging improvements:**
* Added log statements to indicate when the script is auto-logging into a random or specific world, including membership status or world number.
* Imported the necessary `BreakHandlerScript` and `Level` classes to support the new break checks and logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Auto-login now pauses during active breaks and micro-breaks.
  - Logs now indicate which world is used during auto-login (random members-appropriate vs explicit).
  - Existing login flow on the login screen remains unchanged.
  - No configuration changes are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->