### PR TITLE
Fix Ardougne Ship Transport

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/ships.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/ships.tsv
@@ -3,11 +3,11 @@
 3029 3217 0	2956 3143 1	Pay-fare;Captain Tobias;3644		30 Coins			10	Musa Point
 2956 3146 0	3032 3217 1	Pay-Fare;Customs officer;3648		30 Coins			10	Port Sarim
 # Ardougne, Brimhaven, Rimmington								
-2683 3271 0	2775 3233 1	Brimhaven;Captain Barnaby;9250		30 Coins		Y	6	Brimhaven
-2683 3271 0	2915 3221 1	Rimmington;Captain Barnaby;9250		30 Coins		Y	6	Rimmington
-2772 3234 0	2683 3268 1	Ardougne;Captain Barnaby;8764		30 Coins		Y	6	Ardougne
+2673 3275 0	2775 3233 1	Brimhaven;Captain Barnaby;9250		30 Coins		Y	6	Brimhaven
+2673 3275 0	2915 3221 1	Rimmington;Captain Barnaby;9250		30 Coins		Y	6	Rimmington
+2772 3234 0	2683 3263 1	Ardougne;Captain Barnaby;8764		30 Coins		Y	6	Ardougne
 2772 3234 0	2915 3221 1	Rimmington;Captain Barnaby;8764		30 Coins		Y	6	Rimmington
-2915 3225 0	2683 3268 1	Ardougne;Captain Barnaby;8763		30 Coins		Y	6	Ardougne
+2915 3225 0	2683 3263 1	Ardougne;Captain Barnaby;8763		30 Coins		Y	6	Ardougne
 2915 3225 0	2775 3233 1	Brimhaven;Captain Barnaby;8763		30 Coins		Y	6	Brimhaven
 # Rimmington, Corsair Cove
 2910 3226 0	2578 2837 1	Travel;Cabin Boy Colin;7967			The Corsair Curse		6	Corsair Cove

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/transports.tsv
@@ -600,9 +600,7 @@
 2650 3282 0	2650 3282 1	Climb-up;Ladder;16683								2	
 2650 3282 1	2650 3282 0	Climb-down;Ladder;16679								2	
 2649 3282 1	2649 3282 2	Climb-up;Ladder;17026								2	
-2649 3282 2	2649 3282 1	Climb-down;Ladder;16685								2	
-2683 3271 0	2683 3268 1	Cross;Gangplank;2085								3	
-2683 3268 1	2683 3271 0	Cross;Gangplank;2086								3	
+2649 3282 2	2649 3282 1	Climb-down;Ladder;16685								2
 2622 3291 0	2622 3291 1	Climb-up;Ladder;17026								2	
 2622 3291 1	2622 3291 0	Climb-down;Ladder;16685								2	
 2592 3339 0	2592 3338 0	Open;Door;2054								1	
@@ -653,7 +651,9 @@
 2674 3305 0	2674 3306 0	Pick-lock;Door;11719								2	
 2674 3303 0	2674 3304 0	Open;Door;11720								1	
 2674 3306 0	2674 3305 0	Open;Door;11719								1	
-											
+2683 3263 1	2683 3266 0	Cross;Gangplank;2086								1
+2683 3266 0	2683 3263 1	Cross;Gangplank;2085								1
+
 # Witchaven Dungeon											
 2697 3283 0	2696 9683 0	Climb-down;Old ruin entrance;18270
 2696 9683 0	2697 3283 0	Climb-up;Exit;18354


### PR DESCRIPTION
From the Sailing update, this port has changed & caused the player to be put on a ship instead of landing at the docks. Updated respective transports to facilitate this.