### PR TITLE
handleInventoryTeleports with specific teleport actions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1855,15 +1855,14 @@ public class Rs2Walker {
         Rs2ItemModel rs2Item = Rs2Inventory.get(itemId);
         if (rs2Item == null) return false;
 
-        // A list of fallback keywords that can be used if no specific action is found
-        List<String> genericKeyWords = Arrays.asList("farm", "monastery", "lletya", "prifddinas", "rellekka", "waterbirth island", "neitiznot", "jatiszo",
-                "ver sinhaza", "darkmeyer", "slepe", "troll stronghold", "weiss", "ecto", "burgh", "duradel", "gem mine", "nardah", "kalphite cave", "Tele to POH", "inside", "outside",
-                "kourend woodland", "mount karuulm", "outside", "fishing guild", "otto's grotto", "stronghold slayer cave", "slayer tower", "fremennik", "tarn's lair", "dark beasts",
-                "invoke", "empty", "consume", "open", "teleport", "rub", "break", "reminisce", "signal", "play", "commune", "squash");
+        // A list of generic teleports that can be used if no parsable destination action is found
+        List<String> genericKeyWords = Arrays.asList(
+                "invoke", "empty", "consume", "open", "teleport", "rub", "break", "reminisce", "signal", "play", "commune", "squash"
+        );
 
         // Return true when the item can be used to teleport to multiple places
-        boolean hasMultipleDestination = transport.getDisplayInfo().contains(":");
-        String destination = hasMultipleDestination
+        boolean hasParsableDestination = transport.getDisplayInfo().contains(":");
+        String destination = hasParsableDestination
                 ? transport.getDisplayInfo().split(":")[1].trim().toLowerCase()
                 : transport.getDisplayInfo().trim().toLowerCase();
 
@@ -1880,7 +1879,7 @@ public class Rs2Walker {
         }
 
         // If there's only one destination with the item possible, a generic action will also work
-        if (itemAction == null && !hasMultipleDestination) {
+        if (itemAction == null && !hasParsableDestination) {
             itemAction = rs2Item.getActionFromList(genericKeyWords);
         }
 
@@ -2353,7 +2352,7 @@ public class Rs2Walker {
         return false;
     }
     /**
-     * interact with interfaces like spirit tree & xeric talisman etc...
+     * interact with interfaces like spirit tree etc...
      *
      * @param transport
      */

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1860,7 +1860,7 @@ public class Rs2Walker {
                 "invoke", "empty", "consume", "open", "teleport", "rub", "break", "reminisce", "signal", "play", "commune", "squash"
         );
 
-        // Return true when the item can be used to teleport to multiple places
+        // Return true when the item does not use a generic keyword to teleport to its destination
         boolean hasParsableDestination = transport.getDisplayInfo().contains(":");
         String destination = hasParsableDestination
                 ? transport.getDisplayInfo().split(":")[1].trim().toLowerCase()

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
@@ -344,19 +344,19 @@
 2019 6434 0		28327				Y	T	19	4	Ring of shadows: The Scar
 2588 6435 0		28327				Y	T	19	4	Ring of shadows: Lassar Undercity
 1175 3424 0		28327				Y	T	19	4	Ring of shadows: The Stranglewood
-1491 3283 0		29893		11175=1		Y	T	19	4	1. Pendant of ates: Darkfrost
-1668 3223 0		29893		11176=1		Y	T	19	4	2. Pendant of ates: Twilight Temple
-1459 3138 0		29893		11177=1		Y	T	19	4	3. Pendant of ates: Ralos' Rise
-1426 2995 0		29893		11178=1		Y	T	19	4	4. Pendant of ates: North Aldarin
-1367 3087 0		29893		16752=1		Y	T	19	4	5. Pendant of ates: Kastori
-1364 3275 0		29893		16757=1		Y	T	19	4	6. Pendant of ates: Nemus Retreat
+1491 3283 0		29893		11175=1		Y	T	19	4	Pendant of ates: Darkfrost
+1668 3223 0		29893		11176=1		Y	T	19	4	Pendant of ates: Twilight Temple
+1459 3138 0		29893		11177=1		Y	T	19	4	Pendant of ates: Ralos' Rise
+1426 2995 0		29893		11178=1		Y	T	19	4	Pendant of ates: North Aldarin
+1367 3087 0		29893		16752=1		Y	T	19	4	Pendant of ates: Kastori
+1364 3275 0		29893		16757=1		Y	T	19	4	Pendant of ates: Nemus Retreat
 										
 #Quetzal Whistle										
 1585 3053 0		29271;29273;29275	Children of the Sun			Y	T	19	4	Quetzal whistle
 #Giantsoul Amulet										
-3174 9898 0		30638				Y	T	19	4	1. Giantsoul Amulet: Bryophyta
-6208 6336 0		30638				Y	T	19	4	2. Giantsoul Amulet: Obor
-2952 9574 0		30638				Y	T	19	4	3. Giantsoul Amulet: Branda and Eldric
+3174 9898 0		30638				Y	T	19	4	Giantsoul Amulet: Bryophyta
+6208 6336 0		30638				Y	T	19	4	Giantsoul Amulet: Obor
+2952 9574 0		30638				Y	T	19	4	Giantsoul Amulet: Branda and Eldric
 
 #Ruins of Mokhaiotl
 1311 9497 0		31099;31101;31102;31103;31104;31105	The Final Dawn			Y	T	29	4	Mokhaiotl waystone: Channel

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/teleportation_items.tsv
@@ -1,17 +1,20 @@
 # Destination	Skills	Item IDs	Quests	Varbits	Varplayers	isMembers	Consumable	Wilderness level	Duration	Display info
 # Ardougne Cloaks (2-4's farm teleport is limited to 3,5, or infinite times - can this be validated?)										
-2606 3221 0		13121;13122;13123;13124;20760				Y	F	19	4	Ardougne cloak: Kandarin Monastery
+2606 3221 0		13121;13122;13123;13124;20760				Y	F	19	4	Ardougne cloak: Monastery Teleport
 2664 3374 0		13122;13123;13124;20760				Y	T	19	4	Ardougne cloak: Farm Teleport
-# Karamja Gloves										
-2840 9387 0		11140;13103				Y	F	19	4	Karamja gloves
-# Desert Amulets (2 and 3 have one teleport per day, 4 is unlimited)										
-3420 2917 0		13134;13135		4558=0		Y	T	19	4	Desert amulet
-3426 2927 0		13136				Y	F	19	4	Desert amulet
+# Karamja Gloves (Gem Mine underground)
+2840 9387 0		11140;13103				Y	F	19	4	Karamja gloves: Gem Mine
+# Karamja Gloves (Duradel underground)
+2868 2981 1		13103				Y	F	19	4	Karamja gloves: Slayer Master
+# Desert Amulets (2 and 3 have one teleport per day, 4 is unlimited and has multiple teleports)
+3420 2917 0		13134;13135		4558=0		Y	T	19	4	Desert amulet: Teleport
+3426 2927 0		13136				Y	F	19	4	Desert amulet: Nardah
+3322 3122 0		13136				Y	F	19	4	Desert amulet: Kalphite Cave
 # Morytania Legs (2 and 3 have 5 teleports per day to slime, 4 is unlimited)										
-3683 9888 0		13112		4542<2		Y	T	19	4	Morytania legs: Ectofuntus Pit
-3683 9888 0		13113;13114		4542<5		Y	T	19	4	Morytania legs: Ectofuntus Pit
-3683 9888 0		13115				Y	F	19	4	Morytania legs: Ectofuntus Pit
-3482 3230 0		13114;13115				Y	F	19	4	Morytania legs: Burgh de Rott
+3683 9888 0		13112		4542<2		Y	T	19	4	Morytania legs: Ecto Teleport
+3683 9888 0		13113;13114		4542<5		Y	T	19	4	Morytania legs: Ecto Teleport
+3683 9888 0		13115				Y	F	19	4	Morytania legs: Ecto Teleport
+3482 3230 0		13114;13115				Y	F	19	4	Morytania legs: Burgh Teleport
 # Fremennik sea boots (1,2,3 have 1 teleport per day, 4 is unlimited)										
 2643 3675 0		13129;13130;13131		5005=0		Y	T	19	4	Fremennik sea boots
 2643 3675 0		13132				Y	F	19	4	Fremennik sea boots
@@ -32,65 +35,65 @@
 1311 3799 0		22947				Y	F	19	4	Rada's blessing: Mount Karuulm
 										
 # Games Necklace										
-2520 3571 0		3853;3855;3857;3859;3861;3863;3865;3867				Y	T	19	4	2. Games necklace: Barbarian Outpost
-2898 3553 0		3853;3855;3857;3859;3861;3863;3865;3867				Y	T	19	4	1. Games necklace: Burthorpe
-2967 4384 2		3853;3855;3857;3859;3861;3863;3865;3867				Y	T	19	4	3. Games necklace: Corporeal Beast
-3245 9500 2		3853;3855;3857;3859;3861;3863;3865;3867	Tears of Guthix			Y	T	19	4	4. Games necklace: Tears of Guthix
-1631 3940 0		3853;3855;3857;3859;3861;3863;3865;3867				Y	T	19	4	5. Games necklace: Wintertodt Camp
+2520 3571 0		3853;3855;3857;3859;3861;3863;3865;3867				Y	T	19	4	Games necklace: Barbarian Outpost
+2898 3553 0		3853;3855;3857;3859;3861;3863;3865;3867				Y	T	19	4	Games necklace: Burthorpe
+2967 4384 2		3853;3855;3857;3859;3861;3863;3865;3867				Y	T	19	4	Games necklace: Corporeal Beast
+3245 9500 2		3853;3855;3857;3859;3861;3863;3865;3867	Tears of Guthix			Y	T	19	4	Games necklace: Tears of Guthix
+1631 3940 0		3853;3855;3857;3859;3861;3863;3865;3867				Y	T	19	4	Games necklace: Wintertodt Camp
 										
 # Ring of Dueling (1-8)										
-3315 3235 0		2566;2564;2562;2560;2558;2556;2554;2552				Y	T	19	6	1. Ring of dueling: Emir's Arena
-2440 3090 0		2566;2564;2562;2560;2558;2556;2554;2552				Y	T	19	6	2. Ring of dueling: Castle Wars
-3151 3635 0		2566;2564;2562;2560;2558;2556;2554;2552				Y	T	19	6	3. Ring of dueling: Ferox Enclave
+3315 3235 0		2566;2564;2562;2560;2558;2556;2554;2552				Y	T	19	6	Ring of dueling: Emir's Arena
+2440 3090 0		2566;2564;2562;2560;2558;2556;2554;2552				Y	T	19	6	Ring of dueling: Castle Wars
+3151 3635 0		2566;2564;2562;2560;2558;2556;2554;2552				Y	T	19	6	Ring of dueling: Ferox Enclave
 										
 # Combat Bracelet (1-6) (uncharged is 11126)										
-2882 3547 0		11118;11120;11122;11124;11972;11974				Y	T	29	4	1. Combat bracelet: Warriors' Guild
-3192 3368 0		11118;11120;11122;11124;11972;11974				Y	T	29	4	2. Combat bracelet: Champions' Guild
-3052 3490 0		11118;11120;11122;11124;11972;11974				Y	T	29	4	3. Combat bracelet: Monastery
-2653 3439 0		11118;11120;11122;11124;11972;11974				Y	T	29	4	4. Combat bracelet: Ranging Guild
+2882 3547 0		11118;11120;11122;11124;11972;11974				Y	T	29	4	Combat bracelet: Warriors' Guild
+3192 3368 0		11118;11120;11122;11124;11972;11974				Y	T	29	4	Combat bracelet: Champions' Guild
+3052 3490 0		11118;11120;11122;11124;11972;11974				Y	T	29	4	Combat bracelet: Monastery
+2653 3439 0		11118;11120;11122;11124;11972;11974				Y	T	29	4	Combat bracelet: Ranging Guild
 										
 # Skills Necklace (1-6) (uncharged is 11113)										
-2611 3390 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	1. Skills necklace: Fishing Guild
-3049 9763 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	2. Skills necklace: Mining Guild
-2933 3295 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	3. Skills necklace: Crafting Guild
-3144 3438 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	4. Skills necklace: Cooking Guild
-1662 3505 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	5. Skills necklace: Woodcutting Guild
-1248 3725 0	45 Farming	11105;11107;11109;11111;11968;11970				Y	T	29	4	6. Skills necklace: Farming Guild
-1248 3719 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	6. Skills necklace: Farming Guild
+2611 3390 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	Skills necklace: Fishing Guild
+3049 9763 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	Skills necklace: Mining Guild
+2933 3295 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	Skills necklace: Crafting Guild
+3144 3438 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	Skills necklace: Cooking Guild
+1662 3505 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	Skills necklace: Woodcutting Guild
+1248 3725 0	45 Farming	11105;11107;11109;11111;11968;11970				Y	T	29	4	Skills necklace: Farming Guild
+1248 3719 0		11105;11107;11109;11111;11968;11970				Y	T	29	4	Skills necklace: Farming Guild
 										
 # Amulet of Glory (1-6, 1t-6t, Eternal) (uncharged is 1704, trimmed 10362)										
-3087 3496 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707				Y	T	29	4	1. Amulet of glory: Edgeville
-2918 3176 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707				Y	T	29	4	2. Amulet of glory: Karamja
-3105 3251 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707				Y	T	29	4	3. Amulet of glory: Draynor Village
-3293 3163 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707				Y	T	29	4	4. Amulet of glory: Al Kharid
+3087 3496 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707				Y	T	29	4	Amulet of glory: Edgeville
+2918 3176 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707				Y	T	29	4	Amulet of glory: Karamja
+3105 3251 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707				Y	T	29	4	Amulet of glory: Draynor Village
+3293 3163 0		1706;1708;1710;1712;11976;11978;10360;10358;10356;10354;11966;11964;19707				Y	T	29	4	Amulet of glory: Al Kharid
 										
 # Ring of Wealth (1-5, 1i-5i) (uncharged is 2572, trimmed 12785)										
-2534 3862 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786	Throne of Miscellania			Y	T	29	4	1. Ring of wealth: Miscellania
-3163 3478 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786				Y	T	29	4	2. Ring of wealth: Grand Exchange
-2995 3375 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786				Y	T	29	4	3. Ring of wealth: Falador
-2824 10168 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786	Between a Rock...			Y	T	29	4	4. Ring of wealth: Dondakan
+2534 3862 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786	Throne of Miscellania			Y	T	29	4	Ring of wealth: Miscellania
+3163 3478 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786				Y	T	29	4	Ring of wealth: Grand Exchange
+2995 3375 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786				Y	T	29	4	Ring of wealth: Falador
+2824 10168 0		11988;11986;11984;11982;11980;20790;20789;20788;20787;20786	Between a Rock...			Y	T	29	4	Ring of wealth: Dondakan
 										
 # Slayer Ring (1-8, eternal)										
-2432 3423 0		11866;11867;11868;11869;11870;11871;11872;11873;21268				Y	T	29	4	1. Slayer ring: Stronghold Slayer Cave
-3421 3537 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Priest in Peril			Y	T	29	4	2. Slayer ring: Slayer Tower
-2802 10000 0		11866;11867;11868;11869;11870;11871;11872;11873;21268				Y	T	29	4	3. Slayer ring: Fremennik
-3185 4601 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Haunted Mine			Y	T	29	4	4. Slayer ring: Tarn's Lair
-2028 4636 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Mourning's End Part II			Y	T	29	4	5. Slayer ring: Dark Beasts
+2432 3423 0		11866;11867;11868;11869;11870;11871;11872;11873;21268				Y	T	29	4	Slayer ring: Stronghold Slayer Cave
+3421 3537 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Priest in Peril			Y	T	29	4	Slayer ring: Slayer Tower
+2802 10000 0		11866;11867;11868;11869;11870;11871;11872;11873;21268				Y	T	29	4	Slayer ring: Fremennik
+3185 4601 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Haunted Mine			Y	T	29	4	Slayer ring: Tarn's Lair
+2028 4636 0		11866;11867;11868;11869;11870;11871;11872;11873;21268	Mourning's End Part II			Y	T	29	4	Slayer ring: Dark Beasts
 										
 # Digsite Pendant (can't find a varbit for the other location's activation)										
-3341 3445 0		11190;11191;11192;11193;11194				Y	T	19	4	1. Digsite pendant: Digsite
-3763 3869 1		11190;11191;11192;11193;11194	Bone Voyage			Y	T	19	4	2. Digsite pendant: Fossil Island
-3549 10456 0		11190;11191;11192;11193;11194	Dragon Slayer II			Y	T	19	4	3. Digsite pendant: Lithkren
+3341 3445 0		11190;11191;11192;11193;11194				Y	T	19	4	Digsite pendant: Digsite
+3763 3869 1		11190;11191;11192;11193;11194	Bone Voyage			Y	T	19	4	Digsite pendant: Fossil Island
+3549 10456 0		11190;11191;11192;11193;11194	Dragon Slayer II			Y	T	19	4	Digsite pendant: Lithkren
 										
 # Necklace of Passage (1-5)										
-3114 3179 0		21146;21149;21151;21153;21155				Y	T	19	4	1. Necklace of passage: Wizards' Tower
-2428 3350 0		21146;21149;21151;21153;21155				Y	T	19	4	2. Necklace of passage: The Outpost
-3405 3158 0		21146;21149;21151;21153;21155				Y	T	19	4	3. Necklace of passage: Eagles' Eyrie
+3114 3179 0		21146;21149;21151;21153;21155				Y	T	19	4	Necklace of passage: Wizards' Tower
+2428 3350 0		21146;21149;21151;21153;21155				Y	T	19	4	Necklace of passage: The Outpost
+3405 3158 0		21146;21149;21151;21153;21155				Y	T	19	4	Necklace of passage: Eagles' Eyrie
 										
 # Burning Amulet										
-3234 3634 0		21166;21169;21171;21173;21175				Y	T	19	4	1. Burning amulet: Chaos Temple
-3038 3651 0		21166;21169;21171;21173;21175				Y	T	19	4	2. Burning amulet: Bandit Camp
-3028 3842 0		21166;21169;21171;21173;21175				Y	T	19	4	3. Burning amulet: Lava Maze
+3234 3634 0		21166;21169;21171;21173;21175				Y	T	19	4	Burning amulet: Chaos Temple
+3038 3651 0		21166;21169;21171;21173;21175				Y	T	19	4	Burning amulet: Bandit Camp
+3028 3842 0		21166;21169;21171;21173;21175				Y	T	19	4	Burning amulet: Lava Maze
 										
 # Teleport to outside House tablet - These depend on the current player's home location, determined by varbit 2187.										
 # 0 - None										
@@ -204,15 +207,15 @@
 # capes										
 2931 3286 0		9780;9781				Y	F	19	4	Crafting cape: Teleport
 # 8 - Hosidius										
-2952 3224 0		9789;9790				Y	F	19	4	2. Construction cape: Rimmington
-2892 3465 0		9789;9790				Y	F	19	4	3. Construction cape: Taverley
-3339 3004 0		9789;9790				Y	F	19	4	4. Construction cape: Pollnivneach
-1743 3517 0		9789;9790				Y	F	19	4	5. Construction cape: Hosidius
-1422 2965 0		9789;9790				Y	F	19	4	6. Construction cape: Aldarin
-2669 3629 0		9789;9790				Y	F	19	4	7. Construction cape: Rellekka
-2756 3176 0		9789;9790				Y	F	19	4	8. Construction cape: Brimhaven
-2545 3097 0		9789;9790				Y	F	19	4	9. Construction cape: Yanille
-3239 6077 0		9789;9790				Y	F	19	4	10. Construction cape: Prifddinas
+2952 3224 0		9789;9790				Y	F	19	4	Construction cape: Rimmington
+2892 3465 0		9789;9790				Y	F	19	4	Construction cape: Taverley
+3339 3004 0		9789;9790				Y	F	19	4	Construction cape: Pollnivneach
+1743 3517 0		9789;9790				Y	F	19	4	Construction cape: Hosidius
+1422 2965 0		9789;9790				Y	F	19	4	Construction cape: Aldarin
+2669 3629 0		9789;9790				Y	F	19	4	Construction cape: Rellekka
+2756 3176 0		9789;9790				Y	F	19	4	Construction cape: Brimhaven
+2545 3097 0		9789;9790				Y	F	19	4	Construction cape: Yanille
+3239 6077 0		9789;9790				Y	F	19	4	Construction cape: Prifddinas
 2604 3401 0		9798;9799				Y	F	19	4	Fishing cape: Fishing Guild
 2504 3484 0		9798;9799				Y	F	19	4	Fishing cape: Otto's Grotto
 1248 3725 0		9810;9811				Y	F	19	4	Farming cape: Teleport
@@ -255,25 +258,25 @@
 # Quest point cape (instead of using the item name we use the action teleport, we use the itemids to verifiy the item)										
 2728 3347 0		9813;13068				Y	F	19	4	Quest point cape: Teleport
 2689 3547 0		13221;13222				Y	F	19	4	Music cape: Teleport
-2574 3323 0		13069;19476				Y	F	19	4	1. Achievement diary cape: Two-pints
-3302 3122 0		13069;19476				Y	F	19	4	2. Achievement diary cape: Jarr
-2978 3347 0		13069;19476				Y	F	19	4	3. Achievement diary cape: Sir Rebral
-#2689 3547 0		13069;19476				Y	F	19	4	4. Achievement diary cape: Thorodin
-#2978 3347 0		13069;19476				Y	F	19	4	3. Achievement diary cape: Sir Rebral
-2659 3627 0		13069;19476				Y	F	19	4	4. Achievement diary cape: Thorodin
-2744 3443 0		13069;19476				Y	F	19	4	5. Achievement diary cape: Flax keeper
-2808 3192 0		13069;19476				Y	F	19	4	6. Achievement diary cape: Pirate Jackie the Fruit
+2574 3323 0		13069;19476				Y	F	19	4	Achievement diary cape: Two-pints
+3302 3122 0		13069;19476				Y	F	19	4	Achievement diary cape: Jarr
+2978 3347 0		13069;19476				Y	F	19	4	Achievement diary cape: Sir Rebral
+#2689 3547 0		13069;19476				Y	F	19	4	Achievement diary cape: Thorodin
+#2978 3347 0		13069;19476				Y	F	19	4	Achievement diary cape: Sir Rebral
+2659 3627 0		13069;19476				Y	F	19	4	Achievement diary cape: Thorodin
+2744 3443 0		13069;19476				Y	F	19	4	Achievement diary cape: Flax keeper
+2808 3192 0		13069;19476				Y	F	19	4	Achievement diary cape: Pirate Jackie the Fruit
 # The wiki lists these as (retired), so they are left out										
-#2862 2997 0		13069;19476				Y	F	19	4	7. Achievement diary cape: Kaleb Paramaya
-#2795 2947 0		13069;19476				Y	F	19	4	8. Achievement diary cape: Jungle forester
-#2453 5133 0		13069;19476				Y	F	19	4	9. Achievement diary cape: TzHaar-Mej
-1648 3665 0		13069;19476				Y	F	19	4	A. Achievement diary cape: Elise
-3234 3214 0		13069;19476				Y	F	19	4	B. Achievement diary cape: Hatius Cosaintus
-3465 3478 0		13069;19476				Y	F	19	4	C. Achievement diary cape: Le-sabrè
-3225 3415 0		13069;19476				Y	F	19	4	D. Achievement diary cape: Toby
-3121 3516 0		13069;19476				Y	F	19	4	E. Achievement diary cape: Lesser Fanatic
-2467 3459 0		13069;19476				Y	F	19	4	F. Achievement diary cape: Elder Gnome child
-3096 3227 0		13069;19476				Y	F	19	4	G. Achievement diary cape: Twiggy O'Korn
+#2862 2997 0		13069;19476				Y	F	19	4	Achievement diary cape: Kaleb Paramaya
+#2795 2947 0		13069;19476				Y	F	19	4	Achievement diary cape: Jungle forester
+#2453 5133 0		13069;19476				Y	F	19	4	Achievement diary cape: TzHaar-Mej
+1648 3665 0		13069;19476				Y	F	19	4	Achievement diary cape: Elise
+3234 3214 0		13069;19476				Y	F	19	4	Achievement diary cape: Hatius Cosaintus
+3465 3478 0		13069;19476				Y	F	19	4	Achievement diary cape: Le-sabrè
+3225 3415 0		13069;19476				Y	F	19	4	Achievement diary cape: Toby
+3121 3516 0		13069;19476				Y	F	19	4	Achievement diary cape: Lesser Fanatic
+2467 3459 0		13069;19476				Y	F	19	4	Achievement diary cape: Elder Gnome child
+3096 3227 0		13069;19476				Y	F	19	4	Achievement diary cape: Twiggy O'Korn
 										
 # Quest Items										
 # Ectophial - includes the empty version										
@@ -285,26 +288,26 @@
 2465 3495 0		19564				Y	F	29	4	Royal seed pod
 2465 3495 0		9469				Y	T	29	4	Grand seed pod
 # Enchanted lyre - 4493 is DIARY_FREMENNIK_HARD, 4494 is DIARY_FREMENNIK_ELITE										
-2662 3644 0		3691;6125;6126;6127;13079				Y	T	19	4	1. Enchanted lyre: Rellekka
-2551 3755 0		3691;6125;6126;6127;13079		4493=1		Y	T	19	4	2. Enchanted lyre: Waterbirth Island
-2409 3809 0		3691;6125;6126;6127;13079		4494=1		Y	T	19	4	3. Enchanted lyre: Jatizso
-2336 3802 0		3691;6125;6126;6127;13079		4494=1		Y	T	19	4	4. Enchanted lyre: Neitiznot
-2662 3644 0		23458				Y	F	19	4	1. Enchanted lyre(i): Rellekka
-2551 3755 0		23458		4493=1		Y	F	19	4	2. Enchanted lyre(i): Waterbirth Island
-2409 3809 0		23458		4494=1		Y	F	19	4	3. Enchanted lyre(i): Jatizso
-2336 3802 0		23458		4494=1		Y	F	19	4	4. Enchanted lyre(i): Neitiznot
-3105 9315 2		6707		1574>0		Y	F	19	4	1. Camulet: Enakhra's Temple
-3191 2924 0		6707		4485=1;1574>0		Y	F	19	4	2. Camulet: Enakhra's Temple Entrance
-1713 3612 0		21760	The Depths of Despair	6028=1;6035>1		Y	T	19	4	1. Kharedst's memoirs: Lunch by the Lancalliums
-1802 3748 0		21760	The Queen of Thieves	6038=1;6035>1		Y	T	19	4	2. Kharedst's memoirs: The Fisher's Flute
-1478 3576 0		21760	Tale of the Righteous	6359=1;6035>1		Y	T	19	4	3. Kharedst's memoirs: History and Hearsay
-1544 3762 0		21760	The Forsaken Tower	7801=1;6035>1		Y	T	19	4	4. Kharedst's memoirs: Jewellery of Jubilation
-1680 3746 0		21760	The Ascent of Arceuus	7857=1;6035>1		Y	T	19	4	5. Kharedst's memoirs: A Dark Disposition
-1713 3612 0		25818	The Depths of Despair	6028=1;6035>1		Y	T	19	4	1. Book of the dead: Lunch by the Lancalliums
-1802 3748 0		25818	The Queen of Thieves	6038=1;6035>1		Y	T	19	4	2. Book of the dead: The Fisher's Flute
-1478 3576 0		25818	Tale of the Righteous	6359=1;6035>1		Y	T	19	4	3. Book of the dead: History and Hearsay
-1544 3762 0		25818	The Forsaken Tower	7801=1;6035>1		Y	T	19	4	4. Book of the dead: Jewellery of Jubilation
-1680 3746 0		25818	The Ascent of Arceuus	7857=1;6035>1		Y	T	19	4	5. Book of the dead: A Dark Disposition
+2662 3644 0		3691;6125;6126;6127;13079				Y	T	19	4	Enchanted lyre: Rellekka
+2551 3755 0		3691;6125;6126;6127;13079		4493=1		Y	T	19	4	Enchanted lyre: Waterbirth Island
+2409 3809 0		3691;6125;6126;6127;13079		4494=1		Y	T	19	4	Enchanted lyre: Jatizso
+2336 3802 0		3691;6125;6126;6127;13079		4494=1		Y	T	19	4	Enchanted lyre: Neitiznot
+2662 3644 0		23458				Y	F	19	4	Enchanted lyre(i): Rellekka
+2551 3755 0		23458		4493=1		Y	F	19	4	Enchanted lyre(i): Waterbirth Island
+2409 3809 0		23458		4494=1		Y	F	19	4	Enchanted lyre(i): Jatizso
+2336 3802 0		23458		4494=1		Y	F	19	4	Enchanted lyre(i): Neitiznot
+3105 9315 2		6707		1574>0		Y	F	19	4	Camulet: Enakhra's Temple
+3191 2924 0		6707		4485=1;1574>0		Y	F	19	4	Camulet: Enakhra's Temple Entrance
+1713 3612 0		21760	The Depths of Despair	6028=1;6035>1		Y	T	19	4	Kharedst's memoirs: Lunch by the Lancalliums
+1802 3748 0		21760	The Queen of Thieves	6038=1;6035>1		Y	T	19	4	Kharedst's memoirs: The Fisher's Flute
+1478 3576 0		21760	Tale of the Righteous	6359=1;6035>1		Y	T	19	4	Kharedst's memoirs: History and Hearsay
+1544 3762 0		21760	The Forsaken Tower	7801=1;6035>1		Y	T	19	4	Kharedst's memoirs: Jewellery of Jubilation
+1680 3746 0		21760	The Ascent of Arceuus	7857=1;6035>1		Y	T	19	4	Kharedst's memoirs: A Dark Disposition
+1713 3612 0		25818	The Depths of Despair	6028=1;6035>1		Y	T	19	4	Book of the dead: Lunch by the Lancalliums
+1802 3748 0		25818	The Queen of Thieves	6038=1;6035>1		Y	T	19	4	Book of the dead: The Fisher's Flute
+1478 3576 0		25818	Tale of the Righteous	6359=1;6035>1		Y	T	19	4	Book of the dead: History and Hearsay
+1544 3762 0		25818	The Forsaken Tower	7801=1;6035>1		Y	T	19	4	Book of the dead: Jewellery of Jubilation
+1680 3746 0		25818	The Ascent of Arceuus	7857=1;6035>1		Y	T	19	4	Book of the dead: A Dark Disposition
 3649 3230 0		22400				Y	F	19	4	Drakan's medallion: Ver Sinhaza
 3592 3337 0		22400	Sins of the Father			Y	F	19	4	Drakan's medallion: Darkmeyer
 # todo: this only works if you've used a Slepey tablet on the medallion										
@@ -314,7 +317,7 @@
 # Stony Basalt - 4493 is DIARY_FREMENNIK_HARD										
 2845 3694 0		22601				Y	T	19	4	Stony basalt: Troll Stronghold
 2837 3695 0	73 Agility	22601		4493=1		Y	T	19	4	Stony basalt: Troll Stronghold
-2846 3938 0		22599				Y	T	19	4	Icy basalt
+2846 3938 0		22599				Y	T	19	4	Icy basalt: Weiss
 										
 # Other										
 1934 4428 0		26948				Y	T	19	4	Pharaoh's sceptre: Jalsavrah
@@ -322,18 +325,18 @@
 3232 2897 0		26948				Y	T	19	4	Pharaoh's sceptre: Jaldraocht
 3313 2718 0		26948				Y	T	19	4	Pharaoh's sceptre: Jaltevas
 3081 3421 0		9013;21276					T	19	4	Skull sceptre
-1579 3530 0		13393				Y	T	19	4	1. Xeric's talisman: Xeric's Lookout
-1752 3566 0		13393				Y	T	19	4	2. Xeric's talisman: Xeric's Glade
-1504 3815 0		13393				Y	T	19	4	3. Xeric's talisman: Xeric's Inferno
-1644 3673 0		13393				Y	T	19	4	4. Xeric's talisman: Xeric's Heart
+1579 3530 0		13393				Y	T	19	4	Xeric's talisman: Xeric's Lookout
+1752 3566 0		13393				Y	T	19	4	Xeric's talisman: Xeric's Glade
+1504 3815 0		13393				Y	T	19	4	Xeric's talisman: Xeric's Inferno
+1644 3673 0		13393				Y	T	19	4	Xeric's talisman: Xeric's Heart
 # Requires the use of an ancient tablet to activate										
-# 1254 3560 0		13393				Y	T	19	4	5. Xeric's talisman: Xeric's Honour
+# 1254 3560 0		13393				Y	T	19	4	Xeric's talisman: Xeric's Honour
 3200 3355 0		13660					T	19	4	Chronicle: Teleport
 3615 9461 0		26914				Y	F	19	4	Amulet of the eye: Teleport
-2981 3276 0		26818				Y	T	19	4	1. Ring of the elements: Air Altar
-3170 3155 0		26818				Y	T	19	4	2. Ring of the elements: Water Altar
-3288 3468 0		26818				Y	T	19	4	3. Ring of the elements: Earth Altar
-3314 3279 0		26818				Y	T	19	4	4. Ring of the elements: Fire Altar
+2981 3276 0		26818				Y	T	19	4	Ring of the elements: Air Altar
+3170 3155 0		26818				Y	T	19	4	Ring of the elements: Water Altar
+3288 3468 0		26818				Y	T	19	4	Ring of the elements: Earth Altar
+3314 3279 0		26818				Y	T	19	4	Ring of the elements: Fire Altar
 2400 5982 0		24709				Y	T	19	4	Hallowed crystal shard
 3296 6436 0		28327				Y	T	19	4	Ring of shadows: Ancient Vault
 # todo: The remaining Ring of shadows teleports require using a tablet on it once										


### PR DESCRIPTION
Make sure every item that does not use a generic keyword to teleport has the proper action as part of the Display Info