### PR TITLE
feat(aiofighter): add wilderness improvements - looting bag support, blighted foods, ferox pool restoration, combat potion optimization

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
@@ -654,6 +654,17 @@ public interface AIOFighterConfig extends Config {
     default int minFreeSlots() {
         return 0;
     }
+
+    @ConfigItem(
+            keyName = "usePoolAtFerox",
+            name = "Use Pool at Ferox",
+            description = "Use Pool of Restoration at Ferox Enclave after banking if HP/Prayer below 100% or Run below 90%",
+            position = 10,
+            section = banking
+    )
+    default boolean usePoolAtFerox() {
+        return false;
+    }
     // Safety section
     @ConfigItem(
             keyName = "useSafety",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/combat/PotionManagerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/combat/PotionManagerScript.java
@@ -7,6 +7,7 @@ import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.aiofighter.AIOFighterConfig;
 import net.runelite.client.plugins.microbot.aiofighter.AIOFighterPlugin;
 import net.runelite.client.plugins.microbot.aiofighter.enums.State;
+import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 
@@ -35,25 +36,28 @@ public class PotionManagerScript extends Script {
                     Rs2Player.waitForAnimation();
                 }
 
-                // Always attempt to drink ranging potion
-                if (Rs2Player.drinkCombatPotionAt(Skill.RANGED, false)) {
-                    Rs2Player.waitForAnimation();
-                }
+                // Only drink combat potions when in combat
+                if (Rs2Combat.inCombat()) {
+                    // Attempt to drink ranging potion
+                    if (Rs2Player.drinkCombatPotionAt(Skill.RANGED, false)) {
+                        Rs2Player.waitForAnimation();
+                    }
 
-                // Always attempt to drink magic potion
-                if (Rs2Player.drinkCombatPotionAt(Skill.MAGIC, false)) {
-                    Rs2Player.waitForAnimation();
-                }
+                    // Attempt to drink magic potion
+                    if (Rs2Player.drinkCombatPotionAt(Skill.MAGIC, false)) {
+                        Rs2Player.waitForAnimation();
+                    }
 
-                // Always attempt to drink combat potions for STR, ATT, DEF
-                if (Rs2Player.drinkCombatPotionAt(Skill.STRENGTH)) {
-                    Rs2Player.waitForAnimation();
-                }
-                if (Rs2Player.drinkCombatPotionAt(Skill.ATTACK)) {
-                    Rs2Player.waitForAnimation();
-                }
-                if (Rs2Player.drinkCombatPotionAt(Skill.DEFENCE)) {
-                    Rs2Player.waitForAnimation();
+                    // Attempt to drink combat potions for STR, ATT, DEF
+                    if (Rs2Player.drinkCombatPotionAt(Skill.STRENGTH)) {
+                        Rs2Player.waitForAnimation();
+                    }
+                    if (Rs2Player.drinkCombatPotionAt(Skill.ATTACK)) {
+                        Rs2Player.waitForAnimation();
+                    }
+                    if (Rs2Player.drinkCombatPotionAt(Skill.DEFENCE)) {
+                        Rs2Player.waitForAnimation();
+                    }
                 }
 
                 // Always attempt to drink goading potion

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/misc/Rs2Food.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/misc/Rs2Food.java
@@ -64,7 +64,10 @@ public enum Rs2Food {
     COOKED_DASHING_KEBBIT(29134, 23, "Cooked dashing kebbit",3),
     COOKED_MOONLIGHT_ANTELOPE(29143, 26, "Cooked moonlight antelope",3),
     PURPLE_SWEETS(10476, 3, "Purple Sweets",3),
-    CABBAGE(ItemID.CABBAGE, 1, "Cabbage",3);
+    CABBAGE(ItemID.CABBAGE, 1, "Cabbage",3),
+    BLIGHTED_MANTA_RAY(24589, 22, "Blighted manta ray", 3),
+    BLIGHTED_ANGLERFISH(24592, 22, "Blighted anglerfish", 3),
+    BLIGHTED_KARAMBWAN(24595, 18, "Blighted karambwan", 3);
 
     private int id;
     private int heal;


### PR DESCRIPTION
## Description
Adds several wilderness-focused improvements to the AIO Fighter plugin to enhance the combat experience in wilderness areas.

## Changes
- **Looting Bag Support**: Automatically empties looting bag when banking
- **Blighted Food Recognition**: Added support for blighted manta ray, anglerfish, and karambwan to the food system
- **Pool of Restoration**: New optional feature to use the Pool of Restoration at Ferox Enclave after banking (configurable in banking settings)
- **Combat Potion Optimization**: Combat potions now only consumed during active combat to prevent waste
- **Always empty containers when banking**: Previously, containers such as Herb sack were only being emptied when using inventory setups, now they will emptied whenever we bank

## Testing
- Tested looting bag emptying with various items
- Verified blighted foods are properly recognized by the banking system
- Confirmed Pool of Restoration usage at Ferox Enclave
- Verified combat potions are only consumed during combat