### PR TITLE
Add Bank Slot Locking Utilities to Rs2Settings and Integrate with Rs2Bank

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
@@ -2826,13 +2826,14 @@ public class Rs2Bank {
      */
     private static boolean toggleItemLock(Rs2ItemModel rs2Item)
     {
-        if (rs2Item == null
-                || !isOpen()
-                || !Rs2Inventory.hasItem(rs2Item.getId())
-                || Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_IGNOREINVLOCKS) != 0
-                || Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_SHOWOP) != 1) {
+        if (rs2Item == null || !isOpen() || !Rs2Inventory.hasItem(rs2Item.getId())) return false;
+
+        boolean isLockEnabled = Rs2Settings.enableBankSlotLocking();
+        if (!isLockEnabled) {
+            log.debug("Bank slot locking is not enabled in settings.");
             return false;
         }
+
         container = BANK_INVENTORY_ITEM_CONTAINER;
         final int currentLockState = Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_OVERVIEW);
         invokeMenu(10, rs2Item);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/settings/Rs2Settings.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/settings/Rs2Settings.java
@@ -370,38 +370,46 @@ public class Rs2Settings
 	 * and enable the slot locking feature.
 	 * @return {@code true} if bank slot locking is successfully enabled or already enabled, {@code false} otherwise
 	 */
-	public static boolean enableBankSlotLocking()
-	{
+	public static boolean enableBankSlotLocking() {
 		if (isBankSlotLockingEnabled()) return true;
 
-		if (!Rs2Bank.isOpen()) {
-			log.info("Bank is not open, cannot enable bank slot locking.");
+		Rs2Widget.clickWidget(InterfaceID.Bankmain.MENU_BUTTON);
+		if (!sleepUntil(() -> Rs2Widget.isWidgetVisible(InterfaceID.Bankmain.MENU_CONTAINER), 2000)) {
+			log.debug("Bank menu did not open within timeout.");
 			return false;
 		}
 
-		Rs2Widget.clickWidget(InterfaceID.Bankmain.MENU_BUTTON);
-
-		sleepUntil(() -> Rs2Widget.isWidgetVisible(InterfaceID.Bankmain.MENU_CONTAINER), 2000);
-
 		Rs2Widget.clickWidget(InterfaceID.Bankmain.LOCKS);
-
-		sleepUntil(() -> Rs2Widget.isWidgetVisible(InterfaceID.BankSideLocks.DONE), 2000);
+		if (!sleepUntil(() -> Rs2Widget.isWidgetVisible(InterfaceID.BankSideLocks.DONE), 2000)) {
+			log.debug("Bank Locks panel did not appear.");
+			return false;
+		}
 
 		if (Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_IGNOREINVLOCKS) != 0) {
 			Rs2Widget.clickWidget(InterfaceID.BankSideLocks.IGNORELOCKS);
-			sleepUntil(() -> Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_IGNOREINVLOCKS) == 0, 2000);
+			if (!sleepUntil(() -> Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_IGNOREINVLOCKS) == 0, 2000)) {
+				log.debug("Failed to disable 'ignore inventory locks' setting.");
+				return false;
+			}
 		}
 
 		if (Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_SHOWOP) != 1) {
 			Rs2Widget.clickWidget(InterfaceID.BankSideLocks.EXTRAOPTIONS);
-			sleepUntil(()->Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_SHOWOP) == 1, 2000);
+			if (!sleepUntil(() -> Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_SHOWOP) == 1, 2000)) {
+				log.debug("Failed to enable 'show inventory locks menu option' setting.");
+				return false;
+			}
 		}
 
 		Rs2Widget.clickWidget(InterfaceID.BankSideLocks.DONE);
+		if (!sleepUntil(() -> !Rs2Widget.isWidgetVisible(InterfaceID.BankSideLocks.DONE), 2000)) {
+			log.debug("Locks panel did not close after clicking DONE.");
+			return false;
+		}
 
-		sleepUntil(() -> !Rs2Widget.isWidgetVisible(InterfaceID.BankSideLocks.DONE), 2000);
-
-		Rs2Widget.clickWidget(InterfaceID.Bankmain.MENU_BUTTON);
+		if (Rs2Widget.isWidgetVisible(InterfaceID.Bankmain.MENU_CONTAINER)) {
+			Rs2Widget.clickWidget(InterfaceID.Bankmain.MENU_BUTTON);
+		}
 
 		return isBankSlotLockingEnabled();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/settings/Rs2Settings.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/settings/Rs2Settings.java
