### PR TITLE
chore(Rs2Walker): isInArea

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1951,15 +1951,15 @@ public class Rs2Walker {
     /**
      * Checks if the player's current location is within the specified area defined by the given world points.
      *
-     * @param worldPoints an array of two world points of the NW and SE corners of the area
+     * @param worldPoints an array of two world points of the SE and NW corners of the area
      * @return true if the player's current location is within the specified area, false otherwise
      */
     public static boolean isInArea(WorldPoint... worldPoints) {
         WorldPoint playerLocation = Rs2Player.getWorldLocation();
-        return playerLocation.getX() <= worldPoints[0].getX() &&   // NW corner x
-                playerLocation.getY() >= worldPoints[0].getY() &&   // NW corner y
-                playerLocation.getX() >= worldPoints[1].getX() &&   // SE corner x
-                playerLocation.getY() <= worldPoints[1].getY();     // SE corner Y
+        return playerLocation.getX() <= worldPoints[0].getX() &&   // SE corner x
+                playerLocation.getY() >= worldPoints[0].getY() &&   // SE corner y
+                playerLocation.getX() >= worldPoints[1].getX() &&   // NW corner x
+                playerLocation.getY() <= worldPoints[1].getY();     // NW corner Y
         // draws box from 2 points to check against all variations of player X,Y from said points.
     }
 
@@ -1972,9 +1972,9 @@ public class Rs2Walker {
      */
     @Deprecated(since = "1.5.5", forRemoval = true)
     public static boolean isInArea(WorldPoint centerOfArea, int range) {
-        WorldPoint nwCorner = new WorldPoint(centerOfArea.getX() + range + range, centerOfArea.getY() - range, centerOfArea.getPlane());
-        WorldPoint seCorner = new WorldPoint(centerOfArea.getX() - range - range, centerOfArea.getY() + range, centerOfArea.getPlane());
-        return isInArea(nwCorner, seCorner); // call to our sibling
+        WorldPoint seCorner = new WorldPoint(centerOfArea.getX() + range, centerOfArea.getY() - range, centerOfArea.getPlane());
+        WorldPoint nwCorner = new WorldPoint(centerOfArea.getX() - range, centerOfArea.getY() + range, centerOfArea.getPlane());
+        return isInArea(seCorner, nwCorner); // call to our sibling
     }
 
     public static boolean isNear() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1951,16 +1951,29 @@ public class Rs2Walker {
     /**
      * Checks if the player's current location is within the specified area defined by the given world points.
      *
-     * @param worldPoints an array of two world points of the SE and NW corners of the area
+     * @param worldPoints an array of two world points of the NW and SE corners of the area
      * @return true if the player's current location is within the specified area, false otherwise
      */
     public static boolean isInArea(WorldPoint... worldPoints) {
-        WorldPoint playerLocation = Rs2Player.getWorldLocation();
-        return playerLocation.getX() <= worldPoints[0].getX() &&   // SE corner x
-                playerLocation.getY() >= worldPoints[0].getY() &&   // SE corner y
-                playerLocation.getX() >= worldPoints[1].getX() &&   // NW corner x
-                playerLocation.getY() <= worldPoints[1].getY();     // NW corner Y
+        if (worldPoints == null || worldPoints.length < 2 || worldPoints[0] == null || worldPoints[1] == null) {
+            throw new IllegalArgumentException("isInArea requires two WorldPoints.");
+        }
+        WorldPoint a = worldPoints[0];
+        WorldPoint b = worldPoints[1];
+        final int aX = a.getX(), aY = a.getY();
+        final int bX = b.getX(), bY = b.getY();
+
+        final int minX = Math.min(aX, bX);
+        final int maxX = Math.max(aX, bX);
+        final int minY = Math.min(aY, bY);
+        final int maxY = Math.max(aY, bY);
+
+        final WorldPoint playerLocation = Rs2Player.getWorldLocation();
+        final int playerX = playerLocation.getX();
+        final int playerY = playerLocation.getY();
+
         // draws box from 2 points to check against all variations of player X,Y from said points.
+        return (playerX >= minX && playerX <= maxX && playerY >= minY && playerY <= maxY);
     }
 
     /**


### PR DESCRIPTION
The logic for the isInArea() methods are backwards.
This change doesn't change the actual logic, but changes the method description to properly reflect the logic that's applied.

The overloaded isInArea() method that takes in a centre point and a range previously created a rectangle with larger offsets on the x value, rather than an equally sided square with the calculated corners. This is now changed to create an equally sided square around the centre point. Was there a reason we were creating horizontally favoured rectangle areas?

These pedantic changes better reflect the applied logic without changing the original logic (besides creating an equal-sided area, instead of a horizontally favoured rectangle), so this shouldn't have any affect on the current usages of these methods in other scripts/plugins.

I originally became aware of this flawed logic when I tried to use the `isInArea(WorldPoint... worldPoints)` method to determine if I had the player in a certain area using custom points, instead of the simpler to use overloaded method `isInArea(WorldPoint centerOfArea, int range)`, and of course I ran into problems before looking into how the methods were operating.