### PR TITLE
Add toggles for microbot blocking events

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotConfig.java
@@ -20,6 +20,32 @@ public interface MicrobotConfig extends Config
 	)
 	String generalSection = "generalSection";
 
+	String keyDisableLevelUpInterface = "disableLevelUpInterface";
+	@ConfigItem(
+		keyName = keyDisableLevelUpInterface,
+		name = "Disable level-up interface",
+		description = "Automatically close the level-up interface when it appears",
+		position = 0,
+		section = generalSection
+	)
+	default boolean disableLevelUpInterface()
+	{
+		return true;
+	}
+
+	String keyDisableWorldSwitcherConfirmation = "disableWorldSwitcherConfirmation";
+	@ConfigItem(
+		keyName = keyDisableWorldSwitcherConfirmation,
+		name = "Disable world switcher confirmation",
+		description = "Automatically disable the world switcher confirmation prompt",
+		position = 1,
+		section = generalSection
+	)
+	default boolean disableWorldSwitcherConfirmation()
+	{
+		return true;
+	}
+
 	@ConfigSection(
 		name = "Logging",
 		description = "Game chat logging configuration",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DisableLevelUpInterfaceEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DisableLevelUpInterfaceEvent.java
@@ -1,28 +1,50 @@
 package net.runelite.client.plugins.microbot.util.events;
 
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.microbot.BlockingEvent;
 import net.runelite.client.plugins.microbot.BlockingEventPriority;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.MicrobotConfig;
 import net.runelite.client.plugins.microbot.util.settings.Rs2Settings;
 
 public class DisableLevelUpInterfaceEvent implements BlockingEvent {
+	@Override
+	public boolean validate()
+	{
+		return isConfigEnabled() && Microbot.isLoggedIn() && Rs2Settings.isLevelUpNotificationsEnabled();
+	}
 
-    @Override
-    public boolean validate() {
-        return Microbot.isLoggedIn() && Rs2Settings.isLevelUpNotificationsEnabled();
-    }
+	@Override
+	public boolean execute()
+	{
+		if (!isConfigEnabled())
+		{
+			return true;
+		}
 
-    @Override
-    public boolean execute() {
-        var result = Rs2Settings.disableLevelUpNotifications();
-        if (result) {
-            return true;
-        }
-        return !validate();
-    }
+		var result = Rs2Settings.disableLevelUpNotifications();
+		if (result)
+		{
+			return true;
+		}
+		return !validate();
+	}
 
-    @Override
-    public BlockingEventPriority priority() {
-        return BlockingEventPriority.HIGH;
-    }
+	private boolean isConfigEnabled()
+	{
+		ConfigManager configManager = Microbot.getConfigManager();
+		if (configManager == null)
+		{
+			return true;
+		}
+
+		MicrobotConfig config = configManager.getConfig(MicrobotConfig.class);
+		return config == null || config.disableLevelUpInterface();
+	}
+
+	@Override
+	public BlockingEventPriority priority()
+	{
+		return BlockingEventPriority.HIGH;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DisableWorldSwitcherConfirmationEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DisableWorldSwitcherConfirmationEvent.java
@@ -1,8 +1,10 @@
 package net.runelite.client.plugins.microbot.util.events;
 
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.microbot.BlockingEvent;
 import net.runelite.client.plugins.microbot.BlockingEventPriority;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.MicrobotConfig;
 import net.runelite.client.plugins.microbot.util.settings.Rs2Settings;
 
 public class DisableWorldSwitcherConfirmationEvent implements BlockingEvent
@@ -10,13 +12,29 @@ public class DisableWorldSwitcherConfirmationEvent implements BlockingEvent
 	@Override
 	public boolean validate()
 	{
-		return Microbot.isLoggedIn() && Rs2Settings.isWorldSwitcherConfirmationEnabled();
+		return isConfigEnabled() && Microbot.isLoggedIn() && Rs2Settings.isWorldSwitcherConfirmationEnabled();
 	}
 
 	@Override
 	public boolean execute()
 	{
+		if (!isConfigEnabled())
+		{
+			return true;
+		}
 		return Rs2Settings.disableWorldSwitcherConfirmation();
+	}
+
+	private boolean isConfigEnabled()
+	{
+		ConfigManager configManager = Microbot.getConfigManager();
+		if (configManager == null)
+		{
+			return true;
+		}
+
+		MicrobotConfig config = configManager.getConfig(MicrobotConfig.class);
+		return config == null || config.disableWorldSwitcherConfirmation();
 	}
 
 	@Override


### PR DESCRIPTION
## Summary
- add microbot configuration options for disabling the level-up interface and world switcher confirmation
- only execute the associated blocking events when their configuration toggles are enabled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b72575f08328877e1c94734a0088)