### PR TITLE
fix(player-model): use own animation in isSalvaging instead of local player

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/player/models/Rs2PlayerModel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/player/models/Rs2PlayerModel.java
@@ -72,8 +72,8 @@ public class Rs2PlayerModel extends Rs2ActorModel implements IEntity {
     }
 
     // Sailing stuff
-    public  boolean isSalvaging() {
-        int anim = new Rs2PlayerModel().getAnimation();
+    public boolean isSalvaging() {
+        int anim = getAnimation();
         for (int id : SalvagingAnimations.SALVAGING_ANIMATIONS) {
             if (anim == id) {
                 return true;


### PR DESCRIPTION
## Summary
- `Rs2PlayerModel.isSalvaging()` created a `new Rs2PlayerModel()` to get the animation, which always resolves to the local player via the default constructor
- When called on a non-local player instance (e.g., from player cache queries), this incorrectly checked the local player's animation instead of the target player's
- Changed to use `getAnimation()` on `this` instance so it checks the correct player

🤖 Generated with [Claude Code](https://claude.com/claude-code)