### PR TITLE
fix(world-hop): move sleep calls out of client thread in hopToWorld

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/Microbot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/Microbot.java
@@ -309,7 +309,7 @@ public class Microbot {
             log.error("Can't hop world, already trying to hop");
             return false;
         }
-        boolean isHopping = Microbot.getClientThread().runOnClientThreadOptional(() -> {
+        boolean hopInitiated = Microbot.getClientThread().runOnClientThreadOptional(() -> {
             if (Microbot.getClient().getLocalPlayer() != null && Microbot.getClient().getLocalPlayer().isInteracting()) {
                 log.error("Local player is interacting, cannot hop worlds");
                 return false;
@@ -341,10 +341,14 @@ public class Microbot {
             Microbot.getClient().openWorldHopper();
             Microbot.getClient().hopToWorld(rsWorld);
             quickHopTargetWorld = null;
-            sleep(600);
-            sleepUntil(() -> Microbot.isHopping() || Rs2Widget.getWidget(193, 0) != null, 2000);
-            return Microbot.isHopping();
+            return true;
         }).orElse(false);
+        if (!hopInitiated) {
+            return false;
+        }
+        sleep(600);
+        sleepUntil(() -> Microbot.isHopping() || Rs2Widget.getWidget(193, 0) != null, 2000);
+        boolean isHopping = Microbot.isHopping();
         if (!isHopping) {
             Widget confirmRoot = Rs2Widget.getWidget(193, 0);
             if (confirmRoot != null) {


### PR DESCRIPTION
## Summary
- `sleep(600)` and `sleepUntil(...)` were being called inside `runOnClientThreadOptional()` in `Microbot.hopToWorld()`, which executes on the RuneLite client thread
- Sleeping on the client thread blocks all game rendering and input, effectively freezing the game for ~2.6 seconds on every world hop
- Moved these timing calls to execute on the calling (script) thread instead, after the client thread block returns

## Details
The client thread lambda now only performs the hop setup (validation, world creation, `openWorldHopper()`, `hopToWorld()`) and returns a boolean indicating success. The `sleep(600)` and `sleepUntil()` calls now execute on the script thread where blocking is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)