### PR TITLE
fix: prevent multiple Login instances in break handler

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerOverlay.java
@@ -2,15 +2,21 @@ package net.runelite.client.plugins.microbot.breakhandler;
 
 import net.runelite.client.plugins.microbot.pluginscheduler.util.SchedulerPluginUtil;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.ComponentConstants;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 
 import javax.inject.Inject;
+
+import lombok.extern.slf4j.Slf4j;
+
 import java.awt.*;
 import java.time.Duration;
-
+import java.time.Instant;
+@Slf4j
 public class BreakHandlerOverlay extends OverlayPanel {
     private final BreakHandlerConfig config;
 
@@ -20,12 +26,16 @@ public class BreakHandlerOverlay extends OverlayPanel {
         super(plugin);
         this.config = config;
         setPosition(OverlayPosition.TOP_LEFT);
+        setPreferredSize(new Dimension(ComponentConstants.STANDARD_WIDTH, 180));
         setNaughty();
+        setDragTargetable(true);
+        setLayer(OverlayLayer.UNDER_WIDGETS);        
     }
     @Override
     public Dimension render(Graphics2D graphics) {
         try {
-            panelComponent.setPreferredSize(new Dimension(200, 300));
+            panelComponent.getChildren().clear();
+            panelComponent.setPreferredSize(new Dimension(180, 280));
             panelComponent.getChildren().add(TitleComponent.builder()
                     .text("BreakHandler V" + BreakHandlerScript.version)
                     .color(Color.GREEN)
@@ -51,7 +61,7 @@ public class BreakHandlerOverlay extends OverlayPanel {
                         .leftColor(Color.RED)
                         .rightColor(Color.RED)
                         .build());
-
+                
                 // Show specific lock reason if it's manual lock vs plugin lock
                 if (BreakHandlerScript.lockState.get() && !SchedulerPluginUtil.hasLockedSchedulablePlugins()) {
                     panelComponent.getChildren().add(LineComponent.builder()
@@ -83,9 +93,23 @@ public class BreakHandlerOverlay extends OverlayPanel {
                         .left(BreakHandlerScript.formatDuration(Duration.ofSeconds(BreakHandlerScript.breakDuration), "Break duration:"))
                         .build());
             }
+            
+            // Display extended sleep countdown when in LOGIN_EXTENDED_SLEEP state
+            if (BreakHandlerScript.getCurrentState() == BreakHandlerState.LOGIN_EXTENDED_SLEEP && 
+                BreakHandlerScript.getExtendedSleepStartTime() != null) {
+                
+                long elapsedMinutes = Duration.between(BreakHandlerScript.getExtendedSleepStartTime(), Instant.now()).toMinutes();
+                long remainingMinutes = Math.max(0, config.extendedSleepDuration() - elapsedMinutes);
+                Duration remainingDuration = Duration.ofMinutes(remainingMinutes);
+                
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("Extended sleep: " + BreakHandlerScript.formatDuration(remainingDuration))
+                        .leftColor(Color.BLUE)
+                        .build());
+            }
 
-        } catch(Exception ex) {
-            System.out.println(ex.getMessage());
+        } catch(Exception ex) {            
+            log.warn("BreakHandler overlay render error", ex);
         }
         return super.render(graphics);
     }
@@ -105,10 +129,12 @@ public class BreakHandlerOverlay extends OverlayPanel {
             case LOGGING_IN:
                 return Color.CYAN;
             case LOGGED_OUT:
-            case MICRO_BREAK_ACTIVE:
+            case INGAME_BREAK_ACTIVE:
                 return Color.RED;
             case LOGIN_REQUESTED:
                 return Color.MAGENTA;
+            case LOGIN_EXTENDED_SLEEP:
+                return Color.BLUE;
             case BREAK_ENDING:
                 return Color.LIGHT_GRAY;
             default:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerPlugin.java
@@ -73,6 +73,8 @@ public class BreakHandlerPlugin extends Plugin {
                  "\npauseAllScripts: " + Microbot.pauseAllScripts.get() + 
                  "\nPluginPauseEvent.isPaused: " + PluginPauseEvent.isPaused());
         overlayManager.remove(breakHandlerOverlay);
+
+        
     }
 
     // on settings change

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
@@ -1,16 +1,18 @@
 package net.runelite.client.plugins.microbot.breakhandler;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Constants;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.pluginscheduler.util.SchedulerPluginUtil;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.discord.Rs2Discord;
 import net.runelite.client.plugins.microbot.util.events.PluginPauseEvent;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.player.Rs2PlayerModel;
 import net.runelite.client.plugins.microbot.util.security.Login;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
-import net.runelite.client.plugins.microbot.util.world.WorldSelectionMode;
+import net.runelite.client.plugins.microbot.util.world.Rs2WorldUtil;
 import net.runelite.client.ui.ClientUI;
 import java.time.Duration;
 import java.time.Instant;
@@ -18,13 +20,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import net.runelite.api.GameState;
+
 /**
  * Enhanced BreakHandlerScript with state-based break management for reliable automation.
- *
+ * 
  * This script provides comprehensive break handling with proper state transitions, combat/interaction
  * monitoring, and reliable login/logout sequences. It prevents interruption of critical activities
  * and ensures safe break execution.
- *
+ * 
  * Key Features:
  * - State-based break management with proper transitions
  * - Combat and interaction detection before pausing scripts
@@ -33,44 +37,52 @@ import java.util.concurrent.atomic.AtomicReference;
  * - Lock state management for preventing breaks during critical operations
  * - Play schedule enforcement with automatic logout
  * - Configurable retry delays and timeouts
- *
+ * 
  * State Flow:
- * WAITING_FOR_BREAK -> BREAK_REQUESTED -> INITIATING_BREAK -> LOGOUT_REQUESTED ->
+ * WAITING_FOR_BREAK -> BREAK_REQUESTED -> INITIATING_BREAK -> LOGOUT_REQUESTED -> 
  * LOGGED_OUT -> LOGIN_REQUESTED -> LOGGING_IN -> BREAK_ENDING -> WAITING_FOR_BREAK
- *
- * Micro breaks follow: WAITING_FOR_BREAK -> BREAK_REQUESTED -> MICRO_BREAK_ACTIVE -> BREAK_ENDING
- *
+ * 
+ * Micro breaks follow: WAITING_FOR_BREAK -> BREAK_REQUESTED -> INGAME_BREAK_ACTIVE -> BREAK_ENDING
+ * 
  * @version 2.0.0
  */
 @Slf4j
 public class BreakHandlerScript extends Script {
-    public static String version = "2.0.0";
-
+    public static String version = "2.1.0";
+    
+    // ban detection constants  
+    private static final int BANNED_LOGIN_INDEX = 14;
+    
+    // ban detection state
+    public static boolean isBanned = false;
+    private static String lastKnownPlayerName = "";
+    private boolean wasLoggedIn = false;
+    
     // Constants for configuration and timing
     private static final int SCHEDULER_INTERVAL_MS = 1000;
     private static final int MINUTES_TO_SECONDS = 60;
-
+    
     // Configuration-dependent timing values (accessed through helper methods)
     private int getCombatCheckIntervalMs() {
         return config.combatCheckInterval() * 1000;
     }
-
+    
     private int getLogoutRetryDelayMs() {
         return config.logoutRetryDelay() * 1000;
     }
-
+    
     private int getLoginRetryDelayMs() {
         return config.loginRetryDelay() * 1000;
     }
-
+    
     private int getMaxLogoutRetries() {
         return config.maxLogoutRetries();
     }
-
+    
     private int getMaxLoginRetries() {
         return config.maxLoginRetries();
     }
-
+    
     private int getSafeConditionTimeoutMs() {
         return config.safeConditionTimeout() * 60 * 1000; // Convert minutes to milliseconds
     }
@@ -80,17 +92,20 @@ public class BreakHandlerScript extends Script {
     public static int breakDuration = -1;
     public static Duration setBreakDurationTime = Duration.ZERO;
     public static int totalBreaks = 0;
-
+    
     // State management - Thread-safe using atomic references
     private static final AtomicReference<BreakHandlerState> currentState = new AtomicReference<>(BreakHandlerState.WAITING_FOR_BREAK);
     private static final AtomicReference<Instant> stateChangeTime = new AtomicReference<>(Instant.now());
     private static final AtomicInteger retryCount = new AtomicInteger(0);
     private static Instant lastCombatCheckTime = Instant.now();
     private static Instant safeConditionWaitStartTime = null;
-
+    private static volatile Instant loginWatchdogStartTime = null;
+    @Getter
+    private static volatile Instant extendedSleepStartTime = null;
+    
     // Lock state management
     public static AtomicBoolean lockState = new AtomicBoolean(false);
-
+    
     /**
      * Sets the manual lock state and logs the change.
      * When locked, breaks are prevented from starting.
@@ -99,10 +114,10 @@ public class BreakHandlerScript extends Script {
         boolean currentState = BreakHandlerScript.lockState.get();
         if (currentState != state) {
             BreakHandlerScript.lockState.set(state);
-            log.info("Break handler lock state changed: {} -> {}", currentState, state);
+            log.debug("Break handler lock state changed: {} -> {}", currentState, state);
         }
     }
-
+    
     // UI and configuration
     private String originalWindowTitle = "";
     private BreakHandlerConfig config;
@@ -117,16 +132,18 @@ public class BreakHandlerScript extends Script {
     public static boolean isBreakActive() {
         return currentState.get() != BreakHandlerState.WAITING_FOR_BREAK;
     }
-
+    
     /**
      * Checks if a micro break is currently active.
      */
-    public static boolean isMicroBreakActive() {
+    public static boolean isIngameBreakActive() {
         BreakHandlerState state = currentState.get();
-        return state == BreakHandlerState.MICRO_BREAK_ACTIVE ||
-                (Rs2AntibanSettings.takeMicroBreaks && Rs2AntibanSettings.microBreakActive);
+        return state == BreakHandlerState.INGAME_BREAK_ACTIVE ||
+               (Rs2AntibanSettings.takeMicroBreaks && Rs2AntibanSettings.microBreakActive);
     }
-
+    public static boolean isMicroBreakActive() {
+        return Rs2AntibanSettings.takeMicroBreaks && Rs2AntibanSettings.microBreakActive;
+    }
     /**
      * Gets the current break handler state.
      */
@@ -158,22 +175,30 @@ public class BreakHandlerScript extends Script {
      * Main entry point for the break handler script.
      */
     public boolean run(BreakHandlerConfig config) {
-        this.config = config;
-        originalWindowTitle = ClientUI.getFrame().getTitle();
+        this.config = config;        
+        originalWindowTitle = ClientUI.getFrame().getTitle();        
         // Initialize state and timing
         currentState.set(BreakHandlerState.WAITING_FOR_BREAK);
         stateChangeTime.set(Instant.now());
-        retryCount.set(0);
-        initializeNextBreakTimer();
+        retryCount.set(0);        
+        initializeNextBreakTimer();        
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
                 super.run();
-                processBreakHandlerStateMachine();
+                
+                // check for ban detection first
+                checkForBan();
+                updatePlayerNameCache();
+                
+                // only continue with break handling if not banned
+                if (!isBanned) {
+                    processBreakHandlerStateMachine();
+                }
             } catch (Exception ex) {
                 log.error("Error in break handler main loop", ex);
             }
         }, 0, SCHEDULER_INTERVAL_MS, TimeUnit.MILLISECONDS);
-
+        
         return true;
     }
 
@@ -184,7 +209,7 @@ public class BreakHandlerScript extends Script {
         // Handle immediate user config toggles first
         if (handleConfigToggles()) {
             return;
-        }
+        }        
         // Process current state
         BreakHandlerState state = currentState.get();
         switch (state) {
@@ -203,8 +228,8 @@ public class BreakHandlerScript extends Script {
             case LOGGED_OUT:
                 handleLoggedOutState();
                 break;
-            case MICRO_BREAK_ACTIVE:
-                handleMicroBreakActiveState();
+            case INGAME_BREAK_ACTIVE:
+                handleLoginBreakActiveState();
                 break;
             case LOGIN_REQUESTED:
                 handleLoginRequestedState();
@@ -212,11 +237,14 @@ public class BreakHandlerScript extends Script {
             case LOGGING_IN:
                 handleLoggingInState();
                 break;
+            case LOGIN_EXTENDED_SLEEP:
+                handleLoginExtendedSleepState();
+                break;
             case BREAK_ENDING:
                 handleBreakEndingState();
                 break;
         }
-
+        
         // Update UI regardless of state
         updateBreakTimers();
         updateWindowTitle();
@@ -227,7 +255,7 @@ public class BreakHandlerScript extends Script {
      */
     private boolean handleConfigToggles() {
         BreakHandlerState state = currentState.get();
-
+        
         if (config.breakNow() && state == BreakHandlerState.WAITING_FOR_BREAK && !isLockState()) {
             log.info("Manual break requested");
             transitionToState(BreakHandlerState.BREAK_REQUESTED);
@@ -237,17 +265,17 @@ public class BreakHandlerScript extends Script {
 
         if (config.breakEndNow() && isBreakActive() && state != BreakHandlerState.BREAK_ENDING && state != BreakHandlerState.LOGGING_IN) {
             log.info("Manual break end requested");
-            if (state == BreakHandlerState.LOGGED_OUT || state == BreakHandlerState.MICRO_BREAK_ACTIVE) {
+            if (state == BreakHandlerState.LOGGED_OUT || state == BreakHandlerState.INGAME_BREAK_ACTIVE) {
                 if (state == BreakHandlerState.LOGGED_OUT){
-                    transitionToState(BreakHandlerState.LOGGING_IN);
-                }else if (state == BreakHandlerState.MICRO_BREAK_ACTIVE) {
+                    transitionToState(BreakHandlerState.LOGIN_REQUESTED);
+                }else if (state == BreakHandlerState.INGAME_BREAK_ACTIVE) {
                     transitionToState(BreakHandlerState.BREAK_ENDING);
                 }
                 resetConfigToggles();
                 return true;
-            }
+            }         
         }
-
+        
         return false;
     }
 
@@ -262,13 +290,13 @@ public class BreakHandlerScript extends Script {
             transitionToState(BreakHandlerState.BREAK_REQUESTED);
             return;
         }
-
+        
         // Check for normal break conditions
-        boolean normalBreakTime = breakIn <= 0 && !isLockState();
-        boolean microBreakTime = Rs2AntibanSettings.microBreakActive && !isLockState();
-
-        if (normalBreakTime || microBreakTime) {
-            log.info("Break time reached - Normal: {}, Micro: {}", normalBreakTime, microBreakTime);
+        boolean normalBreakTime = (breakIn <= 0 && !isLockState()) && !config.onlyMicroBreaks();
+        boolean microBreakInitiated = Rs2AntibanSettings.microBreakActive && !isLockState();
+        
+        if (normalBreakTime || microBreakInitiated) {
+            log.info("Break time reached \n\t- Normal: {}, Micro: {}", normalBreakTime, microBreakInitiated);
             transitionToState(BreakHandlerState.BREAK_REQUESTED);
         }
     }
@@ -298,21 +326,21 @@ public class BreakHandlerScript extends Script {
                     return;
                 }
             }
-        } else {
-            safeConditionWaitStartTime = Instant.now();
         }
-
+        
         // Check for safe conditions periodically
         Instant now = Instant.now();
-        if (Duration.between(lastCombatCheckTime, now).toMillis() >= getCombatCheckIntervalMs()) {
+        if (safeConditionWaitStartTime==null || Duration.between(lastCombatCheckTime, now).toMillis() >= getCombatCheckIntervalMs()) {
             lastCombatCheckTime = now;
-
+            if(safeConditionWaitStartTime == null) {
+                safeConditionWaitStartTime = now;
+            }
             if (isSafeToBreak()) {
-                log.info("Safe conditions met, initiating break");
+                log.debug("Safe conditions met, initiating break");
                 transitionToState(BreakHandlerState.INITIATING_BREAK);
             } else {
-                log.debug("Waiting for safe conditions - Combat: {}, Interacting: {}",
-                        Rs2Player.isInCombat(), Rs2Player.isInteracting());
+                log.debug("Waiting for safe conditions - Combat: {}, Interacting: {}", 
+                         Rs2Player.isInCombat(), Rs2Player.isInteracting());
             }
         }
     }
@@ -322,8 +350,8 @@ public class BreakHandlerScript extends Script {
      * Safe to pause scripts, starting break process.
      */
     private void handleInitiatingBreakState() {
-        log.info("Initiating break - pausing all scripts");
-
+        log.debug("Initiating break - pausing all scripts");
+        
         // Pause all scripts
         Microbot.pauseAllScripts.compareAndSet(false, true);
         PluginPauseEvent.setPaused(true);
@@ -333,12 +361,12 @@ public class BreakHandlerScript extends Script {
         preBreakWorld = Microbot.getClient().getWorld();
 
         // Determine next state based on break type
-        boolean logout = shouldLogout();
-        loggedOutDuringBreak = logout && !(Rs2AntibanSettings.microBreakActive && config.onlyMicroBreaks());
-        if (!logout || (Rs2AntibanSettings.microBreakActive && config.onlyMicroBreaks())) {
-            setBreakDuration();
-            transitionToState(BreakHandlerState.MICRO_BREAK_ACTIVE);
-        } else {
+        setBreakDuration();
+        if ((Rs2AntibanSettings.microBreakActive && config.onlyMicroBreaks())) {            
+            transitionToState(BreakHandlerState.INGAME_BREAK_ACTIVE);
+        } else if (!shouldLogout()){              
+            transitionToState(BreakHandlerState.INGAME_BREAK_ACTIVE);
+        }else{      
             transitionToState(BreakHandlerState.LOGOUT_REQUESTED);
         }
     }
@@ -349,11 +377,11 @@ public class BreakHandlerScript extends Script {
      */
     private void handleClientShutdown() {
         try {
-            log.info("Shutting down RuneLite client due to break handler configuration");
-
+            log.warn("Shutting down RuneLite client due to break handler configuration");
+            
             // Update break statistics before shutdown
             updateBreakStatistics();
-
+            
             // Clean shutdown of the client
             ClientUI.getFrame().setTitle(originalWindowTitle + " - Shutting Down");
             if (scheduledFuture != null && !scheduledFuture.isDone()) {
@@ -363,7 +391,7 @@ public class BreakHandlerScript extends Script {
             scheduledFuture = scheduledExecutorService.schedule(() -> {
                 System.exit(0);
             }, 1000, TimeUnit.MILLISECONDS);
-
+            
         } catch (Exception ex) {
             log.error("Error during client shutdown", ex);
             // Force shutdown if graceful shutdown fails
@@ -376,42 +404,35 @@ public class BreakHandlerScript extends Script {
      * Attempting to logout, with retry logic.
      */
     private void handleLogoutRequestedState() {
-        int currentRetryCount = retryCount.get();
-        Instant currentStateChangeTime = stateChangeTime.get();
-
-        if (currentRetryCount >= getMaxLogoutRetries()) {
-            log.warn("Max logout retries reached, continuing with logged-in break");
-            setBreakDuration();
-            transitionToState(BreakHandlerState.MICRO_BREAK_ACTIVE);
+        if (!Microbot.isLoggedIn()) {     
+            retryCount.set(0);
+            log.debug("Logout successful");                    
+            transitionToState(BreakHandlerState.LOGGED_OUT);
             return;
         }
-
+        int currentRetryCount = retryCount.get();
+        Instant currentStateChangeTime = stateChangeTime.get();
+        
+        if (currentRetryCount >= getMaxLogoutRetries()) {
+            log.warn("Max logout retries reached, continuing with logged-in break");
+            transitionToState(BreakHandlerState.INGAME_BREAK_ACTIVE);
+            return;
+        }
+        
         // Check if enough time has passed for retry
         if (currentRetryCount > 0 && Duration.between(currentStateChangeTime, Instant.now()).toMillis() < getLogoutRetryDelayMs()) {
             long remainingTime = getLogoutRetryDelayMs() - Duration.between(currentStateChangeTime, Instant.now()).toMillis();
             log.debug("Waiting for next logout retry ({} ms remaining)", remainingTime);
             return;
-        }
-
+        }        
         log.info("Attempting logout (attempt {}/{})", currentRetryCount + 1, getMaxLogoutRetries());
-
         try {
             Rs2Player.logout();
             // Don't immediately transition - wait for next cycle to check if logout was successful
             retryCount.incrementAndGet();
-            stateChangeTime.set(Instant.now());
-            if (scheduledFuture != null && !scheduledFuture.isDone()) {
-                scheduledFuture.cancel(true);
-            }
-            // Check on next cycle if we successfully logged out
-            scheduledFuture = scheduledExecutorService.schedule(() -> {
-                if (!Microbot.isLoggedIn()) {
-                    log.info("Logout successful");
-                    setBreakDuration();
-                    transitionToState(BreakHandlerState.LOGGED_OUT);
-                }
-            }, 2000, TimeUnit.MILLISECONDS);
-
+            stateChangeTime.set(Instant.now());                      
+            // Check on next cycle if we successfully logged out           
+            
         } catch (Exception ex) {
             log.error("Error during logout attempt", ex);
             retryCount.incrementAndGet();
@@ -424,75 +445,167 @@ public class BreakHandlerScript extends Script {
      * Successfully logged out, waiting for break duration to complete.
      */
     private void handleLoggedOutState() {
-        // Check if break should end
-        if (breakDuration <= 0 || config.breakEndNow()) {
-            log.info("Break duration completed, requesting login");
-            transitionToState(BreakHandlerState.LOGIN_REQUESTED);
+        if(!Microbot.isLoggedIn()) {
+            // Check if break should end
+            if (breakDuration <= 0 || config.breakEndNow()) {
+                log.debug("Break duration completed, requesting login");
+                transitionToState(BreakHandlerState.LOGIN_REQUESTED);
+            }
+        }else{
+            log.error("Unexpected state: Logged in while in LOGGED_OUT state. Resetting state.");
+            if (breakDuration <= 0 || config.breakEndNow()){
+                // Reset state to waiting for break if logged in unexpectedly
+                transitionToState(BreakHandlerState.BREAK_ENDING);
+            }else{
+                // If still logged in, reset break duration
+                setBreakDuration();
+                transitionToState( BreakHandlerState.LOGOUT_REQUESTED);
+            }
         }
     }
 
     /**
-     * State: MICRO_BREAK_ACTIVE
+     * State: INGAME_BREAK_ACTIVE
      * In micro break state (no logout), waiting for duration to complete.
      */
-    private void handleMicroBreakActiveState() {
+    private void handleLoginBreakActiveState() {
         // Check if micro break should end
         if ((breakDuration <= 0 && !Rs2AntibanSettings.microBreakActive) || config.breakEndNow()) {
-            log.info("Micro break completed");
+            log.debug("Micro break completed");
             transitionToState(BreakHandlerState.BREAK_ENDING);
         }
     }
 
     /**
      * State: LOGIN_REQUESTED
-     * Break ended, attempting to login.
+     * Break ended, attempting to login with intelligent world selection and watchdog.
      */
     private void handleLoginRequestedState() {
         if (Microbot.isLoggedIn()) {
-            log.info("Already logged in, proceeding to break ending");
+            log.debug("Already logged in, proceeding to break ending");
+            loginWatchdogStartTime = null; // reset watchdog
             transitionToState(BreakHandlerState.BREAK_ENDING);
             return;
         }
-
-        log.info("Attempting login");
+        
+        // initialize login watchdog timer
+        if (loginWatchdogStartTime == null) {
+            loginWatchdogStartTime = Instant.now();
+            log.debug("Login watchdog started for {} minutes", config.loginWatchdogTimeout());
+        }
+        
+        boolean membersOnly = config.membersOnly();
+        log.info("Attempting intelligent login with world selection");
         try {
-            // Use the Login utility class to handle login
-            if (Login.activeProfile != null) {
-                int world = config.worldSelectionMode().equals(WorldSelectionMode.RANDOM_WORLD)
-                        ? Login.getRandomWorld(Rs2Player.isMember(), config.regionPreference().getWorldRegion())
-                        : preBreakWorld;
-                new Login(world);
+            int targetWorld = -1;                       
+            // use world selection mode if no last world or last world not accessible
+            
+            switch (config.worldSelectionMode()) {
+                case CURRENT_PREFERRED_WORLD:
+                    if (preBreakWorld != -1) {
+                        boolean isAccessible = Rs2WorldUtil.canAccessWorld(preBreakWorld);
+                        if (isAccessible) {
+                            targetWorld = preBreakWorld;
+                            log.info("Using last world before break: {}", targetWorld);
+                        } else {
+                            log.warn("Last world {} is not accessible, falling back to world selection mode", preBreakWorld);
+                        }
+                    }
+        
+                    // no specific world selection - use default login
+                    break;
+                    
+                case RANDOM_WORLD:
+                    targetWorld = Rs2WorldUtil.getRandomAccessibleWorldFromRegion(
+                        config.regionPreference().getWorldRegion(),
+                        config.avoidEmptyWorlds(),
+                        config.avoidOvercrowdedWorlds(),
+                        membersOnly);
+                    break;
+                    
+                case BEST_POPULATION:
+                    targetWorld = Rs2WorldUtil.getBestAccessibleWorldForLogin(
+                        false,
+                        config.regionPreference().getWorldRegion(),
+                        config.avoidEmptyWorlds(),
+                        config.avoidOvercrowdedWorlds(),
+                        membersOnly
+                        );
+                    break;
+                    
+                case BEST_PING:
+                    targetWorld = Rs2WorldUtil.getBestAccessibleWorldForLogin(
+                        true,
+                        config.regionPreference().getWorldRegion(),
+                        config.avoidEmptyWorlds(),
+                        config.avoidOvercrowdedWorlds(),
+                        membersOnly
+                        );
+                    break;
+                    
+                case REGIONAL_RANDOM:
+                    targetWorld = Rs2WorldUtil.getRandomAccessibleWorldFromRegion(
+                        config.regionPreference().getWorldRegion(),
+                        config.avoidEmptyWorlds(),
+                        config.avoidOvercrowdedWorlds(),
+                        membersOnly
+                        );
+                    break;
+                    
+                default:
+                    // fallback to current world
+                    break;
+                }
+        
+            
+            // perform login attempt
+            if (targetWorld != -1) {
+                log.info("Attempting login to selected world: {}", targetWorld);
+                new Login(targetWorld);
             } else {
-                // If no active profile, fall back to default login
+                log.info("Using default login (current world or last used)");
                 new Login();
             }
+            
+            // immediately transition to logging in state to prevent multiple login instances
             transitionToState(BreakHandlerState.LOGGING_IN);
+            
         } catch (Exception ex) {
             log.error("Error initiating login", ex);
-            // Retry login request after delay
-            scheduledFuture = scheduledExecutorService.schedule(() -> {
-                if (currentState.get() == BreakHandlerState.LOGIN_REQUESTED) {
-                    retryCount.incrementAndGet();
-                }
-            }, getLoginRetryDelayMs(), TimeUnit.MILLISECONDS);
+            // still transition to prevent getting stuck in login requested state
+            transitionToState(BreakHandlerState.LOGGING_IN);
         }
     }
 
     /**
      * State: LOGGING_IN
-     * Currently attempting to log in, with retry logic.
+     * Currently attempting to log in, with retry logic and watchdog timeout.
      */
     private void handleLoggingInState() {
         if (Microbot.isLoggedIn()) {
             log.info("Login successful");
+            loginWatchdogStartTime = null; // reset watchdog
+            retryCount.set(0);
             transitionToState(BreakHandlerState.BREAK_ENDING);
             return;
         }
-
+        
+        // check login watchdog timeout
+        if (loginWatchdogStartTime != null) {
+            long watchdogTime = Duration.between(loginWatchdogStartTime, Instant.now()).toMinutes();
+            if (watchdogTime >= config.loginWatchdogTimeout()) {
+                log.warn("Login watchdog timeout reached after {} minutes, entering extended sleep", watchdogTime);
+                loginWatchdogStartTime = null; // reset watchdog
+                extendedSleepStartTime = Instant.now();
+                transitionToState(BreakHandlerState.LOGIN_EXTENDED_SLEEP);
+                return;
+            }
+        }
+        
         // Get current values atomically
         int currentRetryCount = retryCount.get();
         Instant currentStateChangeTime = stateChangeTime.get();
-
+        
         // Check for timeout or max retries
         long loginTime = Duration.between(currentStateChangeTime, Instant.now()).toMillis();
         if (loginTime > (getLoginRetryDelayMs() * (currentRetryCount + 1)) && currentRetryCount < getMaxLoginRetries()) {
@@ -500,10 +613,44 @@ public class BreakHandlerScript extends Script {
             retryCount.incrementAndGet();
             transitionToState(BreakHandlerState.LOGIN_REQUESTED);
         } else if (currentRetryCount >= getMaxLoginRetries()) {
-            log.warn("Max login retries reached, staying logged out");
-            // Stay in logged out state and wait for manual intervention or next attempt
-            setBreakDuration(); // Reset break duration to prevent immediate retry
-            transitionToState(BreakHandlerState.LOGGED_OUT);
+            log.warn("Max login retries reached for this attempt, returning to login request");
+            // Reset retry count and return to login request to try again
+            retryCount.set(0);
+            transitionToState(BreakHandlerState.LOGIN_REQUESTED);
+        }
+    }
+    
+    /**
+     * State: LOGIN_EXTENDED_SLEEP
+     * Extended sleep state after login watchdog timeout to avoid constant retry attempts.
+     */
+    private void handleLoginExtendedSleepState() {
+        if (Microbot.isLoggedIn()) {
+            log.info("Login successful during extended sleep, proceeding to break ending");
+            extendedSleepStartTime = null; // reset extended sleep timer
+            transitionToState(BreakHandlerState.BREAK_ENDING);
+            return;
+        }
+        
+        if (extendedSleepStartTime == null) {
+            extendedSleepStartTime = Instant.now();
+            log.info("Extended sleep started for {} minutes", config.extendedSleepDuration());
+            return;
+        }
+        
+        // check if extended sleep period is complete
+        long sleepTime = Duration.between(extendedSleepStartTime, Instant.now()).toMinutes();
+        if (sleepTime >= config.extendedSleepDuration()) {
+            log.info("Extended sleep period completed after {} minutes, resuming login attempts", sleepTime);
+            extendedSleepStartTime = null; // reset extended sleep timer
+            retryCount.set(0); // reset retry count for fresh attempt
+            transitionToState(BreakHandlerState.LOGIN_REQUESTED);
+        } else {
+            // still in extended sleep - show progress occasionally
+            if (sleepTime % 5 == 0) { // every 5 minutes
+                long remaining = config.extendedSleepDuration() - sleepTime;
+                log.debug("Extended sleep in progress - {} minutes remaining", remaining);
+            }
         }
     }
 
@@ -513,23 +660,23 @@ public class BreakHandlerScript extends Script {
      */
     private void handleBreakEndingState() {
         log.info("Break ending, resuming normal operation");
-
+        
         // Resume scripts and reset state
         resumeFromBreak();
-
-        // Handle world switching if configured
-        handleWorldSwitching();
-
+        
+        // Note: World selection is now handled during login in handleLoginRequestedState()
+        // No need for separate world switching here
+        
         // Update statistics and UI
         updateBreakStatistics();
         resetWindowTitle();
-
+        
         // Clean up break state
         cleanupBreakState();
-
+        
         // Reset config toggles
         resetConfigToggles();
-
+        
         // Return to waiting state
         initializeNextBreakTimer();
         transitionToState(BreakHandlerState.WAITING_FOR_BREAK);
@@ -546,7 +693,7 @@ public class BreakHandlerScript extends Script {
             currentState.set(newState);
             stateChangeTime.set(Instant.now());
             retryCount.set(0);
-
+            
             // Reset safe condition wait time when leaving BREAK_REQUESTED
             if (newState != BreakHandlerState.BREAK_REQUESTED) {
                 safeConditionWaitStartTime = null;
@@ -568,7 +715,7 @@ public class BreakHandlerScript extends Script {
         // Only attempt to logout during a normal break. When a micro break is
         // active we should remain logged in regardless of the logout setting.
         return !Rs2AntibanSettings.microBreakActive &&
-                (isOutsidePlaySchedule() || config.logoutAfterBreak());
+            (isOutsidePlaySchedule() || config.logoutAfterBreak());
     }
 
     /**
@@ -576,8 +723,8 @@ public class BreakHandlerScript extends Script {
      */
     private void initializeNextBreakTimer() {
         breakIn = Rs2Random.between(
-                config.timeUntilBreakStart() * MINUTES_TO_SECONDS,
-                config.timeUntilBreakEnd() * MINUTES_TO_SECONDS
+            config.timeUntilBreakStart() * MINUTES_TO_SECONDS, 
+            config.timeUntilBreakEnd() * MINUTES_TO_SECONDS
         );
         log.debug("Next break in {} seconds", breakIn);
     }
@@ -589,12 +736,12 @@ public class BreakHandlerScript extends Script {
         if (Rs2AntibanSettings.microBreakActive) {
             // Micro break duration - use proper range and convert minutes to seconds
             breakDuration = Rs2Random.between(
-                    Rs2AntibanSettings.microBreakDurationLow * MINUTES_TO_SECONDS,
-                    Rs2AntibanSettings.microBreakDurationHigh * MINUTES_TO_SECONDS
+                Rs2AntibanSettings.microBreakDurationLow * MINUTES_TO_SECONDS,
+                Rs2AntibanSettings.microBreakDurationHigh * MINUTES_TO_SECONDS
             );
             setBreakDurationTime = Duration.ofSeconds(breakDuration);
-            log.debug("Micro break duration set to {} seconds ({} minutes)",
-                    breakDuration, breakDuration / MINUTES_TO_SECONDS);
+            log.debug("Micro break duration set to {} seconds ({} minutes)", 
+                     breakDuration, breakDuration / MINUTES_TO_SECONDS);
         } else if (isOutsidePlaySchedule()) {
             // For play schedule, break until next play time
             Duration timeUntilPlaySchedule = config.playSchedule().timeUntilNextSchedule();
@@ -604,8 +751,8 @@ public class BreakHandlerScript extends Script {
         } else {
             // Normal break duration
             breakDuration = Rs2Random.between(
-                    config.breakDurationStart() * MINUTES_TO_SECONDS,
-                    config.breakDurationEnd() * MINUTES_TO_SECONDS
+                config.breakDurationStart() * MINUTES_TO_SECONDS,
+                config.breakDurationEnd() * MINUTES_TO_SECONDS
             );
             setBreakDurationTime = Duration.ofSeconds(breakDuration);
             log.debug("Normal break duration set to {} seconds", breakDuration);
@@ -621,20 +768,6 @@ public class BreakHandlerScript extends Script {
         Rs2AntibanSettings.microBreakActive = false;
     }
 
-    /**
-     * Handles world switching based on configuration.
-     */
-    private void handleWorldSwitching() {
-        if (config.worldSelectionMode().equals(WorldSelectionMode.RANDOM_WORLD) && !loggedOutDuringBreak) {
-            try {
-                int randomWorld = Login.getRandomWorld(Rs2Player.isMember(), config.regionPreference().getWorldRegion());
-                Microbot.hopToWorld(randomWorld);
-                log.info("Switched to world {}", randomWorld);
-            } catch (Exception ex) {
-                log.error("Error switching worlds", ex);
-            }
-        }
-    }
 
     /**
      * Updates break statistics.
@@ -666,7 +799,7 @@ public class BreakHandlerScript extends Script {
         // Note: These will reset automatically due to the config system
         // This method exists for potential future toggle handling
         if (Microbot.getConfigManager() == null) {
-            return;
+           return;
         }
         Microbot.getConfigManager().setConfiguration(BreakHandlerConfig.configGroup, "breakNow", false);
         Microbot.getConfigManager().setConfiguration(BreakHandlerConfig.configGroup, "breakEndNow", false);
@@ -677,15 +810,18 @@ public class BreakHandlerScript extends Script {
      */
     private void updateBreakTimers() {
         BreakHandlerState state = currentState.get();
-
+     
         // Count down to next break (only in waiting state and when logged in)
         if (state == BreakHandlerState.WAITING_FOR_BREAK && breakIn >= 0 && Microbot.isLoggedIn()) {
-            breakIn--;
+            if (!config.onlyMicroBreaks()){
+                breakIn--;    
+            }
+            
         }
 
         // Count down active break duration
-        if ((state == BreakHandlerState.LOGGED_OUT || state == BreakHandlerState.MICRO_BREAK_ACTIVE)
-                && breakDuration >= 0) {
+        if ((state == BreakHandlerState.LOGGED_OUT || state == BreakHandlerState.INGAME_BREAK_ACTIVE) 
+            && breakDuration >= 0) {
             breakDuration--;
         }
     }
@@ -695,11 +831,11 @@ public class BreakHandlerScript extends Script {
      */
     private void updateWindowTitle() {
         BreakHandlerState state = currentState.get();
-
-        if (state == BreakHandlerState.LOGGED_OUT || state == BreakHandlerState.MICRO_BREAK_ACTIVE) {
-            String breakType = state == BreakHandlerState.MICRO_BREAK_ACTIVE ? "Micro Break" : "Break";
-            ClientUI.getFrame().setTitle(originalWindowTitle + " - " + breakType + ": " +
-                    formatDuration(Duration.ofSeconds(Math.max(0, breakDuration))));
+        
+        if (state == BreakHandlerState.LOGGED_OUT || state == BreakHandlerState.INGAME_BREAK_ACTIVE) {
+            String breakType = state == BreakHandlerState.INGAME_BREAK_ACTIVE ? "In Game Break(Microbreak)" : "Break";
+            ClientUI.getFrame().setTitle(originalWindowTitle + " - " + breakType + ": " + 
+                                       formatDuration(Duration.ofSeconds(Math.max(0, breakDuration))));
         } else if (isBreakActive()) {
             ClientUI.getFrame().setTitle(originalWindowTitle + " - " + state.toString().replace("_", " "));
         }
@@ -715,8 +851,11 @@ public class BreakHandlerScript extends Script {
     @Override
     public void shutdown() {
         BreakHandlerState state = currentState.get();
+        if(scheduledFuture != null && !scheduledFuture.isDone()) {
+            scheduledFuture.cancel(true);
+        }        
         log.info("Break handler shutting down. Current state: {}", state);
-
+        
         // If we're in a break state, try to clean up gracefully
         if (state == BreakHandlerState.LOGGED_OUT) {
             log.info("Attempting to resume from logged out state");
@@ -724,9 +863,9 @@ public class BreakHandlerScript extends Script {
         } else if (isBreakActive()) {
             log.info("Attempting to end break gracefully");
             transitionToState(BreakHandlerState.BREAK_ENDING);
-        }
-
+        }        
         resetWindowTitle();
+        resumeFromBreak();
         super.shutdown();
     }
 
@@ -758,5 +897,65 @@ public class BreakHandlerScript extends Script {
      */
     public static boolean isLockState() {
         return lockState.get() || SchedulerPluginUtil.hasLockedSchedulablePlugins();
+    }
+    
+    /**
+     * checks for ban screen during login attempt or when logged out
+     */
+    private void checkForBan() {
+        GameState gameState = Microbot.getClient().getGameState();
+        
+        // detect ban screen on login screen
+        boolean banDetected = gameState == GameState.LOGIN_SCREEN
+                && Microbot.getClient().getLoginIndex() == BANNED_LOGIN_INDEX;
+        
+        if (banDetected && !isBanned) {
+            isBanned = true;
+            handleBanDetection();
+        }
+    }
+
+    /**
+     * updates cached player name when logged in
+     */
+    private void updatePlayerNameCache() {
+        boolean currentlyLoggedIn = Microbot.isLoggedIn();
+        
+        // detect fresh login - update player name cache
+        if (currentlyLoggedIn && !wasLoggedIn) {
+            Rs2PlayerModel localPlayer = Rs2Player.getLocalPlayer();
+            if (localPlayer != null && localPlayer.getName() != null) {
+                lastKnownPlayerName = localPlayer.getName();
+                log.info("Updated cached player name: {}", lastKnownPlayerName);
+            }
+        }
+        
+        wasLoggedIn = currentlyLoggedIn;
+    }
+
+    /**
+     * handles ban detection - sends notification and shuts down plugins
+     */
+    private void handleBanDetection() {
+        log.info("Ban screen detected for player: {}", lastKnownPlayerName);
+        
+        // send discord notification if webhook is configured
+        Rs2Discord.sendAlert("BAN", "Ban screen detected during login attempt.", 0xDC143C, lastKnownPlayerName, "BreakHandler");
+        
+        // shutdown break handler plugin
+        shutdownPlugin();
+    }
+
+    /**
+     * shuts down break handler plugin when ban is detected
+     */
+    private void shutdownPlugin() {
+        try {
+            log.info("Shutting down {} plugin due to ban detection", BreakHandlerPlugin.class.getSimpleName());
+            Microbot.stopPlugin(BreakHandlerPlugin.class);
+            
+        } catch (Exception ex) {
+            log.error("Error shutting down {} plugin", BreakHandlerPlugin.class.getSimpleName(), ex);
+        }
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerState.java
@@ -1,5 +1,7 @@
 package net.runelite.client.plugins.microbot.breakhandler;
 
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+
 /**
  * Enumeration representing the various states of the BreakHandler system.
  * This state machine ensures reliable break transitions and prevents interruption
@@ -10,53 +12,81 @@ public enum BreakHandlerState {
      * Normal operation state - counting down to the next break.
      * Scripts are running normally.
      */
-    WAITING_FOR_BREAK,
-
+    WAITING_FOR_BREAK("Waiting for break"),
+    
     /**
      * Break has been requested but waiting for safe conditions.
      * Monitoring for combat/interaction to end before pausing scripts.
      */
-    BREAK_REQUESTED,
-
+    BREAK_REQUESTED("Break requested"),
+    
     /**
      * Safe conditions met, initiating break by pausing scripts.
      * Brief transition state.
      */
-    INITIATING_BREAK,
-
+    INITIATING_BREAK("Initiating break"),
+    
     /**
      * Logout has been requested and is being attempted.
      * May retry logout if unsuccessful.
      */
-    LOGOUT_REQUESTED,
-
+    LOGOUT_REQUESTED("Logout requested"),
+    
     /**
      * Successfully logged out and in break state.
      * Waiting for break duration to complete.
      */
-    LOGGED_OUT,
-
+    LOGGED_OUT("Logged out"),
+    
     /**
-     * Micro break is active - scripts paused but no logout.
+     * In-game break, used by the micro break system and when user doesn't want to log out - scripts paused but no logout.
      * Used for short antiban breaks.
      */
-    MICRO_BREAK_ACTIVE,
-
+    INGAME_BREAK_ACTIVE("In-game break active"),
+    
     /**
      * Break duration completed, requesting login.
      * Attempting to log back in.
      */
-    LOGIN_REQUESTED,
-
+    LOGIN_REQUESTED("Login requested"),
+    
     /**
      * Currently attempting to log in.
      * May retry if unsuccessful.
      */
-    LOGGING_IN,
-
+    LOGGING_IN("Logging in"),
+    
+    /**
+     * Extended sleep state after login failures.
+     * Used when login watchdog timeout is reached to avoid constant retry attempts.
+     */
+    LOGIN_EXTENDED_SLEEP("Login extended sleep"),
+    
     /**
      * Break ended successfully, resuming normal operation.
      * Brief transition state before returning to WAITING_FOR_BREAK.
      */
-    BREAK_ENDING
+    BREAK_ENDING("Break ending");
+
+    private final String stateName;
+
+    BreakHandlerState(String stateName) {
+        this.stateName = stateName;
+    }
+
+    /**
+     * Returns a user-friendly string representation of the state.
+     * @return formatted state name
+     */
+    @Override
+    public String toString() {
+        if ( this == INGAME_BREAK_ACTIVE) {
+            if(BreakHandlerScript.isMicroBreakActive()) {
+                return "Micro break active";
+            } else {
+                return "In-game break active";
+            }
+        }
+        return stateName;
+    }
 }


### PR DESCRIPTION
- Fixes login state multiplication by immediately transitioning to LOGGING_IN after creating Login instance in handleLoginRequestedState(). This prevents the repeated execution that was causing multiple login attempts.
- Prevent immediately login after taking a break and the break has not been ended.

Appreciate further testing, solves the issues on my end. (also test by @Bolado)