@@ -11,6 +11,7 @@ import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
 import net.runelite.client.plugins.microbot.util.misc.Rs2UiHelper;
@@ -349,5 +350,59 @@ public class Rs2Settings
 
 		Microbot.doInvoke(menuEntry, Rs2UiHelper.getDefaultRectangle());
 		return true;
+	}
+
+	/**
+	 * Checks if bank slot locking is enabled.
+	 * Slot locking allows you to lock specific inventory slots in the bank,
+	 * preventing items from being deposited when using the Deposit All button.
+	 *
+	 * @return {@code true} if bank slot locking is enabled, {@code false} otherwise
+	 */
+	public static boolean isBankSlotLockingEnabled()
+	{
+		return Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_SHOWOP) == 1 && Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_IGNOREINVLOCKS) == 0;
+	}
+
+	/**
+	 * Enables bank slot locking if it's currently disabled.
+	 * If bank is open, it will navigate to the bank settings,
+	 * and enable the slot locking feature.
+	 * @return {@code true} if bank slot locking is successfully enabled or already enabled, {@code false} otherwise
+	 */
+	public static boolean enableBankSlotLocking()
+	{
+		if (isBankSlotLockingEnabled()) return true;
+
+		if (!Rs2Bank.isOpen()) {
+			log.info("Bank is not open, cannot enable bank slot locking.");
+			return false;
+		}
+
+		Rs2Widget.clickWidget(InterfaceID.Bankmain.MENU_BUTTON);
+
+		sleepUntil(() -> Rs2Widget.isWidgetVisible(InterfaceID.Bankmain.MENU_CONTAINER), 2000);
+
+		Rs2Widget.clickWidget(InterfaceID.Bankmain.LOCKS);
+
+		sleepUntil(() -> Rs2Widget.isWidgetVisible(InterfaceID.BankSideLocks.DONE), 2000);
+
+		if (Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_IGNOREINVLOCKS) != 0) {
+			Rs2Widget.clickWidget(InterfaceID.BankSideLocks.IGNORELOCKS);
+			sleepUntil(() -> Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_IGNOREINVLOCKS) == 0, 2000);
+		}
+
+		if (Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_SHOWOP) != 1) {
+			Rs2Widget.clickWidget(InterfaceID.BankSideLocks.EXTRAOPTIONS);
+			sleepUntil(()->Microbot.getVarbitValue(VarbitID.BANK_SIDE_SLOT_SHOWOP) == 1, 2000);
+		}
+
+		Rs2Widget.clickWidget(InterfaceID.BankSideLocks.DONE);
+
+		sleepUntil(() -> !Rs2Widget.isWidgetVisible(InterfaceID.BankSideLocks.DONE), 2000);
+
+		Rs2Widget.clickWidget(InterfaceID.Bankmain.MENU_BUTTON);
+
+		return isBankSlotLockingEnabled();
 	}
 }


### PR DESCRIPTION
Adding the functionality for bank slot locking to `Rs2Bank` and `Rs2Settings`, which has already demonstrated its reliability when used in the Herbiboar plugin banking logic.

## Github Copilot Summary

This pull request adds functionality to programmatically enable and check the status of bank slot locking in the RuneLite client, and updates the slot locking logic to use this new mechanism. The main changes include adding utility methods to `Rs2Settings` to check and enable bank slot locking, and updating `Rs2Bank` to use these methods for improved reliability and maintainability.

**Bank Slot Locking Feature Enhancements:**

* Added `isBankSlotLockingEnabled()` and `enableBankSlotLocking()` methods to `Rs2Settings`, allowing code to check if bank slot locking is enabled and to enable it programmatically through the UI if needed. This includes widget interactions and state checks for robust automation.
* Updated `Rs2Bank.toggleItemLock()` to use `Rs2Settings.enableBankSlotLocking()` for determining whether bank slot locking is enabled, improving encapsulation and reducing direct varbit checks. Now logs a debug message if slot locking is not enabled.

**Dependency and Import Updates:**

* Added an import for `Rs2Bank` in `Rs2Settings.java` to support the new feature integration.