### PR TITLE
Fix BirdHunterScript to check for stackable birdsnares

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/birdhunter/BirdHunterScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/zerozero/birdhunter/BirdHunterScript.java
@@ -90,7 +90,7 @@ public class BirdHunterScript extends Script {
         int hunterLevel = Rs2Player.getRealSkillLevel(Skill.HUNTER);
         int allowedSnares = getAvailableTraps(hunterLevel);  // Calculate the allowed number of snares
 
-        int snaresInInventory = Rs2Inventory.count(ItemID.HUNTING_OJIBWAY_BIRD_SNARE);
+        int snaresInInventory = Rs2Inventory.itemQuantity(ItemID.HUNTING_OJIBWAY_BIRD_SNARE);
         Microbot.log("Allowed snares: " + allowedSnares + ", Snares in inventory: " + snaresInInventory);
 
         return snaresInInventory >= allowedSnares;  // Return true if enough snares, false otherwise


### PR DESCRIPTION
Fix Bird Hunter script* to check for stackable bird snares due to game update making all hunter traps stackable

Change Rs2Inventory.count to Rs2Inventory.itemQuantity as that works for stackable items