### PR TITLE
Rs2RunePouch - use new loadout widgets

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2RunePouch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2RunePouch.java
@@ -1,7 +1,9 @@
 package net.runelite.client.plugins.microbot.util.inventory;
 
+import java.awt.Rectangle;
 import lombok.Getter;
 import lombok.Setter;
+import net.runelite.api.MenuAction;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetLoaded;
@@ -12,6 +14,8 @@ import net.runelite.client.plugins.microbot.inventorysetups.InventorySetupsItem;
 import net.runelite.client.plugins.microbot.util.Global;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.magic.Runes;
+import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
+import net.runelite.client.plugins.microbot.util.misc.Rs2UiHelper;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
 import java.util.*;
@@ -42,10 +46,10 @@ public class Rs2RunePouch
 	};
 
 	private static final int BANK_PARENT_ID = InterfaceID.BANKSIDE;
-	private static final int RUNEPOUCH_ROOT_CHILD_ID = 19;
-	private static final int RUNEPOUCH_CLOSE_CHILD_ID = 22;
-	private static final int RUNEPOUCH_DEPOSIT_ALL_CHILD_ID = 20;
-	private static final List<Integer> RUNEPOUCH_LOADOUT_WIDGETS = Arrays.asList(28, 30, 32, 34);
+	private static final int RUNEPOUCH_ROOT_CHILD_ID = 19; // Validated
+	private static final int RUNEPOUCH_CLOSE_CHILD_ID = 22; // Validated
+	private static final int RUNEPOUCH_DEPOSIT_ALL_CHILD_ID = 20; // Validated
+	private static final List<Integer> RUNEPOUCH_LOADOUT_WIDGETS = Arrays.asList(34, 38, 41, 44, 46, 48, 50, 52, 54, 56); // New Loadout Child IDs
 
 	@Getter
 	private static final List<PouchSlot> slots = new ArrayList<>();
@@ -427,8 +431,12 @@ public class Rs2RunePouch
 
 			if (loadoutMap.equals(requiredRunes))
 			{
-				int widgetIndex = RUNEPOUCH_LOADOUT_WIDGETS.get(entry.getKey());
-				Rs2Widget.clickWidget(BANK_PARENT_ID, (widgetIndex + 1));
+				final int widgetIndex = RUNEPOUCH_LOADOUT_WIDGETS.get(entry.getKey());
+				Widget parentLoadoutWidget = Rs2Widget.getWidget(BANK_PARENT_ID, widgetIndex);
+				Widget loadWidget = Rs2Widget.findWidget("Load", List.of(parentLoadoutWidget.getStaticChildren()));
+				Rectangle loadBounds = loadWidget.getBounds();
+				NewMenuEntry menuEntry = new NewMenuEntry("Load", "", 1, MenuAction.CC_OP, -1, loadWidget.getId(), false);
+				Microbot.doInvoke(menuEntry, loadBounds != null && Rs2UiHelper.isRectangleWithinCanvas(loadBounds) ? loadBounds : Rs2UiHelper.getDefaultRectangle());
 				Global.sleepUntil(() -> getRunes().entrySet().stream().allMatch(e -> requiredRunes.getOrDefault(e.getKey(), 0) <= e.getValue()));
 				return closeRunePouch();
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2RunePouch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2RunePouch.java
@@ -433,7 +433,17 @@ public class Rs2RunePouch
 			{
 				final int widgetIndex = RUNEPOUCH_LOADOUT_WIDGETS.get(entry.getKey());
 				Widget parentLoadoutWidget = Rs2Widget.getWidget(BANK_PARENT_ID, widgetIndex);
+				if (parentLoadoutWidget == null || parentLoadoutWidget.getStaticChildren() == null)
+				{
+					Microbot.log("Failed to find loadout widget for index: " + widgetIndex, Level.WARNING);
+					break;
+				}
 				Widget loadWidget = Rs2Widget.findWidget("Load", List.of(parentLoadoutWidget.getStaticChildren()));
+				if (loadWidget == null)
+				{
+					Microbot.log("Failed to find 'Load' child widget in loadout index: " + widgetIndex, Level.WARNING);
+					break;
+				}
 				Rectangle loadBounds = loadWidget.getBounds();
 				NewMenuEntry menuEntry = new NewMenuEntry("Load", "", 1, MenuAction.CC_OP, -1, loadWidget.getId(), false);
 				Microbot.doInvoke(menuEntry, loadBounds != null && Rs2UiHelper.isRectangleWithinCanvas(loadBounds) ? loadBounds : Rs2UiHelper.getDefaultRectangle());


### PR DESCRIPTION
Someone reached out to me directly to assist with updating the new widgets inside of runepouch loadouts 

This will fix managing the runepouch through inventory setups. or when using the Rs2RunePouch#load method