### PR TITLE
fix(cache): update entity strategies and MicrobotPlugin for worldview…

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotPlugin.java
@@ -306,10 +306,12 @@ public class MicrobotPlugin extends Plugin
 				boolean wasLoggedIn = LoginManager.isLoggedIn();
 				if (!wasLoggedIn) {
 					LoginManager.markLoggedIn();
-					Rs2RunePouch.fullUpdate();
-					if (microbotConfig.isRs2CacheEnabled()) {
-						Rs2CacheManager.registerEventHandlers();
-					}
+					Rs2RunePouch.fullUpdate();					
+				}
+				// Check if already initialized
+				if (microbotConfig.isRs2CacheEnabled() && !Rs2CacheManager.isEventHandlersRegistered()) {
+					Rs2CacheManager.registerEventHandlers();					
+					return;
 				}
 				if (currentRegions != null) {
 					Microbot.setLastKnownRegions(currentRegions.clone());
@@ -323,7 +325,7 @@ public class MicrobotPlugin extends Plugin
 		   //Rs2CacheManager.emptyCacheState(); // should not be nessary here, handled in ClientShutdown event, 
 		   // and we also handle correct cache loading in onRuneScapeProfileChanged event
 		   LoginManager.markLoggedOut();
-		   if (microbotConfig.isRs2CacheEnabled()) {
+		   if (microbotConfig.isRs2CacheEnabled() && Rs2CacheManager.isEventHandlersRegistered()) {
 			   Rs2CacheManager.unregisterEventHandlers();
 		   }
 		   Microbot.setLastKnownRegions(null);
@@ -559,7 +561,7 @@ public class MicrobotPlugin extends Plugin
 		try {
 			// Check if already initialized
 			if (Rs2CacheManager.isEventHandlersRegistered()) {
-				log.debug("Cache system already initialized, skipping");
+				log.debug("Cache system already initialized, skipping");				
 				return;
 			}
 			
@@ -575,10 +577,10 @@ public class MicrobotPlugin extends Plugin
 			// Keep deprecated EntityCache for backward compatibility (for now)
 			//Rs2EntityCache.getInstance();
 			
-			log.info("Cache system initialized successfully with specialized caches");
+			log.info("Cache system initialized successfully");
 			log.info("Cache persistence will be loaded when RS profile becomes available");
 			log.debug("Cache statistics: {}", cacheManager.getCacheStatistics());
-			
+
 		} catch (Exception e) {
 			log.error("Failed to initialize cache system: {}", e.getMessage(), e);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/cache/strategy/entity/NpcUpdateStrategy.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/cache/strategy/entity/NpcUpdateStrategy.java
@@ -202,10 +202,16 @@ public class NpcUpdateStrategy implements CacheUpdateStrategy<Integer, Rs2NpcMod
             }
             
             Player player = Microbot.getClient().getLocalPlayer();
+            WorldView wv = null;
             if (player == null) {
-                log.debug("Cannot perform NPC scene scan - no player");
-                scanActive.set(false);
-                return;
+                wv =  (Microbot.getClient().getTopLevelWorldView());
+                if (wv == null) {
+                    log.debug("Cannot perform NPC scene scan - no world view available");
+                    scanActive.set(false);
+                    return;
+                }
+            }else {
+                wv = player.getWorldView();
             }
             
             // Build a set of all currently existing NPC indices from the scene
@@ -214,7 +220,7 @@ public class NpcUpdateStrategy implements CacheUpdateStrategy<Integer, Rs2NpcMod
             log.debug("Starting NPC scene synchronization (cache size: {})", cache.size());
             
             // Phase 1: Scan scene and add new NPCs
-            for (NPC npc : Microbot.getClient().getTopLevelWorldView().npcs()) {
+            for (NPC npc : wv.npcs()) {
                 if (npc != null && npc.getId() != -1) { // Use ID instead of getName() to avoid client thread requirement
                     currentSceneIndices.add(npc.getIndex()); // Track all scene NPCs
                     


### PR DESCRIPTION
Improves robustness of object and ground item cache updates by:

Adding fallback to top-level WorldView when player WorldView scene is null
Removing premature isLoggedIn() checks that caused event rejection
Preventing double initialization of cache event handlers
Adding diagnostic logging for cache system states
Fixes null pointer exceptions and missed cache updates during world transitions and different game states.

Files changed:

ObjectUpdateStrategy.java
GroundItemUpdateStrategy.java
MicrobotPlugin.java