### PR TITLE
Notify once for outdated Microbot plugins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/externalplugins/MicrobotPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/externalplugins/MicrobotPluginManager.java
@@ -87,6 +87,8 @@ public class MicrobotPluginManager {
     private static final File PLUGIN_DIR = new File(RuneLite.RUNELITE_DIR, "microbot-plugins");
     private static final String INSTALLED_VERSION_GROUP = "microbotPluginVersions";
     private static final String INSTALLED_VERSION_KEY_PREFIX = "plugin.";
+    private static final String UPDATE_NOTIFICATION_GROUP = "microbotPluginUpdateNotifications";
+    private static final String UPDATE_NOTIFICATION_KEY_PREFIX = "plugin.";
 
     private final OkHttpClient okHttpClient;
     private final MicrobotPluginClient microbotPluginClient;
@@ -1244,6 +1246,54 @@ public class MicrobotPluginManager {
         return lookupInstalledPluginVersion(internalName).map(InstalledPluginVersion::getVersion);
     }
 
+    public Optional<OutdatedPluginUpdate> getOutdatedPluginUpdate(Plugin plugin) {
+        MicrobotPluginManifest manifest = getPluginManifest(plugin);
+        if (manifest == null) {
+            return Optional.empty();
+        }
+
+        String internalName = manifest.getInternalName();
+        String latestVersion = manifest.getVersion();
+        String installedVersion = getInstalledPluginVersion(internalName)
+                .orElseGet(() -> {
+                    PluginDescriptor descriptor = plugin.getClass().getAnnotation(PluginDescriptor.class);
+                    return descriptor == null ? null : descriptor.version();
+                });
+
+        if (Strings.isNullOrEmpty(internalName)
+                || Strings.isNullOrEmpty(installedVersion)
+                || Strings.isNullOrEmpty(latestVersion)
+                || latestVersion.equals(installedVersion)) {
+            return Optional.empty();
+        }
+
+        String notificationKey = UPDATE_NOTIFICATION_KEY_PREFIX + internalName;
+        String notifiedVersion = configManager.getConfiguration(UPDATE_NOTIFICATION_GROUP, notificationKey);
+        if (latestVersion.equals(notifiedVersion)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new OutdatedPluginUpdate(
+                internalName,
+                Strings.isNullOrEmpty(manifest.getDisplayName()) ? internalName : manifest.getDisplayName(),
+                installedVersion,
+                latestVersion
+        ));
+    }
+
+    public void rememberOutdatedPluginUpdateNotification(OutdatedPluginUpdate outdatedPluginUpdate) {
+        if (outdatedPluginUpdate == null || Strings.isNullOrEmpty(outdatedPluginUpdate.getInternalName())
+                || Strings.isNullOrEmpty(outdatedPluginUpdate.getLatestVersion())) {
+            return;
+        }
+
+        configManager.setConfiguration(
+                UPDATE_NOTIFICATION_GROUP,
+                UPDATE_NOTIFICATION_KEY_PREFIX + outdatedPluginUpdate.getInternalName(),
+                outdatedPluginUpdate.getLatestVersion()
+        );
+    }
+
     private void rememberInstalledPluginVersion(String internalName, String version, String sha256) {
         if (Strings.isNullOrEmpty(internalName) || Strings.isNullOrEmpty(version) || Strings.isNullOrEmpty(sha256)) {
             return;
@@ -1278,6 +1328,36 @@ public class MicrobotPluginManager {
 
         public String getSha256() {
             return sha256;
+        }
+    }
+
+    public static final class OutdatedPluginUpdate {
+        private final String internalName;
+        private final String displayName;
+        private final String installedVersion;
+        private final String latestVersion;
+
+        private OutdatedPluginUpdate(String internalName, String displayName, String installedVersion, String latestVersion) {
+            this.internalName = internalName;
+            this.displayName = displayName;
+            this.installedVersion = installedVersion;
+            this.latestVersion = latestVersion;
+        }
+
+        public String getInternalName() {
+            return internalName;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public String getInstalledVersion() {
+            return installedVersion;
+        }
+
+        public String getLatestVersion() {
+            return latestVersion;
         }
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginListPanel.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.microbot.ui;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.html.HtmlEscapers;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.config.Config;
@@ -282,6 +283,9 @@ public class MicrobotPluginListPanel extends MicrobotPluginPanel {
     }
 
     void startPlugin(Plugin plugin) {
+        microbotPluginManager.getOutdatedPluginUpdate(plugin)
+                .ifPresent(this::showOutdatedPluginNotification);
+
         pluginManager.setPluginEnabled(plugin, true);
 
         try {
@@ -309,6 +313,25 @@ public class MicrobotPluginListPanel extends MicrobotPluginPanel {
         }
 
         return Text.fromCSV(config);
+    }
+
+    private void showOutdatedPluginNotification(MicrobotPluginManager.OutdatedPluginUpdate outdatedPluginUpdate) {
+        String message = "<html>\""
+                + HtmlEscapers.htmlEscaper().escape(outdatedPluginUpdate.getDisplayName())
+                + "\" is out of date.<br><br>Installed version: "
+                + HtmlEscapers.htmlEscaper().escape(outdatedPluginUpdate.getInstalledVersion())
+                + "<br>Latest version: "
+                + HtmlEscapers.htmlEscaper().escape(outdatedPluginUpdate.getLatestVersion())
+                + "<br><br>Update it from the <strong>Microbot Plugin Hub</strong> to get the latest fixes.</html>";
+
+        JOptionPane.showMessageDialog(
+                this,
+                message,
+                "Microbot Plugin Update Available",
+                JOptionPane.INFORMATION_MESSAGE
+        );
+
+        microbotPluginManager.rememberOutdatedPluginUpdateNotification(outdatedPluginUpdate);
     }
 
     void savePinnedPlugins() {


### PR DESCRIPTION
Show a one-time update notice when an outdated Microbot plugin is enabled from the Microbot plugin manager, using Microbot plugin version metadata instead of RuneLite's Plugin Hub flow.