### PR TITLE
Construction 2, Rs2GroundItem,  and Rs2GrandExchange improvements.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/GeoffPlugins/construction2/Construction2Plugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/GeoffPlugins/construction2/Construction2Plugin.java
@@ -46,6 +46,7 @@ public class Construction2Plugin extends Plugin {
         if (overlayManager != null) {
             overlayManager.add(construction2Overlay);
         }
+        Construction2Script.firstRun = true;
         construction2Script.run(config);
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
@@ -235,6 +235,8 @@ public class Rs2GrandExchange
 				}
 				Rs2Keyboard.typeString(request.getItemName());
 
+				sleep(500,800); //allow the widget to load
+
 				if (!Rs2Widget.sleepUntilHasWidgetText(searchName, 162, 43, false, 5000)) break;
 
 				sleepUntil(() -> getSearchResultWidget(request.getItemName(), request.isExact()) != null, 2200);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItem.java
@@ -274,6 +274,7 @@ public class Rs2GroundItem {
         final int quantFinal = quantity;
         return runWhilePaused(() -> {
             for (int i = 0; i < quantFinal; i++) {
+                if(Rs2Inventory.isFull()) break;
                 waitForGroundItemDespawn(() -> interact(groundItem), groundItem);
             }
             return true;


### PR DESCRIPTION
Construction 2: Added support for break handler, added support for both tile objects and game objects as both are needed depending on what we're building.

Rs2GroundItem: Fixed a bug that would cause Rev Killer to click loot on the ground over and over despite a full inventory.

Rs2GrandExchange: Fixed a bug that would cause the script to loop buying an item unsuccessfully; if we've previously searched the item within the Grand Exchange.