### PR TITLE
fix(blocking-events): re-queue event on failed CAS in shouldBlockAndProcess

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEventManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEventManager.java
@@ -175,7 +175,8 @@ public class BlockingEventManager
 
         if (!isRunning.compareAndSet(false, true))
         {
-            // if somebody else started in the meantime, we consider it “busy”
+            // Another thread started processing; re-queue so the event is not lost
+            eventQueue.offer(event);
             return true;
         }
 


### PR DESCRIPTION
## Summary
- In `BlockingEventManager.shouldBlockAndProcess()`, an event polled from the queue was silently dropped when `compareAndSet(false, true)` failed due to a concurrent thread
- The event had already been removed from the queue by `poll()` but was never put back, causing it to be permanently lost
- Fixed by re-queuing the event with `eventQueue.offer(event)` before returning

## Details
The race condition occurs when two threads call `shouldBlockAndProcess()` nearly simultaneously:
1. Thread A checks `isRunning.get()` → false
2. Thread B checks `isRunning.get()` → false
3. Thread A polls an event from the queue (event removed)
4. Thread B polls another event (or null)
5. Thread A does `compareAndSet(false, true)` → succeeds
6. Thread A's event is processed
7. Thread B does `compareAndSet(false, true)` → **fails** (Thread A set it to true)
8. Thread B returns `true` but **its event is gone**

The fix ensures Thread B's event is placed back in the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)