### PR TITLE
Allow interacting with sub-menu on Rs2ItemModel

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
@@ -1892,13 +1892,13 @@ public class Rs2Inventory {
      */
     private static void invokeMenu(Rs2ItemModel rs2Item, String action, int providedIdentifier) {
         if (rs2Item == null) return;
-
         Rs2Tab.switchToInventoryTab();
         Microbot.status = action + " " + rs2Item.getName();
 
         int param0;
         int param1;
         int identifier = -1;
+        String target = rs2Item.getName();
         MenuAction menuAction = MenuAction.CC_OP;
         Widget[] inventoryWidgets;
         param0 = rs2Item.getSlot();
@@ -1939,7 +1939,16 @@ public class Rs2Inventory {
                     itemWidget.getActions() :
                     rs2Item.getInventoryActions();
 
-            identifier = providedIdentifier == -1 ? indexOfIgnoreCase(stripColTags(actions), action) + 1 : providedIdentifier;
+            int simpleIndex = indexOfIgnoreCase(stripColTags(actions), action);
+            if (simpleIndex != -1) {
+                identifier = simpleIndex + 1;
+            } else {
+                Map.Entry<String, Integer> subActionMap = rs2Item.getIndexOfSubAction(action);
+                // The main menu index depends on the inventory interface from which this item is interacted with
+                int mainMenuIndex = java.util.Arrays.asList(actions).indexOf(subActionMap.getKey()) + 1;
+                identifier = NewMenuEntry.findIdentifier(subActionMap.getValue() + 1, mainMenuIndex);
+                target = "";
+            }
         }
 
 
@@ -1951,7 +1960,7 @@ public class Rs2Inventory {
             menuAction = MenuAction.WIDGET_TARGET_ON_WIDGET;
         }
 
-        Microbot.doInvoke(new NewMenuEntry(action, param0, param1, menuAction.getId(), identifier, rs2Item.getId(), rs2Item.getName()), (itemBounds(rs2Item) == null) ? new Rectangle(1, 1) : itemBounds(rs2Item));
+        Microbot.doInvoke(new NewMenuEntry(action, param0, param1, menuAction.getId(), identifier, rs2Item.getId(), target), (itemBounds(rs2Item) == null) ? new Rectangle(1, 1) : itemBounds(rs2Item));
 
         if (action.equalsIgnoreCase("destroy")) {
             sleepUntil(() -> Rs2Widget.isWidgetVisible(584, 0));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2ItemModel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2ItemModel.java
@@ -6,14 +6,11 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
-import net.runelite.api.gameval.ItemID;
 import net.runelite.api.ParamID;
+import net.runelite.api.gameval.ItemID;
 import net.runelite.client.plugins.microbot.Microbot;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
@@ -23,18 +20,19 @@ public class Rs2ItemModel {
     private int id;
     @Getter
     @Setter
-	private int quantity;
+    private int quantity;
     @Getter
-	private int slot = -1;
-	private String name;
-	private String[] inventoryActions;
+    private int slot = -1;
+    private String name;
+    private String[] inventoryActions;
+    private String[][] subops;
     @Getter
-	private List<String> equipmentActions = new ArrayList<>();
-	private boolean isStackable;
-	private boolean isNoted;
-	private boolean isTradeable;
-	private ItemComposition itemComposition;
-	private int[] wearableActionIndexes = new int[]{
+    private List<String> equipmentActions = new ArrayList<>();
+    private boolean isStackable;
+    private boolean isNoted;
+    private boolean isTradeable;
+    private ItemComposition itemComposition;
+    private int[] wearableActionIndexes = new int[]{
             ParamID.OC_ITEM_OP1,
             ParamID.OC_ITEM_OP2,
             ParamID.OC_ITEM_OP3,
@@ -43,7 +41,7 @@ public class Rs2ItemModel {
             ParamID.OC_ITEM_OP6,
             ParamID.OC_ITEM_OP7,
             ParamID.OC_ITEM_OP8
-	};
+    };
 
 
     public Rs2ItemModel(Item item, ItemComposition itemComposition, int slot) {
@@ -57,10 +55,10 @@ public class Rs2ItemModel {
      * Creates an Rs2ItemModel from cached data (ID, quantity, slot).
      * This is used when loading bank data from config where we don't have the full ItemComposition.
      * ItemComposition data will be loaded lazily when needed.
-     * 
-     * @param id Item ID
+     *
+     * @param id       Item ID
      * @param quantity Item quantity
-     * @param slot Item slot position
+     * @param slot     Item slot position
      * @return Rs2ItemModel with basic data, ItemComposition loaded lazily
      */
     public static Rs2ItemModel createFromCache(int id, int quantity, int slot) {
@@ -69,12 +67,12 @@ public class Rs2ItemModel {
 
 
     /**
-     * Constructor for creating Rs2ItemModel with explicit ItemComposition.     
+     * Constructor for creating Rs2ItemModel with explicit ItemComposition.
      */
     public Rs2ItemModel(int id, int quantity, int slot, ItemComposition itemComposition) {
         this.id = id;
         this.quantity = quantity;
-        this.slot = slot;        
+        this.slot = slot;
         if (itemComposition == null) {
             //lazy loading will handle this
             initializeDefaults();
@@ -82,6 +80,7 @@ public class Rs2ItemModel {
             initializeFromComposition(itemComposition);
         }
     }
+
     /**
      * Private constructor for creating Rs2ItemModel from cached data.
      * ItemComposition will be loaded lazily when needed.
@@ -91,12 +90,12 @@ public class Rs2ItemModel {
         this.quantity = quantity;
         this.slot = slot;
         ItemComposition itemComposition = Microbot.getClientThread().runOnClientThreadOptional(() ->
-                        Microbot.getClient().getItemDefinition(id)).orElse(null);
-        if (itemComposition == null) {            
+                Microbot.getClient().getItemDefinition(id)).orElse(null);
+        if (itemComposition == null) {
             initializeDefaults();
-        }else{
+        } else {
             initializeFromComposition(itemComposition);
-        }        
+        }
     }
 
     /**
@@ -104,29 +103,8 @@ public class Rs2ItemModel {
      * This ensures we can work with cached items while minimizing performance impact.
      */
     private void ensureCompositionLoaded() {
-        
         if (itemComposition == null && id > 0) {
-            this.itemComposition = Microbot.getClientThread().runOnClientThreadOptional(()-> Microbot.getClient().getItemDefinition(id)).orElse(null);
-            if (itemComposition != null) {
-                this.name = itemComposition.getName();
-                this.isStackable = itemComposition.isStackable();
-                this.isNoted = itemComposition.getNote() == 799;
-                if (this.isNoted) {
-                    Microbot.getClientThread().runOnClientThreadOptional(() ->
-                            Microbot.getClient().getItemDefinition(itemComposition.getLinkedNoteId())).ifPresent(itemDefinition -> this.isTradeable = itemDefinition.isTradeable());
-                } else {
-                    this.isTradeable = itemComposition.isTradeable();
-                }
-                this.inventoryActions = itemComposition.getInventoryActions();
-				Microbot.getClientThread().runOnClientThreadOptional(() -> {
-					addEquipmentActions(itemComposition);
-					return true;
-				});
-            }
-            else {
-                // If we can't load the ItemComposition, set defaults
-                log.warn("Failed to load ItemComposition for id: {}, setting defaults", id);
-            }
+            Microbot.getClientThread().runOnClientThreadOptional(() -> Microbot.getClient().getItemDefinition(id)).ifPresent(this::initializeFromComposition);
         }
     }
 
@@ -179,6 +157,55 @@ public class Rs2ItemModel {
         }
         return inventoryActions;
     }
+
+    /**
+     * Gets the sub-actions, loading composition if needed.
+     * This returns a list of sub-menu actions that can be performed on the item.
+     * The first index corresponds to the main menu's index, the second index is the sub-menu index.
+     *
+     * @return A list of sub-actions, or null if none are available
+     */
+    public String[][] getSubops() {
+        if (itemComposition == null) {
+            ensureCompositionLoaded();
+        }
+        return subops;
+    }
+
+    /**
+     * Retrieves the index of a sub-action from the sub-actions list, matching the given action.
+     *
+     * This method searches through the sub-actions of the item, attempting to find a match
+     * for the specified action. If a match is found, it returns the corresponding main action
+     * and index of the sub-action. If no match is found or if the sub-actions are unavailable,
+     * it returns a default result with null and -1.
+     *
+     * @param action The action to search for in the sub-actions list. Case-insensitive comparison is used.
+     * @return A Map.Entry containing the inventory action (String) and the index of the sub-action (Integer)
+     *         if a match is found; otherwise, returns a Map.Entry with null and -1.
+     */
+    public Map.Entry<String, Integer> getIndexOfSubAction(String action) {
+        if (action == null) return Map.entry(null, -1);
+        String alc = action.toLowerCase();
+
+        String[][] subOps = getSubops();
+        if (subOps == null) {
+            return Map.entry(null, -1);
+        }
+        for (int i = 0; i < subOps.length; i++) {
+            String[] subOpsActions = subOps[i];
+            if (subOpsActions == null) continue;
+            for (int j = 0; j < subOpsActions.length; j++) {
+                String subObsAction = subOpsActions[j];
+                if (subObsAction != null && subObsAction.toLowerCase().contains(alc)) {
+                    return Map.entry(inventoryActions[i], j);
+                }
+            }
+        }
+
+        return Map.entry(null, -1);
+    }
+
     /**
      * Gets the equipment actions, loading composition if needed.
      * This returns a list of actions that can be performed on the item when equipped.
@@ -200,15 +227,15 @@ public class Rs2ItemModel {
         return itemComposition;
     }
 
-	public boolean isFood() {
-		if (isNoted()) return false;
+    public boolean isFood() {
+        if (isNoted()) return false;
 
-		String lowerName = getName().toLowerCase();
+        String lowerName = getName().toLowerCase();
 
-		boolean isEdible = Arrays.stream(getInventoryActions()).anyMatch(action -> action != null && action.equalsIgnoreCase("eat"));
+        boolean isEdible = Arrays.stream(getInventoryActions()).anyMatch(action -> action != null && action.equalsIgnoreCase("eat"));
 
-		return (isEdible || lowerName.contains("jug of wine")) && !lowerName.contains("rock cake");
-	}
+        return (isEdible || lowerName.contains("jug of wine")) && !lowerName.contains("rock cake");
+    }
 
     private void addEquipmentActions(ItemComposition itemComposition) {
         for (int i = 0; i < wearableActionIndexes.length; i++) {
@@ -235,7 +262,7 @@ public class Rs2ItemModel {
     public boolean isHaProfitable() {
         int natureRunePrice = Microbot.getClientThread().runOnClientThreadOptional(() ->
                 Microbot.getItemManager().getItemPrice(ItemID.NATURERUNE)).orElse(0);
-        return (getHaPrice() - natureRunePrice) > (getPrice()/quantity) && isTradeable;
+        return (getHaPrice() - natureRunePrice) > (getPrice() / quantity) && isTradeable;
 
     }
 
@@ -271,21 +298,21 @@ public class Rs2ItemModel {
         sb.append("\tisNoted: ").append(isNoted()).append("\n");
         sb.append("\tisTradeable: ").append(isTradeable()).append("\n");
         sb.append("\tisFood: ").append(isFood()).append("\n");
-        
+
         // Price information
         int price = getPrice();
         sb.append("\tprice: ").append(price).append(" gp (total)\n");
         if (quantity > 0) {
             sb.append("\tunitPrice: ").append(price / quantity).append(" gp (each)\n");
         }
-        
+
         // High Alchemy information
         if (itemComposition != null) {
             int haPrice = getHaPrice();
             sb.append("\thaPrice: ").append(haPrice).append(" gp\n");
             sb.append("\tisHaProfitable: ").append(isHaProfitable()).append("\n");
         }
-        
+
         // Actions
         String[] invActions = getInventoryActions();
         if (invActions != null && invActions.length > 0) {
@@ -298,7 +325,7 @@ public class Rs2ItemModel {
             }
             sb.append("]\n");
         }
-        
+
         // Equipment actions
         if (!equipmentActions.isEmpty()) {
             sb.append("\tequipmentActions: [");
@@ -312,10 +339,10 @@ public class Rs2ItemModel {
             }
             sb.append("]\n");
         }
-        
+
         // Composition status
         sb.append("\tcompositionLoaded: ").append(itemComposition != null).append("\n");
-        
+
         sb.append("}");
         return sb.toString();
     }
@@ -336,7 +363,7 @@ public class Rs2ItemModel {
     public static Predicate<Rs2ItemModel> matches(EquipmentInventorySlot... slots) {
         return matches(slots, (item, slot) -> item.getSlot() == slot.getSlotIdx());
     }
-    
+
     /**
      * Initialize default values when ItemComposition is not available.
      */
@@ -348,18 +375,18 @@ public class Rs2ItemModel {
         this.inventoryActions = new String[0];
         this.itemComposition = null;
     }
-    
+
     /**
      * Gets the noted variant of this item if it exists and is stackable.
      * Returns this item's ID if the item is already noted or has no noted variant.
-     * 
+     *
      * @return The noted item ID if available, otherwise the original item ID
      */
     public int getNotedId() {
         if (itemComposition == null) {
             ensureCompositionLoaded();
         }
-        
+
         if (itemComposition == null) {
             return id; // fallback to original ID
         }
@@ -368,18 +395,18 @@ public class Rs2ItemModel {
         }
         return getNotedItemId(itemComposition);
     }
-    
+
     /**
      * Gets the unnoted variant of this item if it exists.
      * Returns this item's ID if the item is already unnoted or has no unnoted variant.
-     * 
+     *
      * @return The unnoted item ID if available, otherwise the original item ID
      */
     public int getUnNotedId() {
         if (itemComposition == null) {
             ensureCompositionLoaded();
         }
-        
+
         if (itemComposition == null) {
             return id; // fallback to original ID
         }
@@ -389,27 +416,27 @@ public class Rs2ItemModel {
         }
         return getUnNotedId(itemComposition);
     }
-    
+
     /**
      * Gets the linked item ID (noted/unnoted counterpart) of this item.
-     * 
+     *
      * @return The linked item ID
      */
     public int getLinkedId() {
         if (itemComposition == null) {
             ensureCompositionLoaded();
         }
-        
+
         if (itemComposition == null) {
             return id; // fallback to original ID
         }
-        
+
         return getLinkedItemId(itemComposition);
     }
-    
+
     /**
      * Static method to get the noted variant of an item ID.
-     * 
+     *
      * @param itemId The original item ID
      * @return The noted item ID if available, otherwise the original item ID
      */
@@ -417,13 +444,13 @@ public class Rs2ItemModel {
         ItemComposition composition = Microbot.getClientThread().runOnClientThreadOptional(() ->
                 Microbot.getClient().getItemDefinition(itemId)
         ).orElse(null);
-        
+
         return getNotedItemId(composition);
     }
-    
+
     /**
      * Static method to get the unnoted variant of an item ID.
-     * 
+     *
      * @param itemId The original item ID
      * @return The unnoted item ID if available, otherwise the original item ID
      */
@@ -431,14 +458,14 @@ public class Rs2ItemModel {
         ItemComposition composition = Microbot.getClientThread().runOnClientThreadOptional(() ->
                 Microbot.getClient().getItemDefinition(itemId)
         ).orElse(null);
-        
+
         return getUnNotedId(composition);
     }
-    
+
     /**
      * Helper method to get the noted variant from ItemComposition.
      * Returns the noted ID if the item has a stackable noted variant.
-     * 
+     *
      * @param composition The ItemComposition to check
      * @return The noted item ID if available, otherwise the original item ID
      */
@@ -447,26 +474,26 @@ public class Rs2ItemModel {
             if (composition == null) {
                 return -1;
             }
-            
+
             int itemId = composition.getId();
             boolean isNoted = composition.getNote() == 799;
             int linkedNoteId = composition.getLinkedNoteId();
             // if already stackable, return original ID
-            if ( (isNoted && composition.isStackable()) || linkedNoteId == - 1) {
+            if ((isNoted && composition.isStackable()) || linkedNoteId == -1) {
                 return itemId;
-            }                        
-            
+            }
+
             return linkedNoteId;
-            
+
         } catch (Exception e) {
             return -1; // fall back to original on error
         }
     }
-    
+
     /**
      * Helper method to get the unnoted variant from ItemComposition.
      * Returns the unnoted ID if the item has an unnoted variant.
-     * 
+     *
      * @param composition The ItemComposition to check
      * @return The unnoted item ID if available, otherwise the original item ID
      */
@@ -475,25 +502,25 @@ public class Rs2ItemModel {
             if (composition == null) {
                 log.warn("Could not get item composition for item ID, returning original ID");
                 return -1;
-            }                                    
+            }
             int itemId = composition.getId();
             boolean isNoted = composition.getNote() == 799;
             int linkedNoteId = composition.getLinkedNoteId();
             // if already stackable, return original ID
-            if ( (!isNoted && !composition.isStackable()) || linkedNoteId == - 1) {
+            if ((!isNoted && !composition.isStackable()) || linkedNoteId == -1) {
                 return itemId;
-            }                                    
+            }
             return linkedNoteId;
-            
+
         } catch (Exception e) {
             log.error("Error getting unnoted item ID: {}", e.getMessage());
             return -1; // fall back to original on error
         }
     }
-    
+
     /**
      * Helper method to get the linked item ID from ItemComposition.
-     * 
+     *
      * @param composition The ItemComposition to check
      * @return The linked item ID
      */
@@ -503,10 +530,10 @@ public class Rs2ItemModel {
                 log.warn("no item composition for item ID, returning -1");
                 return -1;
             }
-            
+
             // check if this item has a noted variant
             return composition.getLinkedNoteId();
-            
+
         } catch (Exception e) {
             log.error("Error getting linked item ID: {}", e.getMessage());
             return -1; // fall back on error
@@ -520,7 +547,7 @@ public class Rs2ItemModel {
         this.name = itemComposition.getName();
         this.isStackable = itemComposition.isStackable();
         this.isNoted = itemComposition.getNote() == 799;
-        
+
         // Handle noted item tradeable status
         if (this.isNoted) {
             Microbot.getClientThread().runOnClientThreadOptional(() ->
@@ -529,10 +556,12 @@ public class Rs2ItemModel {
         } else {
             this.isTradeable = itemComposition.isTradeable();
         }
-        
+
         this.inventoryActions = itemComposition.getInventoryActions();
+        // This has to be run in microbot's client thread
+        this.subops = Microbot.getClientThread().runOnClientThreadOptional(itemComposition::getSubops).orElse(null);
         this.itemComposition = itemComposition;
-        
+
         // Add equipment actions asynchronously
         Microbot.getClientThread().runOnClientThreadOptional(() -> {
             addEquipmentActions(itemComposition);


### PR DESCRIPTION
Rs2ItemModel provides access to subops from which the sub-menu action and main action can be derived.
Lets say you want to teleport to "Castle wars" with your "Ring of dueling":
The ring provides a sub-menu with "Castle Wars" on right-click under "Rub". The sub-menu's "Castle Wars" comes from the Rs2ItemModel's subOps but the index of "Rub" depends on the inventory interface from which this interaction is executed.