### PR TITLE
fix(tile-items): set action index when using default ground action

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/tileitem/models/Rs2TileItemModel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/tileitem/models/Rs2TileItemModel.java
@@ -226,6 +226,7 @@ public class Rs2TileItemModel implements TileItem, IEntity {
             int index = -1;
             if (action.isEmpty()) {
                 action = groundActions[0];
+                index = 0;
             } else {
                 for (int i = 0; i < groundActions.length; i++) {
                     String groundAction = groundActions[i];


### PR DESCRIPTION
## Summary
- In `Rs2TileItemModel.interact()`, when no action string was specified (empty string), the code defaulted to `groundActions[0]` but forgot to set `index = 0`
- With `index` stuck at `-1`, none of the MenuAction conditions matched, leaving `menuAction` as `CANCEL`
- This caused all ground item interactions without an explicit action to silently fail (menu entry sent with CANCEL opcode)
- Added `index = 0` alongside the default action assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)