### PR TITLE
fix: remove Applet dependency for non-applet OSRS client

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLiteDebug.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLiteDebug.java
@@ -35,7 +35,6 @@ import joptsimple.*;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
-import net.runelite.api.Constants;
 import net.runelite.client.account.SessionManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.discord.DiscordService;
@@ -71,7 +70,6 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import javax.swing.*;
-import java.applet.Applet;
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -331,17 +329,18 @@ public class RuneLiteDebug {
         }
 
         setupSystemProps();
-        
-        // Start the applet
+
+        // Start the client
         copyJagexCache();
-        var applet = (Applet) client;
-        applet.setSize(Constants.GAME_FIXED_SIZE);
 
         System.setProperty("jagex.disableBouncyCastle", "true");
         System.setProperty("jagex.userhome", RUNELITE_DIR.getAbsolutePath());
 
-        applet.init();
-        applet.start();
+        if (isOutdated) {
+            throw new IllegalStateException("Client failed to load");
+        }
+
+        client.initialize();
         
         SplashScreen.stage(.57, null, "Loading configuration");
 
@@ -399,6 +398,8 @@ public class RuneLiteDebug {
         microbotPluginManager.loadCorePlugins(pluginsToDebug);
 
         pluginManager.startPlugins();
+
+        client.unblockStartup();
 
         if (telemetryClient != null) {
             telemetryClient.submitTelemetry();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotClientLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotClientLoader.java
@@ -41,13 +41,12 @@ import okhttp3.OkHttpClient;
 
 import javax.annotation.Nonnull;
 import javax.swing.*;
-import java.applet.Applet;
 import java.io.*;
 import java.util.Map;
 import java.util.function.Supplier;
 
 @Slf4j
-@SuppressWarnings({"deprecation", "removal"})
+@SuppressWarnings({"deprecation"})
 public class MicrobotClientLoader implements Supplier<Client>
 {
 	private static final int NUM_ATTEMPTS = 6;
@@ -195,7 +194,7 @@ public class MicrobotClientLoader implements Supplier<Client>
 				.loadClass(initialClass);
 
 		Client rs = (Client) clientClass.newInstance();
-		((Applet) rs).setStub(new MicrobotRSAppletStub(config, runtimeConfigLoader));
+		rs.setConfiguration(new MicrobotRSAppletStub(config, runtimeConfigLoader));
 
 		log.info("injected-client {}", rs.getBuildID());
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotRSAppletStub.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/MicrobotRSAppletStub.java
@@ -26,41 +26,21 @@
 package net.runelite.client.plugins.microbot;
 
 import lombok.RequiredArgsConstructor;
+import net.runelite.api.ClientConfiguration;
 import net.runelite.client.RuntimeConfig;
 import net.runelite.client.RuntimeConfigLoader;
 import net.runelite.client.ui.FatalErrorDialog;
 import net.runelite.client.util.LinkBrowser;
 
 import javax.swing.*;
-import java.applet.Applet;
-import java.applet.AppletContext;
-import java.applet.AppletStub;
-import java.applet.AudioClip;
-import java.awt.*;
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Enumeration;
-import java.util.Iterator;
 
 @RequiredArgsConstructor
-class MicrobotRSAppletStub implements AppletStub
+class MicrobotRSAppletStub implements ClientConfiguration
 {
 	private final MicrobotRSConfig config;
 	private final RuntimeConfigLoader runtimeConfigLoader;
-
-	@Override
-	public boolean isActive()
-	{
-		return true;
-	}
-
-	@Override
-	public URL getDocumentBase()
-	{
-		return getCodeBase();
-	}
 
 	@Override
 	public URL getCodeBase()
@@ -82,129 +62,58 @@ class MicrobotRSAppletStub implements AppletStub
 	}
 
 	@Override
-	public AppletContext getAppletContext()
+	public void onError(String code)
 	{
-		return new AppletContext()
+		try
 		{
-			@Override
-			public AudioClip getAudioClip(URL url)
+			RuntimeConfig rtc = runtimeConfigLoader.get();
+			if (rtc.showOutageMessage())
 			{
-				return null;
+				return;
 			}
+		}
+		catch (Exception e)
+		{
+		}
 
-			@Override
-			public Image getImage(URL url)
-			{
-				return null;
-			}
-
-			@Override
-			public Applet getApplet(String name)
-			{
-				return null;
-			}
-
-			@Override
-			public Enumeration<Applet> getApplets()
-			{
-				return null;
-			}
-
-			@Override
-			public void showDocument(URL url)
-			{
-				if (url.getPath().startsWith("/error_game_"))
-				{
-					try
-					{
-						RuntimeConfig rtc = runtimeConfigLoader.get();
-						if (rtc.showOutageMessage())
-						{
-							return;
-						}
-					}
-					catch (Exception e)
-					{
-					}
-
-					String code = url.getPath()
-						.replace("/", "")
-						.replace(".ws", "");
-
-					if (code.equals("error_game_js5connect"))
-					{
-						SwingUtilities.invokeLater(() ->
-							new FatalErrorDialog("RuneLite is unable to connect to the RuneScape update server. " +
-								"RuneScape might be offline for an update, check the game status page. If the game " +
-								"is online, then either a firewall is blocking RuneLite, or you don't have internet access.")
-								.setTitle("RuneLite", "Unable to connect to update server")
-								.addButton("Game Status", () -> LinkBrowser.browse("https://secure.runescape.com/m=news/game-status-information-centre?oldschool=1"))
-								.open());
-					}
-					else if (code.equals("error_game_js5io"))
-					{
-						SwingUtilities.invokeLater(() ->
-							new FatalErrorDialog("OldSchool RuneScape is unable to retrieve updates from its update server. " +
-								"This is likely due to a firewall blocking the RuneScape server. Try disabling your firewall, or use " +
-								"a different network.")
-								.setTitle("RuneLite", "Unable to connect to update server")
-								.addHelpButtons()
-								.open());
-					}
-					else if (code.equals("error_game_crash"))
-					{
-						SwingUtilities.invokeLater(() ->
-							new FatalErrorDialog("OldSchool RuneScape has crashed. Crashes are most commonly caused by plugin hub plugins, " +
-								"but can also be caused by RuneLite or Jagex client bugs. If you receive this message commonly, try playing in " +
-								"safe mode to eliminate the potential of plugins causing the crash. The client log file will contain additional " +
-								"information about the crash.")
-								.setTitle("RuneLite", "OldSchool RuneScape has crashed")
-								.addHelpButtons()
-								.open());
-					}
-					else
-					{
-						SwingUtilities.invokeLater(() ->
-							new FatalErrorDialog("OldSchool RuneScape has crashed with the message: " + code)
-								.setTitle("RuneLite", "OldSchool RuneScape has crashed")
-								.addHelpButtons()
-								.open());
-					}
-				}
-			}
-
-			@Override
-			public void showDocument(URL url, String target)
-			{
-				showDocument(url);
-			}
-
-			@Override
-			public void showStatus(String status)
-			{
-			}
-
-			@Override
-			public void setStream(String key, InputStream stream) throws IOException
-			{
-			}
-
-			@Override
-			public InputStream getStream(String key)
-			{
-				return null;
-			}
-
-			@Override
-			public Iterator<String> getStreamKeys()
-			{
-				return null;
-			}
-		};
-	}
-
-	@Override
-	public void appletResize(int width, int height)
-	{
+		if (code.equals("error_game_js5connect"))
+		{
+			SwingUtilities.invokeLater(() ->
+				new FatalErrorDialog("RuneLite is unable to connect to the RuneScape update server. " +
+					"RuneScape might be offline for an update, check the game status page. If the game " +
+					"is online, then either a firewall is blocking RuneLite, or you don't have internet access.")
+					.setTitle("RuneLite", "Unable to connect to update server")
+					.addButton("Game Status", () -> LinkBrowser.browse("https://secure.runescape.com/m=news/game-status-information-centre?oldschool=1"))
+					.open());
+		}
+		else if (code.equals("error_game_js5io"))
+		{
+			SwingUtilities.invokeLater(() ->
+				new FatalErrorDialog("OldSchool RuneScape is unable to retrieve updates from its update server. " +
+					"This is likely due to a firewall blocking the RuneScape server. Try disabling your firewall, or use " +
+					"a different network.")
+					.setTitle("RuneLite", "Unable to connect to update server")
+					.addHelpButtons()
+					.open());
+		}
+		else if (code.equals("error_game_crash"))
+		{
+			SwingUtilities.invokeLater(() ->
+				new FatalErrorDialog("OldSchool RuneScape has crashed. Crashes are most commonly caused by plugin hub plugins, " +
+					"but can also be caused by RuneLite or Jagex client bugs. If you receive this message commonly, try playing in " +
+					"safe mode to eliminate the potential of plugins causing the crash. The client log file will contain additional " +
+					"information about the crash.")
+					.setTitle("RuneLite", "OldSchool RuneScape has crashed")
+					.addHelpButtons()
+					.open());
+		}
+		else
+		{
+			SwingUtilities.invokeLater(() ->
+				new FatalErrorDialog("OldSchool RuneScape has crashed with the message: " + code)
+					.setTitle("RuneLite", "OldSchool RuneScape has crashed")
+					.addHelpButtons()
+					.open());
+		}
 	}
 }


### PR DESCRIPTION
## Summary

The OSRS client no longer extends `java.applet.Applet`, causing a `ClassCastException` when running in debug mode via `RuneLiteDebug`:

```
java.lang.ClassCastException: class client cannot be cast to class java.applet.Applet
    at net.runelite.client.plugins.microbot.MicrobotClientLoader.loadClient(MicrobotClientLoader.java:198)
```

This PR updates the Microbot-specific client loading code to use the new `ClientConfiguration` interface, aligning it with the main `RuneLite`/`ClientLoader` implementation.

## Changes

- **MicrobotRSAppletStub.java**: Changed from implementing `AppletStub` to implementing `ClientConfiguration` interface, replacing `showDocument()` error handling with the new `onError(String code)` method
- **MicrobotClientLoader.java**: Changed from `((Applet) rs).setStub()` to `rs.setConfiguration()`
- **RuneLiteDebug.java**: Replaced `applet.init()`/`applet.start()` with `client.initialize()` and added `client.unblockStartup()` after plugins start