### PR TITLE
Barrows improvements, Construction 2 fixes.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/GeoffPlugins/construction2/Construction2Plugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/GeoffPlugins/construction2/Construction2Plugin.java
@@ -46,6 +46,7 @@ public class Construction2Plugin extends Plugin {
         if (overlayManager != null) {
             overlayManager.add(construction2Overlay);
         }
+        Construction2Script.firstRun = true;
         construction2Script.run(config);
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/barrows/BarrowsScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/barrows/BarrowsScript.java
@@ -69,12 +69,6 @@ public class BarrowsScript extends Script {
                 if (!super.run()) return;
                 long startTime = System.currentTimeMillis();
 
-                if (Rs2Player.getQuestState(Quest.HIS_FAITHFUL_SERVANTS) != QuestState.FINISHED) {
-                    Microbot.showMessage("Complete the 'His Faithful Servants' quest for the webwalker to function correctly");
-                    shutdown();
-                    return;
-                }
-
                 var inventorySetup = new Rs2InventorySetup(config.inventorySetup().getName(), mainScheduledFuture);
 
                 if(firstRun) {
@@ -367,6 +361,13 @@ public class BarrowsScript extends Script {
 
                 if(inTunnels && !shouldBank) {
                     Microbot.log("In the tunnels");
+
+                    if (Rs2Player.getQuestState(Quest.HIS_FAITHFUL_SERVANTS) != QuestState.FINISHED) {
+                        Microbot.showMessage("Complete the 'His Faithful Servants' quest for the webwalker to function correctly");
+                        shutdown();
+                        return;
+                    }
+
                     if(!varbitCheckEnabled){
                         varbitCheckEnabled=true;
                     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Construction: Supports both object types for building/removing, auto-summons the Butler on first run, and auto-enters via Oak Dungeon Door when applicable.
  - Barrows: Auto-switches to the Modern spellbook if needed, auto-loots the Skeleton Champion Scroll, and opens the chest when in line of sight or within 4 tiles for smoother runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->