### PR TITLE
Adjust JLabel Layout

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginHubPanel.java
@@ -225,10 +225,13 @@ public class MicrobotPluginHubPanel extends PluginPanel {
             JLabel pluginName = new JLabel(manifest.getDisplayName());
             pluginName.setFont(FontManager.getRunescapeBoldFont());
             pluginName.setToolTipText(manifest.getDisplayName());
+            pluginName.setHorizontalAlignment(JLabel.LEFT);
 
-            JLabel author = new JLabel(manifest.getAuthors().length > 1 ? "Multiple authors" : manifest.getAuthor());
+            JLabel author = new JLabel(manifest.getAuthors().length > 1 ? "Multiple authors" : (manifest.getAuthor().toLowerCase().contains("unknown") ? "Unknown" : manifest.getAuthor()));
             author.setFont(FontManager.getRunescapeSmallFont());
             author.setToolTipText(manifest.getAuthor());
+            author.setHorizontalAlignment(JLabel.LEFT);
+            author.setBorder(new EmptyBorder(0, 0, 0, 5));
 
             JLabel version = new JLabel(currentVersion);
             version.setFont(FontManager.getRunescapeSmallFont());
@@ -387,9 +390,9 @@ public class MicrobotPluginHubPanel extends PluginPanel {
                     .addGap(5)
                     .addGroup(layout.createParallelGroup()
                             .addGroup(layout.createSequentialGroup()
-                                    .addComponent(pluginName, 0, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
-                                    .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
-                                    .addComponent(author, 0, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE))
+                                    .addComponent(pluginName, 0, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                    .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                                    .addComponent(author))
                             .addComponent(description, 0, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
                             .addGroup(layout.createSequentialGroup()
                                     .addComponent(version, 0, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginHubPanel.java
@@ -227,12 +227,25 @@ public class MicrobotPluginHubPanel extends PluginPanel {
             pluginName.setToolTipText(manifest.getDisplayName());
             pluginName.setHorizontalAlignment(JLabel.LEFT);
 
-            JLabel author = new JLabel(manifest.getAuthors().length > 1 ? "Multiple authors" : (manifest.getAuthor().toLowerCase().contains("unknown") ? "Unknown" : manifest.getAuthor()));
+            String[] authorsArr = manifest.getAuthors();
+            String authorRaw = manifest.getAuthor();
+
+            String authorText;
+            String authorTooltip;
+            if (authorsArr != null && authorsArr.length > 1) {
+                authorText = "Multiple authors";
+                authorTooltip = String.join(", ", authorsArr);
+            } else {
+                String a = authorRaw != null ? authorRaw.trim() : "";
+                boolean isUnknown = a.isEmpty() || a.toLowerCase(Locale.ROOT).contains("unknown");
+                authorText = isUnknown ? "Unknown" : a;
+                authorTooltip = isUnknown ? "Unknown" : a;
+            }
+            JLabel author = new JLabel(authorText);
             author.setFont(FontManager.getRunescapeSmallFont());
-            author.setToolTipText(manifest.getAuthor());
+            author.setToolTipText(authorTooltip);
             author.setHorizontalAlignment(JLabel.LEFT);
             author.setBorder(new EmptyBorder(0, 0, 0, 5));
-
             JLabel version = new JLabel(currentVersion);
             version.setFont(FontManager.getRunescapeSmallFont());
             version.setToolTipText(currentVersion);


### PR DESCRIPTION
Changes the layout of the plugin name and author JLabel components to improve the consistency of the visuals.

| Before | After |
|--------|-------|
| <img width="247" height="644" alt="msedge_hItu6hKeSa" src="https://github.com/user-attachments/assets/6560555b-adf7-4f43-b6a7-e17ae9d2bc90" /> | <img width="252" height="630" alt="java_DDfHUD552A" src="https://github.com/user-attachments/assets/ca4317a1-37de-4893-9938-0c5f3131a419" />  |
