### PR TITLE
feat: show startup crash details on splash screen

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -277,6 +277,8 @@ public class RuneLite
 			ClientUI.proxyMessage = " - Proxy enabled (detected IP " + ip + ")";
 		}
 
+
+
 		SplashScreen.stage(0, "Preparing RuneScape", "");
 
 		boolean startupFailed = false;
@@ -348,11 +350,11 @@ public class RuneLite
 			{
 				if (SplashScreen.isOpen())
 				{
-					SplashScreen.showError("RuneLite failed to start", crashSummary, crashDetails);
+					SplashScreen.showError("Microbot failed to start", crashSummary, crashDetails);
 				}
 				else
 				{
-					new FatalErrorDialog("RuneLite has encountered an unexpected error during startup.")
+					new FatalErrorDialog("Microbot has encountered an unexpected error during startup.")
 						.setContent(crashDetails)
 						.addCopyButton("Copy error details")
 						.addHelpButtons()

--- a/runelite-client/src/main/java/net/runelite/client/ui/SplashScreen.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/SplashScreen.java
@@ -35,6 +35,7 @@ import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.plaf.basic.BasicProgressBarUI;
 import java.awt.*;
+import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -55,13 +56,21 @@ public class SplashScreen extends JFrame implements ActionListener {
     private static final int PAD = 14;
     private static final int ARC = 18;
     private static final int CLOSE_BUTTON_SIZE = 20;
+    private static final String CARD_FACTS = "facts";
+    private static final String CARD_ERROR = "error";
 
     private static SplashScreen INSTANCE;
 
     private final JLabel action = new JLabel("Loading");
     private final JProgressBar progress = new JProgressBar();
     private final JLabel subAction = new JLabel();
+    private final CardLayout detailLayout = new CardLayout();
+    private final JPanel detailPanel = new JPanel(detailLayout);
+    private final JTextArea errorDetails = new JTextArea();
+    private final JLabel errorSummaryLabel = new JLabel();
+    private final JButton copyErrorButton = new JButton("Copy error details");
     private final Timer timer;
+    private boolean showingError;
 
     private volatile double overallProgress = 0;
     private volatile String actionText = "Loading";
@@ -251,8 +260,6 @@ public class SplashScreen extends JFrame implements ActionListener {
         factTitle.setBorder(new EmptyBorder(0, 0, 8, 0));
         factCard.add(factTitle, BorderLayout.NORTH);
 
-        // --- build facts panel ---
-        // Replace the JTextPane section with this JTextArea approach
         JTextArea factArea = new JTextArea();
         factArea.setEditable(false);
         factArea.setFocusable(false);
@@ -264,10 +271,11 @@ public class SplashScreen extends JFrame implements ActionListener {
         factArea.setBackground(new Color(0, 0, 0, 0));
         factArea.setText(getFact());
         factArea.setPreferredSize(new Dimension(WIDTH - (PAD * 4), 160));
-        // Add the factPane directly to the card
         factCard.add(factArea, BorderLayout.CENTER);
 
-        // updates
+        detailPanel.setOpaque(false);
+        detailPanel.add(factCard, CARD_FACTS);
+
         pcs.addPropertyChangeListener("fact", evt -> SwingUtilities.invokeLater(() -> {
             factArea.setText(String.valueOf(evt.getNewValue()));
             factArea.setCaretPosition(0);
@@ -275,12 +283,57 @@ public class SplashScreen extends JFrame implements ActionListener {
             factCard.revalidate();
         }));
 
-        // Proper GridBag constraints for the fact card
+        JPanel errorCard = new JPanel(new BorderLayout());
+        errorCard.setOpaque(false);
+        errorCard.setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(new Color(55, 55, 55)),
+                new EmptyBorder(PAD, PAD, PAD, PAD)
+        ));
+
+        errorSummaryLabel.setFont(bodyFont);
+        errorSummaryLabel.setForeground(fg);
+        errorSummaryLabel.setBorder(new EmptyBorder(0, 0, 8, 0));
+        errorCard.add(errorSummaryLabel, BorderLayout.NORTH);
+
+        errorDetails.setEditable(false);
+        errorDetails.setFocusable(true);
+        errorDetails.setOpaque(false);
+        errorDetails.setLineWrap(false);
+        errorDetails.setWrapStyleWord(false);
+        errorDetails.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+        errorDetails.setForeground(fgMuted);
+        errorDetails.setBackground(new Color(0, 0, 0, 0));
+
+        JScrollPane errorScroll = new JScrollPane(errorDetails);
+        errorScroll.setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(new Color(55, 55, 55)),
+                new EmptyBorder(PAD, PAD, PAD, PAD)
+        ));
+        errorScroll.setOpaque(false);
+        errorScroll.getViewport().setOpaque(false);
+        errorScroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        errorScroll.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        errorCard.add(errorScroll, BorderLayout.CENTER);
+
+        JPanel errorButtonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 0));
+        errorButtonPanel.setOpaque(false);
+        copyErrorButton.setFont(bodyFont);
+        copyErrorButton.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+        copyErrorButton.setForeground(Color.LIGHT_GRAY);
+        copyErrorButton.setFocusPainted(false);
+        copyErrorButton.setBorder(new EmptyBorder(6, 12, 6, 12));
+        copyErrorButton.addActionListener(e -> copyErrorDetails());
+        errorButtonPanel.add(copyErrorButton);
+        errorCard.add(errorButtonPanel, BorderLayout.SOUTH);
+
+        detailPanel.add(errorCard, CARD_ERROR);
+
+        // Proper GridBag constraints for the card panel
         gc.gridy++;
         gc.insets = new Insets(0, 0, 0, 0);
         gc.weighty = 1.0; // Allow vertical expansion
         gc.fill = GridBagConstraints.BOTH; // Fill both horizontal and vertical space
