### PR TITLE
feat(microbot): add mouse macro recorder plugin

### DIFF
--- a/docs/api/MouseMacroRecorder.md
+++ b/docs/api/MouseMacroRecorder.md
@@ -1,0 +1,55 @@
+# Mouse Macro Recorder
+
+The Mouse Macro Recorder plugin captures mouse movements and menu entry clicks in the client so you can reuse the
+sequence later (e.g., for scripting or diagnostics).
+
+## Plugin UI
+- **Start Recording**: clears existing events and begins capturing moves/clicks.
+- **Stop Recording**: ends capture while keeping the recorded timeline.
+- **Clear**: removes all recorded events.
+- **Export JSON**: formats the current recording as JSON and copies it to the clipboard.
+
+## Recorded format
+Each event includes a timestamp offset, canvas coordinates, and (for clicks) the clicked `MenuEntry` metadata.
+
+```json
+{
+  "startedAtEpochMs": 1716220000000,
+  "events": [
+    {
+      "type": "MOVE",
+      "offsetMs": 120,
+      "x": 512,
+      "y": 338,
+      "menuEntry": null
+    },
+    {
+      "type": "CLICK",
+      "offsetMs": 420,
+      "x": 516,
+      "y": 340,
+      "menuEntry": {
+        "option": "Chop down",
+        "target": "Tree",
+        "type": "GAME_OBJECT_FIRST_OPTION",
+        "identifier": 1276,
+        "param0": 48,
+        "param1": 57,
+        "itemId": -1,
+        "itemOp": 0,
+        "worldViewId": 0,
+        "forceLeftClick": false,
+        "deprioritized": false,
+        "widgetId": null
+      }
+    }
+  ]
+}
+```
+
+## Configuration
+Movement sampling controls live under **Recording** in the plugin config:
+- **Record mouse movement**: enable or disable movement tracking.
+- **Movement sample interval (ms)**: minimum time between recorded move events.
+- **Movement min distance**: minimum pixel distance for a movement sample to be kept.
+- **Max recorded events**: stops recording after reaching the limit.

--- a/docs/development.md
+++ b/docs/development.md
@@ -52,6 +52,7 @@ Everything that will help you make scripts is under the **util** folder
 ### [Rs2MiniMap](api/Rs2MiniMap.md)
 ### [Rs2Widget](api/Rs2Widget.md)
 ### [Rs2Tile](api/Rs2Tile.md)
+### [MouseMacroRecorder](api/MouseMacroRecorder.md)
 
 ---
 
