### PR TITLE
feat(ui): add toggleable in-client console

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientPanel.java
@@ -27,12 +27,17 @@ package net.runelite.client.ui;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import javax.annotation.Nullable;
 import javax.swing.JPanel;
 import net.runelite.api.Constants;
 
 final class ClientPanel extends JPanel
 {
+	private static final Dimension GAME_SIZE = new Dimension(Constants.GAME_FIXED_SIZE);
+
+	private final JPanel consoleContainer = new JPanel(new BorderLayout());
+
 	public ClientPanel(@Nullable Component client)
 	{
 		setSize(Constants.GAME_FIXED_SIZE);
@@ -40,6 +45,9 @@ final class ClientPanel extends JPanel
 		setPreferredSize(Constants.GAME_FIXED_SIZE);
 		setLayout(new BorderLayout());
 		setBackground(Color.black);
+		consoleContainer.setOpaque(false);
+		consoleContainer.setVisible(false);
+		add(consoleContainer, BorderLayout.SOUTH);
 
 		if (client == null)
 		{
@@ -47,5 +55,52 @@ final class ClientPanel extends JPanel
 		}
 
 		add(client, BorderLayout.CENTER);
+	}
+
+	void setConsole(Component console)
+	{
+		consoleContainer.removeAll();
+		if (console != null)
+		{
+			consoleContainer.add(console, BorderLayout.CENTER);
+		}
+		consoleContainer.revalidate();
+		consoleContainer.repaint();
+	}
+
+	void setConsoleVisible(boolean visible)
+	{
+		if (consoleContainer.isVisible() == visible)
+		{
+			return;
+		}
+		consoleContainer.setVisible(visible);
+		revalidate();
+		repaint();
+	}
+
+	boolean isConsoleVisible()
+	{
+		return consoleContainer.isVisible();
+	}
+
+	@Override
+	public Dimension getMinimumSize()
+	{
+		Dimension size = new Dimension(GAME_SIZE);
+		if (consoleContainer.isVisible())
+		{
+			Dimension consoleSize = consoleContainer.getPreferredSize();
+			size.height += consoleSize != null ? consoleSize.height : 0;
+		}
+		return size;
+	}
+
+	@Override
+	public Dimension getPreferredSize()
+	{
+		Dimension size = getMinimumSize();
+		size.width = Math.max(size.width, GAME_SIZE.width);
+		return size;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/ConsoleLogAppender.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ConsoleLogAppender.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Microbot Contributors
+ * All rights reserved.
+ */
+package net.runelite.client.ui;
+
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import java.util.function.Consumer;
+
+final class ConsoleLogAppender extends AppenderBase<ILoggingEvent>
+{
+	private final Consumer<String> logConsumer;
+	private PatternLayout layout;
+
+	ConsoleLogAppender(Consumer<String> logConsumer)
+	{
+		this.logConsumer = logConsumer;
+	}
+
+	@Override
+	public void start()
+	{
+		layout = new PatternLayout();
+		layout.setContext(getContext());
+		layout.setPattern("%d{HH:mm:ss} %-5level %logger{36} - %msg%n");
+		layout.start();
+		super.start();
+	}
+
+	@Override
+	protected void append(ILoggingEvent eventObject)
+	{
+		if (!isStarted())
+		{
+			return;
+		}
+		String formatted = layout.doLayout(eventObject);
+		logConsumer.accept(formatted);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/LogConsolePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/LogConsolePanel.java
@@ -4,9 +4,7 @@
  */
 package net.runelite.client.ui;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.Font;
+import java.awt.*;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -40,7 +38,7 @@ final class LogConsolePanel extends JPanel
 		textArea.setWrapStyleWord(false);
 		textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
 		textArea.setBackground(ColorScheme.DARK_GRAY_COLOR);
-		textArea.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+		textArea.setForeground(new Color(0, 255, 70));
 		textArea.setBorder(null);
 
 		DefaultCaret caret = (DefaultCaret) textArea.getCaret();

--- a/runelite-client/src/main/java/net/runelite/client/ui/LogConsolePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/LogConsolePanel.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2024 Microbot Contributors
+ * All rights reserved.
+ */
+package net.runelite.client.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.border.MatteBorder;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.DefaultCaret;
+import net.runelite.api.Constants;
+
+final class LogConsolePanel extends JPanel
+{
+	private static final int MAX_CHARACTERS = 100_000;
+	private static final int PREFERRED_HEIGHT = 160;
+
+	private final JTextArea textArea = new JTextArea();
+
+	LogConsolePanel()
+	{
+		super(new BorderLayout());
+		setPreferredSize(new Dimension(Constants.GAME_FIXED_SIZE.width, PREFERRED_HEIGHT));
+		setBorder(new MatteBorder(1, 0, 0, 0, ColorScheme.DARKER_GRAY_COLOR));
+		setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		textArea.setEditable(false);
+		textArea.setLineWrap(false);
+		textArea.setWrapStyleWord(false);
+		textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+		textArea.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		textArea.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+		textArea.setBorder(null);
+
+		DefaultCaret caret = (DefaultCaret) textArea.getCaret();
+		caret.setUpdatePolicy(DefaultCaret.ALWAYS_UPDATE);
+
+		JScrollPane scrollPane = new JScrollPane(textArea);
+		scrollPane.setBorder(null);
+		add(scrollPane, BorderLayout.CENTER);
+	}
+
+	void append(String text)
+	{
+		if (text == null || text.isEmpty())
+		{
+			return;
+		}
+
+		String sanitized = text.replace("\r", "");
+		if (SwingUtilities.isEventDispatchThread())
+		{
+			appendOnEdt(sanitized);
+		}
+		else
+		{
+			SwingUtilities.invokeLater(() -> appendOnEdt(sanitized));
+		}
+	}
+
+	OutputStream createOutputStream()
+	{
+		return new ConsoleOutputStream();
+	}
+
+	private void appendOnEdt(String text)
+	{
+		Document document = textArea.getDocument();
+		try
+		{
+			int length = document.getLength();
+			document.insertString(length, text, null);
+			trimIfNecessary();
+			textArea.setCaretPosition(document.getLength());
+		}
+		catch (BadLocationException ex)
+		{
+			// Ignore append failures to avoid recursive logging.
+		}
+	}
+
+	private void trimIfNecessary()
+	{
+		Document document = textArea.getDocument();
+		int excess = document.getLength() - MAX_CHARACTERS;
+		if (excess <= 0)
+		{
+			return;
+		}
+
+		try
+		{
+			document.remove(0, excess);
+		}
+		catch (BadLocationException ex)
+		{
+			// Ignore trim failures to avoid recursive logging.
+		}
+	}
+
+	private final class ConsoleOutputStream extends OutputStream
+	{
+		private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		@Override
+		public synchronized void write(int b) throws IOException
+		{
+			if (b == '\r')
+			{
+				return;
+			}
+
+			buffer.write(b);
+			if (b == '\n')
+			{
+				flushBuffer();
+			}
+		}
+
+		@Override
+		public synchronized void write(byte[] b, int off, int len) throws IOException
+		{
+			for (int i = 0; i < len; i++)
+			{
+				write(b[off + i]);
+			}
+		}
+
+		@Override
+		public synchronized void flush() throws IOException
+		{
+			flushBuffer();
+		}
+
+		@Override
+		public void close() throws IOException
+		{
+			flush();
+		}
+
+		private void flushBuffer() throws IOException
+		{
+			if (buffer.size() == 0)
+			{
+				return;
+			}
+
+			String value = buffer.toString(StandardCharsets.UTF_8);
+			buffer.reset();
+			append(value);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add an embedded log console panel beneath the client canvas with a toggle button in the toolbar
- stream System.out and SLF4J output to the in-client console via a custom logback appender

## Testing
- mvn -pl runelite-client -DskipTests package *(fails: dependency resolution for com.google.inject:guice-bom 4.1.0 is blocked by HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f006ee88fc832884d71d4eafe0b4cc