### PR TITLE
fix: update chatbox widget IDs for Rs2Bank.withdrawX

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/globval/WidgetIndices.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/globval/WidgetIndices.java
@@ -760,19 +760,19 @@ public class WidgetIndices {
         // 36
         public static final int CONTAINER = 37;
         // 38 - 40 gap
-        public static final int TITLE = 41;
-        public static final int FULL_INPUT = 42;
-        // 43 - 49 gap
-        public static final int GE_SEARCH_RESULTS = 50;
-        // 51 - 52 gap
-        public static final int MESSAGES_CONTAINER = 53;
-        public static final int TRANSPARENT_BACKGROUND_LINES_CONTAINER = 54;
-        public static final int INPUT_LABEL = 55;
-        public static final int MESSAGE_LINES_CONTAINER = 56;
-        public static final int FIRST_MESSAGE_LABEL = 57;
-        public static final int LAST_MESSAGE_LABEL = 556;
-        public static final int SCROLLBAR_CONTAINER = 557;
-        public static final int DIALOG_CONTAINER = 559;
+        public static final int TITLE = 42;
+        public static final int FULL_INPUT = 43;
+        // 44 - 50 gap
+        public static final int GE_SEARCH_RESULTS = 51;
+        // 52 - 53 gap
+        public static final int MESSAGES_CONTAINER = 54;
+        public static final int TRANSPARENT_BACKGROUND_LINES_CONTAINER = 55;
+        public static final int INPUT_LABEL = 56;
+        public static final int MESSAGE_LINES_CONTAINER = 57;
+        public static final int FIRST_MESSAGE_LABEL = 58;
+        public static final int LAST_MESSAGE_LABEL = 557;
+        public static final int SCROLLBAR_CONTAINER = 558;
+        public static final int DIALOG_CONTAINER = 560;
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/Rs2Bank.java
@@ -971,7 +971,7 @@ public class Rs2Bank {
 
         invokeMenu(xPromptOffset, rs2Item);
         boolean foundEnterAmount = sleepUntil(() -> {
-            Widget widget = Rs2Widget.getWidget(162, 42);
+            Widget widget = Rs2Widget.getWidget(162, 43);
             return widget != null && widget.getText().equalsIgnoreCase("Enter amount:");
         }, 5000);
         if (!foundEnterAmount) return false;


### PR DESCRIPTION
 The chatbox widget children in group 162 shifted by +1 in a recent game update. `handleAmount` was checking child 42 (now `CHATBOX_TITLE`) instead of child 43 (`CHATBOX_FULL_INPUT`) for the "Enter amount:" prompt, causing `sleepUntil` to always time out.

  - Updated `Rs2Bank.java` widget check from `(162, 42)` to `(162, 43)`
  - Updated stale `WidgetIndices.ChatBox` constants to match current RuneLite `ComponentID` values

  ## Test plan

  - [ ] Open bank, use Withdraw-X on any item — should type amount and confirm without timing out
  - [ ] Deposit-X should also work correctly (shares `handleAmount`)