### PR TITLE
feat(Rs2Player): add isInPoh() utility method

### DIFF
--- a/docs/api/Rs2Player.md
+++ b/docs/api/Rs2Player.md
@@ -60,6 +60,10 @@ The `Rs2Player` class is responsible for managing the player's state and interac
 ### `isInMulti`
 - **Returns**: `boolean` - True if the player is in a multi-combat area.
 
+### `isInPoh`
+- **Returns**: `boolean` - True if the player is currently inside a Player Owned House (POH).
+- **Description**: Detects POH by checking that the current scene is an instanced region and that the `POH_HOUSE_LOCATION` varbit is non-zero. Using both conditions distinguishes the POH from other instanced regions such as the Gauntlet or Hallowed Sepulchre.
+
 ### `logoutIfPlayerDetected`
 - **Parameters**:
   - `amountOfPlayers`: `int` - Amount of players to detect before logging out.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -1115,6 +1115,24 @@ public class Rs2Player {
                 == 1;
     }
 
+    /**
+     * Checks if the player is currently inside their Player Owned House (POH).
+     *
+     * <p>This is detected by verifying two conditions:</p>
+     * <ul>
+     *     <li>The current scene is an instanced region (all POHs are instanced).</li>
+     *     <li>The {@link VarbitID#POH_HOUSE_LOCATION} varbit is non-zero, which is
+     *         set whenever the player is inside a POH. This distinguishes the POH from
+     *         other instanced regions such as the Gauntlet or Hallowed Sepulchre.</li>
+     * </ul>
+     *
+     * @return {@code true} if the player is inside a POH, {@code false} otherwise.
+     */
+    public static boolean isInPoh() {
+        return Microbot.getClient().getTopLevelWorldView().getScene().isInstance()
+                && Microbot.getVarbitValue(VarbitID.POH_HOUSE_LOCATION) > 0;
+    }
+
     public static boolean drinkPrayerPotion() {
         int maxPrayer = getRealSkillLevel(Skill.PRAYER);
         int maxHerblore = getRealSkillLevel(Skill.HERBLORE);


### PR DESCRIPTION
Adds a new static method to Rs2Player that detects whether the player is currently inside a Player Owned House (POH).

Detection uses two conditions:
- scene.isInstance() — true for all instanced regions
- POH_HOUSE_LOCATION varbit > 0 — specific to POH

Combining both avoids false positives from other instanced regions (Gauntlet, Hallowed Sepulchre, etc).

Also updates docs/api/Rs2Player.md with the new method entry.