### PR TITLE
Fix LoginManager

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotPlugin.java
@@ -50,7 +50,6 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -304,7 +303,7 @@ public class MicrobotPlugin extends Plugin
 		   final Client client = Microbot.getClient();
 		   if (client != null) {
 				int[] currentRegions = client.getTopLevelWorldView().getMapRegions();
-				boolean wasLoggedIn = LoginManager.isLoggedIn();
+				boolean wasLoggedIn = LoginManager.getLastKnownGameState() == GameState.LOGGED_IN;
 				if (!wasLoggedIn) {
 					LoginManager.markLoggedIn();
 					Rs2RunePouch.fullUpdate();
@@ -315,7 +314,6 @@ public class MicrobotPlugin extends Plugin
 				if (currentRegions != null) {
 					Microbot.setLastKnownRegions(currentRegions.clone());
 				}
-				LoginManager.markLoggedIn();
 		   }
 	   }
 	   if (gameStateChanged.getGameState() == GameState.HOPPING || gameStateChanged.getGameState() == GameState.LOGIN_SCREEN || gameStateChanged.getGameState() == GameState.CONNECTION_LOST)
@@ -329,6 +327,8 @@ public class MicrobotPlugin extends Plugin
 		   }
 		   Microbot.setLastKnownRegions(null);
 	   }
+	   // update last known game state to track login/logout transitions
+	   LoginManager.setLastKnownGameState(gameStateChanged.getGameState());
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/security/LoginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/security/LoginManager.java
@@ -41,14 +41,17 @@ public final class LoginManager {
 	private static final AtomicReference<Instant> LAST_LOGIN_ATTEMPT = new AtomicReference<>(null);
 	private static final AtomicReference<GameState> LAST_KNOWN_GAME_STATE = new AtomicReference<>(GameState.UNKNOWN);
 
-	@Getter
-	private static AtomicReference<Instant> lastLoginTimestamp = new AtomicReference<>(null);
+	private static final AtomicReference<Instant> lastLoginTimestamp = new AtomicReference<>(null);
 
     @Setter
 	public static ConfigProfile activeProfile = null;
 
 	public static ConfigProfile getActiveProfile() {
         return Microbot.getConfigManager().getProfile();
+	}
+
+	public static Instant getLastLoginTimestamp() {
+		return lastLoginTimestamp.get();
 	}
 
 	public static GameState getLastKnownGameState() {
@@ -108,10 +111,10 @@ public final class LoginManager {
 	 * Returns the duration the account has been logged in for. Equivalent to Microbot.getLoginTime().
 	 */
 	public static Duration getLoginDuration() {
-		if (lastLoginTimestamp.get() == null || !isLoggedIn()) {
+		if (getLastLoginTimestamp() == null || !isLoggedIn()) {
 			return Duration.of(0, ChronoUnit.MILLIS);
 		}
-		return Duration.between(lastLoginTimestamp.get(), Instant.now());
+		return Duration.between(getLastLoginTimestamp(), Instant.now());
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/security/LoginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/security/LoginManager.java
@@ -39,21 +39,28 @@ public final class LoginManager {
 	private static final Object LOGIN_LOCK = new Object();
 	private static final AtomicBoolean LOGIN_ATTEMPT_ACTIVE = new AtomicBoolean(false);
 	private static final AtomicReference<Instant> LAST_LOGIN_ATTEMPT = new AtomicReference<>(null);
+	private static final AtomicReference<GameState> LAST_KNOWN_GAME_STATE = new AtomicReference<>(GameState.UNKNOWN);
 
 	@Getter
-	private static Instant lastLoginTimestamp = null;
-
+	private static AtomicReference<Instant> lastLoginTimestamp = new AtomicReference<>(null);
 
     @Setter
 	public static ConfigProfile activeProfile = null;
 
 	public static ConfigProfile getActiveProfile() {
         return Microbot.getConfigManager().getProfile();
+	}
 
+	public static GameState getLastKnownGameState() {
+		return LAST_KNOWN_GAME_STATE.get();
+	}
+
+	public static void setLastKnownGameState(GameState gameState) {
+		LAST_KNOWN_GAME_STATE.set(gameState);
 	}
 
 	private LoginManager() {
-		// Utility class
+		throw new IllegalStateException("Unable to instantiate utility class");
 	}
 
     /**
@@ -86,7 +93,7 @@ public final class LoginManager {
 		// Only set timestamp if client reports logged in.
 		if (isLoggedIn()) {
 			LOGIN_ATTEMPT_ACTIVE.set(false);
-			lastLoginTimestamp = Instant.now();
+			lastLoginTimestamp.set(Instant.now());
 		}
 	}
 
@@ -101,10 +108,10 @@ public final class LoginManager {
 	 * Returns the duration the account has been logged in for. Equivalent to Microbot.getLoginTime().
 	 */
 	public static Duration getLoginDuration() {
-		if (lastLoginTimestamp == null || !isLoggedIn()) {
+		if (lastLoginTimestamp.get() == null || !isLoggedIn()) {
 			return Duration.of(0, ChronoUnit.MILLIS);
 		}
-		return Duration.between(lastLoginTimestamp, Instant.now());
+		return Duration.between(lastLoginTimestamp.get(), Instant.now());
 	}
 
 	/**


### PR DESCRIPTION
I think this was vibed a little too hard...

### Issue
the wasLoggedIn variable inside of onGameStateChanged was changed to leverage this new class called `LoginManager.java`, when this happened, this was specifically targeting if the current GameState is LOGGED_IN, which we know is already true as if we look at MicrobotPlugin.java#L301, we have an if statement that `if (gameStateChanged.getGameState() == GameState.LOGGED_IN)`.. Due to this, this caused Rs2RunePouch.fullUpdate(); & Rs2CacheManager.registerEventHandlers(); to be unreachable.

<img width="1670" height="774" alt="idea64_OcfFkMCVIZ" src="https://github.com/user-attachments/assets/8cb2089b-7e9e-4ef1-84bf-9cc899904f56" />


### Fix
I have created a new member variable inside of the LoginManager to store the previously "known" game state by saving it at the end of the onGameStateChanged event. this way we can compare against it inside of the primary logic above. This will allow this previously unreachable logic to function & fixes the initial load of the Runepouch data.

