### PR TITLE
fix(boat-cache): use addition instead of multiplication for cache TTL

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/boat/Rs2BoatCache.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/boat/Rs2BoatCache.java
@@ -29,7 +29,7 @@ public final class Rs2BoatCache {
     }
 
     public Rs2BoatModel getLocalBoat() {
-        if (lastCheckedOnBoat * 2 >= client.getTickCount()) {
+        if (lastCheckedOnBoat + 2 >= client.getTickCount()) {
             return boat;
         }
 
@@ -64,7 +64,7 @@ public final class Rs2BoatCache {
             return getLocalBoat();
         }
 
-        if (lastCheckedOnBoat * 2 >= client.getTickCount()) {
+        if (lastCheckedOnBoat + 2 >= client.getTickCount()) {
             return boat;
         }
 


### PR DESCRIPTION
## Summary
- `Rs2BoatCache.getLocalBoat()` and `getBoat()` used `lastCheckedOnBoat * 2 >= client.getTickCount()` to check cache validity
- This multiplied the tick timestamp by 2 instead of adding a 2-tick TTL, causing the cache to persist for an ever-growing number of ticks (e.g., at tick 500 the cache was valid until tick 1000)
- Changed to `lastCheckedOnBoat + 2 >= client.getTickCount()` so the cache correctly expires after 2 game ticks

## Details
The bug caused boat state to become stale for increasingly long periods as the game session progressed. Early in a session (low tick counts) the effect was minor, but after extended play the cache could return outdated boat data for hundreds of ticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)