### PR TITLE
fix(AutoWoodcutting): Bugfixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -158,7 +158,7 @@ public class Rs2Player {
         return teleBlockTime > 0;
     }
 
-    private static final Map<Player, Long> playerDetectionTimes = new ConcurrentHashMap<>();
+    private static final Map<Integer, Long> playerDetectionTimes = new ConcurrentHashMap<>();
 
     public static void handlePotionTimers(VarbitChanged event) {
         if (event.getVarbitId() == Varbits.ANTIFIRE) {
@@ -512,15 +512,15 @@ public class Rs2Player {
         if (time > 0 && players.size() > amountOfPlayers) {
             // Update detection times for currently detected players
             for (Rs2PlayerModel player : players) {
-                playerDetectionTimes.putIfAbsent(player, currentTime);
+                playerDetectionTimes.putIfAbsent(player.getId(), currentTime);
             }
 
             // Remove players who are no longer detected
-            playerDetectionTimes.keySet().retainAll(players);
+            playerDetectionTimes.keySet().retainAll(players.stream().map(Rs2PlayerModel::getId).collect(Collectors.toSet()));
 
             // Check if any player has been detected for longer than the specified time
             for (Rs2PlayerModel player : players) {
-                long detectionTime = playerDetectionTimes.getOrDefault(player, 0L);
+                long detectionTime = playerDetectionTimes.getOrDefault(player.getId(), 0L);
                 if (currentTime - detectionTime >= time) {
                     logout();
                     playerDetectionTimes.clear();
@@ -582,15 +582,15 @@ public class Rs2Player {
         if (time > 0 && players.size() >= amountOfPlayers) {
             // Update detection times for currently detected players
             for (Rs2PlayerModel player : players) {
-                playerDetectionTimes.putIfAbsent(player, currentTime);
+                playerDetectionTimes.putIfAbsent(player.getId(), currentTime);
             }
 
             // Remove players who are no longer detected
-            playerDetectionTimes.keySet().retainAll(players);
+            playerDetectionTimes.keySet().retainAll(players.stream().map(Rs2PlayerModel::getId).collect(Collectors.toSet()));
 
             // Check if any player has been detected for longer than the specified time
             for (Rs2PlayerModel player : players) {
-                long detectionTime = playerDetectionTimes.getOrDefault(player, 0L);
+                long detectionTime = playerDetectionTimes.getOrDefault(player.getId(), 0L);
                 if (currentTime - detectionTime >= time) {
                     int randomWorld = Login.getRandomWorld(isMember());
                     Microbot.hopToWorld(randomWorld);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -509,7 +509,7 @@ public class Rs2Player {
                     .filter(x -> x != null && x.getWorldLocation().distanceTo(Rs2Player.getWorldLocation()) <= distance)
                     .collect(Collectors.toList());
         }
-        if (time > 0 && players.size() > amountOfPlayers) {
+        if (time > 0 && players.size() >= amountOfPlayers) {
             // Update detection times for currently detected players
             for (Rs2PlayerModel player : players) {
                 playerDetectionTimes.putIfAbsent(player.getId(), currentTime);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingScript.java
@@ -99,7 +99,6 @@ public class AutoWoodcuttingScript extends Script {
         Rs2Antiban.antibanSetupTemplates.applyWoodcuttingSetup();
         Rs2AntibanSettings.dynamicActivity = true;
         Rs2AntibanSettings.dynamicIntensity = true;
-        initialPlayerLocation = null;
         if (config.firemakeOnly()) {
             woodcuttingScriptState = WoodcuttingScriptState.FIREMAKING;
         }
@@ -150,10 +149,6 @@ public class AutoWoodcuttingScript extends Script {
     }
 
     private boolean beforeCuttingTreesChecks(AutoWoodcuttingConfig config) {
-        if (config.hopWhenPlayerDetected()) {
-            if (Rs2Player.logoutIfPlayerDetected(1, 10000))
-                return true;
-        }
 
         if (Rs2Woodcutting.isWearingAxeWithSpecialAttack())
             Rs2Combat.setSpecState(true, 1000);
@@ -194,6 +189,12 @@ public class AutoWoodcuttingScript extends Script {
     private boolean preFlightChecks(AutoWoodcuttingConfig config) {
         if (!Microbot.isLoggedIn()) return true;
         if (!super.run()) return true;
+
+        if (config.hopWhenPlayerDetected()) {
+            if (Rs2Player.logoutIfPlayerDetected(1, 10000))
+                return true;
+        }
+
         if (Rs2AntibanSettings.actionCooldownActive) return true;
 
         if (!hasAutoHopMessageShown && config.hopWhenPlayerDetected()) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/EggEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/EggEvent.java
@@ -72,13 +72,13 @@ public class EggEvent implements BlockingEvent {
             if (Rs2Inventory.contains("Pheasant egg")) {
                 Microbot.log("EggEvent: Interacting with the forester to give the egg.");
                 Rs2Npc.interact(forester.get(), "Talk-to");
-                sleepUntil(() -> Rs2Widget.findWidget("Freaky Forester", null, false) != null, 5000);
+                sleepUntil(Rs2Dialogue::isInDialogue, 5000);
                 while (Rs2Dialogue.isInDialogue()) Rs2Dialogue.clickContinue();
                 continue;
             }
 
             // If we don't have an egg, interact with the pheasant nest
-            var nests = Rs2GameObject.getGameObjects(ObjectID.GATHERING_EVENT_PHEASANT_NEST02);
+            var nests = Rs2GameObject.getGameObjects((gameObject) -> gameObject.getId() == ObjectID.GATHERING_EVENT_PHEASANT_NEST02);
             var pheasants = Rs2Npc.getNpcs(NpcID.GATHERING_EVENT_PHEASANT).collect(Collectors.toList());
 
             if (nests.isEmpty() || pheasants.isEmpty()) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/LeprechaunEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/LeprechaunEvent.java
@@ -8,6 +8,7 @@ import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.Global;
 import net.runelite.client.plugins.microbot.util.cache.Rs2NpcCache;
 import net.runelite.client.plugins.microbot.util.cache.Rs2ObjectCache;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
@@ -51,14 +52,14 @@ public class LeprechaunEvent implements BlockingEvent {
         Rs2Walker.setTarget(null); // stop walking, stop moving to bank for example
         while (this.validate()) {
             log.info("LeprechaunEvent: Leprechaun event still valid, continuing execution get opbject");
-            var endOfRainbow = Rs2ObjectCache.getClosestObjectById(ObjectID.GATHERING_EVENT_WOODCUTTING_LEPRECHAUN_RAINBOW);
-            if (!endOfRainbow.isPresent() || endOfRainbow.isEmpty()) {
+            var endOfRainbow = Rs2GameObject.getGameObject(ObjectID.GATHERING_EVENT_WOODCUTTING_LEPRECHAUN_RAINBOW);
+            if (endOfRainbow == null) {
                 log.warn("LeprechaunEvent: End of the rainbow not found, retrying...");
                 sleepGaussian(900, 300);
                 continue; // If the end of the rainbow is not found, we cannot proceed with the event
             }
             // Move to the end of the rainbow
-            var location = endOfRainbow.get().getWorldLocation();
+            var location = endOfRainbow.getWorldLocation();
             if (!Rs2Player.getWorldLocation().equals(location)) {
                 Microbot.log("LeprechaunEvent: Walking to the end of the rainbow at " + location, Level.INFO);
                 Rs2Walker.walkFastCanvas(location);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/StrugglingSaplingEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/StrugglingSaplingEvent.java
@@ -146,6 +146,7 @@ public class StrugglingSaplingEvent implements BlockingEvent {
                 var randomIngredient = availableIngredients.get((int) (Math.random() * availableIngredients.size()));
                 Microbot.log("StrugglingSaplingEvent: Collecting random ingredient: " + randomIngredient.getWorldLocation());
                 Rs2GameObject.interact(randomIngredient, "Collect");
+                triedIngredients.add(randomIngredient.getId());
                 Rs2Player.waitForAnimation();
             }
 


### PR DESCRIPTION
- fix pheasant event (finally)
- fix leprechaun
- fix not returning to tree after banking
- fix autohop/logout feature
- fix sapling event not saving incorrect ingredients






### Copilot summary:

This pull request primarily improves how player detection is tracked and handled in the woodcutting and player utility modules, and refactors event logic for forestry events. The main changes focus on using player IDs instead of object references for detection, improving event handling robustness, and cleaning up logic for interacting with game objects.

**Player Detection Logic Improvements:**

* Changed `playerDetectionTimes` in `Rs2Player` to use player IDs (`Integer`) as keys instead of `Player` object references, and updated all related logic to use IDs for non buggy tracking. [[1]](diffhunk://#diff-c8d91e0689ac63a80e21760dbd0d3498ad0a82426223fc3d933d6be700a2f0ffL161-R161) [[2]](diffhunk://#diff-c8d91e0689ac63a80e21760dbd0d3498ad0a82426223fc3d933d6be700a2f0ffL515-R523) [[3]](diffhunk://#diff-c8d91e0689ac63a80e21760dbd0d3498ad0a82426223fc3d933d6be700a2f0ffL585-R593)

**Woodcutting Script Logic:**

* Moved the player detection/hop logic in `AutoWoodcuttingScript` from `beforeCuttingTreesChecks` to `preFlightChecks` for better control flow and to ensure it runs at the correct time. [[1]](diffhunk://#diff-e9b37e8667b7bc057aba1bdb6b0170547576b81057e26318d19b015dad5317efL153-L156) [[2]](diffhunk://#diff-e9b37e8667b7bc057aba1bdb6b0170547576b81057e26318d19b015dad5317efR192-R197)
* Removed unnecessary reset of `initialPlayerLocation` in the `run` method of `AutoWoodcuttingScript`.

**Forestry Event Handling:**

* Updated `EggEvent` to use a more reliable dialogue check (`Rs2Dialogue::isInDialogue`) and improved how pheasant nests are found by using a predicate instead of a direct ID call.
* Refactored `LeprechaunEvent` to use `Rs2GameObject.getGameObject` instead of the cache, simplifying object retrieval and null-checking logic. [[1]](diffhunk://#diff-d12e5614812df610693b311ffb1de82b04330c3dc699ac5a7557254965aa7fe7R11) [[2]](diffhunk://#diff-d12e5614812df610693b311ffb1de82b04330c3dc699ac5a7557254965aa7fe7L54-R62)
* In `StrugglingSaplingEvent`, now tracks which ingredient IDs have been tried to avoid repeats.