@@ -215,4 +216,3 @@ Coming soon!
 ---
 
 **Are you stuck? Join our [Discord](https://discord.gg/zaGrfqFEWE) server.**
-

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MenuEntrySnapshot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MenuEntrySnapshot.java
@@ -1,0 +1,40 @@
+package net.runelite.client.plugins.microbot.mouserecorder;
+
+import lombok.Getter;
+import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.widgets.Widget;
+
+@Getter
+public class MenuEntrySnapshot
+{
+	private final String option;
+	private final String target;
+	private final MenuAction type;
+	private final int identifier;
+	private final int param0;
+	private final int param1;
+	private final int itemId;
+	private final int itemOp;
+	private final int worldViewId;
+	private final boolean forceLeftClick;
+	private final boolean deprioritized;
+	private final Integer widgetId;
+
+	public MenuEntrySnapshot(MenuEntry entry)
+	{
+		this.option = entry.getOption();
+		this.target = entry.getTarget();
+		this.type = entry.getType();
+		this.identifier = entry.getIdentifier();
+		this.param0 = entry.getParam0();
+		this.param1 = entry.getParam1();
+		this.itemId = entry.getItemId();
+		this.itemOp = entry.getItemOp();
+		this.worldViewId = entry.getWorldViewId();
+		this.forceLeftClick = entry.isForceLeftClick();
+		this.deprioritized = entry.isDeprioritized();
+		Widget widget = entry.getWidget();
+		this.widgetId = widget != null ? widget.getId() : null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroEvent.java
@@ -1,0 +1,22 @@
+package net.runelite.client.plugins.microbot.mouserecorder;
+
+import lombok.Getter;
+
+@Getter
+public class MouseMacroEvent
+{
+	private final MouseMacroEventType type;
+	private final long offsetMs;
+	private final int x;
+	private final int y;
+	private final MenuEntrySnapshot menuEntry;
+
+	public MouseMacroEvent(MouseMacroEventType type, long offsetMs, int x, int y, MenuEntrySnapshot menuEntry)
+	{
+		this.type = type;
+		this.offsetMs = offsetMs;
+		this.x = x;
+		this.y = y;
+		this.menuEntry = menuEntry;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroEventType.java
@@ -1,0 +1,7 @@
+package net.runelite.client.plugins.microbot.mouserecorder;
+
+public enum MouseMacroEventType
+{
+	MOVE,
+	CLICK
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroRecorderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroRecorderConfig.java
@@ -1,0 +1,71 @@
+package net.runelite.client.plugins.microbot.mouserecorder;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
+
+@ConfigGroup(MouseMacroRecorderConfig.CONFIG_GROUP)
+public interface MouseMacroRecorderConfig extends Config
+{
+	String CONFIG_GROUP = "mouseMacroRecorder";
+
+	@ConfigSection(
+		name = "Recording",
+		description = "Configure how movement samples are recorded",
+		position = 0
+	)
+	String recordingSection = "recording";
+
+	@ConfigItem(
+		keyName = "recordMouseMovement",
+		name = "Record mouse movement",
+		description = "Capture mouse move/drag events",
+		position = 0,
+		section = recordingSection
+	)
+	default boolean recordMouseMovement()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "movementSampleIntervalMs",
+		name = "Movement sample interval (ms)",
+		description = "Minimum time between recorded mouse movement samples",
+		position = 1,
+		section = recordingSection
+	)
+	@Range(min = 5, max = 500)
+	default int movementSampleIntervalMs()
+	{
+		return 30;
+	}
+
+	@ConfigItem(
+		keyName = "movementMinDistance",
+		name = "Movement min distance",
+		description = "Minimum pixel distance before recording a move",
+		position = 2,
+		section = recordingSection
+	)
+	@Range(min = 0, max = 50)
+	default int movementMinDistance()
+	{
+		return 2;
+	}
+
+	@ConfigItem(
+		keyName = "maxRecordedEvents",
+		name = "Max recorded events",
+		description = "Stop recording after reaching this many events",
+		position = 3,
+		section = recordingSection
+	)
+	@Range(min = 100, max = 50000)
+	default int maxRecordedEvents()
+	{
+		return 10000;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroRecorderPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroRecorderPanel.java
@@ -1,0 +1,93 @@
+package net.runelite.client.plugins.microbot.mouserecorder;
+
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.PluginPanel;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+import java.awt.datatransfer.StringSelection;
+
+public class MouseMacroRecorderPanel extends PluginPanel
+{
+	private final JLabel statusLabel = new JLabel();
+	private final JLabel eventCountLabel = new JLabel();
+	private final JLabel moveCountLabel = new JLabel();
+	private final JLabel clickCountLabel = new JLabel();
+	private final JButton recordButton = new JButton();
+	private final JTextArea exportArea = new JTextArea();
+
+	public MouseMacroRecorderPanel(MouseMacroRecorderPlugin plugin)
+	{
+		setLayout(new BorderLayout());
+		setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		JPanel header = new JPanel();
+		header.setLayout(new BoxLayout(header, BoxLayout.Y_AXIS));
+		header.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		header.setBorder(new EmptyBorder(10, 10, 10, 10));
+
+		statusLabel.setForeground(Color.WHITE);
+		eventCountLabel.setForeground(Color.WHITE);
+		moveCountLabel.setForeground(Color.WHITE);
+		clickCountLabel.setForeground(Color.WHITE);
+
+		JPanel statusPanel = new JPanel(new GridLayout(2, 2, 8, 4));
+		statusPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		statusPanel.add(statusLabel);
+		statusPanel.add(eventCountLabel);
+		statusPanel.add(moveCountLabel);
+		statusPanel.add(clickCountLabel);
+
+		recordButton.addActionListener(actionEvent -> plugin.toggleRecording());
+
+		JButton clearButton = new JButton("Clear");
+		clearButton.addActionListener(actionEvent -> plugin.clearRecording());
+
+		JButton exportJsonButton = new JButton("Export JSON");
+		exportJsonButton.addActionListener(actionEvent -> copyToClipboard(plugin.exportJson()));
+
+		JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+		buttonPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		buttonPanel.add(recordButton);
+		buttonPanel.add(clearButton);
+		buttonPanel.add(exportJsonButton);
+
+		header.add(statusPanel);
+		header.add(Box.createVerticalStrut(8));
+		header.add(buttonPanel);
+
+		exportArea.setEditable(false);
+		exportArea.setLineWrap(true);
+		exportArea.setWrapStyleWord(true);
+		exportArea.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		exportArea.setForeground(Color.WHITE);
+		exportArea.setBorder(new EmptyBorder(10, 10, 10, 10));
+
+		add(header, BorderLayout.NORTH);
+		add(new JScrollPane(exportArea), BorderLayout.CENTER);
+
+		updateState(false, 0, 0, 0);
+	}
+
+	public void updateState(boolean recording, int totalEvents, int moveEvents, int clickEvents)
+	{
+		statusLabel.setText("Status: " + (recording ? "Recording" : "Stopped"));
+		eventCountLabel.setText("Events: " + totalEvents);
+		moveCountLabel.setText("Moves: " + moveEvents);
+		clickCountLabel.setText("Clicks: " + clickEvents);
+		recordButton.setText(recording ? "Stop Recording" : "Start Recording");
+	}
+
+	public void showExport(String export)
+	{
+		exportArea.setText(export);
+		exportArea.setCaretPosition(0);
+	}
+
+	private void copyToClipboard(String export)
+	{
+		showExport(export);
+		Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(export), null);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroRecorderPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroRecorderPlugin.java
@@ -1,0 +1,312 @@
+package net.runelite.client.plugins.microbot.mouserecorder;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.Point;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.input.MouseListener;
+import net.runelite.client.input.MouseManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.MicrobotPlugin;
+import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.util.ImageUtil;
+
+import javax.inject.Inject;
+import javax.swing.SwingUtilities;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+
+@PluginDescriptor(
+	name = "Mouse Macro Recorder",
+	description = "Record mouse movements and clicked menu entries",
+	tags = {"mouse", "macro", "recorder", "microbot"}
+)
+@Slf4j
+public class MouseMacroRecorderPlugin extends Plugin implements MouseListener
+{
+	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private ClientToolbar clientToolbar;
+
+	@Inject
+	private MouseManager mouseManager;
+
+	@Inject
+	private MouseMacroRecorderConfig config;
+
+	private final Object lock = new Object();
+	private final List<MouseMacroEvent> events = new ArrayList<>();
+	private long recordingStartMs;
+	private long lastMoveTimeMs;
+	private java.awt.Point lastMovePoint;
+	private long lastUiUpdateMs;
+	private int moveCount;
+	private int clickCount;
+	private boolean recording;
+
+	private MouseMacroRecorderPanel panel;
+	private NavigationButton navButton;
+
+	@Provides
+	MouseMacroRecorderConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(MouseMacroRecorderConfig.class);
+	}
+
+	@Override
+	protected void startUp()
+	{
+		panel = new MouseMacroRecorderPanel(this);
+
+		final BufferedImage icon = ImageUtil.loadImageResource(MicrobotPlugin.class, "microbot_config_icon_lg.png");
+		navButton = NavigationButton.builder()
+			.tooltip("Mouse Macro Recorder")
+			.icon(icon)
+			.priority(8)
+			.panel(panel)
+			.build();
+
+		clientToolbar.addNavigation(navButton);
+		mouseManager.registerMouseListener(this);
+		updatePanelState();
+	}
+
+	@Override
+	protected void shutDown()
+	{
+		mouseManager.unregisterMouseListener(this);
+		clientToolbar.removeNavigation(navButton);
+		recording = false;
+	}
+
+	public void toggleRecording()
+	{
+		if (recording)
+		{
+			stopRecording();
+			return;
+		}
+
+		startRecording();
+	}
+
+	public void startRecording()
+	{
+		synchronized (lock)
+		{
+			events.clear();
+			recordingStartMs = System.currentTimeMillis();
+			lastMoveTimeMs = 0;
+			lastMovePoint = null;
+			moveCount = 0;
+			clickCount = 0;
+			recording = true;
+		}
+		updatePanelState();
+	}
+
+	public void stopRecording()
+	{
+		recording = false;
+		updatePanelState();
+	}
+
+	public void clearRecording()
+	{
+		synchronized (lock)
+		{
+			events.clear();
+			moveCount = 0;
+			clickCount = 0;
+			recordingStartMs = System.currentTimeMillis();
+		}
+		updatePanelState();
+		panel.showExport("");
+	}
+
+	public String exportJson()
+	{
+		MouseMacroRecording snapshot;
+		synchronized (lock)
+		{
+			snapshot = new MouseMacroRecording(recordingStartMs, new ArrayList<>(events));
+		}
+		String export = GSON.toJson(snapshot);
+		panel.showExport(export);
+		return export;
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		if (!recording)
+		{
+			return;
+		}
+
+		MenuEntry menuEntry = event.getMenuEntry();
+		Point mousePosition = client.getMouseCanvasPosition();
+		if (!recordEvent())
+		{
+			return;
+		}
+
+		MenuEntrySnapshot snapshot = new MenuEntrySnapshot(menuEntry);
+		recordEvent(MouseMacroEventType.CLICK, mousePosition.getX(), mousePosition.getY(), snapshot);
+	}
+
+	@Override
+	public MouseEvent mouseMoved(MouseEvent mouseEvent)
+	{
+		recordMouseMove(mouseEvent);
+		return mouseEvent;
+	}
+
+	@Override
+	public MouseEvent mouseDragged(MouseEvent mouseEvent)
+	{
+		recordMouseMove(mouseEvent);
+		return mouseEvent;
+	}
+
+	@Override
+	public MouseEvent mouseClicked(MouseEvent mouseEvent)
+	{
+		return mouseEvent;
+	}
+
+	@Override
+	public MouseEvent mousePressed(MouseEvent mouseEvent)
+	{
+		return mouseEvent;
+	}
+
+	@Override
+	public MouseEvent mouseReleased(MouseEvent mouseEvent)
+	{
+		return mouseEvent;
+	}
+
+	@Override
+	public MouseEvent mouseEntered(MouseEvent mouseEvent)
+	{
+		return mouseEvent;
+	}
+
+	@Override
+	public MouseEvent mouseExited(MouseEvent mouseEvent)
+	{
+		return mouseEvent;
+	}
+
+	private void recordMouseMove(MouseEvent mouseEvent)
+	{
+		if (!recording || !config.recordMouseMovement())
+		{
+			return;
+		}
+
+		long now = System.currentTimeMillis();
+		if (now - lastMoveTimeMs < config.movementSampleIntervalMs())
+		{
+			return;
+		}
+
+		int minDistance = config.movementMinDistance();
+		java.awt.Point point = mouseEvent.getPoint();
+		if (lastMovePoint != null && minDistance > 0)
+		{
+			int dx = point.x - lastMovePoint.x;
+			int dy = point.y - lastMovePoint.y;
+			if (dx * dx + dy * dy < minDistance * minDistance)
+			{
+				return;
+			}
+		}
+
+		if (!recordEvent())
+		{
+			return;
+		}
+
+		recordEvent(MouseMacroEventType.MOVE, point.x, point.y, null);
+		lastMoveTimeMs = now;
+		lastMovePoint = point;
+	}
+
+	private boolean recordEvent()
+	{
+		if (!recording)
+		{
+			return false;
+		}
+
+		synchronized (lock)
+		{
+			if (events.size() >= config.maxRecordedEvents())
+			{
+				recording = false;
+				log.info("Mouse macro recorder hit max events ({}), stopping.", config.maxRecordedEvents());
+				updatePanelState();
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private void recordEvent(MouseMacroEventType type, int x, int y, MenuEntrySnapshot menuEntry)
+	{
+		long now = System.currentTimeMillis();
+		MouseMacroEvent event = new MouseMacroEvent(type, now - recordingStartMs, x, y, menuEntry);
+		synchronized (lock)
+		{
+			events.add(event);
+			if (type == MouseMacroEventType.MOVE)
+			{
+				moveCount++;
+			}
+			else if (type == MouseMacroEventType.CLICK)
+			{
+				clickCount++;
+			}
+		}
+
+		if (type == MouseMacroEventType.CLICK || now - lastUiUpdateMs > 250)
+		{
+			lastUiUpdateMs = now;
+			updatePanelState();
+		}
+	}
+
+	private void updatePanelState()
+	{
+		int totalEvents;
+		int moveEvents;
+		int clickEvents;
+		boolean recordingState;
+		synchronized (lock)
+		{
+			totalEvents = events.size();
+			moveEvents = moveCount;
+			clickEvents = clickCount;
+			recordingState = recording;
+		}
+
+		SwingUtilities.invokeLater(() -> panel.updateState(recordingState, totalEvents, moveEvents, clickEvents));
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroRecording.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/mouserecorder/MouseMacroRecording.java
@@ -1,0 +1,18 @@
+package net.runelite.client.plugins.microbot.mouserecorder;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MouseMacroRecording
+{
+	private final long startedAtEpochMs;
+	private final List<MouseMacroEvent> events;
+
+	public MouseMacroRecording(long startedAtEpochMs, List<MouseMacroEvent> events)
+	{
+		this.startedAtEpochMs = startedAtEpochMs;
+		this.events = events;
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide an in-client way to record mouse movements and clicks and capture the exact `MenuEntry` that was clicked so sequences can be reused for tooling or scripting.
- Allow configurable sampling and limits for movement recording to balance fidelity and performance.
- Offer a simple export format (JSON) to enable reuse of recorded sequences in scripts or external tools.

### Description
- Add a new Mouse Macro Recorder plugin under `net.runelite.client.plugins.microbot.mouserecorder` with `MouseMacroRecorderPlugin`, `MouseMacroRecorderPanel`, and config `MouseMacroRecorderConfig`.
- Add data models `MouseMacroEvent`, `MouseMacroEventType`, `MouseMacroRecording`, and `MenuEntrySnapshot` to represent recorded moves and clicked `MenuEntry` metadata.
- Record movement via the RuneLite `MouseListener` API and capture clicks via a `@Subscribe` handler for `MenuOptionClicked`, snapshotting the clicked `MenuEntry` and storing events in a timeline; export uses `Gson` to produce pretty JSON.
- Document the feature by adding `docs/api/MouseMacroRecorder.md` and linking it from `docs/development.md`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c0cd42a48328a49df1a77f425436)