### PR TITLE
fix(FishingTrawler): improve loot interaction by checking widget visibility

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/fishing/FishingTrawler/FishingTrawlerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/fishing/FishingTrawler/FishingTrawlerScript.java
@@ -52,8 +52,9 @@ public class FishingTrawlerScript extends Script {
                         Microbot.status = "Looting Rewards";
                         Rs2GameObject.interact(OBJECT_TRAWLERNET, "inspect");
                         Rs2Player.waitForWalking();
-                        sleep(Rs2Random.randomGaussian(600, 300));
-                        Rs2Widget.clickWidget("Bank-all");
+                        //check for visible trawler widget
+                        sleepUntil(() -> Rs2Widget.isWidgetVisible(367, 19), 5000);
+                        Rs2Widget.clickWidget(367,19);
                         sleep(Rs2Random.randomGaussian(600, 300));
                         wasInsideBoat = false;
                         BreakHandlerScript.setLockState(false);
@@ -143,6 +144,7 @@ public class FishingTrawlerScript extends Script {
                             log.debug("Tentacle ladder object not found.");
                         }
                     }
+
                 }
 
                 long endTime = System.currentTimeMillis();


### PR DESCRIPTION
This pull request updates the reward looting logic in the `FishingTrawlerScript` to make the interaction with the trawler reward widget more reliable. The main change is to ensure the widget is visible before attempting to click it.

**Fishing trawler reward looting improvements:**

* Updated the reward looting sequence in `FishingTrawlerScript.java` to wait until the trawler reward widget (`367, 19`) is visible before clicking it, replacing the previous method that clicked by widget name. This should reduce failures when the widget is not immediately available.