### PR TITLE
fix(queryable): avoid mutating source stream in nearestReachable

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/AbstractEntityQueryable.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/AbstractEntityQueryable.java
@@ -154,14 +154,29 @@ public abstract class AbstractEntityQueryable<
 
     @Override
     public E nearestReachable() {
-        source = source.filter(IEntity::isReachable);
-        return nearest(Integer.MAX_VALUE);
+        return nearestReachable(Integer.MAX_VALUE);
     }
 
     @Override
     public E nearestReachable(int maxDistance) {
-        source = source.filter(IEntity::isReachable);
-        return nearest(maxDistance);
+        var player = new Rs2PlayerModel();
+        WorldPoint playerLoc = player.getWorldLocation();
+        WorldView worldView = player.getWorldView();
+        if (playerLoc == null || worldView == null) {
+            return null;
+        }
+
+        return source
+                .filter(IEntity::isReachable)
+                .map(entity -> {
+                    WorldPoint loc = entity.getWorldLocation();
+                    int distance = (loc != null) ? loc.distanceTo(playerLoc) : Integer.MAX_VALUE;
+                    return new EntityDistance<>(entity, distance);
+                })
+                .filter(pair -> pair.distance <= maxDistance)
+                .min(Comparator.comparingInt(pair -> pair.distance))
+                .map(pair -> pair.entity)
+                .orElse(null);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- `AbstractEntityQueryable.nearestReachable()` and `nearestReachable(int)` reassigned the `source` stream field via `source = source.filter(IEntity::isReachable)`
- Java streams can only be consumed once, so mutating the `source` field corrupts the queryable for any subsequent operations on the same instance
- Changed to apply the reachability filter inline on the stream pipeline without modifying the `source` field, consistent with how `firstReachable()` already works

## Details
The `firstReachable()` method at line 147 correctly applies `.filter(IEntity::isReachable)` inline without reassigning `source`. The `nearestReachable()` methods now follow the same pattern, performing the reachable filter and distance calculation in a single stream pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)