### PR TITLE
Frostyrc break + startup fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcPlugin.java
@@ -57,7 +57,7 @@ public class RcPlugin extends Plugin {
     @Getter
     private WorldPoint myWorldPoint;
     @Getter
-    public static String version = "v1.1.0";
+    public static String version = "v1.1.2";
 
     @Subscribe
     public void onGameObjectSpawned(GameObjectSpawned event) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -196,14 +196,14 @@ public class RcScript extends Script {
 
         Rs2Tab.switchToInventoryTab();
 
+		if (Rs2Inventory.hasDegradedPouch()) {
+			Rs2Magic.repairPouchesWithLunar();
+			sleepGaussian(900, 200);
+			return;
+		}
+
         if (Rs2Inventory.anyPouchUnknown()) {
             checkPouches();
-        }
-
-        if (Rs2Inventory.hasDegradedPouch()) {
-            Rs2Magic.repairPouchesWithLunar();
-            sleepGaussian(900, 200);
-            return;
         }
 
         if (Rs2Inventory.isFull() && Rs2Inventory.allPouchesFull() && Rs2Inventory.contains(pureEss)) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -194,6 +194,10 @@ public class RcScript extends Script {
             }
         }
 
+		if (plugin.isBreakHandlerEnabled()) {
+			BreakHandlerScript.setLockState(true);
+		}
+
         Rs2Tab.switchToInventoryTab();
 
 		if (Rs2Inventory.hasDegradedPouch()) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -101,6 +101,7 @@ public class RcScript extends Script {
             try {
                 if (!Microbot.isLoggedIn()) return;
                 if (!super.run()) return;
+                if (shouldPauseForBreak()) return;
                 long startTime = System.currentTimeMillis();
 
                 if (lumbyElite == -1) {
@@ -160,6 +161,23 @@ public class RcScript extends Script {
         //Rs2Player.logout();
     }
 
+    private boolean shouldPauseForBreak() {
+        if (!plugin.isBreakHandlerEnabled()) {
+            return false;
+        }
+
+        if (BreakHandlerScript.isBreakActive()) {
+            return true;
+        }
+
+        if (BreakHandlerScript.breakIn <= 0) {
+            BreakHandlerScript.setLockState(false);
+            return true;
+        }
+
+        return false;
+    }
+
     private void checkPouches() {
         Rs2Inventory.interact(colossalPouch, "Check");
         sleepGaussian(900, 200);
@@ -199,6 +217,9 @@ public class RcScript extends Script {
 
         if (plugin.isBreakHandlerEnabled()) {
             BreakHandlerScript.setLockState(false);
+            if (BreakHandlerScript.isBreakActive() || BreakHandlerScript.breakIn <= 0) {
+                return;
+            }
         }
 
         while (!Rs2Bank.isOpen() && isRunning() &&

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -737,6 +737,9 @@ public class RcScript extends Script {
 
 		if (plugin.isBreakHandlerEnabled()) {
 			BreakHandlerScript.setLockState(false);
+			if (BreakHandlerScript.isBreakActive() || BreakHandlerScript.breakIn <= 0) {
+				return;
+			}
 		}
 
         state = State.BANKING;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -477,6 +477,8 @@ public class RcScript extends Script {
             BreakHandlerScript.setLockState(true);
         }
 
+		if (Rs2Bank.isOpen()) { Rs2Bank.closeBank(); }
+
         if (Rs2Inventory.contains(mythCape)) {
             Microbot.log("Interacting with myth cape");
             Rs2Inventory.interact(mythCape, "Teleport");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -215,13 +215,6 @@ public class RcScript extends Script {
             handleFeroxRunEnergy();
         }
 
-        if (plugin.isBreakHandlerEnabled()) {
-            BreakHandlerScript.setLockState(false);
-            if (BreakHandlerScript.isBreakActive() || BreakHandlerScript.breakIn <= 0) {
-                return;
-            }
-        }
-
         while (!Rs2Bank.isOpen() && isRunning() &&
                 (!Rs2Inventory.allPouchesFull()
                         || !Rs2Inventory.contains(colossalPouch)


### PR DESCRIPTION
- Repairs pouches before checking pouch contents prevents script from not starting if starting with degraded pouch.
- Added check to main loop to pause execution whenever a break is scheduled, immediately stopping script when break is detected.
- Close bank if somehow bank is open when teleporting.
- Removed break inside bank logic, prevents many things from breaking while setting up.