### PR TITLE
fix(WebWalker): fix action matching for equipment items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/equipment/Rs2Equipment.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/equipment/Rs2Equipment.java
@@ -319,7 +319,7 @@ public class Rs2Equipment {
             identifier = -1;
             List<String> actions = rs2Item.getEquipmentActions();
             for (int i = 0; i < actions.size(); i++) {
-                if (action.equalsIgnoreCase(actions.get(i))) {
+                if (actions.get(i).toLowerCase().contains(action.toLowerCase())) {
                     identifier = i + 2;
                     break;
                 }


### PR DESCRIPTION

Inventory items are already using a contains check. 

This allows the bug fix from  #1574 to also work with equipped items.

Improvements to equipment action matching:

* Changed the action matching condition in `invokeMenu` so that it now checks if the equipment action contains the input string (case-insensitive), rather than requiring an exact match. This allows for partial matches.