### PR TITLE
fix(aiofighter): restore wait-for-loot config UI options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
@@ -403,8 +403,7 @@ public interface AIOFighterConfig extends Config {
             name = "Wait for Loot",
             description = "Wait for loot to appear before attacking next NPC",
             position = 103,
-            section = lootSection,
-            hidden = true
+            section = lootSection
     )
     default boolean toggleWaitForLoot() {
         return false;
@@ -416,8 +415,7 @@ public interface AIOFighterConfig extends Config {
             name = "Loot Wait Timeout (s)",
             description = "Seconds to wait for loot before resuming combat (1-10)",
             position = 104,
-            section = lootSection,
-            hidden = true
+            section = lootSection
     )
     default int lootWaitTimeout() {
         return 6;


### PR DESCRIPTION
## Summary
- Restores the wait-for-loot configuration options in the AIOFighter plugin UI
- Removes `hidden = true` attribute from both config items that was accidentally added after initial implementation

## Changes
- **Wait for Loot** checkbox - now visible in Loot section
- **Loot Wait Timeout (s)** numeric input (1-10 seconds, default 6) - now visible in Loot section

## Context
The wait-for-loot feature was originally added with visible config options, but they were later hidden with `hidden = true` attributes. This fix restores them to the UI so users can configure the feature.

## Test Plan
- [ ] Verify both config options appear in the Loot section of AIOFighter settings
- [ ] Confirm the checkbox toggles the wait-for-loot feature
- [ ] Confirm the timeout value can be set between 1-10 seconds