### PR TITLE
Microbot Plugin Hub Improvements 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -469,6 +469,7 @@ public class RuneLite
 		eventBus.register(clientUI);
 		eventBus.register(pluginManager);
 		eventBus.register(externalPluginManager);
+		eventBus.register(microbotPluginManager);
 		eventBus.register(overlayManager);
 		eventBus.register(configManager);
 		eventBus.register(discordService);

--- a/runelite-client/src/main/java/net/runelite/client/RuneLiteDebug.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLiteDebug.java
@@ -333,6 +333,9 @@ public class RuneLiteDebug {
         // Load user configuration
         configManager.load();
 
+		// Initialize MicrobotPluginManager after configManager is loaded
+		microbotPluginManager.init();
+
         // Update check requires ConfigManager to be ready before it runs
         Updater updater = injector.getInstance(Updater.class);
         updater.update(); // will exit if an update is in progress
@@ -359,6 +362,7 @@ public class RuneLiteDebug {
         eventBus.register(clientUI);
         eventBus.register(pluginManager);
         eventBus.register(externalPluginManager);
+		eventBus.register(microbotPluginManager);
         eventBus.register(overlayManager);
         eventBus.register(configManager);
         eventBus.register(discordService);
@@ -372,7 +376,7 @@ public class RuneLiteDebug {
 
         clientUI.show();
 
-        pluginManager.loadRuneliteCorePlugins();
+        pluginManager.loadCoreRunelitePlugins();
 
         microbotPluginManager.loadCorePlugins(pluginsToDebug);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/externalplugins/MicrobotPluginClassLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/externalplugins/MicrobotPluginClassLoader.java
@@ -18,14 +18,10 @@ public class MicrobotPluginClassLoader extends URLClassLoader implements Reflect
     @Setter
     private MethodHandles.Lookup lookup;
 
-    @Getter
-    private final File jarFile;
-
 	private final ClassLoader parent;
 
     public MicrobotPluginClassLoader(File jarFile, ClassLoader parent) throws IOException {
         super(new URL[]{jarFile.toURI().toURL()}, null);
-        this.jarFile = jarFile;
         this.parent = parent;
         ReflectUtil.installLookupHelper(this);
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestHelperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestHelperPlugin.java
@@ -29,6 +29,7 @@ import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.questhelper.bank.banktab.BankTabItems;
 import net.runelite.client.plugins.microbot.questhelper.bank.banktab.PotionStorage;
 import net.runelite.client.plugins.microbot.questhelper.managers.*;
@@ -579,7 +580,7 @@ public class QuestHelperPlugin extends Plugin
 			binder.bind(QuestHelper.class).toInstance(questHelper);
 			binder.install(questHelper);
 		};
-		Injector questInjector = RuneLite.getInjector().createChildInjector(questModule);
+		Injector questInjector = Microbot.getInjector().createChildInjector(questModule);
 		injector.injectMembers(questHelper);
 		questHelper.setInjector(questInjector);
 		questHelper.setQuest(quest);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginHubPanel.java
@@ -340,7 +340,7 @@ public class MicrobotPluginHubPanel extends PluginPanel {
 
                     addrm.setText("Installing");
                     addrm.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
-                    microbotPluginManager.installPlugin(manifest.getInternalName());
+                    microbotPluginManager.installPlugin(manifest);
                 });
             } else if (installed) {
                 // Check if update is available
@@ -369,7 +369,7 @@ public class MicrobotPluginHubPanel extends PluginPanel {
                     addrm.addActionListener(l -> {
                         addrm.setText("Removing");
                         addrm.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
-                        microbotPluginManager.removePlugin(manifest.getInternalName());
+                        microbotPluginManager.removePlugin(manifest);
                     });
                 }
             } else {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginHubPanel.java
@@ -340,7 +340,7 @@ public class MicrobotPluginHubPanel extends PluginPanel {
 
                     addrm.setText("Installing");
                     addrm.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
-                    microbotPluginManager.install(manifest);
+                    microbotPluginManager.installPlugin(manifest.getInternalName());
                 });
             } else if (installed) {
                 // Check if update is available
@@ -360,9 +360,8 @@ public class MicrobotPluginHubPanel extends PluginPanel {
                     addrm.addActionListener(l -> {
                         addrm.setText("Updating");
                         addrm.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
-                        microbotPluginManager.remove(manifest.getInternalName());
-                        microbotPluginManager.install(manifest); // This will update the plugin
-                        reloadPluginList();
+                        microbotPluginManager.update();
+						reloadPluginList();
                     });
                 } else {
                     addrm.setText("Remove");
@@ -370,7 +369,7 @@ public class MicrobotPluginHubPanel extends PluginPanel {
                     addrm.addActionListener(l -> {
                         addrm.setText("Removing");
                         addrm.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
-                        microbotPluginManager.remove(manifest.getInternalName());
+                        microbotPluginManager.removePlugin(manifest.getInternalName());
                     });
                 }
             } else {


### PR DESCRIPTION
This update is to provide further stability & improvements to the MicrobotPluginManager as well as how plugins are referenced & stored. This aims to mimic the functionality of the ExternalPluginManager leveraged for Runelite's Plugin hub.

### Features
- Provide better plugin lifecycle when scanning, loading & unloading plugins all through a single `refresh()` method
- Seamless migration path from legacy plugins.json file inside of the `microbot-plugins` directory into the Runelite Config
- Implement safe mode flag into `MicrobotPluginManager` to prevent plugins from loading when safe mode is enabled
- Adds BreakHandlerPlugin & QuestHelperPlugin as 'core' Microbot plugins

### Fixes
- Improve mapping of `internalName` to `MicrobotPluginManifest` when loading plugins.

### Chores
- Migrate/Create method that handles loading Microbot core plugins to remove this functionality out of the Runelite `PluginManager`
- Reverts `install` & `remove` methods to use `MicrobotPluginManifest` directly instead using `internalName` to find the manifest