### PR TITLE
Don't add teleports to POH when already in house

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -307,6 +307,11 @@ public class PathfinderConfig {
                     .computeIfAbsent(entry.getKey(), k -> new HashSet<>())
                     .addAll(entry.getValue());
         }
+
+        // If we're already in Poh there's no reason to add teleports to Poh
+        if (PohTeleports.isInHouse()) {
+            return mergedTransports;
+        }
         // Add transports from the world to PoH
         for (var entry : PohTeleports.getTransportsToPoh().entrySet()) {
             mergedTransports

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/PohTeleports.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/PohTeleports.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.util.poh;
 
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.GameObject;
 import net.runelite.api.Skill;
 import net.runelite.api.TileObject;
@@ -34,6 +35,7 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntilTrue;
  * 2. add fortis colosseum location in jewelleryLocationEnum
  * 3. Add configuration to allow the user to choose between teleports in wilderness or not
  */
+@Slf4j
 public class PohTeleports {
 
     /**
@@ -144,9 +146,13 @@ public class PohTeleports {
      */
     public static boolean usePortalNexus(NexusPortal nexusPortal) {
         //TODO: Add config here to inform the user if the teleport is a wilderness teleport
+        GameObject portal = Rs2GameObject.getGameObject(NexusPortal.PORTAL_IDS);
         if (getPortalNexusInterface() == null) {
-            TileObject tileObject = Rs2GameObject.getTileObject(NexusPortal.PORTAL_IDS);
-            Rs2GameObject.interact(tileObject, "Teleport Menu");
+            if (portal != null) {
+                Rs2GameObject.interact(portal, "Teleport Menu");
+            } else {
+                log.warn("Portal nexus not found");
+            }
         }
 
         sleepUntil(() -> getPortalNexusInterface() != null);
@@ -242,7 +248,7 @@ public class PohTeleports {
 
         transportMap.put(null, Set.of(
                 new Transport(insidePoint, "Teleport to House", TransportType.TELEPORTATION_SPELL, true, 19, Map.of(Skill.MAGIC, 40)),
-                new Transport(insidePoint, "Construction cape: Tele to POH", TransportType.TELEPORTATION_ITEM,true, 19,  Set.of(Set.of(9789), Set.of(9790))),
+                new Transport(insidePoint, "Construction cape: Tele to POH", TransportType.TELEPORTATION_ITEM, true, 19, Set.of(Set.of(9789), Set.of(9790))),
                 new Transport(insidePoint, "Teleport to House tablet: Outside", TransportType.TELEPORTATION_ITEM, true, 19, Set.of(Set.of(8013)))
         ));
         transportMap.put(outsidePoint, Set.of(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -98,7 +98,7 @@ public class Rs2Walker {
 
     // Set this to true, if you want to calculate the path but do not want to walk to it
     static boolean debug = false;
-    
+
     @Named("disableWalkerUpdate")
     static boolean disableWalkerUpdate;
 
@@ -296,7 +296,7 @@ public class Rs2Walker {
                 });
                 Rs2Widget.clickWidget(565, 17);
             }
-            
+
             // entering down ladder strong hold of security
             if (Rs2Widget.clickWidget(579, 20)) {
                 sleepUntil(() -> {
@@ -341,7 +341,7 @@ public class Rs2Walker {
                     System.out.println("break out of door");
                     break;
                 }
-                
+
                 doorOrTransportResult = handleRockfall(path, i);
                 if (doorOrTransportResult) {
                     System.out.println("break out of rockfall");
@@ -605,25 +605,25 @@ public class Rs2Walker {
      * @return total amount of tiles
      */
     public static int getTotalTiles(WorldPoint start, WorldPoint destination) {
-        if (ShortestPathPlugin.getPathfinderConfig().getTransports().isEmpty()) {            
+        if (ShortestPathPlugin.getPathfinderConfig().getTransports().isEmpty()) {
             ShortestPathPlugin.getPathfinderConfig().refresh();
-        }      
+        }
         Pathfinder pathfinder = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), start, destination);
-        pathfinder.run();        
-        List<WorldPoint> path = pathfinder.getPath();       
+        pathfinder.run();
+        List<WorldPoint> path = pathfinder.getPath();
         if (path.isEmpty() || path.get(path.size() - 1).getPlane() != destination.getPlane()) return Integer.MAX_VALUE;
         // Create a WorldArea centered on the worldPoint by calculating the south-west corner
         WorldPoint pathPoint_SW = new WorldPoint(
-            path.get(path.size() - 1).getX() - 2, 
-            path.get(path.size() - 1).getY() - 2, 
+            path.get(path.size() - 1).getX() - 2,
+            path.get(path.size() - 1).getY() - 2,
             path.get(path.size() - 1).getPlane()
         );
         // Create a WorldArea centered on the worldPoint by calculating the south-west corner
         WorldPoint objectPoint_SW = new WorldPoint(
-            destination.getX() - 2, 
-            destination.getY() - 2, 
+            destination.getX() - 2,
+            destination.getY() - 2,
             destination.getPlane()
-        ); 
+        );
         WorldArea pathArea = new WorldArea(pathPoint_SW, 5, 5);
         WorldArea objectArea = new WorldArea(objectPoint_SW, 5, 5);
         if (!pathArea.intersectsWith2D(objectArea)) {
@@ -632,7 +632,7 @@ public class Rs2Walker {
 
         return path.size();
     }
-    
+
     /**
      * Calculates the total number of tiles from a given path to a destination.
      * This method validates that the path can actually reach the destination by checking
@@ -645,23 +645,23 @@ public class Rs2Walker {
      */
     public static int getTotalTilesFromPath(List<WorldPoint> path, WorldPoint destination) {
         if (path.isEmpty() || path.get(path.size() - 1).getPlane() != destination.getPlane()) return Integer.MAX_VALUE;
-        
+
         // Create centered WorldAreas instead of corner-based
         WorldPoint pathEndpoint = path.get(path.size() - 1);
         WorldPoint pathSouthWest = new WorldPoint(
-            pathEndpoint.getX() - 4, 
-            pathEndpoint.getY() - 4, 
+            pathEndpoint.getX() - 4,
+            pathEndpoint.getY() - 4,
             pathEndpoint.getPlane()
         );
         WorldArea pathArea = new WorldArea(pathSouthWest, 8, 8);
-        
+
         WorldPoint destSouthWest = new WorldPoint(
-            destination.getX() - 4, 
-            destination.getY() - 4, 
+            destination.getX() - 4,
+            destination.getY() - 4,
             destination.getPlane()
         );
         WorldArea objectArea = new WorldArea(destSouthWest, 8, 8);
-        
+
         if (!pathArea.intersectsWith2D(objectArea)) {
             return Integer.MAX_VALUE;
         }
@@ -682,32 +682,32 @@ public class Rs2Walker {
     public static boolean canReach(WorldPoint worldPoint, int sizeX, int sizeY, int pathSizeX, int pathSizeY,boolean useBankedItems) {
         boolean originalUseBankItems = ShortestPathPlugin.getPathfinderConfig().isUseBankItems();
         WorldArea pathArea = null;
-        
+
         // Create centered WorldArea for the object instead of corner-based
         WorldPoint objectSouthWest = new WorldPoint(
-            worldPoint.getX() - (sizeX + 2) / 2, 
-            worldPoint.getY() - (sizeY + 2) / 2, 
+            worldPoint.getX() - (sizeX + 2) / 2,
+            worldPoint.getY() - (sizeY + 2) / 2,
             worldPoint.getPlane()
         );
         WorldArea objectArea = new WorldArea(objectSouthWest, sizeX + 2, sizeY + 2);
-        
-        try {                            
+
+        try {
             ShortestPathPlugin.getPathfinderConfig().setUseBankItems(useBankedItems);
             ShortestPathPlugin.getPathfinderConfig().refresh(worldPoint);
             if (ShortestPathPlugin.getPathfinderConfig().getTransports().isEmpty()) {
                 ShortestPathPlugin.getPathfinderConfig().refresh(worldPoint);
             }
             Pathfinder pathfinder = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), Rs2Player.getWorldLocation(), worldPoint);
-            pathfinder.run();            
-            
+            pathfinder.run();
+
             // Create centered WorldArea for the path endpoint instead of corner-based
             WorldPoint pathEndpoint = pathfinder.getPath().get(pathfinder.getPath().size() - 1);
             WorldPoint pathSouthWest = new WorldPoint(
-                pathEndpoint.getX() - pathSizeX / 2, 
-                pathEndpoint.getY() - pathSizeY / 2, 
+                pathEndpoint.getX() - pathSizeX / 2,
+                pathEndpoint.getY() - pathSizeY / 2,
                 pathEndpoint.getPlane()
             );
-            pathArea = new WorldArea(pathSouthWest, pathSizeX, pathSizeY);                       
+            pathArea = new WorldArea(pathSouthWest, pathSizeX, pathSizeY);
         } catch (Exception e) {
             log.trace("Exception in canReach: {} - ", e.getMessage(), e);
             return false;
@@ -735,7 +735,7 @@ public class Rs2Walker {
      */
     public static boolean canReach(WorldPoint worldPoint) {
         return canReach(worldPoint, 2, 2, 2, 2);
-    } 
+    }
     public static boolean canReach(WorldPoint worldPoint, int sizeX, int sizeY, boolean useBankedItems) {
         return canReach(worldPoint, sizeX, sizeY, 2, 2, useBankedItems);
     }
@@ -746,7 +746,7 @@ public class Rs2Walker {
         return canReach(worldPoint, sizeX, sizeY, pathSizeX, pathSizeY, useBankedItems);
     }
 
-   
+
     /**
      * Retrieves the walk path from the player's current location to the specified target location.
      * @param start The starting `WorldPoint` from which the path should be calculated.
@@ -754,18 +754,18 @@ public class Rs2Walker {
      * @return A list of `WorldPoint` objects representing the path from the player's current location to the target.
      */
     public static List<WorldPoint> getWalkPath(WorldPoint start, WorldPoint target) {
-        long startTime = System.nanoTime();        
-        ShortestPathPlugin.getPathfinderConfig().refresh(target);                       
+        long startTime = System.nanoTime();
+        ShortestPathPlugin.getPathfinderConfig().refresh(target);
         long pathfinderStartTime = System.nanoTime();
-        Pathfinder pathfinderLocal = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), start, target);        
-        pathfinderLocal.run();                     
-        List<WorldPoint> path = pathfinderLocal.getPath();        
-        long pathfinderEndTime = System.nanoTime();        
+        Pathfinder pathfinderLocal = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), start, target);
+        pathfinderLocal.run();
+        List<WorldPoint> path = pathfinderLocal.getPath();
+        long pathfinderEndTime = System.nanoTime();
         long totalEndTime = System.nanoTime();
         double configTimeMs = (pathfinderStartTime - startTime) / 1_000_000.0;
         double pathfinderTimeMs = (pathfinderEndTime - pathfinderStartTime) / 1_000_000.0;
         double totalTimeMs = (totalEndTime - startTime) / 1_000_000.0;
-        
+
         StringBuilder performanceLog = new StringBuilder();
         performanceLog.append("getWalkPath Performance: ")
                 .append("Config: ").append(String.format("%.2f ms", configTimeMs))
@@ -773,11 +773,11 @@ public class Rs2Walker {
                 .append(", Total: ").append(String.format("%.2f ms", totalTimeMs))
                 .append(" | Path: ").append(start).append(" -> ").append(target)
                 .append(" (").append(path.size()).append(" waypoints)");
-        
+
         log.debug(performanceLog.toString());
-        
+
         return path;
-    } 
+    }
     /**
      * Retrieves the walk path from the player's current location to the specified target location.
      *
@@ -785,7 +785,7 @@ public class Rs2Walker {
      * @return A list of `WorldPoint` objects representing the path from the player's current location to the target.
      */
     public static List<WorldPoint> getWalkPath(WorldPoint target) {
-        return getWalkPath(Rs2Player.getWorldLocation(), target);        
+        return getWalkPath(Rs2Player.getWorldLocation(), target);
     }
 
     /**
@@ -799,11 +799,11 @@ public class Rs2Walker {
     public static List<Transport> getTransportsForPath(List<WorldPoint> path, int indexOfStartPoint) {
         return getTransportsForPath(path, indexOfStartPoint, TransportType.TELEPORTATION_ITEM, false);
     }
-    
+
     /**
      * Retrieves all transports found along the given path starting from a specific index.
      * Analyzes the path for available transport options, prioritizing the specified transport type.
-     * 
+     *
      * This method examines each point in the path starting from the given index and identifies
      * available transport options (teleportation items, spells, objects, etc.) that can be used
      * to optimize travel. Transport types are sorted with teleportation items getting highest priority.
@@ -821,7 +821,7 @@ public class Rs2Walker {
      * Retrieves all transports found along the given path starting from a specific index.
      * Analyzes the path for available transport options, prioritizing the specified transport type.
      * This version applies filtering and requirement setup for transports that require items.
-     * 
+     *
      * This method examines each point in the path starting from the given index and identifies
      * available transport options (teleportation items, spells, objects, etc.) that can be used
      * to optimize travel. Transport types are sorted with teleportation items getting highest priority.
@@ -847,7 +847,7 @@ public class Rs2Walker {
             transportsAtPoint = transportsAtPoint.stream()
                     .sorted(Comparator.comparing(Transport::getType, (type1, type2) -> {
                         // sort teleportation items by preference transport type for the current path point.
-                        
+
                         if (type1 == prefTransportType && type2 != prefTransportType) {
                             return -1;
                         }
@@ -924,48 +924,48 @@ public class Rs2Walker {
 
         log.info("\n\nFound " + transportList.size() + " transports for path from " +
                 path.get(0) + " to " + path.get(path.size() - 1));
-        
+
         // Apply filtering and requirement setup if requested
         if (applyFiltering) {
             transportList = applyTransportFiltering(transportList);
         }
-        
+
         return transportList;
     }
-    
+
     /**
      * Applies transport filtering and requirement setup for transport items.
      * This method filters transports to only include those that require items and
      * sets up item requirements for fairy rings and currency-based transports.
-     * 
+     *
      * @param transports The list of transports to filter and process
      * @return The filtered and processed list of transports
      */
     private static List<Transport> applyTransportFiltering(List<Transport> transports) {
         return transports.stream()
-                .filter(t -> t.getType() == TransportType.TELEPORTATION_ITEM || t.getType() == TransportType.FAIRY_RING || 
+                .filter(t -> t.getType() == TransportType.TELEPORTATION_ITEM || t.getType() == TransportType.FAIRY_RING ||
                              t.getType() == TransportType.TELEPORTATION_SPELL || t.getType() == TransportType.CANOE ||
                              t.getType() == TransportType.BOAT || t.getType() == TransportType.CHARTER_SHIP ||
                              t.getType() == TransportType.SHIP || t.getType() == TransportType.MINECART ||
                              t.getType() == TransportType.MAGIC_CARPET)
                 .peek(t -> {
                     // Set fairy ring requirements if not already set
-                    if (t.getType() == TransportType.FAIRY_RING && 
+                    if (t.getType() == TransportType.FAIRY_RING &&
                         ((t.getItemIdRequirements() == null || t.getItemIdRequirements().isEmpty()) ) &&  Microbot.getVarbitValue(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE)  != 1) {
                         t.setItemIdRequirements(Set.of(Set.of(
 							ItemID.DRAMEN_STAFF,
                             ItemID.LUNAR_MOONCLAN_LIMINAL_STAFF
                         )));
                     }
-                    
+
                     // Set currency requirements for currency-based transports
-                    if (isCurrencyBasedTransport(t.getType()) && 
+                    if (isCurrencyBasedTransport(t.getType()) &&
                         (t.getItemIdRequirements() == null || t.getItemIdRequirements().isEmpty()) &&
                         t.getCurrencyName() != null && !t.getCurrencyName().isEmpty() && t.getCurrencyAmount() > 0) {
                         int currencyItemId = getCurrencyItemId(t.getCurrencyName());
                         if (currencyItemId != -1) {
                             t.setItemIdRequirements(Set.of(Set.of(currencyItemId)));
-                            log.debug("Set currency requirement for {}: {} x{} (ID: {})", 
+                            log.debug("Set currency requirement for {}: {} x{} (ID: {})",
                                 t.getType(), t.getCurrencyName(), t.getCurrencyAmount(), currencyItemId);
                         }
                     }
@@ -992,18 +992,18 @@ public class Rs2Walker {
 
         return worldPoint.distanceTo(Microbot.getClient().getLocalPlayer().getWorldLocation());
     }
-    
+
     private static boolean handleRockfall(List<WorldPoint> path, int index) {
         if (ShortestPathPlugin.getPathfinder() == null) return false;
 
         if (index == path.size() - 1) return false;
-        
+
         // If we are in instance, ignore checking RegionID
         if(Microbot.getClient().getTopLevelWorldView().isInstance()) return false;
-        
+
         // If we are not inside of the Motherloade mine, ignore the following logic
         if (Rs2Player.getWorldLocation().getRegionID() != 14936 || currentTarget.getRegionID() != 14936) return false;
-        
+
         // We kill the path if no pickaxe is found to avoid walking around like an idiot
         if (!Rs2Inventory.hasItem("pickaxe")) {
             if (!Rs2Equipment.isWearing("pickaxe")) {
@@ -1012,7 +1012,7 @@ public class Rs2Walker {
                 return false;
             }
         }
-        
+
         // Check current index & next index for rockfall
         for (int rockIndex = index; rockIndex < index + 2; rockIndex++) {
             var point = path.get(rockIndex);
@@ -1032,7 +1032,7 @@ public class Rs2Walker {
                 return sleepUntil(() -> Rs2GameObject.getGameObject(point) == null);
             }
         }
-        
+
         return false;
     }
 
@@ -1364,7 +1364,7 @@ public class Rs2Walker {
         ShortestPathPlugin.getPathfinderConfig().refresh();
         if (Rs2Player.isInCave()) {
             pathfinder = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), start, ends);
-            pathfinder.run();            
+            pathfinder.run();
             ShortestPathPlugin.getPathfinderConfig().setIgnoreTeleportAndItems(true);
             Pathfinder pathfinderWithoutTeleports = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), start, ends);
             pathfinderWithoutTeleports.run();
@@ -1494,8 +1494,8 @@ public class Rs2Walker {
                         }
                     }
 
+                    log.debug("Handling {} transport: {}", transport.getType(), transport.getDisplayInfo());
                     if (transport.getType() == TransportType.POH) {
-                        log.debug("Using POH transport: " + transport.getDisplayInfo());
                         if (handlePohTransport(transport)) {
                             sleepUntil(() -> Rs2Player.getWorldLocation().distanceTo(transport.getDestination()) < OFFSET, 10000);
                             break;
@@ -1516,21 +1516,21 @@ public class Rs2Walker {
                             break;
                         }
                     }
-                    
+
                     if (transport.getType() == TransportType.QUETZAL) {
                         if (handleQuetzal(transport)) {
                             sleep(600 * 2); // wait 2 extra ticks before walking
                             break;
                         }
                     }
-                    
+
                     if (transport.getType() == TransportType.MAGIC_CARPET) {
                         if (handleMagicCarpet(transport)) {
                             sleep(600 * 2); // wait 2 extra ticks before walking
                             break;
                         }
                     }
-                    
+
                     if (transport.getType() == TransportType.WILDERNESS_OBELISK) {
                         if (handleWildernessObelisk(transport)) {
                             sleep(600 * 2);
@@ -1553,7 +1553,7 @@ public class Rs2Walker {
 							break;
 						}
                     }
-                    
+
                     if (transport.getType() == TransportType.TELEPORTATION_MINIGAME) {
                         if (handleMinigameTeleport(transport)) {
                             sleepUntilTrue(() -> Rs2Player.getWorldLocation().distanceTo(transport.getDestination()) < (OFFSET * 2));
@@ -1728,7 +1728,7 @@ public class Rs2Walker {
 			Rs2Walker.walkFastCanvas(transport.getDestination());
             return sleepUntil(() -> !Objects.equals(currentPlayerPoint, Microbot.getClient().getLocalPlayer().getWorldLocation()));
         }
-        
+
         // Handle Brimhaven Dungeon Entrance
         if (tileObject.getId() == 20877) {
             if (Rs2Player.isMoving()) {
@@ -1744,13 +1744,13 @@ public class Rs2Walker {
             Rs2Player.waitForAnimation(600 * 7);
             return true;
         }
-        
+
         // Handle Morte Myre Cave Agility Shortcut
         if (tileObject.getId() == ObjectID.FAIRY2_ROUTE_CAVEWALLTUNNEL) {
             Rs2Player.waitForAnimation((600 * 4 ) + 300);
             return true;
         }
-        
+
         // Handle Crash Site Cavern Gate
         if (tileObject.getId() == 28807 && transport.getOrigin().equals(new WorldPoint(2435,3519, 0))) {
             if (Rs2Player.isMoving()) {
@@ -1760,7 +1760,7 @@ public class Rs2Walker {
             Rs2Dialogue.clickOption("yes");
             return true;
         }
-        
+
         // Handle Cave Entrance inside of Asgarnia Ice Caves
         if (tileObject.getId() == ObjectID.CAVEWALL_SHORTCUT_ROYAL_TITANS_EAST || tileObject.getId() == ObjectID.CAVEWALL_SHORTCUT_ROYAL_TITANS_WEST) {
             Rs2Player.waitForAnimation();
@@ -1810,10 +1810,10 @@ public class Rs2Walker {
 		}
         return false;
     }
-    
+
     private static boolean handleWildernessObelisk(Transport transport) {
         GameObject obelisk = Rs2GameObject.getGameObject(obj -> obj.getId() == transport.getObjectId(), transport.getOrigin());
-        
+
         if (obelisk != null) {
             Rs2GameObject.interact(obelisk, transport.getAction());
             sleepUntil(() -> Rs2GameObject.getGameObject(obj -> obj.getId() == transport.getObjectId(), transport.getOrigin()) != null);
@@ -1826,15 +1826,15 @@ public class Rs2Walker {
     private static boolean handleTeleportSpell(Transport transport) {
         if (Rs2Pvp.isInWilderness() && (Rs2Pvp.getWildernessLevelFrom(Rs2Player.getWorldLocation()) > (transport.getMaxWildernessLevel() + 1))) return false;
         boolean hasMultipleDestination = transport.getDisplayInfo().contains(":");
-        
+
         String spellName = hasMultipleDestination
                 ? transport.getDisplayInfo().split(":")[0].trim().toLowerCase()
                 : transport.getDisplayInfo().toLowerCase();
-        
+
         String option = hasMultipleDestination
                 ? transport.getDisplayInfo().split(":")[1].trim().toLowerCase()
                 : "cast";
-        
+
         int identifier = hasMultipleDestination
                 ? 2
                 : 1;
@@ -2298,7 +2298,7 @@ public class Rs2Walker {
         }
         return false;
     }
-    
+
     private static boolean handleQuetzal(Transport transport) {
 		@Component
         int VARLAMORE_QUETZAL_MAP = InterfaceID.QuetzalMenu.CONTENTS;
@@ -2312,7 +2312,7 @@ public class Rs2Walker {
         if (Rs2Tile.isTileReachable(transport.getOrigin()) && Rs2Npc.interact(renu, "travel")) {
             Rs2Player.waitForWalking();
             boolean isVarlamoreMapVisible = sleepUntilTrue(() -> Rs2Widget.isWidgetVisible(VARLAMORE_QUETZAL_MAP), 100, 10000);
-            
+
             if (!isVarlamoreMapVisible) {
                 log.error("Varlamore Map Widget not visable within timeout");
                 return false;
@@ -2354,7 +2354,7 @@ public class Rs2Walker {
 		}
 		Rs2Player.waitForAnimation();
 	}
-    
+
     private static boolean handleMagicCarpet(Transport transport) {
         final int flyingPoseAnimation = 6936;
         var rugMerchant = Rs2Npc.getNpc(transport.getObjectId());
@@ -2716,7 +2716,7 @@ public class Rs2Walker {
     /**
      * Finds the nearest accessible target from a list of WorldPoints using pathfinding.
      * This is a generalized version of the logic used in Rs2Bank.getNearestBank().
-     * 
+     *
      * @param startPoint The starting location for pathfinding
      * @param targets List of target WorldPoints to evaluate
      * @param tolerance Tolerance in tiles for matching the final path point to targets (default: 2)
@@ -2726,39 +2726,39 @@ public class Rs2Walker {
         if (targets == null || targets.isEmpty()) {
             return -1;
         }
-        
+
         if (startPoint == null) {
             startPoint = Rs2Player.getWorldLocation();
         }
-        
+
         if (startPoint == null) {
             log.warn("Unable to determine starting point for pathfinding");
             return -1;
         }
-        
+
         // Convert list to set for pathfinder
         Set<WorldPoint> targetSet = new HashSet<>(targets);
-        
+
         // Store original configuration to restore later
         boolean originalUseBankItems =  ShortestPathPlugin.getPathfinderConfig().isUseBankItems();
-        try {            
+        try {
             ShortestPathPlugin.getPathfinderConfig().setUseBankItems(useBankItems);
             // Configure pathfinder            
-            ShortestPathPlugin.getPathfinderConfig().refresh();                                              
+            ShortestPathPlugin.getPathfinderConfig().refresh();
             // Run pathfinder
             Pathfinder pf = new Pathfinder(ShortestPathPlugin.getPathfinderConfig(), startPoint, targetSet);
             pf.run();
-            
+
             List<WorldPoint> path = pf.getPath();
             if (path.isEmpty()) {
                 log.debug("Unable to find path to any target from starting point: " + startPoint);
                 return -1;
             }
-            
+
             // Find which target corresponds to the end of the path
             WorldPoint nearestTile = path.get(path.size() - 1);
             WorldArea nearestTileArea = new WorldArea(nearestTile, tolerance, tolerance);
-            
+
             // Find the target that matches the final path destination
             for (int i = 0; i < targets.size(); i++) {
                 WorldPoint target = targets.get(i);
@@ -2768,21 +2768,21 @@ public class Rs2Walker {
                     return i;
                 }
             }
-            
+
             log.debug("Path found but no target matched the destination: " + nearestTile);
             return -1;
-            
+
         } finally {
             // Always restore original configuration
             ShortestPathPlugin.getPathfinderConfig().setUseBankItems(originalUseBankItems);
             ShortestPathPlugin.getPathfinderConfig().refresh();
         }
     }
-    
+
     /**
      * Finds the nearest accessible target from a list of WorldPoints using pathfinding.
      * Uses default tolerance of 2 tiles and no bank item usage.
-     * 
+     *
      * @param startPoint The starting location for pathfinding
      * @param targets List of target WorldPoints to evaluate
      * @return The index of the nearest accessible target in the list, or -1 if none are reachable
@@ -2790,11 +2790,11 @@ public class Rs2Walker {
     public static int findNearestAccessibleTarget(WorldPoint startPoint, List<WorldPoint> targets) {
         return findNearestAccessibleTarget(startPoint, targets, false, 2);
     }
-    
+
     /**
      * Finds the nearest accessible target from a list of WorldPoints using pathfinding.
      * Uses the player's current location as starting point.
-     * 
+     *
      * @param targets List of target WorldPoints to evaluate
      * @param useBankItems Whether to enable bank item usage for transport calculations
      * @return The index of the nearest accessible target in the list, or -1 if none are reachable
@@ -2802,22 +2802,22 @@ public class Rs2Walker {
     public static int findNearestAccessibleTarget(List<WorldPoint> targets, boolean useBankItems) {
         return findNearestAccessibleTarget(Rs2Player.getWorldLocation(), targets, useBankItems, 2);
     }
-    
+
     /**
      * Finds the nearest accessible target from a list of WorldPoints using pathfinding.
      * Uses the player's current location as starting point and no bank item usage.
-     * 
+     *
      * @param targets List of target WorldPoints to evaluate
      * @return The index of the nearest accessible target in the list, or -1 if none are reachable
      */
     public static int findNearestAccessibleTarget(List<WorldPoint> targets) {
         return findNearestAccessibleTarget(Rs2Player.getWorldLocation(), targets, false, 2);
     }
-    
+
     /**
      * Prepares and analyzes required transport items for reaching a destination.
      * Similar but improved to Rs2Slayer.prepareItemTransports()
-     * 
+     *
      * @param destination The target location to reach
      * @param useBankItems Whether to consider bank items in pathfinding
      * @return List of Transport objects that are missing required items
@@ -2825,11 +2825,11 @@ public class Rs2Walker {
     public static List<Transport> getTransportsForDestination(WorldPoint destination, boolean useBankItems) {
         return getTransportsForDestination(destination, useBankItems, TransportType.TELEPORTATION_ITEM);
     }
-    
+
     /**
      * Prepares and analyzes required transport items for reaching a destination.
      * Similar but improved to Rs2Slayer.prepareItemTransports()
-     * 
+     *
      * @param destination The target location to reach
      * @param useBankItems Whether to consider bank items in pathfinding
      * @param prefTransportType The preferred transport type to prioritize
@@ -2839,7 +2839,7 @@ public class Rs2Walker {
         if (destination == null) {
             return new ArrayList<>();
         }
-        
+
         boolean originalUseBankItems = ShortestPathPlugin.getPathfinderConfig().isUseBankItems();
         try {
             // Store and configure pathfinder settings
@@ -2852,7 +2852,7 @@ public class Rs2Walker {
 
             // Log found transports for debugging
             transports.forEach(t -> log.debug("Transport found: " + t));
-            
+
             return transports;
 
         } finally {
@@ -2861,22 +2861,22 @@ public class Rs2Walker {
             ShortestPathPlugin.getPathfinderConfig().refresh();
         }
     }
-    
+
     /**
      * Prepares and analyzes required transport items for reaching a destination.
      * Uses bank items in calculations by default.
-     * 
+     *
      * @param destination The target location to reach
      * @return List of Transport objects that are missing required items
      */
     public static List<Transport> prepareTransportsForDestination(WorldPoint destination) {
         return getTransportsForDestination(destination, true);
     }
-    
+
     /**
      * Checks if the player has the required items for a specific transport.
      * Similar to Rs2Slayer.hasRequiredTeleportItem() but accessible in Rs2Walker.
-     * 
+     *
      * @param transport The transport to check requirements for
      * @return true if the player has all required items, false otherwise
      */
@@ -2884,23 +2884,23 @@ public class Rs2Walker {
         if (transport == null) {
             return false;
         }
-        
+
         if (transport.getType() == TransportType.FAIRY_RING) {
             return Rs2Inventory.hasItem(ItemID.DRAMEN_STAFF) ||
                     Rs2Equipment.isWearing(ItemID.DRAMEN_STAFF) ||
                     Rs2Inventory.hasItem(ItemID.LUNAR_MOONCLAN_LIMINAL_STAFF) ||
                     Rs2Equipment.isWearing(ItemID.LUNAR_MOONCLAN_LIMINAL_STAFF) ||  Microbot.getVarbitValue(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE)  == 1;
-        } else if (transport.getType() == TransportType.TELEPORTATION_ITEM || 
+        } else if (transport.getType() == TransportType.TELEPORTATION_ITEM ||
                              transport.getType() == TransportType.TELEPORTATION_SPELL || transport.getType() == TransportType.CANOE ||
                              transport.getType() == TransportType.BOAT || transport.getType() == TransportType.CHARTER_SHIP ||
                              transport.getType() == TransportType.SHIP || transport.getType() == TransportType.MINECART ||
                              transport.getType() == TransportType.MAGIC_CARPET
         ) {
-            if (transport.getType() == TransportType.TELEPORTATION_SPELL && transport.getDisplayInfo() != null) {                              
+            if (transport.getType() == TransportType.TELEPORTATION_SPELL && transport.getDisplayInfo() != null) {
                 // Extract spell name from displayInfo (handle potential format "spellname:option")
-                String spellName = transport.getDisplayInfo().contains(":") 
+                String spellName = transport.getDisplayInfo().contains(":")
                     ? transport.getDisplayInfo().split(":")[0].trim()
-                    : transport.getDisplayInfo().trim();                                                            
+                    : transport.getDisplayInfo().trim();
                 // Find matching Rs2Spells enum by name (case-insensitive partial match)
                 boolean hasMultipleDestination = transport.getDisplayInfo().contains(":");
                 String displayInfo = hasMultipleDestination
@@ -2910,7 +2910,7 @@ public class Rs2Walker {
                 Rs2Spells rs2Spell = Rs2Magic.getRs2Spell(displayInfo);
                 return Rs2Magic.hasRequiredRunes(rs2Spell);
             }
-            if (isCurrencyBasedTransport(transport.getType()) && 
+            if (isCurrencyBasedTransport(transport.getType()) &&
                 (transport.getItemIdRequirements() == null || transport.getItemIdRequirements().isEmpty()) &&
                 transport.getCurrencyName() != null && !transport.getCurrencyName().isEmpty() && transport.getCurrencyAmount() > 0) {
                 int currencyItemId = getCurrencyItemId(transport.getCurrencyName());
@@ -2919,20 +2919,20 @@ public class Rs2Walker {
             if (transport.getItemIdRequirements() == null || transport.getItemIdRequirements().isEmpty()) {
                 return true; // No requirements specified
             }
-            
+
             return transport.getItemIdRequirements()
                     .stream()
                     .flatMap(Collection::stream)
                     .anyMatch(itemId -> Rs2Equipment.isWearing(itemId) || Rs2Inventory.hasItem(itemId));
         }
-        
+
         return true; // For other transport types, assume available for now -> we need to think about later
     }
-    
+
     /**
      * Filters a list of transports to return only those missing required items.
      * Similar to Rs2Slayer.getMissingItemTransports() but accessible in Rs2Walker.
-     * 
+     *
      * @param transports List of transports to check
      * @return List of transports that are missing required items
      */
@@ -2940,16 +2940,16 @@ public class Rs2Walker {
         if (transports == null) {
             return new ArrayList<>();
         }
-        
+
         return transports.stream()
                 .filter(t -> !hasRequiredTransportItems(t))
                 .collect(Collectors.toList());
     }
-    
+
     /**
      * Extracts item IDs and their required quantities for the given transports that are missing and available in bank.
      * Enhanced version that uses Rs2Magic and Rs2Spells systems for actual rune quantities on teleportation spells.
-     * 
+     *
      * @param transports List of transports to check for missing items
      * @return Map where key=itemId and value=quantity needed (actual quantities for teleportation spells)
      */
@@ -2957,9 +2957,9 @@ public class Rs2Walker {
         if (transports == null) {
             return new HashMap<>();
         }
-        
+
         Map<Integer, Integer> itemQuantityMap = new HashMap<>();
-        
+
         transports.stream()
                 .forEach(transport -> {
                     // Special handling for teleportation spells - use actual rune requirements
@@ -2973,7 +2973,7 @@ public class Rs2Walker {
                                     if (bankQuantity >= requiredQuantity) {
                                         int currentQuantity = itemQuantityMap.getOrDefault(runeItemId, 0);
                                         itemQuantityMap.put(runeItemId, currentQuantity + requiredQuantity);
-                                        log.debug("Added teleportation spell rune requirement: {} (ID: {}) x{} (bank has: {})", 
+                                        log.debug("Added teleportation spell rune requirement: {} (ID: {}) x{} (bank has: {})",
                                             runeItemId, runeItemId, requiredQuantity, bankQuantity);
                                     }
                                 } catch (Exception e) {
@@ -2983,7 +2983,7 @@ public class Rs2Walker {
                         }
                         return; // Skip normal item requirement processing for spell transports
                     }
-                    
+
                     // Normal processing for non-spell transports
                     if (transport.getItemIdRequirements() != null) {
                         for (Set<Integer> alternativeItems : transport.getItemIdRequirements()) {
@@ -3004,7 +3004,7 @@ public class Rs2Walker {
                                             return false;
                                         }
                                     });
-                            
+
                             if (hasAnyAlternative) {
                                 // Find the first available alternative in bank and add it to our map
                                 alternativeItems.stream()
@@ -3029,13 +3029,13 @@ public class Rs2Walker {
                                             if (isCurrencyBasedTransport(transport.getType()) && transport.getCurrencyAmount() > 0) {
                                                 // For currency-based transports, use the actual currency amount
                                                 requiredQuantity = transport.getCurrencyAmount();
-                                                log.debug("Currency-based transport {} requires {} x{}", 
+                                                log.debug("Currency-based transport {} requires {} x{}",
                                                     transport.getType(), transport.getCurrencyName(), requiredQuantity);
                                             } else {
                                                 // For regular items (teleportation items, fairy rings, etc.), assume 1 is needed
                                                 requiredQuantity = 1;
                                             }
-                                            
+
                                             int currentQuantity = itemQuantityMap.getOrDefault(itemId, 0);
                                             itemQuantityMap.put(itemId, currentQuantity + requiredQuantity);
                                         });
@@ -3044,27 +3044,27 @@ public class Rs2Walker {
                         }
                     }
                 });
-        
+
         return itemQuantityMap;
     }
-    
+
     /**
      * Gets the actual rune requirements for a teleportation spell transport.
      * Maps spell names to Rs2Spells enum and extracts rune quantities.
-     * 
+     *
      * @param transport The teleportation spell transport
      * @return Map of item IDs to required quantities for the spell's runes
      */
     private static Map<Integer, Integer> getSpellRuneRequirements(Transport transport) {
-        Map<Integer, Integer> runeRequirements = new HashMap<>();        
+        Map<Integer, Integer> runeRequirements = new HashMap<>();
         if (transport.getType() != TransportType.TELEPORTATION_SPELL || transport.getDisplayInfo() == null) {
             return runeRequirements;
-        }        
+        }
         try {
             // Extract spell name from displayInfo (handle potential format "spellname:option")
-            String spellName = transport.getDisplayInfo().contains(":") 
+            String spellName = transport.getDisplayInfo().contains(":")
                 ? transport.getDisplayInfo().split(":")[0].trim()
-                : transport.getDisplayInfo().trim();                                    
+                : transport.getDisplayInfo().trim();
             // Find matching Rs2Spells enum by name (case-insensitive partial match)
             boolean hasMultipleDestination = transport.getDisplayInfo().contains(":");
             String displayInfo = hasMultipleDestination
@@ -3072,45 +3072,45 @@ public class Rs2Walker {
                 : transport.getDisplayInfo();
             log.debug("Looking for spell rune requirements for: '{}' - display info {}", spellName, displayInfo);
             Rs2Spells rs2Spell = Rs2Magic.getRs2Spell(displayInfo);
-            if (rs2Spell == null) return runeRequirements;            
+            if (rs2Spell == null) return runeRequirements;
             // Get rune requirements and check for elemental runes that might be provided by staves
             Map<Runes, Integer> requiredRunes = Rs2Magic.getRequiredRunes(rs2Spell,1,true);
-            List<Runes> elementalRunes = rs2Spell.getElementalRunes();            
-            log.debug("Spell '{}' requires {} runes, including {} elemental runes", 
-                spellName, requiredRunes.size(), elementalRunes.size());           
+            List<Runes> elementalRunes = rs2Spell.getElementalRunes();
+            log.debug("Spell '{}' requires {} runes, including {} elemental runes",
+                spellName, requiredRunes.size(), elementalRunes.size());
             // Convert rune requirements to item IDs with quantities
             requiredRunes.forEach((rune, quantity) -> {
                     int runeItemId = rune.getItemId();
-                    runeRequirements.put(runeItemId, quantity);                
-                    log.debug("Spell '{}' requires {} x {} (ID: {})", 
+                    runeRequirements.put(runeItemId, quantity);
+                    log.debug("Spell '{}' requires {} x {} (ID: {})",
                     spellName, quantity, rune.name(), runeItemId);
             });
-            
+
         } catch (Exception e) {
-            log.warn("Error getting spell rune requirements for transport '{}': {}", 
+            log.warn("Error getting spell rune requirements for transport '{}': {}",
                 transport.getDisplayInfo(), e.getMessage());
         }
-        
+
         return runeRequirements;
     }
-    
+
     /**
      * Checks if a transport type is currency-based (requires coins or other currency).
-     * 
+     *
      * @param transportType The transport type to check
      * @return true if the transport type requires currency
      */
     private static boolean isCurrencyBasedTransport(TransportType transportType) {
-        return transportType == TransportType.BOAT || 
-               transportType == TransportType.CHARTER_SHIP || 
-               transportType == TransportType.SHIP || 
-               transportType == TransportType.MINECART || 
+        return transportType == TransportType.BOAT ||
+               transportType == TransportType.CHARTER_SHIP ||
+               transportType == TransportType.SHIP ||
+               transportType == TransportType.MINECART ||
                transportType == TransportType.MAGIC_CARPET;
     }
-    
+
     /**
      * Maps currency name to item ID from RuneLite API.
-     * 
+     *
      * @param currencyName The name of the currency (e.g., "Coins")
      * @return The item ID for the currency, or -1 if not found
      */
@@ -3118,7 +3118,7 @@ public class Rs2Walker {
         if (currencyName == null || currencyName.trim().isEmpty()) {
             return -1;
         }
-        
+
         String currency = currencyName.trim().toLowerCase();
         switch (currency) {
             case "coins":
@@ -3131,23 +3131,23 @@ public class Rs2Walker {
                 return -1;
         }
     }
-    
+
     /**
      * Extracts item IDs that are missing for the given transports and available in bank.
      * Legacy method maintained for backward compatibility.
      * Similar to Rs2Slayer.getMissingItemIds() but accessible in Rs2Walker.
-     * 
+     *
      * @param transports List of transports to check for missing items
      * @return List of item IDs that are needed and available in bank
      */
     public static List<Integer> getMissingTransportItemIds(List<Transport> transports) {
         return new ArrayList<>(getMissingTransportItemIdsWithQuantities(transports).keySet());
     }
-    
+
     /**
      * Compares the efficiency of traveling directly to a target versus going via bank first.
      * This is useful when transport items may be needed from the bank.
-     * 
+     *
      * @param target The target destination
      * @param startPoint Starting location (null to use current player location)
      * @return TransportRouteAnalysis containing the analysis of both routes
@@ -3155,57 +3155,57 @@ public class Rs2Walker {
     public static TransportRouteAnalysis compareRoutes(WorldPoint startPoint,WorldPoint target) {
         long totalStartTime = System.nanoTime();
         StringBuilder performanceLog = new StringBuilder();
-        performanceLog.append("\n\t=== compareRoutes Performance Analysis ===\n");        
+        performanceLog.append("\n\t=== compareRoutes Performance Analysis ===\n");
         if (target == null) {
             return new TransportRouteAnalysis(new ArrayList<>(), null, null,new ArrayList<>(),new ArrayList<>(), "Target location is null");
         }
-        
+
         if (startPoint == null) {
             startPoint = Rs2Player.getWorldLocation();
         }
-        
+
         if (startPoint == null) {
             return new TransportRouteAnalysis(new ArrayList<>(), null, null, new ArrayList<>(),new ArrayList<>(),"Cannot determine starting location");
         }
-        
+
         try {
             // Get direct path distance with timing
-            performanceLog.append("\tStart Point: ").append(startPoint).append(", Target: ").append(target).append("\n");            
+            performanceLog.append("\tStart Point: ").append(startPoint).append(", Target: ").append(target).append("\n");
             long directPathStartTime = System.nanoTime();
             List<WorldPoint> directPath = getWalkPath(startPoint, target);
             long directPathEndTime = System.nanoTime();
             double directPathTimeMs = (directPathEndTime - directPathStartTime) / 1_000_000.0;
-            
+
             int directDistance = getTotalTilesFromPath(directPath, target);
             performanceLog.append("\t-Direct path calculation: ").append(String.format("%.2f ms", directPathTimeMs))
                     .append(" (").append(directPath.size()).append(" waypoints, ").append(directDistance).append(" tiles)\n");
-            
+
             // Find nearest bank and calculate banking route distance
             BankLocation nearestBank = null;
             List<WorldPoint> pathToBank  = new ArrayList<>();
             List<WorldPoint> pathWithBankedItemsToTarget = new ArrayList<>();
-            int bankingRouteDistance = -1;            
-            
+            int bankingRouteDistance = -1;
+
             try {
-                
-            
-             
-                
+
+
+
+
                 boolean originalUseBankItems = ShortestPathPlugin.getPathfinderConfig().isUseBankItems();
-                try {                            
+                try {
                     ShortestPathPlugin.getPathfinderConfig().setUseBankItems(true);
                     ShortestPathPlugin.getPathfinderConfig().refresh(target);
-                    
+
                     performanceLog.append("\t-Bank items available: ").append(Rs2Bank.bankItems().size()).append("\n");
-                    
+
                     long pathWithBankedItemsStartTime = System.nanoTime();
                     pathWithBankedItemsToTarget = getWalkPath(startPoint, target);
                     long pathWithBankedItemsEndTime = System.nanoTime();
                     double pathWithBankedItemsTimeMs = (pathWithBankedItemsEndTime - pathWithBankedItemsStartTime) / 1_000_000.0;
-                    
+
                     int distanceWithBankedItemsToTarget = getTotalTilesFromPath(pathWithBankedItemsToTarget, target);
                     bankingRouteDistance = distanceWithBankedItemsToTarget;
-                    
+
                     performanceLog.append("\t-Path from start to target with banked items: ").append(String.format("%.2f ms", pathWithBankedItemsTimeMs))
                             .append(" (").append(pathWithBankedItemsToTarget.size()).append(" waypoints, ").append(distanceWithBankedItemsToTarget).append(" tiles)\n");
                     performanceLog.append("\t-Total banking route distance: ").append(bankingRouteDistance).append(" tiles\n");
@@ -3213,7 +3213,7 @@ public class Rs2Walker {
                 } finally {
                     // Always restore original configuration
                     ShortestPathPlugin.getPathfinderConfig().setUseBankItems(false);
-                    ShortestPathPlugin.getPathfinderConfig().refresh();                        
+                    ShortestPathPlugin.getPathfinderConfig().refresh();
                 }
                 if (bankingRouteDistance<directDistance){
                     long bankSearchStartTime = System.nanoTime();
@@ -3224,13 +3224,13 @@ public class Rs2Walker {
                         performanceLog.append("\t-Nearest bank search: ").append(String.format("%.2f ms", bankSearchTimeMs));
                         WorldPoint bankLocation = nearestBank.getWorldPoint();
                         performanceLog.append("\t -> Found: ").append(nearestBank).append(" at ").append(bankLocation).append("\n");
-                    
+
                         // Calculate distance from start point to bank
                         long pathToBankStartTime = System.nanoTime();
                         pathToBank = getWalkPath(startPoint, bankLocation);
                         long pathToBankEndTime = System.nanoTime();
                         double pathToBankTimeMs = (pathToBankEndTime - pathToBankStartTime) / 1_000_000.0;
-                        
+
                         int distanceToBank = getTotalTilesFromPath(pathToBank, bankLocation);
                         performanceLog.append("\t-Path to bank calculation: ").append(String.format("%.2f ms", pathToBankTimeMs))
                                 .append(" (").append(pathToBank.size()).append(" waypoints, ").append(distanceToBank).append(" tiles)\n");
@@ -3239,34 +3239,34 @@ public class Rs2Walker {
                         performanceLog.append("\t -> No accessible bank found\n");
                     }
                 }
-                
+
             } catch (Exception e) {
                 performanceLog.append("Banking route calculation failed: ").append(e.getMessage()).append("\n");
                 log.debug("Could not calculate banking route: " + e.getMessage());
             }
-            
+
             long totalEndTime = System.nanoTime();
             double totalTimeMs = (totalEndTime - totalStartTime) / 1_000_000.0;
             performanceLog.append("\t=== Total compareRoutes time: ").append(String.format("%.2f ms", totalTimeMs)).append(" ===\n");
-            
+
             if (bankingRouteDistance == -1) {
                 performanceLog.append("\tResult: Direct route only (banking route unavailable)\n");
                 log.info(performanceLog.toString());
                 return new TransportRouteAnalysis(directPath, null, null, new ArrayList<>(),new ArrayList<>(),
                     "Direct route only (banking route unavailable)");
             }
-            
+
             boolean directIsFaster = directDistance <= bankingRouteDistance;
-            String recommendation = directIsFaster ? 
+            String recommendation = directIsFaster ?
                 String.format("\tDirect route is faster (%d vs %d tiles)", directDistance, bankingRouteDistance) :
                 String.format("\tBanking route is faster (%d vs %d tiles)", bankingRouteDistance, directDistance);
-            
+
             performanceLog.append("\tResult:\n\t\t ").append(recommendation).append("\n");
             log.info(performanceLog.toString());
-            
-            return new TransportRouteAnalysis(directPath, 
+
+            return new TransportRouteAnalysis(directPath,
                 nearestBank, nearestBank != null ? nearestBank.getWorldPoint() : null,pathToBank,pathWithBankedItemsToTarget, recommendation);
-                
+
         } catch (Exception e) {
             long totalEndTime = System.nanoTime();
             double totalTimeMs = (totalEndTime - totalStartTime) / 1_000_000.0;
@@ -3277,18 +3277,18 @@ public class Rs2Walker {
             return new TransportRouteAnalysis(new ArrayList<>(), null, null,new ArrayList<>(),new ArrayList<>(), "Error calculating routes: " + e.getMessage());
         }
     }
-    
+
     /**
      * Compares direct vs banking route using current player location as start point.
      */
     public static TransportRouteAnalysis compareRoutes(WorldPoint target) {
         return compareRoutes(null,target);
     }
-    
+
     /**
      * Travels to the target destination using the legacy walkTo-based approach with transport support.
      * Uses default settings: considers bank items and allows efficiency-based banking decisions.
-     * 
+     *
      * @param target The destination to travel to
      * @return true if travel was successful, false otherwise
      */
@@ -3301,12 +3301,12 @@ public class Rs2Walker {
     public static boolean walkWithBankedTransports(WorldPoint target, int distance, boolean forceBanking){
         WalkerState state = walkWithBankedTransportsAndState(target, distance, forceBanking);
         return state == WalkerState.ARRIVED;
-        
+
     }
     /**
      * Travels to the target destination using the legacy walkTo-based approach with transport support.
      * Analyzes whether to go directly or via bank first for transport items.
-     * 
+     *
      * @param target The destination to travel to
      * @param forceBanking If true, forces banking route regardless of efficiency
      * @return true if travel was successful, false otherwise
@@ -3327,18 +3327,18 @@ public class Rs2Walker {
         final Pathfinder pathfinder = ShortestPathPlugin.getPathfinder();
         if (pathfinder != null && !pathfinder.isDone())
             return WalkerState.MOVING;
-        if ((currentTarget != null && currentTarget.equals(target)) && ShortestPathPlugin.getMarker() != null){            
-            return WalkerState.MOVING;        
+        if ((currentTarget != null && currentTarget.equals(target)) && ShortestPathPlugin.getMarker() != null){
+            return WalkerState.MOVING;
         }
-        Rs2Walker.currentTarget =  null;        
+        Rs2Walker.currentTarget =  null;
         // Check what transport items are needed
         TransportRouteAnalysis comparison = compareRoutes(target);
         List<Transport> missingTransports = getMissingTransports(getTransportsForDestination(target, true, TransportType.TELEPORTATION_SPELL));
-        
+
         Map<Integer, Integer> missingItemsWithQuantities = getMissingTransportItemIdsWithQuantities(missingTransports);
-        if(!missingTransports.isEmpty()){            
-            log.info("\n\tFor {} transports to destination in the bank to target {} we found {} missing items", 
-                missingTransports.size(), target, missingItemsWithQuantities.size());                    
+        if(!missingTransports.isEmpty()){
+            log.info("\n\tFor {} transports to destination in the bank to target {} we found {} missing items",
+                missingTransports.size(), target, missingItemsWithQuantities.size());
         }
         // If no missing transport items, go directly
         if (missingItemsWithQuantities.isEmpty() && !forceBanking) {
@@ -3351,7 +3351,7 @@ public class Rs2Walker {
                 log.warn("\n\tFailed to arrive directly at target: " + target + ", state: " + state);
                 setTarget(null);
                 return state;
-                
+
             }
             return state;
         } else {
@@ -3363,7 +3363,7 @@ public class Rs2Walker {
             // If forced banking or banking route is more efficient (with min savings), go via bank
             if (forceBanking || bankRouteIsBetter) {
                 if (comparison.getNearestBank() != null) {
-                    log.info("\n\tUsing banking route: \n\t\tStart: {} -> Bank: {} -> Target: {}", 
+                    log.info("\n\tUsing banking route: \n\t\tStart: {} -> Bank: {} -> Target: {}",
                             Rs2Player.getWorldLocation(), comparison.getBankLocation(), target);
                     // Handle the complete banking workflow using legacy walkTo approach
                     return walkWithBankingState(comparison.getBankLocation(), missingItemsWithQuantities, target, distance);
@@ -3378,18 +3378,18 @@ public class Rs2Walker {
                 return walkWithStateInternal(target, distance);
             }
         }
-        
-    
+
+
     }
-    
-    
-   
-   
-    
+
+
+
+
+
     /**
      * Handles the complete banking workflow using legacy walkTo: walk to bank, open, withdraw items, close, continue to target.
      * Enhanced version that accepts a map of item IDs with their required quantities and returns boolean.
-     * 
+     *
      * @param bankLocation The bank location to visit
      * @param missingItemsWithQuantities Map of item IDs and their required quantities
      * @param finalTarget The final destination after banking
@@ -3398,7 +3398,7 @@ public class Rs2Walker {
     private static boolean walkWithBanking(WorldPoint bankLocation, Map<Integer, Integer> missingItemsWithQuantities, WorldPoint finalTarget) {
        return walkWithBankingState(bankLocation, missingItemsWithQuantities, finalTarget, 10)== WalkerState.ARRIVED;
     }
-    
+
     /**
      * Handles the complete banking workflow using walkWithState: walk to bank, open, withdraw items, close, continue to target.
      * Enhanced version that accepts a map of item IDs with their required quantities and returns WalkerState.
@@ -3408,7 +3408,7 @@ public class Rs2Walker {
      * @return WalkerState indicating the result of the banking workflow
      */
     private static WalkerState walkWithBankingState(WorldPoint bankLocation,
-                                                    Map<Integer, Integer> missingItemsWithQuantities, 
+                                                    Map<Integer, Integer> missingItemsWithQuantities,
                                                     WorldPoint finalTarget,int distance) {
         try {
             if (bankLocation == null || finalTarget == null) {
@@ -3422,7 +3422,7 @@ public class Rs2Walker {
                 log.warn("Failed to arrive at bank at: " + bankLocation + ", state: " + bankWalkResult);
                 return bankWalkResult;
             }
-            log.info("Arrived at bank location: " + bankLocation);                                    
+            log.info("Arrived at bank location: " + bankLocation);
             // Step 2: Open bank
             if (!Rs2Bank.openBank()) {
                 log.warn("Failed to open bank at: " + bankLocation);
@@ -3432,40 +3432,40 @@ public class Rs2Walker {
                 log.warn("Failed to open bank within timeout at: " + bankLocation);
                 return WalkerState.EXIT;
             }
-            
+
             // Step 3: Withdraw missing transport items
             if (!missingItemsWithQuantities.isEmpty()) {
                 log.debug("Withdrawing transport items with quantities: " + missingItemsWithQuantities);
-                
+
                 // Withdraw the correct amount of each unique item
                 for (Map.Entry<Integer, Integer> entry : missingItemsWithQuantities.entrySet()) {
                     int itemId = entry.getKey();
                     int amountNeeded = entry.getValue();
                     int currentCount = Rs2Inventory.count(itemId);
                     int amountToWithdraw = Math.max(0, amountNeeded );
-                    
+
                     if (amountToWithdraw > 0) {
                         if (Rs2Bank.hasBankItem(itemId, amountToWithdraw)) {
                             log.debug("Withdrawing {} x {} (item ID: {})", amountToWithdraw, itemId, itemId);
                             Rs2Bank.withdrawX(itemId, amountToWithdraw);
                             sleepUntil(() -> Rs2Inventory.count(itemId) >= currentCount + amountToWithdraw, 3000);
                         } else {
-                            log.warn("Required transport item {} not found in bank (need {} but bank has less)", 
+                            log.warn("Required transport item {} not found in bank (need {} but bank has less)",
                                 itemId, amountToWithdraw);
                         }
                     } else {
                         log.debug("Already have enough of item {}: {} (need {})", itemId, currentCount, amountNeeded);
                     }
                 }
-                
+
                 // Wait a bit for all withdrawals to complete
                 sleep(600); // 1 tick
             }
-            
+
             // Step 4: Close bank
             Rs2Bank.closeBank();
             sleepUntil(() -> !Rs2Bank.isOpen(), 3000);
-            if (Rs2Bank.isOpen()) {            
+            if (Rs2Bank.isOpen()) {
                 log.warn("Failed to close bank after withdrawals");
                 return WalkerState.EXIT;
             }
@@ -3475,7 +3475,7 @@ public class Rs2Walker {
             log.debug("Banking complete, continuing to final target: " + finalTarget);
             setTarget(null); // Clear current target to avoid conflicts           
             return walkWithStateInternal(finalTarget, distance);
-            
+
         } catch (Exception e) {
             log.error("Error in banking workflow: " + e.getMessage(), e);
             return WalkerState.EXIT;


### PR DESCRIPTION
Currently when the players starts webwalker inside PoH the teleport towards PoH is still added and might be executed after the player teleported outside of the house