### PR TITLE
feat: persist antiban settings per profile

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/AntibanPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/AntibanPlugin.java
@@ -160,6 +160,7 @@ public class AntibanPlugin extends Plugin {
                 .panel(panel)
                 .build();
         Rs2AntibanSettings.reset();
+        Rs2AntibanSettings.loadFromProfile();
         validateAndSetBreakDurations();
 
         Timer timer = new Timer();
@@ -190,6 +191,8 @@ public class AntibanPlugin extends Plugin {
     @Subscribe
     public void onProfileChanged(ProfileChanged event) {
         Rs2Antiban.resetAntibanSettings();
+        Rs2AntibanSettings.loadFromProfile();
+        validateAndSetBreakDurations();
     }
 
     @Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/Rs2AntibanSettings.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/Rs2AntibanSettings.java
@@ -1,5 +1,11 @@
 package net.runelite.client.plugins.microbot.util.antiban;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.microbot.Microbot;
+
 /**
  * Provides configuration settings for the anti-ban system used by various plugins within the bot framework.
  *
@@ -73,7 +79,199 @@ package net.runelite.client.plugins.microbot.util.antiban;
  * </pre>
  */
 
+@Slf4j
 public class Rs2AntibanSettings {
+    private static final String CONFIG_GROUP = "MicrobotAntiban";
+    private static final String CONFIG_KEY = "settings";
+    private static final Gson GSON = new Gson();
+
+    private Rs2AntibanSettings() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    private static class PersistentSettings {
+        private Boolean antibanEnabled;
+        private Boolean usePlayStyle;
+        private Boolean randomIntervals;
+        private Boolean simulateFatigue;
+        private Boolean simulateAttentionSpan;
+        private Boolean behavioralVariability;
+        private Boolean nonLinearIntervals;
+        private Boolean profileSwitching;
+        private Boolean timeOfDayAdjust;
+        private Boolean simulateMistakes;
+        private Boolean naturalMouse;
+        private Boolean moveMouseOffScreen;
+        private Boolean moveMouseRandomly;
+        private Boolean contextualVariability;
+        private Boolean dynamicIntensity;
+        private Boolean dynamicActivity;
+        private Boolean devDebug;
+        private Boolean overwriteScriptSettings;
+        private Boolean takeMicroBreaks;
+        private Boolean playSchedule;
+        private Boolean universalAntiban;
+        private Integer microBreakDurationLow;
+        private Integer microBreakDurationHigh;
+        private Double actionCooldownChance;
+        private Double microBreakChance;
+        private Double moveMouseRandomlyChance;
+        private Double moveMouseOffScreenChance;
+    }
+
+    public static void saveToProfile() {
+        ConfigManager configManager = Microbot.getConfigManager();
+        if (configManager == null) {
+            log.debug("ConfigManager not available, skipping antiban settings save");
+            return;
+        }
+
+        PersistentSettings settings = snapshot();
+        try {
+            configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY, GSON.toJson(settings));
+        } catch (Exception ex) {
+            log.warn("Unable to save antiban settings to profile", ex);
+        }
+    }
+
+    public static void loadFromProfile() {
+        ConfigManager configManager = Microbot.getConfigManager();
+        if (configManager == null) {
+            log.debug("ConfigManager not available, skipping antiban settings load");
+            return;
+        }
+
+        String json = configManager.getConfiguration(CONFIG_GROUP, CONFIG_KEY);
+        if (json == null || json.isEmpty()) {
+            return;
+        }
+
+        try {
+            PersistentSettings settings = GSON.fromJson(json, PersistentSettings.class);
+            if (settings != null) {
+                apply(settings);
+            }
+        } catch (JsonSyntaxException ex) {
+            log.warn("Unable to parse antiban settings from profile", ex);
+        }
+    }
+
+    private static PersistentSettings snapshot() {
+        PersistentSettings settings = new PersistentSettings();
+        settings.antibanEnabled = antibanEnabled;
+        settings.usePlayStyle = usePlayStyle;
+        settings.randomIntervals = randomIntervals;
+        settings.simulateFatigue = simulateFatigue;
+        settings.simulateAttentionSpan = simulateAttentionSpan;
+        settings.behavioralVariability = behavioralVariability;
+        settings.nonLinearIntervals = nonLinearIntervals;
+        settings.profileSwitching = profileSwitching;
+        settings.timeOfDayAdjust = timeOfDayAdjust;
+        settings.simulateMistakes = simulateMistakes;
+        settings.naturalMouse = naturalMouse;
+        settings.moveMouseOffScreen = moveMouseOffScreen;
+        settings.moveMouseRandomly = moveMouseRandomly;
+        settings.contextualVariability = contextualVariability;
+        settings.dynamicIntensity = dynamicIntensity;
+        settings.dynamicActivity = dynamicActivity;
+        settings.devDebug = devDebug;
+        settings.overwriteScriptSettings = overwriteScriptSettings;
+        settings.takeMicroBreaks = takeMicroBreaks;
+        settings.playSchedule = playSchedule;
+        settings.universalAntiban = universalAntiban;
+        settings.microBreakDurationLow = microBreakDurationLow;
+        settings.microBreakDurationHigh = microBreakDurationHigh;
+        settings.actionCooldownChance = actionCooldownChance;
+        settings.microBreakChance = microBreakChance;
+        settings.moveMouseRandomlyChance = moveMouseRandomlyChance;
+        settings.moveMouseOffScreenChance = moveMouseOffScreenChance;
+        return settings;
+    }
+
+    private static void apply(PersistentSettings settings) {
+        if (settings.antibanEnabled != null) {
+            antibanEnabled = settings.antibanEnabled;
+        }
+        if (settings.usePlayStyle != null) {
+            usePlayStyle = settings.usePlayStyle;
+        }
+        if (settings.randomIntervals != null) {
+            randomIntervals = settings.randomIntervals;
+        }
+        if (settings.simulateFatigue != null) {
+            simulateFatigue = settings.simulateFatigue;
+        }
+        if (settings.simulateAttentionSpan != null) {
+            simulateAttentionSpan = settings.simulateAttentionSpan;
+        }
+        if (settings.behavioralVariability != null) {
+            behavioralVariability = settings.behavioralVariability;
+        }
+        if (settings.nonLinearIntervals != null) {
+            nonLinearIntervals = settings.nonLinearIntervals;
+        }
+        if (settings.profileSwitching != null) {
+            profileSwitching = settings.profileSwitching;
+        }
+        if (settings.timeOfDayAdjust != null) {
+            timeOfDayAdjust = settings.timeOfDayAdjust;
+        }
+        if (settings.simulateMistakes != null) {
+            simulateMistakes = settings.simulateMistakes;
+        }
+        if (settings.naturalMouse != null) {
+            naturalMouse = settings.naturalMouse;
+        }
+        if (settings.moveMouseOffScreen != null) {
+            moveMouseOffScreen = settings.moveMouseOffScreen;
+        }
+        if (settings.moveMouseRandomly != null) {
+            moveMouseRandomly = settings.moveMouseRandomly;
+        }
+        if (settings.contextualVariability != null) {
+            contextualVariability = settings.contextualVariability;
+        }
+        if (settings.dynamicIntensity != null) {
+            dynamicIntensity = settings.dynamicIntensity;
+        }
+        if (settings.dynamicActivity != null) {
+            dynamicActivity = settings.dynamicActivity;
+        }
+        if (settings.devDebug != null) {
+            devDebug = settings.devDebug;
+        }
+        if (settings.overwriteScriptSettings != null) {
+            overwriteScriptSettings = settings.overwriteScriptSettings;
+        }
+        if (settings.takeMicroBreaks != null) {
+            takeMicroBreaks = settings.takeMicroBreaks;
+        }
+        if (settings.playSchedule != null) {
+            playSchedule = settings.playSchedule;
+        }
+        if (settings.universalAntiban != null) {
+            universalAntiban = settings.universalAntiban;
+        }
+        if (settings.microBreakDurationLow != null) {
+            microBreakDurationLow = settings.microBreakDurationLow;
+        }
+        if (settings.microBreakDurationHigh != null) {
+            microBreakDurationHigh = settings.microBreakDurationHigh;
+        }
+        if (settings.actionCooldownChance != null) {
+            actionCooldownChance = settings.actionCooldownChance;
+        }
+        if (settings.microBreakChance != null) {
+            microBreakChance = settings.microBreakChance;
+        }
+        if (settings.moveMouseRandomlyChance != null) {
+            moveMouseRandomlyChance = settings.moveMouseRandomlyChance;
+        }
+        if (settings.moveMouseOffScreenChance != null) {
+            moveMouseOffScreenChance = settings.moveMouseOffScreenChance;
+        }
+    }
+
     public static boolean actionCooldownActive = false;
     public static boolean microBreakActive = false;
     public static boolean antibanEnabled = true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/ActivityPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/ActivityPanel.java
@@ -49,14 +49,38 @@ public class ActivityPanel extends JPanel {
     }
 
     private void setupActionListeners() {
-        usePlayStyle.addActionListener(e -> Rs2AntibanSettings.usePlayStyle = usePlayStyle.isSelected());
-        useRandomIntervals.addActionListener(e -> Rs2AntibanSettings.randomIntervals = useRandomIntervals.isSelected());
-        simulateFatigue.addActionListener(e -> Rs2AntibanSettings.simulateFatigue = simulateFatigue.isSelected());
-        simulateAttentionSpan.addActionListener(e -> Rs2AntibanSettings.simulateAttentionSpan = simulateAttentionSpan.isSelected());
-        useBehavioralVariability.addActionListener(e -> Rs2AntibanSettings.behavioralVariability = useBehavioralVariability.isSelected());
-        useNonLinearIntervals.addActionListener(e -> Rs2AntibanSettings.nonLinearIntervals = useNonLinearIntervals.isSelected());
-        dynamicActivityIntensity.addActionListener(e -> Rs2AntibanSettings.dynamicIntensity = dynamicActivityIntensity.isSelected());
-        dynamicActivity.addActionListener(e -> Rs2AntibanSettings.dynamicActivity = dynamicActivity.isSelected());
+        usePlayStyle.addActionListener(e -> {
+            Rs2AntibanSettings.usePlayStyle = usePlayStyle.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        useRandomIntervals.addActionListener(e -> {
+            Rs2AntibanSettings.randomIntervals = useRandomIntervals.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        simulateFatigue.addActionListener(e -> {
+            Rs2AntibanSettings.simulateFatigue = simulateFatigue.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        simulateAttentionSpan.addActionListener(e -> {
+            Rs2AntibanSettings.simulateAttentionSpan = simulateAttentionSpan.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        useBehavioralVariability.addActionListener(e -> {
+            Rs2AntibanSettings.behavioralVariability = useBehavioralVariability.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        useNonLinearIntervals.addActionListener(e -> {
+            Rs2AntibanSettings.nonLinearIntervals = useNonLinearIntervals.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        dynamicActivityIntensity.addActionListener(e -> {
+            Rs2AntibanSettings.dynamicIntensity = dynamicActivityIntensity.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        dynamicActivity.addActionListener(e -> {
+            Rs2AntibanSettings.dynamicActivity = dynamicActivity.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
 
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/CooldownPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/CooldownPanel.java
@@ -61,6 +61,9 @@ public class CooldownPanel extends JPanel {
         actionCooldownChance.addChangeListener(e -> {
             Rs2AntibanSettings.actionCooldownChance = actionCooldownChance.getValue() / 100.0;
             actionCooldownChanceLabel.setText("Action Cooldown Chance (%): " + actionCooldownChance.getValue());
+            if (!actionCooldownChance.getValueIsAdjusting()) {
+                Rs2AntibanSettings.saveToProfile();
+            }
         });
         timeout.addChangeListener(e -> {
             Rs2Antiban.setTIMEOUT(timeout.getValue());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/GeneralPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/GeneralPanel.java
@@ -57,12 +57,30 @@ public class GeneralPanel extends JPanel {
     }
 
     private void setupActionListeners() {
-        isEnabled.addActionListener(e -> Rs2AntibanSettings.antibanEnabled = isEnabled.isSelected());
-        universalAntiban.addActionListener(e -> Rs2AntibanSettings.universalAntiban = universalAntiban.isSelected());
-        useContextualVariability.addActionListener(e -> Rs2AntibanSettings.contextualVariability = useContextualVariability.isSelected());
-        devDebug.addActionListener(e -> Rs2AntibanSettings.devDebug = devDebug.isSelected());
-        overwriteScriptSetting.addActionListener(e -> Rs2AntibanSettings.overwriteScriptSettings = overwriteScriptSetting.isSelected());
-        universalAntibanSettings.addActionListener(e -> Rs2Antiban.antibanSetupTemplates.applyUniversalAntibanSetup());
+        isEnabled.addActionListener(e -> {
+            Rs2AntibanSettings.antibanEnabled = isEnabled.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        universalAntiban.addActionListener(e -> {
+            Rs2AntibanSettings.universalAntiban = universalAntiban.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        useContextualVariability.addActionListener(e -> {
+            Rs2AntibanSettings.contextualVariability = useContextualVariability.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        devDebug.addActionListener(e -> {
+            Rs2AntibanSettings.devDebug = devDebug.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        overwriteScriptSetting.addActionListener(e -> {
+            Rs2AntibanSettings.overwriteScriptSettings = overwriteScriptSetting.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        universalAntibanSettings.addActionListener(e -> {
+            Rs2Antiban.antibanSetupTemplates.applyUniversalAntibanSetup();
+            Rs2AntibanSettings.saveToProfile();
+        });
     }
 
     public void updateValues() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/MasterPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/MasterPanel.java
@@ -3,6 +3,7 @@ package net.runelite.client.plugins.microbot.util.antiban.ui;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.antiban.AntibanPlugin;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.ImageUtil;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/MasterPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/MasterPanel.java
@@ -180,6 +180,7 @@ public class MasterPanel extends PluginPanel {
     public void setupResetButton() {
         resetButton.addActionListener(e -> {
             Rs2Antiban.resetAntibanSettings(true);
+            Rs2AntibanSettings.saveToProfile();
             loadSettings();
         });
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/MicroBreakPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/MicroBreakPanel.java
@@ -75,18 +75,30 @@ public class MicroBreakPanel extends JPanel {
 
     private void setupActionListeners() {
         isMicroBreakActive.addActionListener(e -> Rs2AntibanSettings.microBreakActive = isMicroBreakActive.isSelected());
-        takeMicroBreaks.addActionListener(e -> Rs2AntibanSettings.takeMicroBreaks = takeMicroBreaks.isSelected());
+        takeMicroBreaks.addActionListener(e -> {
+            Rs2AntibanSettings.takeMicroBreaks = takeMicroBreaks.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
         microBreakDurationLow.addChangeListener(e -> {
             Rs2AntibanSettings.microBreakDurationLow = microBreakDurationLow.getValue();
             microBreakDurationLowLabel.setText("Micro Break Duration Low (min): " + microBreakDurationLow.getValue());
+            if (!microBreakDurationLow.getValueIsAdjusting()) {
+                Rs2AntibanSettings.saveToProfile();
+            }
         });
         microBreakDurationHigh.addChangeListener(e -> {
             Rs2AntibanSettings.microBreakDurationHigh = microBreakDurationHigh.getValue();
             microBreakDurationHighLabel.setText("Micro Break Duration High (min): " + microBreakDurationHigh.getValue());
+            if (!microBreakDurationHigh.getValueIsAdjusting()) {
+                Rs2AntibanSettings.saveToProfile();
+            }
         });
         microBreakChance.addChangeListener(e -> {
             Rs2AntibanSettings.microBreakChance = microBreakChance.getValue() / 100.0;
             microBreakChanceLabel.setText("Micro Break Chance (%): " + microBreakChance.getValue());
+            if (!microBreakChance.getValueIsAdjusting()) {
+                Rs2AntibanSettings.saveToProfile();
+            }
         });
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/MousePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/MousePanel.java
@@ -89,17 +89,35 @@ public class MousePanel extends JPanel
 
     private void setupActionListeners()
     {
-        useNaturalMouse.addActionListener(e -> Rs2AntibanSettings.naturalMouse = useNaturalMouse.isSelected());
-        simulateMistakes.addActionListener(e -> Rs2AntibanSettings.simulateMistakes = simulateMistakes.isSelected());
-        moveMouseOffScreen.addActionListener(e -> Rs2AntibanSettings.moveMouseOffScreen = moveMouseOffScreen.isSelected());
+        useNaturalMouse.addActionListener(e -> {
+            Rs2AntibanSettings.naturalMouse = useNaturalMouse.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        simulateMistakes.addActionListener(e -> {
+            Rs2AntibanSettings.simulateMistakes = simulateMistakes.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        moveMouseOffScreen.addActionListener(e -> {
+            Rs2AntibanSettings.moveMouseOffScreen = moveMouseOffScreen.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
         moveMouseOffScreenChance.addChangeListener(e -> {
             Rs2AntibanSettings.moveMouseOffScreenChance = moveMouseOffScreenChance.getValue() / 100.0;
             moveMouseOffScreenChanceLabel.setText("Move Mouse Off Screen (%): " + moveMouseOffScreenChance.getValue());
+            if (!moveMouseOffScreenChance.getValueIsAdjusting()) {
+                Rs2AntibanSettings.saveToProfile();
+            }
         });
-        moveMouseRandomly.addActionListener(e -> Rs2AntibanSettings.moveMouseRandomly = moveMouseRandomly.isSelected());
+        moveMouseRandomly.addActionListener(e -> {
+            Rs2AntibanSettings.moveMouseRandomly = moveMouseRandomly.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
         moveMouseRandomlyChance.addChangeListener(e -> {
             Rs2AntibanSettings.moveMouseRandomlyChance = moveMouseRandomlyChance.getValue() / 100.0;
             moveMouseRandomlyChanceLabel.setText("Random Mouse Movement (%): " + moveMouseRandomlyChance.getValue());
+            if (!moveMouseRandomlyChance.getValueIsAdjusting()) {
+                Rs2AntibanSettings.saveToProfile();
+            }
         });
 
         // 3) When mouseSpeedSlider changes, update the ActivityIntensity

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/ProfilePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/ProfilePanel.java
@@ -41,9 +41,18 @@ public class ProfilePanel extends JPanel {
     }
 
     private void setupActionListeners() {
-        enableProfileSwitching.addActionListener(e -> Rs2AntibanSettings.profileSwitching = enableProfileSwitching.isSelected());
-        adjustForTimeOfDay.addActionListener(e -> Rs2AntibanSettings.timeOfDayAdjust = adjustForTimeOfDay.isSelected());
-        simulatePlaySchedule.addActionListener(e -> Rs2AntibanSettings.playSchedule = simulatePlaySchedule.isSelected());
+        enableProfileSwitching.addActionListener(e -> {
+            Rs2AntibanSettings.profileSwitching = enableProfileSwitching.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        adjustForTimeOfDay.addActionListener(e -> {
+            Rs2AntibanSettings.timeOfDayAdjust = adjustForTimeOfDay.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
+        simulatePlaySchedule.addActionListener(e -> {
+            Rs2AntibanSettings.playSchedule = simulatePlaySchedule.isSelected();
+            Rs2AntibanSettings.saveToProfile();
+        });
 
     }
 


### PR DESCRIPTION
## Summary
- add JSON-based persistence for antiban settings scoped to the active config profile
- reload saved antiban settings when the plugin starts or the RuneLite profile changes
- update antiban UI controls to save changes back to the profile whenever toggles or sliders are adjusted

## Testing
- `mvn -pl runelite-client -am -DskipTests compile` *(fails: repository access to com.google.inject:guice-bom is forbidden in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69104ffba54083289a529a0590fccefb)