### PR TITLE
feat: Character-Specific Cache Serialization

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/accountselector/AutoLoginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/accountselector/AutoLoginConfig.java
@@ -155,7 +155,7 @@ public interface AutoLoginConfig extends Config {
             position = 4,
             section = loginBehaviorSection
     )
-    @Range(min = 1, max = 60)
+    @Range(min = 5, max = 60)
     default int loginRetryDelay() {
         return 5;
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/accountselector/AutoLoginScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/accountselector/AutoLoginScript.java
@@ -327,6 +327,7 @@ public class AutoLoginScript extends Script {
                 new Login();
             }
             
+            
         } catch (Exception ex) {
             log.error("Error during intelligent login", ex);
             retryCount++;
@@ -353,6 +354,7 @@ public class AutoLoginScript extends Script {
         extendedSleepStartTime = null;
         lastLoginAttemptTime = null;
         lastExtendedSleepLoggedMinute = -1;
+        loginState = LoginState.WAITING_FOR_LOGIN_SCREEN;
     }
     
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerConfig.java
@@ -229,7 +229,7 @@ public interface BreakHandlerConfig extends Config {
             position = 2,
             section = advancedOptions
     )
-    @Range(min = 1, max = 60)
+    @Range(min = 5, max = 60)
     default int loginRetryDelay() {
         return 5;
     }


### PR DESCRIPTION
Problem: Multiple characters using the same RuneLite profile had their cache data (bank items, skills, quests, etc.) overwriting each other, causing data loss and inconsistent behaviour.

Solution: Implements character-specific cache keys that separate data by player name within each profile.

Key Changes:
  - Cache Separation: Uses character-specific keys (e.g., bankitems_PlayerName vs bankitems)
  - Shutdown Safety: Tracks last known player name for saves when player is unavailable
  - Thread Safety: AtomicReference for concurrent player name operations
  - Validation: Prevents cache operations without valid player context
Impact:
  - Each character now has isolated cache data within shared profiles
  - Eliminates cache conflicts between different characters
  - Maintains existing API compatibility