-        root.add(factCard, gc);
+        root.add(detailPanel, gc);
 
         // Size and center
         setSize(WIDTH, 520);
@@ -293,7 +346,7 @@ public class SplashScreen extends JFrame implements ActionListener {
 
         setVisible(true);
 
-        ScheduledExecutorService scheduledRandomFactExecutorService = Executors.newSingleThreadScheduledExecutor();
+        scheduledRandomFactExecutorService = Executors.newSingleThreadScheduledExecutor();
         scheduledRandomFactFuture = scheduledRandomFactExecutorService.scheduleAtFixedRate(
                 () -> {
                     RandomFactClient.getRandomFactAsync(SplashScreen::setFact);
@@ -359,6 +412,19 @@ public class SplashScreen extends JFrame implements ActionListener {
         });
     }
 
+    public static void showError(String title, String summary, String details)
+    {
+        SwingUtilities.invokeLater(() ->
+        {
+            if (INSTANCE == null)
+            {
+                return;
+            }
+
+            INSTANCE.displayError(title, summary, details);
+        });
+    }
+
     public static void stage(double overallProgress, @Nullable String actionText, String subActionText) {
         stage(overallProgress, actionText, subActionText, null);
     }
@@ -378,13 +444,60 @@ public class SplashScreen extends JFrame implements ActionListener {
     }
 
     public static void stage(double overallProgress, @Nullable String actionText, String subActionText, @Nullable String progressText) {
-        if (INSTANCE != null) {
+        if (INSTANCE != null && !INSTANCE.showingError) {
             INSTANCE.overallProgress = overallProgress;
             if (actionText != null) {
                 INSTANCE.actionText = actionText;
             }
             INSTANCE.subActionText = subActionText;
             INSTANCE.progressText = progressText;
+        }
+    }
+
+    private void displayError(@Nullable String title, @Nullable String summary, @Nullable String details)
+    {
+        showingError = true;
+
+        String header = title == null || title.isEmpty() ? "Startup failed" : title;
+        String summaryText = summary == null || summary.isEmpty() ? "RuneLite encountered an unexpected error while starting." : summary;
+        String detailText = details == null ? "" : details;
+
+        actionText = header;
+        subActionText = "See the details below and contact support if the issue persists.";
+        progressText = null;
+        overallProgress = 1.0;
+
+        action.setText(actionText);
+        subAction.setText(subActionText);
+        progress.setValue(progress.getMaximum());
+        progress.setStringPainted(false);
+
+        errorSummaryLabel.setText("<html><body style='width:100%'>" + summaryText.replace("\n", "<br>") + "</body></html>");
+        errorDetails.setText(detailText);
+        errorDetails.setCaretPosition(0);
+
+        boolean hasDetails = !detailText.isEmpty();
+        copyErrorButton.setEnabled(hasDetails);
+
+        detailLayout.show(detailPanel, CARD_ERROR);
+    }
+
+    private void copyErrorDetails()
+    {
+        String text = errorDetails.getText();
+        if (text == null || text.isEmpty())
+        {
+            return;
+        }
+
+        try
+        {
+            StringSelection selection = new StringSelection(text);
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(selection, selection);
+        }
+        catch (IllegalStateException ex)
+        {
+            log.warn("Unable to copy error details", ex);
         }
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/SplashScreen.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/SplashScreen.java
@@ -304,16 +304,18 @@ public class SplashScreen extends JFrame implements ActionListener {
         errorDetails.setForeground(fgMuted);
         errorDetails.setBackground(new Color(0, 0, 0, 0));
 
-        JScrollPane errorScroll = new JScrollPane(errorDetails);
-        errorScroll.setBorder(BorderFactory.createCompoundBorder(
-                BorderFactory.createLineBorder(new Color(55, 55, 55)),
-                new EmptyBorder(PAD, PAD, PAD, PAD)
-        ));
-        errorScroll.setOpaque(false);
-        errorScroll.getViewport().setOpaque(false);
-        errorScroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-        errorScroll.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
-        errorCard.add(errorScroll, BorderLayout.CENTER);
+JScrollPane errorScroll = new JScrollPane(errorDetails);
+errorScroll.setBorder(BorderFactory.createCompoundBorder(
+BorderFactory.createLineBorder(new Color(55, 55, 55)),
+new EmptyBorder(PAD, PAD, PAD, PAD)
+));
+errorScroll.setOpaque(false);
+errorScroll.getViewport().setOpaque(false);
+errorScroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+errorScroll.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+errorScroll.setPreferredSize(new Dimension(WIDTH - (PAD * 4), 220));
+errorScroll.setMinimumSize(new Dimension(0, 180));
+errorCard.add(errorScroll, BorderLayout.CENTER);
 
         JPanel errorButtonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 0));
         errorButtonPanel.setOpaque(false);

--- a/runelite-client/src/main/java/net/runelite/client/util/CrashReportFormatter.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/CrashReportFormatter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024
+ * All rights reserved.
+ */
+package net.runelite.client.util;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public final class CrashReportFormatter
+{
+    private CrashReportFormatter()
+    {
+    }
+
+    public static String summarize(Throwable throwable)
+    {
+        if (throwable == null)
+        {
+            return "";
+        }
+
+        Throwable root = throwable;
+        while (root.getCause() != null && root.getCause() != root)
+        {
+            root = root.getCause();
+        }
+
+        StringBuilder summary = new StringBuilder(root.getClass().getName());
+        String message = root.getMessage();
+        if (message != null && !message.isBlank())
+        {
+            summary.append(": ").append(message);
+        }
+
+        return summary.toString();
+    }
+
+    public static String stackTrace(Throwable throwable)
+    {
+        if (throwable == null)
+        {
+            return "";
+        }
+
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        throwable.printStackTrace(pw);
+        pw.flush();
+        return sw.toString();
+    }
+
+    public static String buildReport(Throwable throwable)
+    {
+        if (throwable == null)
+        {
+            return "";
+        }
+
+        String summary = summarize(throwable);
+        String trace = stackTrace(throwable);
+
+        if (summary.isEmpty())
+        {
+            return trace;
+        }
+
+        if (trace.isEmpty())
+        {
+            return summary;
+        }
+
+        return summary + "\n\nStack trace:\n" + trace;
+    }
+}


### PR DESCRIPTION
## Summary
- add a CrashReportFormatter helper and expose crash details via FatalErrorDialog copy buttons
- surface startup failures on the splash screen with an error card and clipboard-friendly copy action

## Testing
- ⚠️ `mvn -pl runelite-client -DskipTests compile` *(fails: unable to download com.google.inject:guice-bom:4.1.0 due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f06d7cf3bc83289fcd48cebf149198