### PR TITLE
fix(FishingTrawler): fix reward looting by checking for visible widget

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/fishing/FishingTrawler/FishingTrawlerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/fishing/FishingTrawler/FishingTrawlerScript.java
@@ -52,8 +52,9 @@ public class FishingTrawlerScript extends Script {
                         Microbot.status = "Looting Rewards";
                         Rs2GameObject.interact(OBJECT_TRAWLERNET, "inspect");
                         Rs2Player.waitForWalking();
-                        sleep(Rs2Random.randomGaussian(600, 300));
-                        Rs2Widget.clickWidget("Bank-all");
+                        //check for visible trawler widget
+                        sleepUntil(() -> Rs2Widget.isWidgetVisible(367, 19), 5000);
+                        Rs2Widget.clickWidget(367,19);
                         sleep(Rs2Random.randomGaussian(600, 300));
                         wasInsideBoat = false;
                         BreakHandlerScript.setLockState(false);


### PR DESCRIPTION
This pull request improves the reliability of the loot collection step in the Fishing Trawler script by ensuring the script waits for the trawler reward widget to become visible before attempting to claim rewards. This change helps prevent misclicks or failed interactions when the widget is not yet available.

Enhancements to loot collection logic:

* Added a check to wait until the trawler reward widget (`367, 19`) is visible before attempting to click it, replacing the previous generic "Bank-all" widget click. This ensures the script interacts with the correct UI element at the appropriate time.