### PR TITLE
feat(cache): implement global per-tick value caching mechanism

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/Rs2Cache.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/Rs2Cache.java
@@ -1,0 +1,95 @@
+package net.runelite.client.plugins.microbot.util;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Global per-tick value cache.
+ *
+ * <p>Each entry stores its own populator. Calling {@link #getValue()} returns the
+ * cached value when the stored tick matches the current game tick; otherwise the
+ * populator is invoked, the result is stored with the current tick, and then returned.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * List<NPC> npcs = Rs2Cache.NPCS.getValue();
+ * Player local = Rs2Cache.LOCAL_PLAYER.getValue();
+ * }</pre>
+ */
+public enum Rs2Cache {
+
+    LOCAL_PLAYER_POSITION(Rs2Player::getWorldLocation_Internal),
+    LOCAL_PLAYER_WORLD_VIEW(Rs2Player::getWorldView_Internal),
+    ;
+
+    // ---------------------------------------------------------------------------
+    // Internal state
+    // ---------------------------------------------------------------------------
+
+    private static final Map<Rs2Cache, Entry> CACHE = new EnumMap<>(Rs2Cache.class);
+
+    private final Supplier<Object> populator;
+
+    Rs2Cache(Supplier<Object> populator) {
+        this.populator = populator;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Public API
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Returns the cached value for this entry.
+     *
+     * <p>If the value was already computed on the current game tick it is returned
+     * directly. Otherwise the populator is called, the result is cached alongside
+     * the current tick, and then returned.
+     *
+     * @param <T> expected return type
+     * @return the (possibly freshly populated) cached value
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getValue() {
+        int currentTick = Microbot.getClient().getTickCount();
+        Entry entry = CACHE.get(this);
+        if (entry != null && entry.tick == currentTick) {
+            return (T) entry.value;
+        }
+        Object value = populator.get();
+        CACHE.put(this, new Entry(value, currentTick));
+        return (T) value;
+    }
+
+    /**
+     * Invalidates the cached value for this entry, forcing a fresh call to the
+     * populator on the next {@link #getValue()} invocation.
+     */
+    public void invalidate() {
+        CACHE.remove(this);
+    }
+
+    /**
+     * Invalidates all cached entries.
+     */
+    public static void invalidateAll() {
+        CACHE.clear();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Internal helpers
+    // ---------------------------------------------------------------------------
+
+    private static final class Entry {
+        final Object value;
+        final int tick;
+
+        Entry(Object value, int tick) {
+            this.value = value;
+            this.tick = tick;
+        }
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/Rs2Cache.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/Rs2Cache.java
@@ -22,74 +22,74 @@ import java.util.function.Supplier;
  */
 public enum Rs2Cache {
 
-    LOCAL_PLAYER_POSITION(Rs2Player::getWorldLocation_Internal),
-    LOCAL_PLAYER_WORLD_VIEW(Rs2Player::getWorldView_Internal),
-    ;
+	LOCAL_PLAYER_POSITION(Rs2Player::getWorldLocation_Internal),
+	LOCAL_PLAYER_WORLD_VIEW(Rs2Player::getWorldView_Internal),
+	;
 
-    // ---------------------------------------------------------------------------
-    // Internal state
-    // ---------------------------------------------------------------------------
+	// ---------------------------------------------------------------------------
+	// Internal state
+	// ---------------------------------------------------------------------------
 
-    private static final Map<Rs2Cache, Entry> CACHE = new EnumMap<>(Rs2Cache.class);
+	private static final Map<Rs2Cache, Entry> CACHE = new EnumMap<>(Rs2Cache.class);
 
-    private final Supplier<Object> populator;
+	private final Supplier<Object> populator;
 
-    Rs2Cache(Supplier<Object> populator) {
-        this.populator = populator;
-    }
+	Rs2Cache(Supplier<Object> populator) {
+		this.populator = populator;
+	}
 
-    // ---------------------------------------------------------------------------
-    // Public API
-    // ---------------------------------------------------------------------------
+	// ---------------------------------------------------------------------------
+	// Public API
+	// ---------------------------------------------------------------------------
 
-    /**
-     * Returns the cached value for this entry.
-     *
-     * <p>If the value was already computed on the current game tick it is returned
-     * directly. Otherwise the populator is called, the result is cached alongside
-     * the current tick, and then returned.
-     *
-     * @param <T> expected return type
-     * @return the (possibly freshly populated) cached value
-     */
-    @SuppressWarnings("unchecked")
-    public <T> T getValue() {
-        int currentTick = Microbot.getClient().getTickCount();
-        Entry entry = CACHE.get(this);
-        if (entry != null && entry.tick == currentTick) {
-            return (T) entry.value;
-        }
-        Object value = populator.get();
-        CACHE.put(this, new Entry(value, currentTick));
-        return (T) value;
-    }
+	/**
+	 * Returns the cached value for this entry.
+	 *
+	 * <p>If the value was already computed on the current game tick it is returned
+	 * directly. Otherwise the populator is called, the result is cached alongside
+	 * the current tick, and then returned.
+	 *
+	 * @param <T> expected return type
+	 * @return the (possibly freshly populated) cached value
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T getValue() {
+		int currentTick = Microbot.getClient().getTickCount();
+		Entry entry = CACHE.get(this);
+		if (entry != null && entry.tick == currentTick) {
+			return (T) entry.value;
+		}
+		Object value = populator.get();
+		CACHE.put(this, new Entry(value, currentTick));
+		return (T) value;
+	}
 
-    /**
-     * Invalidates the cached value for this entry, forcing a fresh call to the
-     * populator on the next {@link #getValue()} invocation.
-     */
-    public void invalidate() {
-        CACHE.remove(this);
-    }
+	/**
+	 * Invalidates the cached value for this entry, forcing a fresh call to the
+	 * populator on the next {@link #getValue()} invocation.
+	 */
+	public void invalidate() {
+		CACHE.remove(this);
+	}
 
-    /**
-     * Invalidates all cached entries.
-     */
-    public static void invalidateAll() {
-        CACHE.clear();
-    }
+	/**
+	 * Invalidates all cached entries.
+	 */
+	public static void invalidateAll() {
+		CACHE.clear();
+	}
 
-    // ---------------------------------------------------------------------------
-    // Internal helpers
-    // ---------------------------------------------------------------------------
+	// ---------------------------------------------------------------------------
+	// Internal helpers
+	// ---------------------------------------------------------------------------
 
-    private static final class Entry {
-        final Object value;
-        final int tick;
+	private static final class Entry {
+		final Object value;
+		final int tick;
 
-        Entry(Object value, int tick) {
-            this.value = value;
-            this.tick = tick;
-        }
-    }
+		Entry(Object value, int tick) {
+			this.value = value;
+			this.tick = tick;
+		}
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
@@ -38,1974 +38,1974 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
  */
 @Deprecated(since = "2.1.0 - Use Rs2TileObjectQueryable instead", forRemoval = true)
 public class Rs2GameObject {
-    /**
-     * Extracts all {@link GameObject}s located on a given {@link Tile}.
-     *
-     * @see Tile#getGameObjects()
-     * @param tile the tile from which to extract game objects
-     * @return a {@link List} of {@link GameObject} instances on the tile (never null)
-     */
-    private static final Function<Tile, Collection<? extends GameObject>> GAMEOBJECT_EXTRACTOR =
-            tile -> Arrays.asList(tile.getGameObjects());
-
-    /**
-     * Extracts the {@link GroundObject} located on a given {@link Tile}.
-     *
-     * @see Tile#getGroundObject()
-     * @param tile the tile from which to extract the ground object
-     * @return a singleton {@link List} containing the {@link GroundObject},
-     *         or a list with a single null element if none is present
-     */
-    private static final Function<Tile, Collection<? extends GroundObject>> GROUNDOBJECT_EXTRACTOR =
-            tile -> Collections.singletonList(tile.getGroundObject());
-
-    /**
-     * Extracts the {@link DecorativeObject} located on a given {@link Tile}.
-     *
-     * @see Tile#getDecorativeObject()
-     * @param tile the tile from which to extract the decorative object
-     * @return a singleton {@link List} containing the {@link DecorativeObject},
-     *         or a list with a single null element if none is present
-     */
-    private static final Function<Tile, Collection<? extends DecorativeObject>> DECORATIVEOBJECT_EXTRACTOR =
-            tile -> Collections.singletonList(tile.getDecorativeObject());
-
-    /**
-     * Extracts the {@link WallObject} located on a given {@link Tile}.
-     *
-     * @see Tile#getWallObject()
-     * @param tile the tile from which to extract the wall object
-     * @return a singleton {@link List} containing the {@link WallObject},
-     *         or a list with a single null element if none is present
-     */
-    private static final Function<Tile, Collection<? extends WallObject>> WALLOBJECT_EXTRACTOR =
-            tile -> Collections.singletonList(tile.getWallObject());
-
-    /**
-     * Extracts all types of {@link TileObject} (decorative, ground, wall) from a given {@link Tile}.
-     *
-     * @param tile the tile from which to extract all tile objects
-     * @return a {@link List} containing the {@link DecorativeObject}, {@link GroundObject},
-     *         and {@link WallObject} (some entries may be null if that object is not present)
-     */
-    private static final Function<Tile, Collection<? extends TileObject>> TILEOBJECT_EXTRACTOR =
-            tile -> Arrays.asList(
-                    tile.getDecorativeObject(),
-                    tile.getGroundObject(),
-                    tile.getWallObject()
-            );
-
-
-    public static boolean interact(WorldPoint worldPoint) {
-        return interact(worldPoint, "");
-    }
-
-    public static boolean interact(WorldPoint worldPoint, String action) {
-        TileObject gameObject = findObjectByLocation(worldPoint);
-        return clickObject(gameObject, action);
-    }
-
-    public static boolean interact(GameObject gameObject) {
-        return clickObject(gameObject);
-    }
-
-    public static boolean interact(TileObject tileObject) {
-        return clickObject(tileObject, "");
-    }
-
-    public static boolean interact(TileObject tileObject, String action) {
-        return clickObject(tileObject, action);
-    }
-
-    public static boolean interact(GameObject gameObject, String action) {
-        return clickObject(gameObject, action);
-    }
-
-    public static boolean interact(int id) {
-        TileObject object = findObjectById(id);
-        return clickObject(object);
-    }
-
-    public static int interact(List<Integer> ids) {
-        for (int objectId : ids) {
-            if (interact(objectId)) return objectId;
-        }
-        return -1;
-    }
-
-    public static boolean interact(TileObject tileObject, String action, boolean checkCanReach) {
-        if (tileObject == null) return false;
-        if (!checkCanReach) return clickObject(tileObject, action);
-
-        if (checkCanReach && Rs2GameObject.hasLineOfSight(tileObject))
-            return clickObject(tileObject, action);
-
-        Rs2Walker.walkFastCanvas(tileObject.getWorldLocation());
-
-        return false;
-    }
-
-    public static boolean interact(TileObject tileObject, boolean checkCanReach) {
-        return interact(tileObject, "", checkCanReach);
-    }
-
-    public static boolean interact(int id, boolean checkCanReach) {
-        TileObject object = findObjectById(id);
-        return interact(object, checkCanReach);
-    }
-
-    public static boolean interact(int id, String action) {
-        TileObject object = findObjectById(id);
-        return clickObject(object, action);
-    }
-
-    public static boolean interact(int id, String action, int distance) {
-        TileObject object = findObjectByIdAndDistance(id, distance);
-        return clickObject(object, action);
-    }
-
-    public static boolean interact(String name, String action) {
-        TileObject object = get(name);
-        return clickObject(object, action);
-    }
-
-    public static boolean interact(int[] objectIds, String action) {
-        for (int objectId : objectIds) {
-            if (interact(objectId, action)) return true;
-        }
-        return false;
-    }
-
-    public static boolean interact(String name) {
-        GameObject object = get(name, true);
-        return clickObject(object);
-    }
-
-    public static boolean interact(String name, boolean exact) {
-        GameObject object = get(name, exact);
-        return clickObject(object);
-    }
-
-    public static boolean interact(String name, String action, boolean exact) {
-        GameObject object = get(name, exact);
-        return clickObject(object, action);
-    }
-
-    public static boolean exists(int id) {
-        return findObjectById(id) != null;
-    }
-
-    public static boolean canReach(WorldPoint target, int objectSizeX, int objectSizeY, int pathSizeX, int pathSizeY) {
-        if (target == null) return false;
-
-        List<WorldPoint> path = Rs2Player.getRs2WorldPoint().pathTo(target, true);
-        if (path == null || path.isEmpty()) return false;
-
-        // Create centered WorldAreas instead of using corner-based construction
-        WorldPoint pathEndpoint = path.get(path.size() - 1);
-        WorldPoint pathSouthWest = new WorldPoint(
-                pathEndpoint.getX() - pathSizeX / 2,
-                pathEndpoint.getY() - pathSizeY / 2,
-                pathEndpoint.getPlane()
-        );
-        WorldArea pathArea = new WorldArea(pathSouthWest, pathSizeX, pathSizeY);
-
-        WorldPoint objectSouthWest = new WorldPoint(
-                target.getX() - (objectSizeX + 2) / 2,
-                target.getY() - (objectSizeY + 2) / 2,
-                target.getPlane()
-        );
-        WorldArea objectArea = new WorldArea(objectSouthWest, objectSizeX + 2, objectSizeY + 2);
-
-        return pathArea.intersectsWith2D(objectArea);
-    }
-
-    public static boolean canReach(WorldPoint target, int objectSizeX, int objectSizeY) {
-        return canReach(target, objectSizeX, objectSizeY, 3, 3);
-    }
-
-    public static boolean canReach(WorldPoint target) {
-        return canReach(target, 2, 2, 2, 2);
-    }
-
-    @Deprecated
-    public static TileObject findObjectById(int id) {
-        var list = getAll(o -> o.getId() == id);
-        return list.stream().filter(x -> x.getId() == id).findFirst().orElse(null);
-    }
-
-    @Deprecated
-    public static TileObject findObjectByLocation(WorldPoint worldPoint) {
-        return getAll(o -> o.getWorldLocation().equals(worldPoint)).stream().findFirst().orElse(null);
-    }
-
-    @Deprecated
-    public static TileObject findGameObjectByLocation(WorldPoint worldPoint) {
-        return getGameObject(o -> o.getWorldLocation().equals(worldPoint));
-    }
-
-    /**
-     * find ground object by location
-     *
-     * @param worldPoint
-     * @return groundobject
-     */
-    @Deprecated
-    public static TileObject findGroundObjectByLocation(WorldPoint worldPoint) {
-        return getGroundObject(worldPoint);
-    }
-
-    @Deprecated
-    public static TileObject findObjectByIdAndDistance(int id, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) return null;
-        LocalPoint anchor = player.getLocalLocation();
-        return getAll(o -> o.getId() == id).stream().filter(withinTilesPredicate(Rs2LocalPoint.worldToLocalDistance(distance), anchor)).findFirst().orElse(null);
-    }
-
-    @Deprecated
-    public static GameObject findObjectById(int id, int x) {
-        return getGameObject(o -> o.getId() == id && o.getWorldLocation().getX() == x);
-    }
-
-    @Deprecated
-    public static GameObject findObject(int id, WorldPoint worldPoint) {
-        return getGameObject(o -> o.getId() == id && o.getWorldLocation().equals(worldPoint));
-    }
-
-    @Deprecated
-    public static ObjectComposition findObjectComposition(int id) {
-        return convertToObjectComposition(id);
-    }
-
-    @Deprecated
-    public static GameObject get(String name) {
-        return get(name, false);
-    }
-
-    @Deprecated
-    public static GameObject get(String name, boolean exact) {
-        return getGameObject(name, exact);
-    }
-
-    @Deprecated
-    public static GameObject findObject(String objectName, boolean exact, int distance, boolean checkLineOfSight, WorldPoint anchorPoint) {
-        return getGameObjects(nameMatches(objectName, exact), anchorPoint, distance).stream().filter(o -> !checkLineOfSight || Rs2GameObject.hasLineOfSight(o)).findFirst().orElse(null);
-    }
-
-    /**
-     * Finds a reachable game object by name within a specified distance from an anchor point, optionally checking for a specific action.
-     *
-     * @param objectName  The name of the game object to find.
-     * @param exact       Whether to match the name exactly or partially.
-     * @param distance    The maximum distance from the anchor point to search for the game object.
-     * @param anchorPoint The point from which to measure the distance.
-     * @param checkAction Whether to check for a specific action on the game object.
-     * @param action      The action to check for if checkAction is true.
-     * @return The nearest reachable game object that matches the criteria, or null if none is found.
-     */
-    @Deprecated
-    public static GameObject findReachableObject(String objectName, boolean exact, int distance, WorldPoint anchorPoint, boolean checkAction, String action) {
-        Predicate<TileObject> namePred = nameMatches(objectName, exact);
-
-        Predicate<GameObject> filter = o -> {
-            if (!Rs2GameObject.isReachable(o)) {
-                return false;
-            }
-
-            if (!namePred.test(o)) {
-                return false;
-            }
-
-            if (checkAction) {
-                ObjectComposition comp = convertToObjectComposition(o);
-                return hasAction(comp, action);
-            }
-
-            return true;
-        };
-
-        return getGameObjects(filter, anchorPoint, distance)
-                .stream()
-                .min(Comparator.comparingInt(o ->
-                        Rs2Player.getRs2WorldPoint()
-                                .distanceToPath(o.getWorldLocation())))
-                .orElse(null);
-    }
-
-    /**
-     * Finds a reachable game object by name within a specified distance from an anchor point.
-     *
-     * @param objectName  The name of the game object to find.
-     * @param exact       Whether to match the name exactly or partially.
-     * @param distance    The maximum distance from the anchor point to search for the game object.
-     * @param anchorPoint The point from which to measure the distance.
-     * @return The nearest reachable game object that matches the criteria, or null if none is found.
-     */
-    @Deprecated
-    public static GameObject findReachableObject(String objectName, boolean exact, int distance, WorldPoint anchorPoint) {
-        return findReachableObject(objectName, exact, distance, anchorPoint, false, "");
-    }
-
-    public static boolean hasAction(TileObject tileObject, String action) {
-        return hasAction(tileObject, action, false);
-    }
-
-    public static boolean hasAction(TileObject tileObject, String action, boolean exact) {
-        return hasAction(convertToObjectComposition(tileObject), action, exact);
-    }
-
-    public static boolean hasAction(ObjectComposition objComp, String action, boolean exact) {
-        if (objComp == null) return false;
-
-        return Arrays.stream(objComp.getActions())
-                .filter(Objects::nonNull)
-                .anyMatch(a -> exact ? a.equalsIgnoreCase(action) : a.toLowerCase().contains(action.toLowerCase()));
-    }
-
-    public static boolean hasAction(ObjectComposition objComp, String action) {
-        return hasAction(objComp, action, true);
-    }
-
-    /**
-     * Imposter objects are objects that have their menu action changed but still remain the same object.
-     * for example: farming patches
-     */
-    @Deprecated
-    public static GameObject findObjectByImposter(int id, String action) {
-        return findObjectByImposter(id, action, true);
-    }
-
-    @Deprecated
-    public static GameObject findObjectByImposter(int id, String optionName, boolean exact) {
-        return getGameObjects(o -> o.getId() == id)
-                .stream()
-                .filter(o -> {
-                    ObjectComposition comp = convertToObjectComposition(o);
-                    return hasAction(comp, optionName, exact);
-                })
-                .findFirst()
-                .orElse(null);
-    }
-
-    public static GameObject findBank(int maxSearchRadius) {
-        Predicate<GameObject> bankableFilter = gameObject -> {
-            WorldPoint loc = gameObject.getWorldLocation();
-
-            //cooks guild (exception)
-            if ((loc.equals(new WorldPoint(3147, 3449, 0)) || loc.equals(new WorldPoint(3148, 3449, 0))) && !BankLocation.COOKS_GUILD.hasRequirements()) {
-                return false;
-            }
-
-            //farming guild (exception)
-            //At the farming guild there’s 2 banks, one in the southern half of the guild and one northern part of the guild which requires a certain higher farming level to enter
-            if ((loc.equals(new WorldPoint(1248, 3759, 0)) || loc.equals(new WorldPoint(1249, 3759, 0))) && !Rs2Player.getSkillRequirement(Skill.FARMING, 85, true)) {
-                return false;
-            }
-
-            // Lunar Isle (exception)
-            // There is a bank booth @ Lunar Isle that is only accessible when Dream Mentor is completed
-            if (loc.equals(new WorldPoint(2099, 3920, 0)) && Rs2Player.getQuestState(Quest.DREAM_MENTOR) != QuestState.FINISHED) {
-                return false;
-            }
-
-            // Lunar Isle (additional exception to not use these banks if no seal of passage)
-            if ((loc.equals(new WorldPoint(2098, 3920, 0)) || loc.equals(new WorldPoint(2097, 3920, 0))) &&
-                    !(Rs2Inventory.hasItem(ItemID.LUNAR_SEAL_OF_PASSAGE) || Rs2Equipment.isWearing(ItemID.LUNAR_SEAL_OF_PASSAGE))) {
-                return false;
-            }
-
-            ObjectComposition comp = convertToObjectComposition(gameObject);
-            if (comp == null) return false;
-            return hasAction(comp, "Bank", false) || hasAction(comp, "Collect", false);
-        };
-
-        return getGameObjects(o -> Arrays.stream(Rs2BankID.bankIds).anyMatch(bid -> o.getId() == bid), maxSearchRadius).stream()
-                .filter(bankableFilter)
-                .findFirst()
-                .orElse(null);
-    }
-
-    public static GameObject findBank() {
-        return findBank(20);
-    }
-
-    /**
-     * Find nearest Deposit box
-     *
-     * @return GameObject
-     */
-    public static GameObject findDepositBox() {
-        return findDepositBox(20);
-    }
-
-    public static GameObject findDepositBox(int maxSearchRadius) {
-        Predicate<GameObject> depositableFilter = gameObject -> {
-            ObjectComposition comp = convertToObjectComposition(gameObject);
-            if (comp == null) return false;
-            return hasAction(comp, "Deposit", false);
-        };
-        return getGameObjects(o -> Arrays.stream(Rs2BankID.bankIds).anyMatch(bid -> o.getId() == bid), maxSearchRadius).stream()
-                .filter(depositableFilter)
-                .findFirst()
-                .orElse(null);
-    }
-
-    public static WallObject findGrandExchangeBooth(int maxSearchRadius) {
-        Integer[] grandExchangeBoothIds = new Integer[]{10060, 30389};
-        return getWallObjects(o -> Arrays.stream(grandExchangeBoothIds).anyMatch(gid -> o.getId() == gid) && Rs2Tile.isTileReachable(o.getWorldLocation()), maxSearchRadius).stream()
-                .findFirst()
-                .orElse(null);
-    }
-
-    public static WallObject findGrandExchangeBooth() {
-        return findGrandExchangeBooth(20);
-    }
-
-    @Deprecated
-    public static ObjectComposition convertGameObjectToObjectComposition(TileObject tileObject) {
-        return convertToObjectComposition(tileObject);
-    }
-
-    @Deprecated
-    public static ObjectComposition convertGameObjectToObjectComposition(int objectId) {
-        return convertToObjectComposition(objectId);
-    }
-
-    public static String getObjectType(TileObject object)
-    {
-        String type;
-        if (object instanceof WallObject) {
-            type = "WallObject";
-        } else if (object instanceof DecorativeObject) {
-            type = "DecorativeObject";
-        } else if (object instanceof GameObject) {
-            type = "GameObject";
-        } else if (object instanceof GroundObject) {
-            type = "GroundObject";
-        } else {
-            type = "TileObject";
-        }
-        return type;
-    }
-
-    public static List<Tile> getTiles(int maxTileDistance) {
-        int maxDistance = Math.max(2400, maxTileDistance * 128);
-
-        Player player = Microbot.getClient().getLocalPlayer();
-        Scene scene = Microbot.getClient().getScene();
-        Tile[][][] tiles = scene.getTiles();
-
-        int z = Microbot.getClient().getPlane();
-        List<Tile> tileObjects = new ArrayList<>();
-        for (int x = 0; x < Constants.SCENE_SIZE; ++x) {
-            for (int y = 0; y < Constants.SCENE_SIZE; ++y) {
-                Tile tile = tiles[z][x][y];
-
-                if (tile == null) {
-                    continue;
-                }
-
-                if (player.getLocalLocation().distanceTo(tile.getLocalLocation()) <= maxDistance) {
-                    tileObjects.add(tile);
-                }
-
-            }
-        }
-
-        return tileObjects;
-    }
-
-    public static List<Tile> getTiles() {
-        return getTiles(2400);
-    }
-
-    public static List<TileObject> getAll() {
-        return getAll(o -> true);
-    }
-
-    public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate) {
-        return getAll(predicate, Constants.SCENE_SIZE);
-    }
-
-    public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate, int distance) {
-        WorldPoint worldPoint = Rs2Player.getWorldLocation();
-        return getAll(predicate, worldPoint, distance);
-    }
-
-    public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate, WorldPoint anchor) {
-        return getAll(predicate, anchor, Constants.SCENE_SIZE);
-    }
-
-    public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate, WorldPoint anchor, int distance) {
-        List<TileObject> all = new ArrayList<>();
-        all.addAll(fetchGameObjects(predicate, anchor, distance));
-        all.addAll(fetchTileObjects(predicate, anchor, distance));
-        return all;
-    }
-
-    public static TileObject getTileObject(int id) {
-        return getTileObject(o -> o.getId() == id);
-    }
-
-    public static TileObject getTileObject(int id, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getTileObject(id, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static TileObject getTileObject(int id, WorldPoint anchor) {
-        return getTileObject(id, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static TileObject getTileObject(int id, WorldPoint anchor, int distance) {
-        return getTileObject(o -> o.getId() == id, anchor, distance);
-    }
-
-    public static TileObject getTileObject(Integer[] ids) {
-        Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
-        return getTileObject(o -> idSet.contains(o.getId()));
-    }
-
-    public static TileObject getTileObject(Integer[] ids, int distance) {
-        Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
-        return getTileObject(o -> idSet.contains(o.getId()), distance);
-    }
-
-    public static TileObject getTileObject(String objectName, boolean exact) {
-        return getTileObject(nameMatches(objectName, exact));
-    }
-
-    public static TileObject getTileObject(String objectName) {
-        return getTileObject(objectName, false);
-    }
-
-    public static TileObject getTileObject(String objectName, boolean exact, int distance) {
-        return getTileObject(nameMatches(objectName, exact), distance);
-    }
-
-    public static TileObject getTileObject(String objectName, int distance) {
-        return getTileObject(objectName, false, distance);
-    }
-
-    public static TileObject getTileObject(String objectName, boolean exact, WorldPoint anchor) {
-        return getTileObject(nameMatches(objectName, exact), anchor);
-    }
-
-    public static TileObject getTileObject(String objectName, WorldPoint anchor) {
-        return getTileObject(objectName, false, anchor);
-    }
-
-    public static TileObject getTileObject(String objectName, boolean exact, LocalPoint anchorLocal) {
-        return getTileObject(nameMatches(objectName, exact), anchorLocal);
-    }
-
-    public static TileObject getTileObject(String objectName, LocalPoint anchorLocal) {
-        return getTileObject(objectName, false, anchorLocal);
-    }
-
-    public static TileObject getTileObject(String objectName, boolean exact, WorldPoint anchor, int distance) {
-        return getTileObject(nameMatches(objectName, exact), anchor, distance);
-    }
-
-    public static TileObject getTileObject(String objectName, WorldPoint anchor, int distance) {
-        return getTileObject(objectName, false, anchor, distance);
-    }
-
-    public static TileObject getTileObject(String objectName, boolean exact, LocalPoint anchorLocal, int distance) {
-        return getTileObject(nameMatches(objectName, exact), anchorLocal, distance);
-    }
-
-    public static TileObject getTileObject(String objectName, LocalPoint anchorLocal, int distance) {
-        return getTileObject(nameMatches(objectName), anchorLocal, distance);
-    }
-
-    public static TileObject getTileObject(Predicate<TileObject> predicate) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getTileObject(predicate, Rs2Player.getWorldLocation());
-    }
-
-    public static TileObject getTileObject(WorldPoint anchor) {
-        return getTileObject(o -> true, anchor);
-    }
-
-    public static TileObject getTileObject(LocalPoint anchorLocal) {
-        return getTileObject(o -> true, anchorLocal);
-    }
-
-    public static TileObject getTileObject(WorldPoint anchor, int distance) {
-        return getTileObject(o -> true, anchor, distance);
-    }
-
-    public static TileObject getTileObject(LocalPoint anchorLocal, int distance) {
-        return getTileObject(o -> true, anchorLocal, distance);
-    }
-
-    public static TileObject getTileObject(Predicate<TileObject> predicate, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getTileObject(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static TileObject getTileObject(Predicate<TileObject> predicate, WorldPoint anchor) {
-        return getTileObject(predicate, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static TileObject getTileObject(Predicate<TileObject> predicate, LocalPoint anchorLocal) {
-        return getTileObject(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
-    }
-
-    public static TileObject getTileObject(Predicate<TileObject> predicate, WorldPoint anchor, int distance) {
-        LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
-        if (anchorLocal == null) {
-            return null;
-        }
-        return getTileObject(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
-    }
-
-    public static TileObject getTileObject(Predicate<TileObject> predicate, LocalPoint anchorLocal, int distance) {
-        return getSceneObject(TILEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
-    }
-
-    public static List<TileObject> getTileObjects() {
-        return getTileObjects(o -> true);
-    }
-
-    public static List<TileObject> getTileObjects(int distance) {
-        return getTileObjects(o -> true, distance);
-    }
-
-    public static List<TileObject> getTileObjects(Predicate<TileObject> predicate, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return getTileObjects(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static List<TileObject> getTileObjects(WorldPoint anchor) {
-        return getTileObjects(o -> true, anchor);
-    }
-
-    public static List<TileObject> getTileObjects(LocalPoint anchorLocal) {
-        return getTileObjects(o -> true, anchorLocal);
-    }
-
-    public static List<TileObject> getTileObjects(Predicate<TileObject> predicate) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return getTileObjects(predicate, Rs2Player.getWorldLocation());
-    }
-
-    public static List<TileObject> getTileObjects(Predicate<TileObject> predicate, WorldPoint anchor) {
-        return getTileObjects(predicate, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static List<TileObject> getTileObjects(Predicate<TileObject> predicate, LocalPoint anchorLocal) {
-        return getTileObjects(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
-    }
-
-    public static List<TileObject> getTileObjects(Predicate<TileObject> predicate, WorldPoint anchor, int distance) {
-        LocalPoint anchorLocal = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), anchor);
-        if (anchorLocal == null) {
-            return Collections.emptyList();
-        }
-        return getTileObjects(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
-    }
-
-    public static List<TileObject> getTileObjects(Predicate<TileObject> predicate, LocalPoint anchorLocal, int distance) {
-        return getSceneObjects(TILEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
-    }
-
-    public static GameObject getGameObject(int id) {
-        return getGameObject(id, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static GameObject getGameObject(int id, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getGameObject(id, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static GameObject getGameObject(int id, WorldPoint anchor) {
-        return getGameObject(id, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static GameObject getGameObject(int id, WorldPoint anchor, int distance) {
-        return getGameObject(o -> o.getId() == id, anchor, distance);
-    }
-
-    public static GameObject getGameObject(Integer[] ids) {
-        Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
-        return getGameObject(o -> idSet.contains(o.getId()));
-    }
-
-    @Deprecated
-    public static GameObject findObject(Integer[] ids) {
-        Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
-        return getGameObject(o -> idSet.contains(o.getId()));
-    }
-
-    public static GameObject getGameObject(Integer[] ids, int distance) {
-        Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
-        return getGameObject(o -> idSet.contains(o.getId()), distance);
-    }
-
-    public static GameObject getGameObject(String objectName, boolean exact, int distance) {
-        return getGameObject(nameMatches(objectName, exact), distance);
-    }
-
-    public static GameObject getGameObject(String objectName, boolean exact) {
-        return getGameObject(nameMatches(objectName, exact));
-    }
-
-    public static GameObject getGameObject(String objectName) {
-        return getGameObject(objectName, false);
-    }
-
-    public static GameObject getGameObject(String objectName, int distance) {
-        return getGameObject(objectName, false, distance);
-    }
-
-    public static GameObject getGameObject(String objectName, boolean exact, WorldPoint anchor) {
-        return getGameObject(nameMatches(objectName, exact), anchor);
-    }
-
-    public static GameObject getGameObject(String objectName, WorldPoint anchor) {
-        return getGameObject(objectName, false, anchor);
-    }
-
-    public static GameObject getGameObject(String objectName, boolean exact, LocalPoint anchorLocal) {
-        return getGameObject(nameMatches(objectName, exact), anchorLocal);
-    }
-
-    public static GameObject getGameObject(String objectName, LocalPoint anchorLocal) {
-        return getGameObject(objectName, false, anchorLocal);
-    }
-
-    public static GameObject getGameObject(String objectName, boolean exact, WorldPoint anchor, int distance) {
-        return getGameObject(nameMatches(objectName, exact), anchor, distance);
-    }
-
-    public static GameObject getGameObject(String objectName, WorldPoint anchor, int distance) {
-        return getGameObject(objectName, false, anchor, distance);
-    }
-
-    public static GameObject getGameObject(String objectName, boolean exact, LocalPoint anchorLocal, int distance) {
-        return getGameObject(nameMatches(objectName, exact), anchorLocal, distance);
-    }
-
-    public static GameObject getGameObject(String objectName, LocalPoint anchorLocal, int distance) {
-        return getGameObject(objectName, false, anchorLocal, distance);
-    }
-
-    public static GameObject getGameObject(Predicate<GameObject> predicate) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getGameObject(predicate, Rs2Player.getWorldLocation());
-    }
-
-    public static GameObject getGameObject(WorldPoint anchor) {
-        return getGameObject(o -> true, anchor);
-    }
-
-    public static GameObject getGameObject(LocalPoint anchorLocal) {
-        return getGameObject(o -> true, anchorLocal);
-    }
-
-    public static GameObject getGameObject(WorldPoint anchor, int distance) {
-        return getGameObject(o -> true, anchor, distance);
-    }
-
-    public static GameObject getGameObject(LocalPoint anchorLocal, int distance) {
-        return getGameObject(o -> true, anchorLocal, distance);
-    }
-
-    public static GameObject getGameObject(Predicate<GameObject> predicate, int distance) {
-        return getGameObject(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static GameObject getGameObject(Predicate<GameObject> predicate, WorldPoint anchor) {
-        return getGameObject(predicate, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static GameObject getGameObject(Predicate<GameObject> predicate, LocalPoint anchorLocal) {
-        return getGameObject(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
-    }
-
-    public static GameObject getGameObject(Predicate<GameObject> predicate, WorldPoint anchor, int distance) {
-        LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
-        if (anchorLocal == null) {
-            return null;
-        }
-        return getGameObject(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
-    }
-
-    public static GameObject getGameObject(Predicate<GameObject> predicate, LocalPoint anchorLocal, int distance) {
-        return getSceneObject(GAMEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
-    }
-
-    public static List<GameObject> getGameObjects() {
-        return getGameObjects(o -> true);
-    }
-
-    public static List<GameObject> getGameObjects(int distance) {
-        return getGameObjects(o -> true, distance);
-    }
-
-    public static List<GameObject> getGameObjects(Predicate<GameObject> predicate, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return getGameObjects(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static List<GameObject> getGameObjects(WorldPoint anchor) {
-        return getGameObjects(o -> true, anchor);
-    }
-
-    public static List<GameObject> getGameObjects(LocalPoint anchorLocal) {
-        return getGameObjects(o -> true, anchorLocal);
-    }
-
-    public static List<GameObject> getGameObjects(Predicate<GameObject> predicate) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return getGameObjects(predicate, Rs2Player.getWorldLocation());
-    }
-
-    public static List<GameObject> getGameObjects(Predicate<GameObject> predicate, WorldPoint anchor) {
-        return getGameObjects(predicate, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static List<GameObject> getGameObjects(Predicate<GameObject> predicate, LocalPoint anchorLocal) {
-        return getGameObjects(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
-    }
-
-    public static List<GameObject> getGameObjects(Predicate<GameObject> predicate, WorldPoint anchor, int distance) {
-        LocalPoint anchorLocal = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), anchor);
-        if (anchorLocal == null) {
-            return Collections.emptyList();
-        }
-        return getGameObjects(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
-    }
-
-    public static List<GameObject> getGameObjects(Predicate<GameObject> predicate, LocalPoint anchorLocal, int distance) {
-        return getSceneObjects(GAMEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
-    }
-
-    public static GroundObject getGroundObject(int id) {
-        return getGroundObject(id, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static GroundObject getGroundObject(int id, int distance) {
-        return getGroundObject(id, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static GroundObject getGroundObject(int id, WorldPoint anchor) {
-        return getGroundObject(id, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static GroundObject getGroundObject(int id, WorldPoint anchor, int distance) {
-        return getGroundObject(o -> o.getId() == id, anchor, distance);
-    }
-
-    public static GroundObject getGroundObject(Integer[] ids) {
-        Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
-        return getGroundObject(o -> idSet.contains(o.getId()));
-    }
-
-    public static GroundObject getGroundObject(Integer[] ids, int distance) {
-        Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
-        return getGroundObject(o -> idSet.contains(o.getId()), distance);
-    }
-
-    public static GroundObject getGroundObject(String objectName, boolean exact, int distance) {
-        return getGroundObject(nameMatches(objectName, exact), distance);
-    }
-
-    public static GroundObject getGroundObject(String objectName, boolean exact) {
-        return getGroundObject(nameMatches(objectName, exact));
-    }
-
-    public static GroundObject getGroundObject(String objectName) {
-        return getGroundObject(objectName, false);
-    }
-
-    public static GroundObject getGroundObject(String objectName, int distance) {
-        return getGroundObject(objectName, false, distance);
-    }
-
-    public static GroundObject getGroundObject(String objectName, boolean exact, WorldPoint anchor) {
-        return getGroundObject(nameMatches(objectName, exact), anchor);
-    }
-
-    public static GroundObject getGroundObject(String objectName, WorldPoint anchor) {
-        return getGroundObject(objectName, false, anchor);
-    }
-
-    public static GroundObject getGroundObject(String objectName, boolean exact, LocalPoint anchorLocal) {
-        return getGroundObject(nameMatches(objectName, exact), anchorLocal);
-    }
-
-    public static GroundObject getGroundObject(String objectName, LocalPoint anchorLocal) {
-        return getGroundObject(objectName, false, anchorLocal);
-    }
-
-    public static GroundObject getGroundObject(String objectName, boolean exact, WorldPoint anchor, int distance) {
-        return getGroundObject(nameMatches(objectName, exact), anchor, distance);
-    }
-
-    public static GroundObject getGroundObject(String objectName, WorldPoint anchor, int distance) {
-        return getGroundObject(objectName, false, anchor, distance);
-    }
-
-    public static GroundObject getGroundObject(String objectName, boolean exact, LocalPoint anchorLocal, int distance) {
-        return getGroundObject(nameMatches(objectName, exact), anchorLocal, distance);
-    }
-
-    public static GroundObject getGroundObject(String objectName, LocalPoint anchorLocal, int distance) {
-        return getGroundObject(objectName, false, anchorLocal, distance);
-    }
-
-    public static GroundObject getGroundObject(Predicate<GroundObject> predicate) {
-        return getGroundObject(predicate, Rs2Player.getWorldLocation());
-    }
-
-    public static GroundObject getGroundObject(WorldPoint anchor) {
-        return getGroundObject(o -> true, anchor);
-    }
-
-    public static GroundObject getGroundObject(LocalPoint anchorLocal) {
-        return getGroundObject(o -> true, anchorLocal);
-    }
-
-    public static GroundObject getGroundObject(WorldPoint anchor, int distance) {
-        return getGroundObject(o -> true, anchor, distance);
-    }
-
-    public static GroundObject getGroundObject(LocalPoint anchorLocal, int distance) {
-        return getGroundObject(o -> true, anchorLocal, distance);
-    }
-
-    public static GroundObject getGroundObject(Predicate<GroundObject> predicate, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getGroundObject(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static GroundObject getGroundObject(Predicate<GroundObject> predicate, WorldPoint anchor) {
-        return getGroundObject(predicate, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static GroundObject getGroundObject(Predicate<GroundObject> predicate, LocalPoint anchorLocal) {
-        return getGroundObject(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
-    }
-
-    public static GroundObject getGroundObject(Predicate<GroundObject> predicate, WorldPoint anchor, int distance) {
-        LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
-        if (anchorLocal == null) {
-            return null;
-        }
-        return getGroundObject(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
-    }
-
-    public static GroundObject getGroundObject(Predicate<GroundObject> predicate, LocalPoint anchorLocal, int distance) {
-        return getSceneObject(GROUNDOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
-    }
-
-    public static List<GroundObject> getGroundObjects() {
-        return getGroundObjects(o -> true);
-    }
-
-    public static List<GroundObject> getGroundObjects(int distance) {
-        return getGroundObjects(o -> true, distance);
-    }
-
-    public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return getGroundObjects(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static List<GroundObject> getGroundObjects(WorldPoint anchor) {
-        return getGroundObjects(o -> true, anchor);
-    }
-
-    public static List<GroundObject> getGroundObjects(LocalPoint anchorLocal) {
-        return getGroundObjects(o -> true, anchorLocal);
-    }
-
-    public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return getGroundObjects(predicate, Rs2Player.getWorldLocation());
-    }
-
-    public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate, WorldPoint anchor) {
-        return getGroundObjects(predicate, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate, LocalPoint anchorLocal) {
-        return getGroundObjects(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
-    }
-
-    public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate, WorldPoint anchor, int distance) {
-        LocalPoint anchorLocal = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), anchor);
-        if (anchorLocal == null) {
-            return Collections.emptyList();
-        }
-        return getGroundObjects(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
-    }
-
-    public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate, LocalPoint anchorLocal, int distance) {
-        return getSceneObjects(GROUNDOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
-    }
-
-    public static WallObject getWallObject(int id) {
-        return getWallObject(id, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static WallObject getWallObject(int id, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getWallObject(id, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static WallObject getWallObject(int id, WorldPoint anchor) {
-        return getWallObject(id, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static WallObject getWallObject(int id, WorldPoint anchor, int distance) {
-        return getWallObject(o -> o.getId() == id, anchor, distance);
-    }
-
-    public static WallObject getWallObject(Integer[] ids) {
-        Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
-        return getWallObject(o -> idSet.contains(o.getId()));
-    }
-
-    public static WallObject getWallObject(Integer[] ids, int distance) {
-        Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
-        return getWallObject(o -> idSet.contains(o.getId()), distance);
-    }
-
-    public static WallObject getWallObject(String objectName, boolean exact, int distance) {
-        return getWallObject(nameMatches(objectName, exact), distance);
-    }
-
-    public static WallObject getWallObject(String objectName, boolean exact) {
-        return getWallObject(nameMatches(objectName, exact));
-    }
-
-    public static WallObject getWallObject(String objectName) {
-        return getWallObject(objectName, false);
-    }
-
-    public static WallObject getWallObject(String objectName, int distance) {
-        return getWallObject(objectName, false, distance);
-    }
-
-    public static WallObject getWallObject(String objectName, boolean exact, WorldPoint anchor) {
-        return getWallObject(nameMatches(objectName, exact), anchor);
-    }
-
-    public static WallObject getWallObject(String objectName, WorldPoint anchor) {
-        return getWallObject(objectName, false, anchor);
-    }
-
-    public static WallObject getWallObject(String objectName, boolean exact, LocalPoint anchorLocal) {
-        return getWallObject(nameMatches(objectName, exact), anchorLocal);
-    }
-
-    public static WallObject getWallObject(String objectName, LocalPoint anchorLocal) {
-        return getWallObject(objectName, false, anchorLocal);
-    }
-
-    public static WallObject getWallObject(String objectName, boolean exact, WorldPoint anchor, int distance) {
-        return getWallObject(nameMatches(objectName, exact), anchor, distance);
-    }
-
-    public static WallObject getWallObject(String objectName, WorldPoint anchor, int distance) {
-        return getWallObject(objectName, false, anchor, distance);
-    }
-
-    public static WallObject getWallObject(String objectName, boolean exact, LocalPoint anchorLocal, int distance) {
-        return getWallObject(nameMatches(objectName, exact), anchorLocal, distance);
-    }
-
-    public static WallObject getWallObject(String objectName, LocalPoint anchorLocal, int distance) {
-        return getWallObject(objectName, false, anchorLocal, distance);
-    }
-
-    public static WallObject getWallObject(Predicate<WallObject> predicate) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getWallObject(predicate, Rs2Player.getWorldLocation());
-    }
-
-    public static WallObject getWallObject(WorldPoint anchor) {
-        return getWallObject(o -> true, anchor);
-    }
-
-    public static WallObject getWallObject(LocalPoint anchorLocal) {
-        return getWallObject(o -> true, anchorLocal);
-    }
-
-    public static WallObject getWallObject(WorldPoint anchor, int distance) {
-        return getWallObject(o -> true, anchor, distance);
-    }
-
-    public static WallObject getWallObject(LocalPoint anchorLocal, int distance) {
-        return getWallObject(o -> true, anchorLocal, distance);
-    }
-
-    public static WallObject getWallObject(Predicate<WallObject> predicate, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getWallObject(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static WallObject getWallObject(Predicate<WallObject> predicate, WorldPoint anchor) {
-        return getWallObject(predicate, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static WallObject getWallObject(Predicate<WallObject> predicate, LocalPoint anchorLocal) {
-        return getWallObject(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
-    }
-
-    public static WallObject getWallObject(Predicate<WallObject> predicate, WorldPoint anchor, int distance) {
-        LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
-        if (anchorLocal == null) {
-            return null;
-        }
-        return getWallObject(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
-    }
-
-    public static WallObject getWallObject(Predicate<WallObject> predicate, LocalPoint anchorLocal, int distance) {
-        return getSceneObject(WALLOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
-    }
-
-    public static List<WallObject> getWallObjects() {
-        return getWallObjects(o -> true);
-    }
-
-    public static List<WallObject> getWallObjects(int distance) {
-        return getWallObjects(o -> true, distance);
-    }
-
-    public static List<WallObject> getWallObjects(Predicate<WallObject> predicate, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return getWallObjects(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static List<WallObject> getWallObjects(WorldPoint anchor) {
-        return getWallObjects(o -> true, anchor);
-    }
-
-    public static List<WallObject> getWallObjects(LocalPoint anchorLocal) {
-        return getWallObjects(o -> true, anchorLocal);
-    }
-
-    public static List<WallObject> getWallObjects(Predicate<WallObject> predicate) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return getWallObjects(predicate, Rs2Player.getWorldLocation());
-    }
-
-    public static List<WallObject> getWallObjects(Predicate<WallObject> predicate, WorldPoint anchor) {
-        return getWallObjects(predicate, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static List<WallObject> getWallObjects(Predicate<WallObject> predicate, LocalPoint anchorLocal) {
-        return getWallObjects(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
-    }
-
-    public static List<WallObject> getWallObjects(Predicate<WallObject> predicate, WorldPoint anchor, int distance) {
-        LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
-        if (anchorLocal == null) {
-            return Collections.emptyList();
-        }
-        return getWallObjects(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
-    }
-
-    public static List<WallObject> getWallObjects(Predicate<WallObject> predicate, LocalPoint anchorLocal, int distance) {
-        return getSceneObjects(WALLOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(int id) {
-        return getDecorativeObject(id, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static DecorativeObject getDecorativeObject(int id, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getDecorativeObject(id, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(int id, WorldPoint anchor) {
-        return getDecorativeObject(id, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static DecorativeObject getDecorativeObject(int id, WorldPoint anchor, int distance) {
-        return getDecorativeObject(o -> o.getId() == id, anchor, distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(Integer[] ids) {
-        Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
-        return getDecorativeObject(o -> idSet.contains(o.getId()));
-    }
-
-    public static DecorativeObject getDecorativeObject(Integer[] ids, int distance) {
-        Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
-        return getDecorativeObject(o -> idSet.contains(o.getId()), distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName, boolean exact, int distance) {
-        return getDecorativeObject(nameMatches(objectName, exact), distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName, boolean exact) {
-        return getDecorativeObject(nameMatches(objectName, exact));
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName) {
-        return getDecorativeObject(objectName, false);
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName, int distance) {
-        return getDecorativeObject(objectName, false, distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName, boolean exact, WorldPoint anchor) {
-        return getDecorativeObject(nameMatches(objectName, exact), anchor);
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName, WorldPoint anchor) {
-        return getDecorativeObject(objectName, false, anchor);
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName, boolean exact, LocalPoint anchorLocal) {
-        return getDecorativeObject(nameMatches(objectName, exact), anchorLocal);
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName, LocalPoint anchorLocal) {
-        return getDecorativeObject(objectName, false, anchorLocal);
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName, boolean exact, WorldPoint anchor, int distance) {
-        return getDecorativeObject(nameMatches(objectName, exact), anchor, distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName, WorldPoint anchor, int distance) {
-        return getDecorativeObject(objectName, false, anchor, distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName, boolean exact, LocalPoint anchorLocal, int distance) {
-        return getDecorativeObject(nameMatches(objectName, exact), anchorLocal, distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(String objectName, LocalPoint anchorLocal, int distance) {
-        return getDecorativeObject(objectName, false, anchorLocal, distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getDecorativeObject(predicate, Rs2Player.getWorldLocation());
-    }
-
-    public static DecorativeObject getDecorativeObject(WorldPoint anchor) {
-        return getDecorativeObject(o -> true, anchor);
-    }
-
-    public static DecorativeObject getDecorativeObject(LocalPoint anchorLocal) {
-        return getDecorativeObject(o -> true, anchorLocal);
-    }
-
-    public static DecorativeObject getDecorativeObject(WorldPoint anchor, int distance) {
-        return getDecorativeObject(o -> true, anchor, distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(LocalPoint anchorLocal, int distance) {
-        return getDecorativeObject(o -> true, anchorLocal, distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return null;
-        }
-        return getDecorativeObject(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate, WorldPoint anchor) {
-        return getDecorativeObject(predicate, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate, LocalPoint anchorLocal) {
-        return getDecorativeObject(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
-    }
-
-    public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate, WorldPoint anchor, int distance) {
-        LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
-        if (anchorLocal == null) {
-            return null;
-        }
-        return getDecorativeObject(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
-    }
-
-    public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate, LocalPoint anchorLocal, int distance) {
-        return getSceneObject(DECORATIVEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
-    }
-
-    public static List<DecorativeObject> getDecorativeObjects() {
-        return getDecorativeObjects(o -> true);
-    }
-
-    public static List<DecorativeObject> getDecorativeObjects(int distance) {
-        return getDecorativeObjects(o -> true, distance);
-    }
-
-    public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return getDecorativeObjects(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    public static List<DecorativeObject> getDecorativeObjects(WorldPoint anchor) {
-        return getDecorativeObjects(o -> true, anchor);
-    }
-
-    public static List<DecorativeObject> getDecorativeObjects(LocalPoint anchorLocal) {
-        return getDecorativeObjects(o -> true, anchorLocal);
-    }
-
-    public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return getDecorativeObjects(predicate, Rs2Player.getWorldLocation());
-    }
-
-    public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate, WorldPoint anchor) {
-        return getDecorativeObjects(predicate, anchor, (Constants.SCENE_SIZE / 2));
-    }
-
-    public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate, LocalPoint anchorLocal) {
-        return getDecorativeObjects(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
-    }
-
-    public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate, WorldPoint anchor, int distance) {
-        LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
-        if (anchorLocal == null) {
-            return Collections.emptyList();
-        }
-        return getDecorativeObjects(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
-    }
-
-    public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate, LocalPoint anchorLocal, int distance) {
-        return getSceneObjects(DECORATIVEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
-    }
-
-    @Nullable
-    public static <T extends TileObject> ObjectComposition convertToObjectComposition(T object) {
-        return convertToObjectComposition(object.getId(), false);
-    }
-
-    @Nullable
-    public static ObjectComposition convertToObjectComposition(int objectId) {
-        return convertToObjectCompositionInternal(objectId, false);
-    }
-
-    @Nullable
-    public static <T extends TileObject> ObjectComposition convertToObjectComposition(T object, boolean ignoreImpostor) {
-        return convertToObjectCompositionInternal(object.getId(), ignoreImpostor);
-    }
-
-    @Nullable
-    public static ObjectComposition convertToObjectComposition(int objectId, boolean ignoreImpostor) {
-        return convertToObjectCompositionInternal(objectId, ignoreImpostor);
-    }
-
-    public static <T> Optional<T> pickClosest(Collection<T> candidates, Function<T, WorldPoint> locFn, WorldPoint anchor) {
-        return candidates.stream()
-                .filter(Objects::nonNull)
-                .min(Comparator.comparingInt(c -> locFn.apply(c).distanceTo(anchor)));
-    }
-
-    // private methods
-    private static <T extends TileObject> Stream<T> getSceneObjects(Function<Tile, Collection<? extends T>> extractor) {
-        var triple = Microbot.getClientThread().invoke(() -> {
-            Player player = Microbot.getClient().getLocalPlayer();
-
-            Scene scene = player.getWorldView().getScene();
-
-            Tile[][][] tiles = scene.getTiles();
-            if (tiles == null) {
-                return Triple.of(null, null, 0);
-            }
-
-            int z = player.getWorldView().getPlane();
-
-            return Triple.of(scene, tiles, z);
-        });
-
-        var result = new ArrayList<T>();
-        Tile[][][] tiles = (Tile[][][]) triple.getMiddle();
-        int z = triple.getRight();
-
-        int sceneSize = Constants.SCENE_SIZE;
-
-        for (int x = 0; x < sceneSize; x++) {
-            for (int y = 0; y < sceneSize; y++) {
-                for (int h = 0; h <= z; h++) {
-                    Tile tile = tiles[h][x][y];
-                    if (tile == null) continue;
-
-                    Collection<? extends T> objs = extractor.apply(tile);
-                    if (objs != null) {
-                        for (T obj : objs) {
-                            if (obj == null) continue;
-
-                            if (obj instanceof GameObject) {
-                                GameObject gameObject = (GameObject) obj;
-                                if (gameObject.getSceneMinLocation().equals(tile.getSceneLocation())) {
-                                    result.add(obj);
-                                }
-                            } else {
-                                if (obj.getLocalLocation().equals(tile.getLocalLocation())) {
-                                    result.add(obj);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return result.stream();
-    }
-
-    private static <T extends TileObject> List<T> getSceneObjects(Function<Tile, Collection<? extends T>> extractor, Predicate<T> predicate, LocalPoint anchorLocal, int distance) {
-        if (distance > Rs2LocalPoint.worldToLocalDistance(Constants.SCENE_SIZE)) {
-            distance = Rs2LocalPoint.worldToLocalDistance(Constants.SCENE_SIZE);
-        }
-
-        return getSceneObjects(extractor)
-                .filter(withinTilesPredicate(distance, anchorLocal))
-                .filter(predicate)
-                .sorted(Comparator.comparingInt(o -> o.getLocalLocation().distanceTo(anchorLocal)))
-                .collect(Collectors.toList());
-    }
-
-    private static <T extends TileObject> T getSceneObject(Function<Tile, Collection<? extends T>> extractor, Predicate<T> predicate, LocalPoint anchorLocal, int distance) {
-        return getSceneObjects(extractor, predicate, anchorLocal, distance)
-                .stream()
-                .findFirst()
-                .orElse(null);
-    }
-
-    private static boolean isWithinTiles(LocalPoint anchor, LocalPoint objLoc, int distance) {
-        int dx = Math.abs(anchor.getX() - objLoc.getX());
-        int dy = Math.abs(anchor.getY() - objLoc.getY());
-
-        if (distance == 0) {
-            // exactly one tile away, no diagonals
-            return (dx == Perspective.LOCAL_TILE_SIZE && dy == 0)
-                    || (dy == Perspective.LOCAL_TILE_SIZE && dx == 0);
-        } else {
-            return objLoc.distanceTo(anchor) <= distance;
-        }
-    }
-
-    private static <T extends TileObject> Predicate<T> withinTilesPredicate(int distance, LocalPoint anchor) {
-        return to -> isWithinTiles(anchor, to.getLocalLocation(), distance);
-    }
-
-    private static LocalPoint localPointFromWorldSafe(WorldPoint anchor) {
-        if(Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.getValue() == null){
-            return null;
-        }
-
-        return LocalPoint.fromWorld(Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.<WorldView>getValue(), anchor);
-    }
-
-    public static Optional<String> getCompositionName(TileObject obj) {
-        ObjectComposition comp = convertToObjectComposition(obj);
-        if (comp == null) {
-            return Optional.empty();
-        }
-        String name = comp.getName();
-        return (name == null || name.equals("null"))
-                ? Optional.empty()
-                : Optional.of(Rs2UiHelper.stripColTags(name));
-    }
-
-    /**
-     * Creates a predicate that matches TileObjects whose name matches the given name.
-     * Optionally, it can require an exact match or allow partial (contains) match.
-     *
-     * @param objectName The name of the object to match.
-     * @param exact      If true, the object name must exactly match (case-insensitive).
-     *                   If false, the name must only contain the given string (case-insensitive).
-     * @param <T>        A type that extends TileObject.
-     * @return A predicate that returns true if the object's name matches the given name.
-     */
-    public static <T extends TileObject> Predicate<T> nameMatches(String objectName, boolean exact)
-    {
-        String normalizedForIds = objectName.toLowerCase().replace(" ", "_");
-        Set<Integer> ids = new HashSet<>(getObjectIdsByName(normalizedForIds));
-
-        String lower = objectName.toLowerCase();
-
-        return obj -> {
-            if (!ids.isEmpty() && !ids.contains(obj.getId())) {
-                return false;
-            }
-
-            return getCompositionName(obj)
-                    .map(compName -> exact ? compName.equalsIgnoreCase(objectName) : compName.toLowerCase().contains(lower))
-                    .orElse(false);
-        };
-    }
-
-    /**
-     * Creates a predicate that matches TileObjects whose name contains the given name (case-insensitive).
-     *
-     * @param objectName The partial or full name to match against.
-     * @param <T>        A type that extends TileObject.
-     * @return A predicate that returns true if the object's name contains the given string.
-     */
-    public static <T extends TileObject> Predicate<T> nameMatches(String objectName)
-    {
-        return nameMatches(objectName, false);
-    }
-
-    /**
-     * Creates a predicate that matches TileObjects whose name and one of the actions match the given values.
-     * Matching can be exact or partial based on the 'exact' parameter.
-     *
-     * @param objectName The name of the object to match.
-     * @param actionName The action text to match (e.g. "Open", "Climb").
-     * @param exact      If true, both the name and action must match exactly (case-insensitive).
-     *                   If false, both may partially match (case-insensitive).
-     * @param <T>        A type that extends TileObject.
-     * @return A predicate that returns true if both the name and action match.
-     */
-    public static <T extends TileObject> Predicate<T> nameAndActionMatches(String objectName, String actionName, boolean exact)
-    {
-        Predicate<T> namePredicate = nameMatches(objectName, exact);
-        Predicate<T> actionPredicate = obj -> {
-            ObjectComposition comp = convertToObjectComposition(obj);
-            return hasAction(comp, actionName, exact);
-        };
-
-        return namePredicate.and(actionPredicate);
-    }
-
-    /**
-     * Creates a predicate that matches TileObjects by name and action using partial (contains) matching.
-     *
-     * @param objectName The name of the object to match.
-     * @param actionName The action text to match (e.g. "Open", "Climb").
-     * @param <T>        A type that extends TileObject.
-     * @return A predicate that returns true if both the name and action partially match.
-     */
-    public static <T extends TileObject> Predicate<T> nameAndActionMatches(String objectName, String actionName)
-    {
-        return nameAndActionMatches(objectName, actionName, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate, WorldPoint anchor, int distance) {
-        return (List<T>) getTileObjects((Predicate<TileObject>) predicate, anchor, distance);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate, WorldPoint anchor, int distance) {
-        return (List<T>) getGameObjects((Predicate<GameObject>) predicate, anchor, distance);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate, WorldPoint anchor) {
-        return fetchTileObjects(predicate, anchor, Constants.SCENE_SIZE);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate, WorldPoint anchor) {
-        return fetchTileObjects(predicate, anchor, Constants.SCENE_SIZE);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return fetchTileObjects(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate, int distance) {
-        Player player = Microbot.getClient().getLocalPlayer();
-        if (player == null) {
-            return Collections.emptyList();
-        }
-        return fetchGameObjects(predicate, Rs2Player.getWorldLocation(), distance);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate) {
-        return fetchTileObjects(predicate, Constants.SCENE_SIZE);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate) {
-        return fetchGameObjects(predicate, Constants.SCENE_SIZE);
-    }
-
-    @Nullable
-    private static ObjectComposition convertToObjectCompositionInternal(int objectId, boolean ignoreImpostor) {
-        return Microbot.getClientThread().runOnClientThreadOptional(() -> {
-            ObjectComposition comp = Microbot.getClient().getObjectDefinition(objectId);
-            if (comp == null) return null;
-            return (ignoreImpostor || comp.getImpostorIds() == null) ? comp : comp.getImpostor();
-        }).orElse(null);
-    }
-
-    private static boolean clickObject(TileObject object) {
-        return clickObject(object, "");
-    }
-
-    public static boolean clickObject(TileObject object, String action) {
-        if (object == null) return false;
-        if (Rs2Player.getWorldLocation().distanceTo(object.getWorldLocation()) > 51) {
-            Microbot.log("Object with id " + object.getId() + " is not close enough to interact with. Walking to the object....");
-            Rs2Walker.walkTo(object.getWorldLocation());
-            return false;
-        }
-
-        try {
-
-            int param0;
-            int param1;
-            MenuAction menuAction = MenuAction.WALK;
-
-            ObjectComposition objComp = convertToObjectComposition(object);
-            if (objComp == null) return false;
-
-            Microbot.status = action + " " + objComp.getName();
-
-            if (object instanceof GameObject) {
-                GameObject obj = (GameObject) object;
-                if (obj.sizeX() > 1) {
-                    param0 = obj.getLocalLocation().getSceneX() - obj.sizeX() / 2;
-                } else {
-                    param0 = obj.getLocalLocation().getSceneX();
-                }
-
-                if (obj.sizeY() > 1) {
-                    param1 = obj.getLocalLocation().getSceneY() - obj.sizeY() / 2;
-                } else {
-                    param1 = obj.getLocalLocation().getSceneY();
-                }
-            } else {
-                // Default objects like walls, groundobjects, decorationobjects etc...
-                param0 = object.getLocalLocation().getSceneX();
-                param1 = object.getLocalLocation().getSceneY();
-            }
-
-            int index = 0;
-            if (action != null) {
-                String[] actions;
-                if (objComp.getImpostorIds() != null && objComp.getImpostor() != null) {
-                    actions = objComp.getImpostor().getActions();
-                } else {
-                    actions = objComp.getActions();
-                }
-
-                for (int i = 0; i < actions.length; i++) {
-                    if (actions[i] == null) continue;
-                    if (action.equalsIgnoreCase(Rs2UiHelper.stripColTags(actions[i]))) {
-                        index = i;
-                        break;
-                    }
-                }
-
-                if (index == actions.length)
-                    index = 0;
-            }
-
-            if (index == -1) {
-                Microbot.log("Failed to interact with object " + object.getId() + " " + action);
-            }
-
-
-            if (Microbot.getClient().isWidgetSelected()) {
-                menuAction = MenuAction.WIDGET_TARGET_ON_GAME_OBJECT;
-            } else if (index == 0) {
-                menuAction = MenuAction.GAME_OBJECT_FIRST_OPTION;
-            } else if (index == 1) {
-                menuAction = MenuAction.GAME_OBJECT_SECOND_OPTION;
-            } else if (index == 2) {
-                menuAction = MenuAction.GAME_OBJECT_THIRD_OPTION;
-            } else if (index == 3) {
-                menuAction = MenuAction.GAME_OBJECT_FOURTH_OPTION;
-            } else if (index == 4) {
-                menuAction = MenuAction.GAME_OBJECT_FIFTH_OPTION;
-            }
-
-            if (!Rs2Camera.isTileOnScreen(object.getLocalLocation())) {
-                Rs2Camera.turnTo(object);
-            }
-
-            // both hands must be free before using MINECART
-            if (objComp.getName().toLowerCase().contains("train cart")) {
-                Rs2Equipment.unEquip(EquipmentInventorySlot.WEAPON);
-                Rs2Equipment.unEquip(EquipmentInventorySlot.SHIELD);
-                sleepUntil(() -> Rs2Equipment.get(EquipmentInventorySlot.WEAPON) == null && Rs2Equipment.get(EquipmentInventorySlot.SHIELD) == null);
-            }
+	/**
+	 * Extracts all {@link GameObject}s located on a given {@link Tile}.
+	 *
+	 * @see Tile#getGameObjects()
+	 * @param tile the tile from which to extract game objects
+	 * @return a {@link List} of {@link GameObject} instances on the tile (never null)
+	 */
+	private static final Function<Tile, Collection<? extends GameObject>> GAMEOBJECT_EXTRACTOR =
+			tile -> Arrays.asList(tile.getGameObjects());
+
+	/**
+	 * Extracts the {@link GroundObject} located on a given {@link Tile}.
+	 *
+	 * @see Tile#getGroundObject()
+	 * @param tile the tile from which to extract the ground object
+	 * @return a singleton {@link List} containing the {@link GroundObject},
+	 *         or a list with a single null element if none is present
+	 */
+	private static final Function<Tile, Collection<? extends GroundObject>> GROUNDOBJECT_EXTRACTOR =
+			tile -> Collections.singletonList(tile.getGroundObject());
+
+	/**
+	 * Extracts the {@link DecorativeObject} located on a given {@link Tile}.
+	 *
+	 * @see Tile#getDecorativeObject()
+	 * @param tile the tile from which to extract the decorative object
+	 * @return a singleton {@link List} containing the {@link DecorativeObject},
+	 *         or a list with a single null element if none is present
+	 */
+	private static final Function<Tile, Collection<? extends DecorativeObject>> DECORATIVEOBJECT_EXTRACTOR =
+			tile -> Collections.singletonList(tile.getDecorativeObject());
+
+	/**
+	 * Extracts the {@link WallObject} located on a given {@link Tile}.
+	 *
+	 * @see Tile#getWallObject()
+	 * @param tile the tile from which to extract the wall object
+	 * @return a singleton {@link List} containing the {@link WallObject},
+	 *         or a list with a single null element if none is present
+	 */
+	private static final Function<Tile, Collection<? extends WallObject>> WALLOBJECT_EXTRACTOR =
+			tile -> Collections.singletonList(tile.getWallObject());
+
+	/**
+	 * Extracts all types of {@link TileObject} (decorative, ground, wall) from a given {@link Tile}.
+	 *
+	 * @param tile the tile from which to extract all tile objects
+	 * @return a {@link List} containing the {@link DecorativeObject}, {@link GroundObject},
+	 *         and {@link WallObject} (some entries may be null if that object is not present)
+	 */
+	private static final Function<Tile, Collection<? extends TileObject>> TILEOBJECT_EXTRACTOR =
+			tile -> Arrays.asList(
+					tile.getDecorativeObject(),
+					tile.getGroundObject(),
+					tile.getWallObject()
+			);
+
+
+	public static boolean interact(WorldPoint worldPoint) {
+		return interact(worldPoint, "");
+	}
+
+	public static boolean interact(WorldPoint worldPoint, String action) {
+		TileObject gameObject = findObjectByLocation(worldPoint);
+		return clickObject(gameObject, action);
+	}
+
+	public static boolean interact(GameObject gameObject) {
+		return clickObject(gameObject);
+	}
+
+	public static boolean interact(TileObject tileObject) {
+		return clickObject(tileObject, "");
+	}
+
+	public static boolean interact(TileObject tileObject, String action) {
+		return clickObject(tileObject, action);
+	}
+
+	public static boolean interact(GameObject gameObject, String action) {
+		return clickObject(gameObject, action);
+	}
+
+	public static boolean interact(int id) {
+		TileObject object = findObjectById(id);
+		return clickObject(object);
+	}
+
+	public static int interact(List<Integer> ids) {
+		for (int objectId : ids) {
+			if (interact(objectId)) return objectId;
+		}
+		return -1;
+	}
+
+	public static boolean interact(TileObject tileObject, String action, boolean checkCanReach) {
+		if (tileObject == null) return false;
+		if (!checkCanReach) return clickObject(tileObject, action);
+
+		if (checkCanReach && Rs2GameObject.hasLineOfSight(tileObject))
+			return clickObject(tileObject, action);
+
+		Rs2Walker.walkFastCanvas(tileObject.getWorldLocation());
+
+		return false;
+	}
+
+	public static boolean interact(TileObject tileObject, boolean checkCanReach) {
+		return interact(tileObject, "", checkCanReach);
+	}
+
+	public static boolean interact(int id, boolean checkCanReach) {
+		TileObject object = findObjectById(id);
+		return interact(object, checkCanReach);
+	}
+
+	public static boolean interact(int id, String action) {
+		TileObject object = findObjectById(id);
+		return clickObject(object, action);
+	}
+
+	public static boolean interact(int id, String action, int distance) {
+		TileObject object = findObjectByIdAndDistance(id, distance);
+		return clickObject(object, action);
+	}
+
+	public static boolean interact(String name, String action) {
+		TileObject object = get(name);
+		return clickObject(object, action);
+	}
+
+	public static boolean interact(int[] objectIds, String action) {
+		for (int objectId : objectIds) {
+			if (interact(objectId, action)) return true;
+		}
+		return false;
+	}
+
+	public static boolean interact(String name) {
+		GameObject object = get(name, true);
+		return clickObject(object);
+	}
+
+	public static boolean interact(String name, boolean exact) {
+		GameObject object = get(name, exact);
+		return clickObject(object);
+	}
+
+	public static boolean interact(String name, String action, boolean exact) {
+		GameObject object = get(name, exact);
+		return clickObject(object, action);
+	}
+
+	public static boolean exists(int id) {
+		return findObjectById(id) != null;
+	}
+
+	public static boolean canReach(WorldPoint target, int objectSizeX, int objectSizeY, int pathSizeX, int pathSizeY) {
+		if (target == null) return false;
+
+		List<WorldPoint> path = Rs2Player.getRs2WorldPoint().pathTo(target, true);
+		if (path == null || path.isEmpty()) return false;
+
+		// Create centered WorldAreas instead of using corner-based construction
+		WorldPoint pathEndpoint = path.get(path.size() - 1);
+		WorldPoint pathSouthWest = new WorldPoint(
+				pathEndpoint.getX() - pathSizeX / 2,
+				pathEndpoint.getY() - pathSizeY / 2,
+				pathEndpoint.getPlane()
+		);
+		WorldArea pathArea = new WorldArea(pathSouthWest, pathSizeX, pathSizeY);
+
+		WorldPoint objectSouthWest = new WorldPoint(
+				target.getX() - (objectSizeX + 2) / 2,
+				target.getY() - (objectSizeY + 2) / 2,
+				target.getPlane()
+		);
+		WorldArea objectArea = new WorldArea(objectSouthWest, objectSizeX + 2, objectSizeY + 2);
+
+		return pathArea.intersectsWith2D(objectArea);
+	}
+
+	public static boolean canReach(WorldPoint target, int objectSizeX, int objectSizeY) {
+		return canReach(target, objectSizeX, objectSizeY, 3, 3);
+	}
+
+	public static boolean canReach(WorldPoint target) {
+		return canReach(target, 2, 2, 2, 2);
+	}
+
+	@Deprecated
+	public static TileObject findObjectById(int id) {
+		var list = getAll(o -> o.getId() == id);
+		return list.stream().filter(x -> x.getId() == id).findFirst().orElse(null);
+	}
+
+	@Deprecated
+	public static TileObject findObjectByLocation(WorldPoint worldPoint) {
+		return getAll(o -> o.getWorldLocation().equals(worldPoint)).stream().findFirst().orElse(null);
+	}
+
+	@Deprecated
+	public static TileObject findGameObjectByLocation(WorldPoint worldPoint) {
+		return getGameObject(o -> o.getWorldLocation().equals(worldPoint));
+	}
+
+	/**
+	 * find ground object by location
+	 *
+	 * @param worldPoint
+	 * @return groundobject
+	 */
+	@Deprecated
+	public static TileObject findGroundObjectByLocation(WorldPoint worldPoint) {
+		return getGroundObject(worldPoint);
+	}
+
+	@Deprecated
+	public static TileObject findObjectByIdAndDistance(int id, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) return null;
+		LocalPoint anchor = player.getLocalLocation();
+		return getAll(o -> o.getId() == id).stream().filter(withinTilesPredicate(Rs2LocalPoint.worldToLocalDistance(distance), anchor)).findFirst().orElse(null);
+	}
+
+	@Deprecated
+	public static GameObject findObjectById(int id, int x) {
+		return getGameObject(o -> o.getId() == id && o.getWorldLocation().getX() == x);
+	}
+
+	@Deprecated
+	public static GameObject findObject(int id, WorldPoint worldPoint) {
+		return getGameObject(o -> o.getId() == id && o.getWorldLocation().equals(worldPoint));
+	}
+
+	@Deprecated
+	public static ObjectComposition findObjectComposition(int id) {
+		return convertToObjectComposition(id);
+	}
+
+	@Deprecated
+	public static GameObject get(String name) {
+		return get(name, false);
+	}
+
+	@Deprecated
+	public static GameObject get(String name, boolean exact) {
+		return getGameObject(name, exact);
+	}
+
+	@Deprecated
+	public static GameObject findObject(String objectName, boolean exact, int distance, boolean checkLineOfSight, WorldPoint anchorPoint) {
+		return getGameObjects(nameMatches(objectName, exact), anchorPoint, distance).stream().filter(o -> !checkLineOfSight || Rs2GameObject.hasLineOfSight(o)).findFirst().orElse(null);
+	}
+
+	/**
+	 * Finds a reachable game object by name within a specified distance from an anchor point, optionally checking for a specific action.
+	 *
+	 * @param objectName  The name of the game object to find.
+	 * @param exact       Whether to match the name exactly or partially.
+	 * @param distance    The maximum distance from the anchor point to search for the game object.
+	 * @param anchorPoint The point from which to measure the distance.
+	 * @param checkAction Whether to check for a specific action on the game object.
+	 * @param action      The action to check for if checkAction is true.
+	 * @return The nearest reachable game object that matches the criteria, or null if none is found.
+	 */
+	@Deprecated
+	public static GameObject findReachableObject(String objectName, boolean exact, int distance, WorldPoint anchorPoint, boolean checkAction, String action) {
+		Predicate<TileObject> namePred = nameMatches(objectName, exact);
+
+		Predicate<GameObject> filter = o -> {
+			if (!Rs2GameObject.isReachable(o)) {
+				return false;
+			}
+
+			if (!namePred.test(o)) {
+				return false;
+			}
+
+			if (checkAction) {
+				ObjectComposition comp = convertToObjectComposition(o);
+				return hasAction(comp, action);
+			}
+
+			return true;
+		};
+
+		return getGameObjects(filter, anchorPoint, distance)
+				.stream()
+				.min(Comparator.comparingInt(o ->
+						Rs2Player.getRs2WorldPoint()
+								.distanceToPath(o.getWorldLocation())))
+				.orElse(null);
+	}
+
+	/**
+	 * Finds a reachable game object by name within a specified distance from an anchor point.
+	 *
+	 * @param objectName  The name of the game object to find.
+	 * @param exact       Whether to match the name exactly or partially.
+	 * @param distance    The maximum distance from the anchor point to search for the game object.
+	 * @param anchorPoint The point from which to measure the distance.
+	 * @return The nearest reachable game object that matches the criteria, or null if none is found.
+	 */
+	@Deprecated
+	public static GameObject findReachableObject(String objectName, boolean exact, int distance, WorldPoint anchorPoint) {
+		return findReachableObject(objectName, exact, distance, anchorPoint, false, "");
+	}
+
+	public static boolean hasAction(TileObject tileObject, String action) {
+		return hasAction(tileObject, action, false);
+	}
+
+	public static boolean hasAction(TileObject tileObject, String action, boolean exact) {
+		return hasAction(convertToObjectComposition(tileObject), action, exact);
+	}
+
+	public static boolean hasAction(ObjectComposition objComp, String action, boolean exact) {
+		if (objComp == null) return false;
+
+		return Arrays.stream(objComp.getActions())
+				.filter(Objects::nonNull)
+				.anyMatch(a -> exact ? a.equalsIgnoreCase(action) : a.toLowerCase().contains(action.toLowerCase()));
+	}
+
+	public static boolean hasAction(ObjectComposition objComp, String action) {
+		return hasAction(objComp, action, true);
+	}
+
+	/**
+	 * Imposter objects are objects that have their menu action changed but still remain the same object.
+	 * for example: farming patches
+	 */
+	@Deprecated
+	public static GameObject findObjectByImposter(int id, String action) {
+		return findObjectByImposter(id, action, true);
+	}
+
+	@Deprecated
+	public static GameObject findObjectByImposter(int id, String optionName, boolean exact) {
+		return getGameObjects(o -> o.getId() == id)
+				.stream()
+				.filter(o -> {
+					ObjectComposition comp = convertToObjectComposition(o);
+					return hasAction(comp, optionName, exact);
+				})
+				.findFirst()
+				.orElse(null);
+	}
+
+	public static GameObject findBank(int maxSearchRadius) {
+		Predicate<GameObject> bankableFilter = gameObject -> {
+			WorldPoint loc = gameObject.getWorldLocation();
+
+			//cooks guild (exception)
+			if ((loc.equals(new WorldPoint(3147, 3449, 0)) || loc.equals(new WorldPoint(3148, 3449, 0))) && !BankLocation.COOKS_GUILD.hasRequirements()) {
+				return false;
+			}
+
+			//farming guild (exception)
+			//At the farming guild there’s 2 banks, one in the southern half of the guild and one northern part of the guild which requires a certain higher farming level to enter
+			if ((loc.equals(new WorldPoint(1248, 3759, 0)) || loc.equals(new WorldPoint(1249, 3759, 0))) && !Rs2Player.getSkillRequirement(Skill.FARMING, 85, true)) {
+				return false;
+			}
+
+			// Lunar Isle (exception)
+			// There is a bank booth @ Lunar Isle that is only accessible when Dream Mentor is completed
+			if (loc.equals(new WorldPoint(2099, 3920, 0)) && Rs2Player.getQuestState(Quest.DREAM_MENTOR) != QuestState.FINISHED) {
+				return false;
+			}
+
+			// Lunar Isle (additional exception to not use these banks if no seal of passage)
+			if ((loc.equals(new WorldPoint(2098, 3920, 0)) || loc.equals(new WorldPoint(2097, 3920, 0))) &&
+					!(Rs2Inventory.hasItem(ItemID.LUNAR_SEAL_OF_PASSAGE) || Rs2Equipment.isWearing(ItemID.LUNAR_SEAL_OF_PASSAGE))) {
+				return false;
+			}
+
+			ObjectComposition comp = convertToObjectComposition(gameObject);
+			if (comp == null) return false;
+			return hasAction(comp, "Bank", false) || hasAction(comp, "Collect", false);
+		};
+
+		return getGameObjects(o -> Arrays.stream(Rs2BankID.bankIds).anyMatch(bid -> o.getId() == bid), maxSearchRadius).stream()
+				.filter(bankableFilter)
+				.findFirst()
+				.orElse(null);
+	}
+
+	public static GameObject findBank() {
+		return findBank(20);
+	}
+
+	/**
+	 * Find nearest Deposit box
+	 *
+	 * @return GameObject
+	 */
+	public static GameObject findDepositBox() {
+		return findDepositBox(20);
+	}
+
+	public static GameObject findDepositBox(int maxSearchRadius) {
+		Predicate<GameObject> depositableFilter = gameObject -> {
+			ObjectComposition comp = convertToObjectComposition(gameObject);
+			if (comp == null) return false;
+			return hasAction(comp, "Deposit", false);
+		};
+		return getGameObjects(o -> Arrays.stream(Rs2BankID.bankIds).anyMatch(bid -> o.getId() == bid), maxSearchRadius).stream()
+				.filter(depositableFilter)
+				.findFirst()
+				.orElse(null);
+	}
+
+	public static WallObject findGrandExchangeBooth(int maxSearchRadius) {
+		Integer[] grandExchangeBoothIds = new Integer[]{10060, 30389};
+		return getWallObjects(o -> Arrays.stream(grandExchangeBoothIds).anyMatch(gid -> o.getId() == gid) && Rs2Tile.isTileReachable(o.getWorldLocation()), maxSearchRadius).stream()
+				.findFirst()
+				.orElse(null);
+	}
+
+	public static WallObject findGrandExchangeBooth() {
+		return findGrandExchangeBooth(20);
+	}
+
+	@Deprecated
+	public static ObjectComposition convertGameObjectToObjectComposition(TileObject tileObject) {
+		return convertToObjectComposition(tileObject);
+	}
+
+	@Deprecated
+	public static ObjectComposition convertGameObjectToObjectComposition(int objectId) {
+		return convertToObjectComposition(objectId);
+	}
+
+	public static String getObjectType(TileObject object)
+	{
+		String type;
+		if (object instanceof WallObject) {
+			type = "WallObject";
+		} else if (object instanceof DecorativeObject) {
+			type = "DecorativeObject";
+		} else if (object instanceof GameObject) {
+			type = "GameObject";
+		} else if (object instanceof GroundObject) {
+			type = "GroundObject";
+		} else {
+			type = "TileObject";
+		}
+		return type;
+	}
+
+	public static List<Tile> getTiles(int maxTileDistance) {
+		int maxDistance = Math.max(2400, maxTileDistance * 128);
+
+		Player player = Microbot.getClient().getLocalPlayer();
+		Scene scene = Microbot.getClient().getScene();
+		Tile[][][] tiles = scene.getTiles();
+
+		int z = Microbot.getClient().getPlane();
+		List<Tile> tileObjects = new ArrayList<>();
+		for (int x = 0; x < Constants.SCENE_SIZE; ++x) {
+			for (int y = 0; y < Constants.SCENE_SIZE; ++y) {
+				Tile tile = tiles[z][x][y];
+
+				if (tile == null) {
+					continue;
+				}
+
+				if (player.getLocalLocation().distanceTo(tile.getLocalLocation()) <= maxDistance) {
+					tileObjects.add(tile);
+				}
+
+			}
+		}
+
+		return tileObjects;
+	}
+
+	public static List<Tile> getTiles() {
+		return getTiles(2400);
+	}
+
+	public static List<TileObject> getAll() {
+		return getAll(o -> true);
+	}
+
+	public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate) {
+		return getAll(predicate, Constants.SCENE_SIZE);
+	}
+
+	public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate, int distance) {
+		WorldPoint worldPoint = Rs2Player.getWorldLocation();
+		return getAll(predicate, worldPoint, distance);
+	}
+
+	public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate, WorldPoint anchor) {
+		return getAll(predicate, anchor, Constants.SCENE_SIZE);
+	}
+
+	public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate, WorldPoint anchor, int distance) {
+		List<TileObject> all = new ArrayList<>();
+		all.addAll(fetchGameObjects(predicate, anchor, distance));
+		all.addAll(fetchTileObjects(predicate, anchor, distance));
+		return all;
+	}
+
+	public static TileObject getTileObject(int id) {
+		return getTileObject(o -> o.getId() == id);
+	}
+
+	public static TileObject getTileObject(int id, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getTileObject(id, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static TileObject getTileObject(int id, WorldPoint anchor) {
+		return getTileObject(id, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static TileObject getTileObject(int id, WorldPoint anchor, int distance) {
+		return getTileObject(o -> o.getId() == id, anchor, distance);
+	}
+
+	public static TileObject getTileObject(Integer[] ids) {
+		Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
+		return getTileObject(o -> idSet.contains(o.getId()));
+	}
+
+	public static TileObject getTileObject(Integer[] ids, int distance) {
+		Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
+		return getTileObject(o -> idSet.contains(o.getId()), distance);
+	}
+
+	public static TileObject getTileObject(String objectName, boolean exact) {
+		return getTileObject(nameMatches(objectName, exact));
+	}
+
+	public static TileObject getTileObject(String objectName) {
+		return getTileObject(objectName, false);
+	}
+
+	public static TileObject getTileObject(String objectName, boolean exact, int distance) {
+		return getTileObject(nameMatches(objectName, exact), distance);
+	}
+
+	public static TileObject getTileObject(String objectName, int distance) {
+		return getTileObject(objectName, false, distance);
+	}
+
+	public static TileObject getTileObject(String objectName, boolean exact, WorldPoint anchor) {
+		return getTileObject(nameMatches(objectName, exact), anchor);
+	}
+
+	public static TileObject getTileObject(String objectName, WorldPoint anchor) {
+		return getTileObject(objectName, false, anchor);
+	}
+
+	public static TileObject getTileObject(String objectName, boolean exact, LocalPoint anchorLocal) {
+		return getTileObject(nameMatches(objectName, exact), anchorLocal);
+	}
+
+	public static TileObject getTileObject(String objectName, LocalPoint anchorLocal) {
+		return getTileObject(objectName, false, anchorLocal);
+	}
+
+	public static TileObject getTileObject(String objectName, boolean exact, WorldPoint anchor, int distance) {
+		return getTileObject(nameMatches(objectName, exact), anchor, distance);
+	}
+
+	public static TileObject getTileObject(String objectName, WorldPoint anchor, int distance) {
+		return getTileObject(objectName, false, anchor, distance);
+	}
+
+	public static TileObject getTileObject(String objectName, boolean exact, LocalPoint anchorLocal, int distance) {
+		return getTileObject(nameMatches(objectName, exact), anchorLocal, distance);
+	}
+
+	public static TileObject getTileObject(String objectName, LocalPoint anchorLocal, int distance) {
+		return getTileObject(nameMatches(objectName), anchorLocal, distance);
+	}
+
+	public static TileObject getTileObject(Predicate<TileObject> predicate) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getTileObject(predicate, Rs2Player.getWorldLocation());
+	}
+
+	public static TileObject getTileObject(WorldPoint anchor) {
+		return getTileObject(o -> true, anchor);
+	}
+
+	public static TileObject getTileObject(LocalPoint anchorLocal) {
+		return getTileObject(o -> true, anchorLocal);
+	}
+
+	public static TileObject getTileObject(WorldPoint anchor, int distance) {
+		return getTileObject(o -> true, anchor, distance);
+	}
+
+	public static TileObject getTileObject(LocalPoint anchorLocal, int distance) {
+		return getTileObject(o -> true, anchorLocal, distance);
+	}
+
+	public static TileObject getTileObject(Predicate<TileObject> predicate, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getTileObject(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static TileObject getTileObject(Predicate<TileObject> predicate, WorldPoint anchor) {
+		return getTileObject(predicate, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static TileObject getTileObject(Predicate<TileObject> predicate, LocalPoint anchorLocal) {
+		return getTileObject(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
+	}
+
+	public static TileObject getTileObject(Predicate<TileObject> predicate, WorldPoint anchor, int distance) {
+		LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
+		if (anchorLocal == null) {
+			return null;
+		}
+		return getTileObject(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
+	}
+
+	public static TileObject getTileObject(Predicate<TileObject> predicate, LocalPoint anchorLocal, int distance) {
+		return getSceneObject(TILEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
+	}
+
+	public static List<TileObject> getTileObjects() {
+		return getTileObjects(o -> true);
+	}
+
+	public static List<TileObject> getTileObjects(int distance) {
+		return getTileObjects(o -> true, distance);
+	}
+
+	public static List<TileObject> getTileObjects(Predicate<TileObject> predicate, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return getTileObjects(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static List<TileObject> getTileObjects(WorldPoint anchor) {
+		return getTileObjects(o -> true, anchor);
+	}
+
+	public static List<TileObject> getTileObjects(LocalPoint anchorLocal) {
+		return getTileObjects(o -> true, anchorLocal);
+	}
+
+	public static List<TileObject> getTileObjects(Predicate<TileObject> predicate) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return getTileObjects(predicate, Rs2Player.getWorldLocation());
+	}
+
+	public static List<TileObject> getTileObjects(Predicate<TileObject> predicate, WorldPoint anchor) {
+		return getTileObjects(predicate, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static List<TileObject> getTileObjects(Predicate<TileObject> predicate, LocalPoint anchorLocal) {
+		return getTileObjects(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
+	}
+
+	public static List<TileObject> getTileObjects(Predicate<TileObject> predicate, WorldPoint anchor, int distance) {
+		LocalPoint anchorLocal = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), anchor);
+		if (anchorLocal == null) {
+			return Collections.emptyList();
+		}
+		return getTileObjects(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
+	}
+
+	public static List<TileObject> getTileObjects(Predicate<TileObject> predicate, LocalPoint anchorLocal, int distance) {
+		return getSceneObjects(TILEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
+	}
+
+	public static GameObject getGameObject(int id) {
+		return getGameObject(id, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static GameObject getGameObject(int id, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getGameObject(id, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static GameObject getGameObject(int id, WorldPoint anchor) {
+		return getGameObject(id, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static GameObject getGameObject(int id, WorldPoint anchor, int distance) {
+		return getGameObject(o -> o.getId() == id, anchor, distance);
+	}
+
+	public static GameObject getGameObject(Integer[] ids) {
+		Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
+		return getGameObject(o -> idSet.contains(o.getId()));
+	}
+
+	@Deprecated
+	public static GameObject findObject(Integer[] ids) {
+		Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
+		return getGameObject(o -> idSet.contains(o.getId()));
+	}
+
+	public static GameObject getGameObject(Integer[] ids, int distance) {
+		Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
+		return getGameObject(o -> idSet.contains(o.getId()), distance);
+	}
+
+	public static GameObject getGameObject(String objectName, boolean exact, int distance) {
+		return getGameObject(nameMatches(objectName, exact), distance);
+	}
+
+	public static GameObject getGameObject(String objectName, boolean exact) {
+		return getGameObject(nameMatches(objectName, exact));
+	}
+
+	public static GameObject getGameObject(String objectName) {
+		return getGameObject(objectName, false);
+	}
+
+	public static GameObject getGameObject(String objectName, int distance) {
+		return getGameObject(objectName, false, distance);
+	}
+
+	public static GameObject getGameObject(String objectName, boolean exact, WorldPoint anchor) {
+		return getGameObject(nameMatches(objectName, exact), anchor);
+	}
+
+	public static GameObject getGameObject(String objectName, WorldPoint anchor) {
+		return getGameObject(objectName, false, anchor);
+	}
+
+	public static GameObject getGameObject(String objectName, boolean exact, LocalPoint anchorLocal) {
+		return getGameObject(nameMatches(objectName, exact), anchorLocal);
+	}
+
+	public static GameObject getGameObject(String objectName, LocalPoint anchorLocal) {
+		return getGameObject(objectName, false, anchorLocal);
+	}
+
+	public static GameObject getGameObject(String objectName, boolean exact, WorldPoint anchor, int distance) {
+		return getGameObject(nameMatches(objectName, exact), anchor, distance);
+	}
+
+	public static GameObject getGameObject(String objectName, WorldPoint anchor, int distance) {
+		return getGameObject(objectName, false, anchor, distance);
+	}
+
+	public static GameObject getGameObject(String objectName, boolean exact, LocalPoint anchorLocal, int distance) {
+		return getGameObject(nameMatches(objectName, exact), anchorLocal, distance);
+	}
+
+	public static GameObject getGameObject(String objectName, LocalPoint anchorLocal, int distance) {
+		return getGameObject(objectName, false, anchorLocal, distance);
+	}
+
+	public static GameObject getGameObject(Predicate<GameObject> predicate) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getGameObject(predicate, Rs2Player.getWorldLocation());
+	}
+
+	public static GameObject getGameObject(WorldPoint anchor) {
+		return getGameObject(o -> true, anchor);
+	}
+
+	public static GameObject getGameObject(LocalPoint anchorLocal) {
+		return getGameObject(o -> true, anchorLocal);
+	}
+
+	public static GameObject getGameObject(WorldPoint anchor, int distance) {
+		return getGameObject(o -> true, anchor, distance);
+	}
+
+	public static GameObject getGameObject(LocalPoint anchorLocal, int distance) {
+		return getGameObject(o -> true, anchorLocal, distance);
+	}
+
+	public static GameObject getGameObject(Predicate<GameObject> predicate, int distance) {
+		return getGameObject(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static GameObject getGameObject(Predicate<GameObject> predicate, WorldPoint anchor) {
+		return getGameObject(predicate, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static GameObject getGameObject(Predicate<GameObject> predicate, LocalPoint anchorLocal) {
+		return getGameObject(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
+	}
+
+	public static GameObject getGameObject(Predicate<GameObject> predicate, WorldPoint anchor, int distance) {
+		LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
+		if (anchorLocal == null) {
+			return null;
+		}
+		return getGameObject(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
+	}
+
+	public static GameObject getGameObject(Predicate<GameObject> predicate, LocalPoint anchorLocal, int distance) {
+		return getSceneObject(GAMEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
+	}
+
+	public static List<GameObject> getGameObjects() {
+		return getGameObjects(o -> true);
+	}
+
+	public static List<GameObject> getGameObjects(int distance) {
+		return getGameObjects(o -> true, distance);
+	}
+
+	public static List<GameObject> getGameObjects(Predicate<GameObject> predicate, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return getGameObjects(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static List<GameObject> getGameObjects(WorldPoint anchor) {
+		return getGameObjects(o -> true, anchor);
+	}
+
+	public static List<GameObject> getGameObjects(LocalPoint anchorLocal) {
+		return getGameObjects(o -> true, anchorLocal);
+	}
+
+	public static List<GameObject> getGameObjects(Predicate<GameObject> predicate) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return getGameObjects(predicate, Rs2Player.getWorldLocation());
+	}
+
+	public static List<GameObject> getGameObjects(Predicate<GameObject> predicate, WorldPoint anchor) {
+		return getGameObjects(predicate, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static List<GameObject> getGameObjects(Predicate<GameObject> predicate, LocalPoint anchorLocal) {
+		return getGameObjects(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
+	}
+
+	public static List<GameObject> getGameObjects(Predicate<GameObject> predicate, WorldPoint anchor, int distance) {
+		LocalPoint anchorLocal = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), anchor);
+		if (anchorLocal == null) {
+			return Collections.emptyList();
+		}
+		return getGameObjects(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
+	}
+
+	public static List<GameObject> getGameObjects(Predicate<GameObject> predicate, LocalPoint anchorLocal, int distance) {
+		return getSceneObjects(GAMEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
+	}
+
+	public static GroundObject getGroundObject(int id) {
+		return getGroundObject(id, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static GroundObject getGroundObject(int id, int distance) {
+		return getGroundObject(id, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static GroundObject getGroundObject(int id, WorldPoint anchor) {
+		return getGroundObject(id, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static GroundObject getGroundObject(int id, WorldPoint anchor, int distance) {
+		return getGroundObject(o -> o.getId() == id, anchor, distance);
+	}
+
+	public static GroundObject getGroundObject(Integer[] ids) {
+		Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
+		return getGroundObject(o -> idSet.contains(o.getId()));
+	}
+
+	public static GroundObject getGroundObject(Integer[] ids, int distance) {
+		Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
+		return getGroundObject(o -> idSet.contains(o.getId()), distance);
+	}
+
+	public static GroundObject getGroundObject(String objectName, boolean exact, int distance) {
+		return getGroundObject(nameMatches(objectName, exact), distance);
+	}
+
+	public static GroundObject getGroundObject(String objectName, boolean exact) {
+		return getGroundObject(nameMatches(objectName, exact));
+	}
+
+	public static GroundObject getGroundObject(String objectName) {
+		return getGroundObject(objectName, false);
+	}
+
+	public static GroundObject getGroundObject(String objectName, int distance) {
+		return getGroundObject(objectName, false, distance);
+	}
+
+	public static GroundObject getGroundObject(String objectName, boolean exact, WorldPoint anchor) {
+		return getGroundObject(nameMatches(objectName, exact), anchor);
+	}
+
+	public static GroundObject getGroundObject(String objectName, WorldPoint anchor) {
+		return getGroundObject(objectName, false, anchor);
+	}
+
+	public static GroundObject getGroundObject(String objectName, boolean exact, LocalPoint anchorLocal) {
+		return getGroundObject(nameMatches(objectName, exact), anchorLocal);
+	}
+
+	public static GroundObject getGroundObject(String objectName, LocalPoint anchorLocal) {
+		return getGroundObject(objectName, false, anchorLocal);
+	}
+
+	public static GroundObject getGroundObject(String objectName, boolean exact, WorldPoint anchor, int distance) {
+		return getGroundObject(nameMatches(objectName, exact), anchor, distance);
+	}
+
+	public static GroundObject getGroundObject(String objectName, WorldPoint anchor, int distance) {
+		return getGroundObject(objectName, false, anchor, distance);
+	}
+
+	public static GroundObject getGroundObject(String objectName, boolean exact, LocalPoint anchorLocal, int distance) {
+		return getGroundObject(nameMatches(objectName, exact), anchorLocal, distance);
+	}
+
+	public static GroundObject getGroundObject(String objectName, LocalPoint anchorLocal, int distance) {
+		return getGroundObject(objectName, false, anchorLocal, distance);
+	}
+
+	public static GroundObject getGroundObject(Predicate<GroundObject> predicate) {
+		return getGroundObject(predicate, Rs2Player.getWorldLocation());
+	}
+
+	public static GroundObject getGroundObject(WorldPoint anchor) {
+		return getGroundObject(o -> true, anchor);
+	}
+
+	public static GroundObject getGroundObject(LocalPoint anchorLocal) {
+		return getGroundObject(o -> true, anchorLocal);
+	}
+
+	public static GroundObject getGroundObject(WorldPoint anchor, int distance) {
+		return getGroundObject(o -> true, anchor, distance);
+	}
+
+	public static GroundObject getGroundObject(LocalPoint anchorLocal, int distance) {
+		return getGroundObject(o -> true, anchorLocal, distance);
+	}
+
+	public static GroundObject getGroundObject(Predicate<GroundObject> predicate, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getGroundObject(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static GroundObject getGroundObject(Predicate<GroundObject> predicate, WorldPoint anchor) {
+		return getGroundObject(predicate, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static GroundObject getGroundObject(Predicate<GroundObject> predicate, LocalPoint anchorLocal) {
+		return getGroundObject(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
+	}
+
+	public static GroundObject getGroundObject(Predicate<GroundObject> predicate, WorldPoint anchor, int distance) {
+		LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
+		if (anchorLocal == null) {
+			return null;
+		}
+		return getGroundObject(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
+	}
+
+	public static GroundObject getGroundObject(Predicate<GroundObject> predicate, LocalPoint anchorLocal, int distance) {
+		return getSceneObject(GROUNDOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
+	}
+
+	public static List<GroundObject> getGroundObjects() {
+		return getGroundObjects(o -> true);
+	}
+
+	public static List<GroundObject> getGroundObjects(int distance) {
+		return getGroundObjects(o -> true, distance);
+	}
+
+	public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return getGroundObjects(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static List<GroundObject> getGroundObjects(WorldPoint anchor) {
+		return getGroundObjects(o -> true, anchor);
+	}
+
+	public static List<GroundObject> getGroundObjects(LocalPoint anchorLocal) {
+		return getGroundObjects(o -> true, anchorLocal);
+	}
+
+	public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return getGroundObjects(predicate, Rs2Player.getWorldLocation());
+	}
+
+	public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate, WorldPoint anchor) {
+		return getGroundObjects(predicate, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate, LocalPoint anchorLocal) {
+		return getGroundObjects(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
+	}
+
+	public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate, WorldPoint anchor, int distance) {
+		LocalPoint anchorLocal = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), anchor);
+		if (anchorLocal == null) {
+			return Collections.emptyList();
+		}
+		return getGroundObjects(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
+	}
+
+	public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate, LocalPoint anchorLocal, int distance) {
+		return getSceneObjects(GROUNDOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
+	}
+
+	public static WallObject getWallObject(int id) {
+		return getWallObject(id, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static WallObject getWallObject(int id, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getWallObject(id, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static WallObject getWallObject(int id, WorldPoint anchor) {
+		return getWallObject(id, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static WallObject getWallObject(int id, WorldPoint anchor, int distance) {
+		return getWallObject(o -> o.getId() == id, anchor, distance);
+	}
+
+	public static WallObject getWallObject(Integer[] ids) {
+		Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
+		return getWallObject(o -> idSet.contains(o.getId()));
+	}
+
+	public static WallObject getWallObject(Integer[] ids, int distance) {
+		Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
+		return getWallObject(o -> idSet.contains(o.getId()), distance);
+	}
+
+	public static WallObject getWallObject(String objectName, boolean exact, int distance) {
+		return getWallObject(nameMatches(objectName, exact), distance);
+	}
+
+	public static WallObject getWallObject(String objectName, boolean exact) {
+		return getWallObject(nameMatches(objectName, exact));
+	}
+
+	public static WallObject getWallObject(String objectName) {
+		return getWallObject(objectName, false);
+	}
+
+	public static WallObject getWallObject(String objectName, int distance) {
+		return getWallObject(objectName, false, distance);
+	}
+
+	public static WallObject getWallObject(String objectName, boolean exact, WorldPoint anchor) {
+		return getWallObject(nameMatches(objectName, exact), anchor);
+	}
+
+	public static WallObject getWallObject(String objectName, WorldPoint anchor) {
+		return getWallObject(objectName, false, anchor);
+	}
+
+	public static WallObject getWallObject(String objectName, boolean exact, LocalPoint anchorLocal) {
+		return getWallObject(nameMatches(objectName, exact), anchorLocal);
+	}
+
+	public static WallObject getWallObject(String objectName, LocalPoint anchorLocal) {
+		return getWallObject(objectName, false, anchorLocal);
+	}
+
+	public static WallObject getWallObject(String objectName, boolean exact, WorldPoint anchor, int distance) {
+		return getWallObject(nameMatches(objectName, exact), anchor, distance);
+	}
+
+	public static WallObject getWallObject(String objectName, WorldPoint anchor, int distance) {
+		return getWallObject(objectName, false, anchor, distance);
+	}
+
+	public static WallObject getWallObject(String objectName, boolean exact, LocalPoint anchorLocal, int distance) {
+		return getWallObject(nameMatches(objectName, exact), anchorLocal, distance);
+	}
+
+	public static WallObject getWallObject(String objectName, LocalPoint anchorLocal, int distance) {
+		return getWallObject(objectName, false, anchorLocal, distance);
+	}
+
+	public static WallObject getWallObject(Predicate<WallObject> predicate) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getWallObject(predicate, Rs2Player.getWorldLocation());
+	}
+
+	public static WallObject getWallObject(WorldPoint anchor) {
+		return getWallObject(o -> true, anchor);
+	}
+
+	public static WallObject getWallObject(LocalPoint anchorLocal) {
+		return getWallObject(o -> true, anchorLocal);
+	}
+
+	public static WallObject getWallObject(WorldPoint anchor, int distance) {
+		return getWallObject(o -> true, anchor, distance);
+	}
+
+	public static WallObject getWallObject(LocalPoint anchorLocal, int distance) {
+		return getWallObject(o -> true, anchorLocal, distance);
+	}
+
+	public static WallObject getWallObject(Predicate<WallObject> predicate, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getWallObject(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static WallObject getWallObject(Predicate<WallObject> predicate, WorldPoint anchor) {
+		return getWallObject(predicate, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static WallObject getWallObject(Predicate<WallObject> predicate, LocalPoint anchorLocal) {
+		return getWallObject(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
+	}
+
+	public static WallObject getWallObject(Predicate<WallObject> predicate, WorldPoint anchor, int distance) {
+		LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
+		if (anchorLocal == null) {
+			return null;
+		}
+		return getWallObject(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
+	}
+
+	public static WallObject getWallObject(Predicate<WallObject> predicate, LocalPoint anchorLocal, int distance) {
+		return getSceneObject(WALLOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
+	}
+
+	public static List<WallObject> getWallObjects() {
+		return getWallObjects(o -> true);
+	}
+
+	public static List<WallObject> getWallObjects(int distance) {
+		return getWallObjects(o -> true, distance);
+	}
+
+	public static List<WallObject> getWallObjects(Predicate<WallObject> predicate, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return getWallObjects(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static List<WallObject> getWallObjects(WorldPoint anchor) {
+		return getWallObjects(o -> true, anchor);
+	}
+
+	public static List<WallObject> getWallObjects(LocalPoint anchorLocal) {
+		return getWallObjects(o -> true, anchorLocal);
+	}
+
+	public static List<WallObject> getWallObjects(Predicate<WallObject> predicate) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return getWallObjects(predicate, Rs2Player.getWorldLocation());
+	}
+
+	public static List<WallObject> getWallObjects(Predicate<WallObject> predicate, WorldPoint anchor) {
+		return getWallObjects(predicate, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static List<WallObject> getWallObjects(Predicate<WallObject> predicate, LocalPoint anchorLocal) {
+		return getWallObjects(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
+	}
+
+	public static List<WallObject> getWallObjects(Predicate<WallObject> predicate, WorldPoint anchor, int distance) {
+		LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
+		if (anchorLocal == null) {
+			return Collections.emptyList();
+		}
+		return getWallObjects(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
+	}
+
+	public static List<WallObject> getWallObjects(Predicate<WallObject> predicate, LocalPoint anchorLocal, int distance) {
+		return getSceneObjects(WALLOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(int id) {
+		return getDecorativeObject(id, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static DecorativeObject getDecorativeObject(int id, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getDecorativeObject(id, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(int id, WorldPoint anchor) {
+		return getDecorativeObject(id, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static DecorativeObject getDecorativeObject(int id, WorldPoint anchor, int distance) {
+		return getDecorativeObject(o -> o.getId() == id, anchor, distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(Integer[] ids) {
+		Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
+		return getDecorativeObject(o -> idSet.contains(o.getId()));
+	}
+
+	public static DecorativeObject getDecorativeObject(Integer[] ids, int distance) {
+		Set<Integer> idSet = Stream.of(ids).collect(Collectors.toSet());
+		return getDecorativeObject(o -> idSet.contains(o.getId()), distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName, boolean exact, int distance) {
+		return getDecorativeObject(nameMatches(objectName, exact), distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName, boolean exact) {
+		return getDecorativeObject(nameMatches(objectName, exact));
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName) {
+		return getDecorativeObject(objectName, false);
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName, int distance) {
+		return getDecorativeObject(objectName, false, distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName, boolean exact, WorldPoint anchor) {
+		return getDecorativeObject(nameMatches(objectName, exact), anchor);
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName, WorldPoint anchor) {
+		return getDecorativeObject(objectName, false, anchor);
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName, boolean exact, LocalPoint anchorLocal) {
+		return getDecorativeObject(nameMatches(objectName, exact), anchorLocal);
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName, LocalPoint anchorLocal) {
+		return getDecorativeObject(objectName, false, anchorLocal);
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName, boolean exact, WorldPoint anchor, int distance) {
+		return getDecorativeObject(nameMatches(objectName, exact), anchor, distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName, WorldPoint anchor, int distance) {
+		return getDecorativeObject(objectName, false, anchor, distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName, boolean exact, LocalPoint anchorLocal, int distance) {
+		return getDecorativeObject(nameMatches(objectName, exact), anchorLocal, distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(String objectName, LocalPoint anchorLocal, int distance) {
+		return getDecorativeObject(objectName, false, anchorLocal, distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getDecorativeObject(predicate, Rs2Player.getWorldLocation());
+	}
+
+	public static DecorativeObject getDecorativeObject(WorldPoint anchor) {
+		return getDecorativeObject(o -> true, anchor);
+	}
+
+	public static DecorativeObject getDecorativeObject(LocalPoint anchorLocal) {
+		return getDecorativeObject(o -> true, anchorLocal);
+	}
+
+	public static DecorativeObject getDecorativeObject(WorldPoint anchor, int distance) {
+		return getDecorativeObject(o -> true, anchor, distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(LocalPoint anchorLocal, int distance) {
+		return getDecorativeObject(o -> true, anchorLocal, distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return null;
+		}
+		return getDecorativeObject(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate, WorldPoint anchor) {
+		return getDecorativeObject(predicate, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate, LocalPoint anchorLocal) {
+		return getDecorativeObject(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
+	}
+
+	public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate, WorldPoint anchor, int distance) {
+		LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
+		if (anchorLocal == null) {
+			return null;
+		}
+		return getDecorativeObject(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
+	}
+
+	public static DecorativeObject getDecorativeObject(Predicate<DecorativeObject> predicate, LocalPoint anchorLocal, int distance) {
+		return getSceneObject(DECORATIVEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
+	}
+
+	public static List<DecorativeObject> getDecorativeObjects() {
+		return getDecorativeObjects(o -> true);
+	}
+
+	public static List<DecorativeObject> getDecorativeObjects(int distance) {
+		return getDecorativeObjects(o -> true, distance);
+	}
+
+	public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return getDecorativeObjects(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	public static List<DecorativeObject> getDecorativeObjects(WorldPoint anchor) {
+		return getDecorativeObjects(o -> true, anchor);
+	}
+
+	public static List<DecorativeObject> getDecorativeObjects(LocalPoint anchorLocal) {
+		return getDecorativeObjects(o -> true, anchorLocal);
+	}
+
+	public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return getDecorativeObjects(predicate, Rs2Player.getWorldLocation());
+	}
+
+	public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate, WorldPoint anchor) {
+		return getDecorativeObjects(predicate, anchor, (Constants.SCENE_SIZE / 2));
+	}
+
+	public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate, LocalPoint anchorLocal) {
+		return getDecorativeObjects(predicate, anchorLocal, (Constants.SCENE_SIZE / 2) * Perspective.LOCAL_TILE_SIZE);
+	}
+
+	public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate, WorldPoint anchor, int distance) {
+		LocalPoint anchorLocal = localPointFromWorldSafe(anchor);
+		if (anchorLocal == null) {
+			return Collections.emptyList();
+		}
+		return getDecorativeObjects(predicate, anchorLocal, Rs2LocalPoint.worldToLocalDistance(distance));
+	}
+
+	public static List<DecorativeObject> getDecorativeObjects(Predicate<DecorativeObject> predicate, LocalPoint anchorLocal, int distance) {
+		return getSceneObjects(DECORATIVEOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
+	}
+
+	@Nullable
+	public static <T extends TileObject> ObjectComposition convertToObjectComposition(T object) {
+		return convertToObjectComposition(object.getId(), false);
+	}
+
+	@Nullable
+	public static ObjectComposition convertToObjectComposition(int objectId) {
+		return convertToObjectCompositionInternal(objectId, false);
+	}
+
+	@Nullable
+	public static <T extends TileObject> ObjectComposition convertToObjectComposition(T object, boolean ignoreImpostor) {
+		return convertToObjectCompositionInternal(object.getId(), ignoreImpostor);
+	}
+
+	@Nullable
+	public static ObjectComposition convertToObjectComposition(int objectId, boolean ignoreImpostor) {
+		return convertToObjectCompositionInternal(objectId, ignoreImpostor);
+	}
+
+	public static <T> Optional<T> pickClosest(Collection<T> candidates, Function<T, WorldPoint> locFn, WorldPoint anchor) {
+		return candidates.stream()
+				.filter(Objects::nonNull)
+				.min(Comparator.comparingInt(c -> locFn.apply(c).distanceTo(anchor)));
+	}
+
+	// private methods
+	private static <T extends TileObject> Stream<T> getSceneObjects(Function<Tile, Collection<? extends T>> extractor) {
+		var triple = Microbot.getClientThread().invoke(() -> {
+			Player player = Microbot.getClient().getLocalPlayer();
+
+			Scene scene = player.getWorldView().getScene();
+
+			Tile[][][] tiles = scene.getTiles();
+			if (tiles == null) {
+				return Triple.of(null, null, 0);
+			}
+
+			int z = player.getWorldView().getPlane();
+
+			return Triple.of(scene, tiles, z);
+		});
+
+		var result = new ArrayList<T>();
+		Tile[][][] tiles = (Tile[][][]) triple.getMiddle();
+		int z = triple.getRight();
+
+		int sceneSize = Constants.SCENE_SIZE;
+
+		for (int x = 0; x < sceneSize; x++) {
+			for (int y = 0; y < sceneSize; y++) {
+				for (int h = 0; h <= z; h++) {
+					Tile tile = tiles[h][x][y];
+					if (tile == null) continue;
+
+					Collection<? extends T> objs = extractor.apply(tile);
+					if (objs != null) {
+						for (T obj : objs) {
+							if (obj == null) continue;
+
+							if (obj instanceof GameObject) {
+								GameObject gameObject = (GameObject) obj;
+								if (gameObject.getSceneMinLocation().equals(tile.getSceneLocation())) {
+									result.add(obj);
+								}
+							} else {
+								if (obj.getLocalLocation().equals(tile.getLocalLocation())) {
+									result.add(obj);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		return result.stream();
+	}
+
+	private static <T extends TileObject> List<T> getSceneObjects(Function<Tile, Collection<? extends T>> extractor, Predicate<T> predicate, LocalPoint anchorLocal, int distance) {
+		if (distance > Rs2LocalPoint.worldToLocalDistance(Constants.SCENE_SIZE)) {
+			distance = Rs2LocalPoint.worldToLocalDistance(Constants.SCENE_SIZE);
+		}
+
+		return getSceneObjects(extractor)
+				.filter(withinTilesPredicate(distance, anchorLocal))
+				.filter(predicate)
+				.sorted(Comparator.comparingInt(o -> o.getLocalLocation().distanceTo(anchorLocal)))
+				.collect(Collectors.toList());
+	}
+
+	private static <T extends TileObject> T getSceneObject(Function<Tile, Collection<? extends T>> extractor, Predicate<T> predicate, LocalPoint anchorLocal, int distance) {
+		return getSceneObjects(extractor, predicate, anchorLocal, distance)
+				.stream()
+				.findFirst()
+				.orElse(null);
+	}
+
+	private static boolean isWithinTiles(LocalPoint anchor, LocalPoint objLoc, int distance) {
+		int dx = Math.abs(anchor.getX() - objLoc.getX());
+		int dy = Math.abs(anchor.getY() - objLoc.getY());
+
+		if (distance == 0) {
+			// exactly one tile away, no diagonals
+			return (dx == Perspective.LOCAL_TILE_SIZE && dy == 0)
+					|| (dy == Perspective.LOCAL_TILE_SIZE && dx == 0);
+		} else {
+			return objLoc.distanceTo(anchor) <= distance;
+		}
+	}
+
+	private static <T extends TileObject> Predicate<T> withinTilesPredicate(int distance, LocalPoint anchor) {
+		return to -> isWithinTiles(anchor, to.getLocalLocation(), distance);
+	}
+
+	private static LocalPoint localPointFromWorldSafe(WorldPoint anchor) {
+		if(Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.getValue() == null){
+			return null;
+		}
+
+		return LocalPoint.fromWorld(Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.<WorldView>getValue(), anchor);
+	}
+
+	public static Optional<String> getCompositionName(TileObject obj) {
+		ObjectComposition comp = convertToObjectComposition(obj);
+		if (comp == null) {
+			return Optional.empty();
+		}
+		String name = comp.getName();
+		return (name == null || name.equals("null"))
+				? Optional.empty()
+				: Optional.of(Rs2UiHelper.stripColTags(name));
+	}
+
+	/**
+	 * Creates a predicate that matches TileObjects whose name matches the given name.
+	 * Optionally, it can require an exact match or allow partial (contains) match.
+	 *
+	 * @param objectName The name of the object to match.
+	 * @param exact      If true, the object name must exactly match (case-insensitive).
+	 *                   If false, the name must only contain the given string (case-insensitive).
+	 * @param <T>        A type that extends TileObject.
+	 * @return A predicate that returns true if the object's name matches the given name.
+	 */
+	public static <T extends TileObject> Predicate<T> nameMatches(String objectName, boolean exact)
+	{
+		String normalizedForIds = objectName.toLowerCase().replace(" ", "_");
+		Set<Integer> ids = new HashSet<>(getObjectIdsByName(normalizedForIds));
+
+		String lower = objectName.toLowerCase();
+
+		return obj -> {
+			if (!ids.isEmpty() && !ids.contains(obj.getId())) {
+				return false;
+			}
+
+			return getCompositionName(obj)
+					.map(compName -> exact ? compName.equalsIgnoreCase(objectName) : compName.toLowerCase().contains(lower))
+					.orElse(false);
+		};
+	}
+
+	/**
+	 * Creates a predicate that matches TileObjects whose name contains the given name (case-insensitive).
+	 *
+	 * @param objectName The partial or full name to match against.
+	 * @param <T>        A type that extends TileObject.
+	 * @return A predicate that returns true if the object's name contains the given string.
+	 */
+	public static <T extends TileObject> Predicate<T> nameMatches(String objectName)
+	{
+		return nameMatches(objectName, false);
+	}
+
+	/**
+	 * Creates a predicate that matches TileObjects whose name and one of the actions match the given values.
+	 * Matching can be exact or partial based on the 'exact' parameter.
+	 *
+	 * @param objectName The name of the object to match.
+	 * @param actionName The action text to match (e.g. "Open", "Climb").
+	 * @param exact      If true, both the name and action must match exactly (case-insensitive).
+	 *                   If false, both may partially match (case-insensitive).
+	 * @param <T>        A type that extends TileObject.
+	 * @return A predicate that returns true if both the name and action match.
+	 */
+	public static <T extends TileObject> Predicate<T> nameAndActionMatches(String objectName, String actionName, boolean exact)
+	{
+		Predicate<T> namePredicate = nameMatches(objectName, exact);
+		Predicate<T> actionPredicate = obj -> {
+			ObjectComposition comp = convertToObjectComposition(obj);
+			return hasAction(comp, actionName, exact);
+		};
+
+		return namePredicate.and(actionPredicate);
+	}
+
+	/**
+	 * Creates a predicate that matches TileObjects by name and action using partial (contains) matching.
+	 *
+	 * @param objectName The name of the object to match.
+	 * @param actionName The action text to match (e.g. "Open", "Climb").
+	 * @param <T>        A type that extends TileObject.
+	 * @return A predicate that returns true if both the name and action partially match.
+	 */
+	public static <T extends TileObject> Predicate<T> nameAndActionMatches(String objectName, String actionName)
+	{
+		return nameAndActionMatches(objectName, actionName, false);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate, WorldPoint anchor, int distance) {
+		return (List<T>) getTileObjects((Predicate<TileObject>) predicate, anchor, distance);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate, WorldPoint anchor, int distance) {
+		return (List<T>) getGameObjects((Predicate<GameObject>) predicate, anchor, distance);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate, WorldPoint anchor) {
+		return fetchTileObjects(predicate, anchor, Constants.SCENE_SIZE);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate, WorldPoint anchor) {
+		return fetchTileObjects(predicate, anchor, Constants.SCENE_SIZE);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return fetchTileObjects(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate, int distance) {
+		Player player = Microbot.getClient().getLocalPlayer();
+		if (player == null) {
+			return Collections.emptyList();
+		}
+		return fetchGameObjects(predicate, Rs2Player.getWorldLocation(), distance);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate) {
+		return fetchTileObjects(predicate, Constants.SCENE_SIZE);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate) {
+		return fetchGameObjects(predicate, Constants.SCENE_SIZE);
+	}
+
+	@Nullable
+	private static ObjectComposition convertToObjectCompositionInternal(int objectId, boolean ignoreImpostor) {
+		return Microbot.getClientThread().runOnClientThreadOptional(() -> {
+			ObjectComposition comp = Microbot.getClient().getObjectDefinition(objectId);
+			if (comp == null) return null;
+			return (ignoreImpostor || comp.getImpostorIds() == null) ? comp : comp.getImpostor();
+		}).orElse(null);
+	}
+
+	private static boolean clickObject(TileObject object) {
+		return clickObject(object, "");
+	}
+
+	public static boolean clickObject(TileObject object, String action) {
+		if (object == null) return false;
+		if (Rs2Player.getWorldLocation().distanceTo(object.getWorldLocation()) > 51) {
+			Microbot.log("Object with id " + object.getId() + " is not close enough to interact with. Walking to the object....");
+			Rs2Walker.walkTo(object.getWorldLocation());
+			return false;
+		}
+
+		try {
+
+			int param0;
+			int param1;
+			MenuAction menuAction = MenuAction.WALK;
+
+			ObjectComposition objComp = convertToObjectComposition(object);
+			if (objComp == null) return false;
+
+			Microbot.status = action + " " + objComp.getName();
+
+			if (object instanceof GameObject) {
+				GameObject obj = (GameObject) object;
+				if (obj.sizeX() > 1) {
+					param0 = obj.getLocalLocation().getSceneX() - obj.sizeX() / 2;
+				} else {
+					param0 = obj.getLocalLocation().getSceneX();
+				}
+
+				if (obj.sizeY() > 1) {
+					param1 = obj.getLocalLocation().getSceneY() - obj.sizeY() / 2;
+				} else {
+					param1 = obj.getLocalLocation().getSceneY();
+				}
+			} else {
+				// Default objects like walls, groundobjects, decorationobjects etc...
+				param0 = object.getLocalLocation().getSceneX();
+				param1 = object.getLocalLocation().getSceneY();
+			}
+
+			int index = 0;
+			if (action != null) {
+				String[] actions;
+				if (objComp.getImpostorIds() != null && objComp.getImpostor() != null) {
+					actions = objComp.getImpostor().getActions();
+				} else {
+					actions = objComp.getActions();
+				}
+
+				for (int i = 0; i < actions.length; i++) {
+					if (actions[i] == null) continue;
+					if (action.equalsIgnoreCase(Rs2UiHelper.stripColTags(actions[i]))) {
+						index = i;
+						break;
+					}
+				}
+
+				if (index == actions.length)
+					index = 0;
+			}
+
+			if (index == -1) {
+				Microbot.log("Failed to interact with object " + object.getId() + " " + action);
+			}
+
+
+			if (Microbot.getClient().isWidgetSelected()) {
+				menuAction = MenuAction.WIDGET_TARGET_ON_GAME_OBJECT;
+			} else if (index == 0) {
+				menuAction = MenuAction.GAME_OBJECT_FIRST_OPTION;
+			} else if (index == 1) {
+				menuAction = MenuAction.GAME_OBJECT_SECOND_OPTION;
+			} else if (index == 2) {
+				menuAction = MenuAction.GAME_OBJECT_THIRD_OPTION;
+			} else if (index == 3) {
+				menuAction = MenuAction.GAME_OBJECT_FOURTH_OPTION;
+			} else if (index == 4) {
+				menuAction = MenuAction.GAME_OBJECT_FIFTH_OPTION;
+			}
+
+			if (!Rs2Camera.isTileOnScreen(object.getLocalLocation())) {
+				Rs2Camera.turnTo(object);
+			}
+
+			// both hands must be free before using MINECART
+			if (objComp.getName().toLowerCase().contains("train cart")) {
+				Rs2Equipment.unEquip(EquipmentInventorySlot.WEAPON);
+				Rs2Equipment.unEquip(EquipmentInventorySlot.SHIELD);
+				sleepUntil(() -> Rs2Equipment.get(EquipmentInventorySlot.WEAPON) == null && Rs2Equipment.get(EquipmentInventorySlot.SHIELD) == null);
+			}
 
 /*            if (object.getWorldView().getId() != -1) {
                 param0 = 3;
                 param1 = 4;
             }*/
 
-            int worldViewId = WorldView.TOPLEVEL;
+			int worldViewId = WorldView.TOPLEVEL;
 
-            if (!object.getWorldView().isTopLevel()) {
-                var worldView =Microbot.getClientThread().invoke(() ->  Microbot.getClient().getLocalPlayer().getWorldView());
-                if (worldView == null) {
-                    worldViewId = Microbot.getClient().getTopLevelWorldView().getId();
-                } else {
-                    worldViewId = worldView
-                            .getId();
-                }
+			if (!object.getWorldView().isTopLevel()) {
+				var worldView =Microbot.getClientThread().invoke(() ->  Microbot.getClient().getLocalPlayer().getWorldView());
+				if (worldView == null) {
+					worldViewId = Microbot.getClient().getTopLevelWorldView().getId();
+				} else {
+					worldViewId = worldView
+							.getId();
+				}
 
-            }
+			}
 
 
-            Microbot.doInvoke(new NewMenuEntry()
-                            .param0(param0)
-                            .param1(param1)
-                            .opcode(menuAction.getId())
-                            .identifier(object.getId())
-                            .itemId(-1)
-                            .option(action)
-                            .target(objComp.getName())
-                            .gameObject(object)
-                            .worldViewId(worldViewId)
-                    ,
-                    Rs2UiHelper.getObjectClickbox(object));
+			Microbot.doInvoke(new NewMenuEntry()
+							.param0(param0)
+							.param1(param1)
+							.opcode(menuAction.getId())
+							.identifier(object.getId())
+							.itemId(-1)
+							.option(action)
+							.target(objComp.getName())
+							.gameObject(object)
+							.worldViewId(worldViewId)
+					,
+					Rs2UiHelper.getObjectClickbox(object));
 // MenuEntryImpl(getOption=Use, getTarget=Barrier, getIdentifier=43700, getType=GAME_OBJECT_THIRD_OPTION, getParam0=53, getParam1=51, getItemId=-1, isForceLeftClick=true, getWorldViewId=-1, isDeprioritized=false)
-            //Rs2Reflection.invokeMenu(param0, param1, menuAction.getId(), object.getId(),-1, "", "", -1, -1);
+			//Rs2Reflection.invokeMenu(param0, param1, menuAction.getId(), object.getId(),-1, "", "", -1, -1);
 
-        } catch (Exception ex) {
-            Microbot.log("Failed to interact with object " + ex.getMessage());
-        }
+		} catch (Exception ex) {
+			Microbot.log("Failed to interact with object " + ex.getMessage());
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    public static boolean hasLineOfSight(TileObject tileObject) {
-        return hasLineOfSight(Rs2Player.getWorldLocation(), tileObject);
-    }
+	public static boolean hasLineOfSight(TileObject tileObject) {
+		return hasLineOfSight(Rs2Player.getWorldLocation(), tileObject);
+	}
 
-    public static boolean hasLineOfSight(WorldPoint point, TileObject tileObject) {
-        if (tileObject == null) return false;
-        if (tileObject instanceof GameObject) {
-            GameObject gameObject = (GameObject) tileObject;
-            WorldPoint worldPoint = WorldPoint.fromScene(Microbot.getClient(), gameObject.getSceneMinLocation().getX(), gameObject.getSceneMinLocation().getY(), gameObject.getPlane());
-            return new WorldArea(
-                    worldPoint,
-                    gameObject.sizeX(),
-                    gameObject.sizeY())
-                    .hasLineOfSightTo(Microbot.getClient().getTopLevelWorldView(), point.toWorldArea());
-        } else {
-            return new WorldArea(
-                    tileObject.getWorldLocation(),
-                    2,
-                    2)
-                    .hasLineOfSightTo(Microbot.getClient().getTopLevelWorldView(), new WorldArea(point.getX(),
-                            point.getY(), 2, 2, point.getPlane()));
-        }
-    }
+	public static boolean hasLineOfSight(WorldPoint point, TileObject tileObject) {
+		if (tileObject == null) return false;
+		if (tileObject instanceof GameObject) {
+			GameObject gameObject = (GameObject) tileObject;
+			WorldPoint worldPoint = WorldPoint.fromScene(Microbot.getClient(), gameObject.getSceneMinLocation().getX(), gameObject.getSceneMinLocation().getY(), gameObject.getPlane());
+			return new WorldArea(
+					worldPoint,
+					gameObject.sizeX(),
+					gameObject.sizeY())
+					.hasLineOfSightTo(Microbot.getClient().getTopLevelWorldView(), point.toWorldArea());
+		} else {
+			return new WorldArea(
+					tileObject.getWorldLocation(),
+					2,
+					2)
+					.hasLineOfSightTo(Microbot.getClient().getTopLevelWorldView(), new WorldArea(point.getX(),
+							point.getY(), 2, 2, point.getPlane()));
+		}
+	}
 
-    @SneakyThrows
-    public static List<Integer> getObjectIdsByName(String name) {
-        List<Integer> ids = new ArrayList<>();
-        String lowerName = name.toLowerCase();
+	@SneakyThrows
+	public static List<Integer> getObjectIdsByName(String name) {
+		List<Integer> ids = new ArrayList<>();
+		String lowerName = name.toLowerCase();
 
-        Class<?>[] classesToScan = {
-                net.runelite.api.ObjectID.class,
-                net.runelite.api.gameval.ObjectID.class,
-                net.runelite.client.plugins.microbot.util.gameobject.ObjectID.class
-        };
+		Class<?>[] classesToScan = {
+				net.runelite.api.ObjectID.class,
+				net.runelite.api.gameval.ObjectID.class,
+				net.runelite.client.plugins.microbot.util.gameobject.ObjectID.class
+		};
 
-        for (Class<?> clazz : classesToScan) {
-            for (Field f : clazz.getFields()) {
-                if (f.getType() != int.class) continue;
+		for (Class<?> clazz : classesToScan) {
+			for (Field f : clazz.getFields()) {
+				if (f.getType() != int.class) continue;
 
-                if (f.getName().toLowerCase().contains(lowerName)) {
-                    f.setAccessible(true);
-                    ids.add(f.getInt(null));
-                }
-            }
-        }
-        return ids;
-    }
+				if (f.getName().toLowerCase().contains(lowerName)) {
+					f.setAccessible(true);
+					ids.add(f.getInt(null));
+				}
+			}
+		}
+		return ids;
+	}
 
-    @Nullable
-    @Deprecated
-    public static ObjectComposition getObjectComposition(int id) {
-        ObjectComposition objectComposition = Microbot.getClientThread().runOnClientThreadOptional(() -> Microbot.getClient().getObjectDefinition(id))
-                .orElse(null);
-        if (objectComposition == null) return null;
-        return objectComposition.getImpostorIds() == null ?
-                objectComposition :
-                Microbot.getClientThread().runOnClientThreadOptional((objectComposition::getImpostor)).orElse(null);
-    }
+	@Nullable
+	@Deprecated
+	public static ObjectComposition getObjectComposition(int id) {
+		ObjectComposition objectComposition = Microbot.getClientThread().runOnClientThreadOptional(() -> Microbot.getClient().getObjectDefinition(id))
+				.orElse(null);
+		if (objectComposition == null) return null;
+		return objectComposition.getImpostorIds() == null ?
+				objectComposition :
+				Microbot.getClientThread().runOnClientThreadOptional((objectComposition::getImpostor)).orElse(null);
+	}
 
-    public static boolean canWalkTo(TileObject tileObject, int distance) {
-        if (tileObject == null) return false;
-        WorldArea objectArea;
+	public static boolean canWalkTo(TileObject tileObject, int distance) {
+		if (tileObject == null) return false;
+		WorldArea objectArea;
 
-        if (tileObject instanceof GameObject) {
-            GameObject gameObject = (GameObject) tileObject;
-            WorldPoint worldPoint = WorldPoint.fromScene(Microbot.getClient(), gameObject.getSceneMinLocation().getX(), gameObject.getSceneMinLocation().getY(), gameObject.getPlane());
+		if (tileObject instanceof GameObject) {
+			GameObject gameObject = (GameObject) tileObject;
+			WorldPoint worldPoint = WorldPoint.fromScene(Microbot.getClient(), gameObject.getSceneMinLocation().getX(), gameObject.getSceneMinLocation().getY(), gameObject.getPlane());
 
-            if (Microbot.getClient().isInInstancedRegion()) {
-                var localPoint = LocalPoint.fromWorld(Microbot.getClient(), worldPoint);
-                worldPoint = WorldPoint.fromLocalInstance(Microbot.getClient(), localPoint);
-            }
+			if (Microbot.getClient().isInInstancedRegion()) {
+				var localPoint = LocalPoint.fromWorld(Microbot.getClient(), worldPoint);
+				worldPoint = WorldPoint.fromLocalInstance(Microbot.getClient(), localPoint);
+			}
 
-            objectArea = new WorldArea(
-                    worldPoint,
-                    gameObject.sizeX(),
-                    gameObject.sizeY());
-        } else {
-            objectArea = new WorldArea(
-                    tileObject.getWorldLocation(),
-                    2,
-                    2);
-        }
+			objectArea = new WorldArea(
+					worldPoint,
+					gameObject.sizeX(),
+					gameObject.sizeY());
+		} else {
+			objectArea = new WorldArea(
+					tileObject.getWorldLocation(),
+					2,
+					2);
+		}
 
-        var tiles = Rs2Tile.getReachableTilesFromTile(Rs2Player.getWorldLocation(), distance);
-        for (var tile : tiles.keySet()) {
-            if (tile.distanceTo(objectArea) < 2)
-                return true;
-        }
+		var tiles = Rs2Tile.getReachableTilesFromTile(Rs2Player.getWorldLocation(), distance);
+		for (var tile : tiles.keySet()) {
+			if (tile.distanceTo(objectArea) < 2)
+				return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Returns the object is reachable from the player
-     *
-     * @param tileObject
-     * @return boolean
-     */
-    public static boolean isReachable(GameObject tileObject) {
-        WorldArea worldArea = getWorldArea(tileObject);
-        if (worldArea == null) {
-            return false;
-        }
-        Rs2WorldArea gameObjectArea = new Rs2WorldArea(worldArea);
-        List<WorldPoint> interactablePoints = gameObjectArea.getInteractable();
+	/**
+	 * Returns the object is reachable from the player
+	 *
+	 * @param tileObject
+	 * @return boolean
+	 */
+	public static boolean isReachable(GameObject tileObject) {
+		WorldArea worldArea = getWorldArea(tileObject);
+		if (worldArea == null) {
+			return false;
+		}
+		Rs2WorldArea gameObjectArea = new Rs2WorldArea(worldArea);
+		List<WorldPoint> interactablePoints = gameObjectArea.getInteractable();
 
-        if (interactablePoints.isEmpty()) {
-            interactablePoints.addAll(gameObjectArea.offset(1).toWorldPointList());
-            interactablePoints.removeIf(gameObjectArea::contains);
-        }
+		if (interactablePoints.isEmpty()) {
+			interactablePoints.addAll(gameObjectArea.offset(1).toWorldPointList());
+			interactablePoints.removeIf(gameObjectArea::contains);
+		}
 
-        WorldPoint walkableInteractPoint = interactablePoints.stream()
-                .filter(Rs2Tile::isWalkable)
-                .filter(Rs2Tile::isTileReachable)
-                .findFirst()
-                .orElse(null);
-        return walkableInteractPoint != null;
-    }
+		WorldPoint walkableInteractPoint = interactablePoints.stream()
+				.filter(Rs2Tile::isWalkable)
+				.filter(Rs2Tile::isTileReachable)
+				.findFirst()
+				.orElse(null);
+		return walkableInteractPoint != null;
+	}
 
-    public static WorldArea getWorldArea(GameObject gameObject) {
-        if (!gameObject.getLocalLocation().isInScene()) {
-            return null;
-        }
+	public static WorldArea getWorldArea(GameObject gameObject) {
+		if (!gameObject.getLocalLocation().isInScene()) {
+			return null;
+		}
 
-        LocalPoint localSWTile = new LocalPoint(
-                gameObject.getLocalLocation().getX() - (gameObject.sizeX() - 1) * Perspective.LOCAL_TILE_SIZE / 2,
-                gameObject.getLocalLocation().getY() - (gameObject.sizeY() - 1) * Perspective.LOCAL_TILE_SIZE / 2
-        );
+		LocalPoint localSWTile = new LocalPoint(
+				gameObject.getLocalLocation().getX() - (gameObject.sizeX() - 1) * Perspective.LOCAL_TILE_SIZE / 2,
+				gameObject.getLocalLocation().getY() - (gameObject.sizeY() - 1) * Perspective.LOCAL_TILE_SIZE / 2
+		);
 
-        LocalPoint localNETile = new LocalPoint(
-                gameObject.getLocalLocation().getX() + (gameObject.sizeX() - 1) * Perspective.LOCAL_TILE_SIZE / 2,
-                gameObject.getLocalLocation().getY() + (gameObject.sizeY() - 1) * Perspective.LOCAL_TILE_SIZE / 2
-        );
+		LocalPoint localNETile = new LocalPoint(
+				gameObject.getLocalLocation().getX() + (gameObject.sizeX() - 1) * Perspective.LOCAL_TILE_SIZE / 2,
+				gameObject.getLocalLocation().getY() + (gameObject.sizeY() - 1) * Perspective.LOCAL_TILE_SIZE / 2
+		);
 
 
-        return new Rs2WorldArea(
-                WorldPoint.fromLocal(Microbot.getClient(), localSWTile),
-                WorldPoint.fromLocal(Microbot.getClient(), localNETile)
-        );
-    }
+		return new Rs2WorldArea(
+				WorldPoint.fromLocal(Microbot.getClient(), localSWTile),
+				WorldPoint.fromLocal(Microbot.getClient(), localNETile)
+		);
+	}
 
-    /**
-     * Hovers over the given game object using the natural mouse.
-     *
-     * @param object The game object to hover over.
-     * @return True if successfully hovered, otherwise false.
-     */
-    public static boolean hoverOverObject(TileObject object) {
-        if (!Rs2AntibanSettings.naturalMouse) {
-            if (Rs2AntibanSettings.devDebug)
-                Microbot.log("Natural mouse is not enabled, can't hover");
-            return false;
-        }
-        Point point = Rs2UiHelper.getClickingPoint(Rs2UiHelper.getObjectClickbox(object), true);
-        // if the point is 1,1 then the object is not on screen and we should return false
-        if (point.getX() == 1 && point.getY() == 1) {
-            return false;
-        }
-        Microbot.getNaturalMouse().moveTo(point.getX(), point.getY());
-        return true;
-    }
+	/**
+	 * Hovers over the given game object using the natural mouse.
+	 *
+	 * @param object The game object to hover over.
+	 * @return True if successfully hovered, otherwise false.
+	 */
+	public static boolean hoverOverObject(TileObject object) {
+		if (!Rs2AntibanSettings.naturalMouse) {
+			if (Rs2AntibanSettings.devDebug)
+				Microbot.log("Natural mouse is not enabled, can't hover");
+			return false;
+		}
+		Point point = Rs2UiHelper.getClickingPoint(Rs2UiHelper.getObjectClickbox(object), true);
+		// if the point is 1,1 then the object is not on screen and we should return false
+		if (point.getX() == 1 && point.getY() == 1) {
+			return false;
+		}
+		Microbot.getNaturalMouse().moveTo(point.getX(), point.getY());
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
@@ -1562,6 +1562,7 @@ public class Rs2GameObject {
 		return to -> isWithinTiles(anchor, to.getLocalLocation(), distance);
 	}
 
+
 	private static LocalPoint localPointFromWorldSafe(WorldPoint anchor) {
 		if(Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.getValue() == null){
 			return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
@@ -7,6 +7,7 @@ import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.Rs2Cache;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.bank.enums.BankLocation;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
@@ -37,62 +38,62 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
  */
 @Deprecated(since = "2.1.0 - Use Rs2TileObjectQueryable instead", forRemoval = true)
 public class Rs2GameObject {
-	/**
-	 * Extracts all {@link GameObject}s located on a given {@link Tile}.
-	 *
-	 * @see Tile#getGameObjects()
-	 * @param tile the tile from which to extract game objects
-	 * @return a {@link List} of {@link GameObject} instances on the tile (never null)
-	 */
-	private static final Function<Tile, Collection<? extends GameObject>> GAMEOBJECT_EXTRACTOR =
-		tile -> Arrays.asList(tile.getGameObjects());
+    /**
+     * Extracts all {@link GameObject}s located on a given {@link Tile}.
+     *
+     * @see Tile#getGameObjects()
+     * @param tile the tile from which to extract game objects
+     * @return a {@link List} of {@link GameObject} instances on the tile (never null)
+     */
+    private static final Function<Tile, Collection<? extends GameObject>> GAMEOBJECT_EXTRACTOR =
+            tile -> Arrays.asList(tile.getGameObjects());
 
-	/**
-	 * Extracts the {@link GroundObject} located on a given {@link Tile}.
-	 *
-	 * @see Tile#getGroundObject()
-	 * @param tile the tile from which to extract the ground object
-	 * @return a singleton {@link List} containing the {@link GroundObject},
-	 *         or a list with a single null element if none is present
-	 */
-	private static final Function<Tile, Collection<? extends GroundObject>> GROUNDOBJECT_EXTRACTOR =
-		tile -> Collections.singletonList(tile.getGroundObject());
+    /**
+     * Extracts the {@link GroundObject} located on a given {@link Tile}.
+     *
+     * @see Tile#getGroundObject()
+     * @param tile the tile from which to extract the ground object
+     * @return a singleton {@link List} containing the {@link GroundObject},
+     *         or a list with a single null element if none is present
+     */
+    private static final Function<Tile, Collection<? extends GroundObject>> GROUNDOBJECT_EXTRACTOR =
+            tile -> Collections.singletonList(tile.getGroundObject());
 
-	/**
-	 * Extracts the {@link DecorativeObject} located on a given {@link Tile}.
-	 *
-	 * @see Tile#getDecorativeObject()
-	 * @param tile the tile from which to extract the decorative object
-	 * @return a singleton {@link List} containing the {@link DecorativeObject},
-	 *         or a list with a single null element if none is present
-	 */
-	private static final Function<Tile, Collection<? extends DecorativeObject>> DECORATIVEOBJECT_EXTRACTOR =
-		tile -> Collections.singletonList(tile.getDecorativeObject());
+    /**
+     * Extracts the {@link DecorativeObject} located on a given {@link Tile}.
+     *
+     * @see Tile#getDecorativeObject()
+     * @param tile the tile from which to extract the decorative object
+     * @return a singleton {@link List} containing the {@link DecorativeObject},
+     *         or a list with a single null element if none is present
+     */
+    private static final Function<Tile, Collection<? extends DecorativeObject>> DECORATIVEOBJECT_EXTRACTOR =
+            tile -> Collections.singletonList(tile.getDecorativeObject());
 
-	/**
-	 * Extracts the {@link WallObject} located on a given {@link Tile}.
-	 *
-	 * @see Tile#getWallObject()
-	 * @param tile the tile from which to extract the wall object
-	 * @return a singleton {@link List} containing the {@link WallObject},
-	 *         or a list with a single null element if none is present
-	 */
-	private static final Function<Tile, Collection<? extends WallObject>> WALLOBJECT_EXTRACTOR =
-		tile -> Collections.singletonList(tile.getWallObject());
+    /**
+     * Extracts the {@link WallObject} located on a given {@link Tile}.
+     *
+     * @see Tile#getWallObject()
+     * @param tile the tile from which to extract the wall object
+     * @return a singleton {@link List} containing the {@link WallObject},
+     *         or a list with a single null element if none is present
+     */
+    private static final Function<Tile, Collection<? extends WallObject>> WALLOBJECT_EXTRACTOR =
+            tile -> Collections.singletonList(tile.getWallObject());
 
-	/**
-	 * Extracts all types of {@link TileObject} (decorative, ground, wall) from a given {@link Tile}.
-	 *
-	 * @param tile the tile from which to extract all tile objects
-	 * @return a {@link List} containing the {@link DecorativeObject}, {@link GroundObject},
-	 *         and {@link WallObject} (some entries may be null if that object is not present)
-	 */
-	private static final Function<Tile, Collection<? extends TileObject>> TILEOBJECT_EXTRACTOR =
-		tile -> Arrays.asList(
-			tile.getDecorativeObject(),
-			tile.getGroundObject(),
-			tile.getWallObject()
-		);
+    /**
+     * Extracts all types of {@link TileObject} (decorative, ground, wall) from a given {@link Tile}.
+     *
+     * @param tile the tile from which to extract all tile objects
+     * @return a {@link List} containing the {@link DecorativeObject}, {@link GroundObject},
+     *         and {@link WallObject} (some entries may be null if that object is not present)
+     */
+    private static final Function<Tile, Collection<? extends TileObject>> TILEOBJECT_EXTRACTOR =
+            tile -> Arrays.asList(
+                    tile.getDecorativeObject(),
+                    tile.getGroundObject(),
+                    tile.getWallObject()
+            );
 
 
     public static boolean interact(WorldPoint worldPoint) {
@@ -194,40 +195,40 @@ public class Rs2GameObject {
         return findObjectById(id) != null;
     }
 
-	public static boolean canReach(WorldPoint target, int objectSizeX, int objectSizeY, int pathSizeX, int pathSizeY) {
-		if (target == null) return false;
+    public static boolean canReach(WorldPoint target, int objectSizeX, int objectSizeY, int pathSizeX, int pathSizeY) {
+        if (target == null) return false;
 
-		List<WorldPoint> path = Rs2Player.getRs2WorldPoint().pathTo(target, true);
-		if (path == null || path.isEmpty()) return false;
+        List<WorldPoint> path = Rs2Player.getRs2WorldPoint().pathTo(target, true);
+        if (path == null || path.isEmpty()) return false;
 
-		// Create centered WorldAreas instead of using corner-based construction
-		WorldPoint pathEndpoint = path.get(path.size() - 1);
-		WorldPoint pathSouthWest = new WorldPoint(
-			pathEndpoint.getX() - pathSizeX / 2, 
-			pathEndpoint.getY() - pathSizeY / 2, 
-			pathEndpoint.getPlane()
-		);
-		WorldArea pathArea = new WorldArea(pathSouthWest, pathSizeX, pathSizeY);
-		
-		WorldPoint objectSouthWest = new WorldPoint(
-			target.getX() - (objectSizeX + 2) / 2, 
-			target.getY() - (objectSizeY + 2) / 2, 
-			target.getPlane()
-		);
-		WorldArea objectArea = new WorldArea(objectSouthWest, objectSizeX + 2, objectSizeY + 2);
+        // Create centered WorldAreas instead of using corner-based construction
+        WorldPoint pathEndpoint = path.get(path.size() - 1);
+        WorldPoint pathSouthWest = new WorldPoint(
+                pathEndpoint.getX() - pathSizeX / 2,
+                pathEndpoint.getY() - pathSizeY / 2,
+                pathEndpoint.getPlane()
+        );
+        WorldArea pathArea = new WorldArea(pathSouthWest, pathSizeX, pathSizeY);
 
-		return pathArea.intersectsWith2D(objectArea);
-	}
+        WorldPoint objectSouthWest = new WorldPoint(
+                target.getX() - (objectSizeX + 2) / 2,
+                target.getY() - (objectSizeY + 2) / 2,
+                target.getPlane()
+        );
+        WorldArea objectArea = new WorldArea(objectSouthWest, objectSizeX + 2, objectSizeY + 2);
 
-	public static boolean canReach(WorldPoint target, int objectSizeX, int objectSizeY) {
-		return canReach(target, objectSizeX, objectSizeY, 3, 3);
-	}
+        return pathArea.intersectsWith2D(objectArea);
+    }
 
-	public static boolean canReach(WorldPoint target) {
-		return canReach(target, 2, 2, 2, 2);
-	}
+    public static boolean canReach(WorldPoint target, int objectSizeX, int objectSizeY) {
+        return canReach(target, objectSizeX, objectSizeY, 3, 3);
+    }
 
-	@Deprecated
+    public static boolean canReach(WorldPoint target) {
+        return canReach(target, 2, 2, 2, 2);
+    }
+
+    @Deprecated
     public static TileObject findObjectById(int id) {
         var list = getAll(o -> o.getId() == id);
         return list.stream().filter(x -> x.getId() == id).findFirst().orElse(null);
@@ -271,7 +272,7 @@ public class Rs2GameObject {
     public static GameObject findObject(int id, WorldPoint worldPoint) {
         return getGameObject(o -> o.getId() == id && o.getWorldLocation().equals(worldPoint));
     }
-    
+
     @Deprecated
     public static ObjectComposition findObjectComposition(int id) {
         return convertToObjectComposition(id);
@@ -284,7 +285,7 @@ public class Rs2GameObject {
 
     @Deprecated
     public static GameObject get(String name, boolean exact) {
-       return getGameObject(name, exact);
+        return getGameObject(name, exact);
     }
 
     @Deprecated
@@ -402,17 +403,17 @@ public class Rs2GameObject {
                 return false;
             }
 
-			// Lunar Isle (exception)
-			// There is a bank booth @ Lunar Isle that is only accessible when Dream Mentor is completed
-			if (loc.equals(new WorldPoint(2099, 3920, 0)) && Rs2Player.getQuestState(Quest.DREAM_MENTOR) != QuestState.FINISHED) {
-				return false;
-			}
+            // Lunar Isle (exception)
+            // There is a bank booth @ Lunar Isle that is only accessible when Dream Mentor is completed
+            if (loc.equals(new WorldPoint(2099, 3920, 0)) && Rs2Player.getQuestState(Quest.DREAM_MENTOR) != QuestState.FINISHED) {
+                return false;
+            }
 
-			// Lunar Isle (additional exception to not use these banks if no seal of passage)
-			if ((loc.equals(new WorldPoint(2098, 3920, 0)) || loc.equals(new WorldPoint(2097, 3920, 0))) &&
-				!(Rs2Inventory.hasItem(ItemID.LUNAR_SEAL_OF_PASSAGE) || Rs2Equipment.isWearing(ItemID.LUNAR_SEAL_OF_PASSAGE))) {
-				return false;
-			}
+            // Lunar Isle (additional exception to not use these banks if no seal of passage)
+            if ((loc.equals(new WorldPoint(2098, 3920, 0)) || loc.equals(new WorldPoint(2097, 3920, 0))) &&
+                    !(Rs2Inventory.hasItem(ItemID.LUNAR_SEAL_OF_PASSAGE) || Rs2Equipment.isWearing(ItemID.LUNAR_SEAL_OF_PASSAGE))) {
+                return false;
+            }
 
             ObjectComposition comp = convertToObjectComposition(gameObject);
             if (comp == null) return false;
@@ -471,22 +472,22 @@ public class Rs2GameObject {
         return convertToObjectComposition(objectId);
     }
 
-	public static String getObjectType(TileObject object)
-	{
-		String type;
-		if (object instanceof WallObject) {
-			type = "WallObject";
-		} else if (object instanceof DecorativeObject) {
-			type = "DecorativeObject";
-		} else if (object instanceof GameObject) {
-			type = "GameObject";
-		} else if (object instanceof GroundObject) {
-			type = "GroundObject";
-		} else {
-			type = "TileObject";
-		}
-		return type;
-	}
+    public static String getObjectType(TileObject object)
+    {
+        String type;
+        if (object instanceof WallObject) {
+            type = "WallObject";
+        } else if (object instanceof DecorativeObject) {
+            type = "DecorativeObject";
+        } else if (object instanceof GameObject) {
+            type = "GameObject";
+        } else if (object instanceof GroundObject) {
+            type = "GroundObject";
+        } else {
+            type = "TileObject";
+        }
+        return type;
+    }
 
     public static List<Tile> getTiles(int maxTileDistance) {
         int maxDistance = Math.max(2400, maxTileDistance * 128);
@@ -527,19 +528,19 @@ public class Rs2GameObject {
         return getAll(predicate, Constants.SCENE_SIZE);
     }
 
-	public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate, int distance) {
+    public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate, int distance) {
         WorldPoint worldPoint = Rs2Player.getWorldLocation();
-		return getAll(predicate, worldPoint, distance);
-	}
+        return getAll(predicate, worldPoint, distance);
+    }
 
-	public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate, WorldPoint anchor) {
-		return getAll(predicate, anchor, Constants.SCENE_SIZE);
-	}
+    public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate, WorldPoint anchor) {
+        return getAll(predicate, anchor, Constants.SCENE_SIZE);
+    }
 
     public static <T extends TileObject> List<TileObject> getAll(Predicate<? super T> predicate, WorldPoint anchor, int distance) {
         List<TileObject> all = new ArrayList<>();
         all.addAll(fetchGameObjects(predicate, anchor, distance));
-		all.addAll(fetchTileObjects(predicate, anchor, distance));
+        all.addAll(fetchTileObjects(predicate, anchor, distance));
         return all;
     }
 
@@ -1080,7 +1081,7 @@ public class Rs2GameObject {
     }
 
     public static List<GroundObject> getGroundObjects(Predicate<GroundObject> predicate, LocalPoint anchorLocal, int distance) {
-       return getSceneObjects(GROUNDOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
+        return getSceneObjects(GROUNDOBJECT_EXTRACTOR, predicate, anchorLocal, distance);
     }
 
     public static WallObject getWallObject(int id) {
@@ -1562,11 +1563,11 @@ public class Rs2GameObject {
     }
 
     private static LocalPoint localPointFromWorldSafe(WorldPoint anchor) {
-        return Microbot.getClientThread().runOnClientThreadOptional(() -> {
-            Player player = Microbot.getClient().getLocalPlayer();
-            if (player == null) return null;
-            return LocalPoint.fromWorld(player.getWorldView(), anchor);
-        }).orElse(null);
+        if(Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.getValue() == null){
+            return null;
+        }
+
+        return LocalPoint.fromWorld(Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.<WorldView>getValue(), anchor);
     }
 
     public static Optional<String> getCompositionName(TileObject obj) {
@@ -1580,18 +1581,18 @@ public class Rs2GameObject {
                 : Optional.of(Rs2UiHelper.stripColTags(name));
     }
 
-	/**
-	 * Creates a predicate that matches TileObjects whose name matches the given name.
-	 * Optionally, it can require an exact match or allow partial (contains) match.
-	 *
-	 * @param objectName The name of the object to match.
-	 * @param exact      If true, the object name must exactly match (case-insensitive).
-	 *                   If false, the name must only contain the given string (case-insensitive).
-	 * @param <T>        A type that extends TileObject.
-	 * @return A predicate that returns true if the object's name matches the given name.
-	 */
+    /**
+     * Creates a predicate that matches TileObjects whose name matches the given name.
+     * Optionally, it can require an exact match or allow partial (contains) match.
+     *
+     * @param objectName The name of the object to match.
+     * @param exact      If true, the object name must exactly match (case-insensitive).
+     *                   If false, the name must only contain the given string (case-insensitive).
+     * @param <T>        A type that extends TileObject.
+     * @return A predicate that returns true if the object's name matches the given name.
+     */
     public static <T extends TileObject> Predicate<T> nameMatches(String objectName, boolean exact)
-	{
+    {
         String normalizedForIds = objectName.toLowerCase().replace(" ", "_");
         Set<Integer> ids = new HashSet<>(getObjectIdsByName(normalizedForIds));
 
@@ -1608,88 +1609,88 @@ public class Rs2GameObject {
         };
     }
 
-	/**
-	 * Creates a predicate that matches TileObjects whose name contains the given name (case-insensitive).
-	 *
-	 * @param objectName The partial or full name to match against.
-	 * @param <T>        A type that extends TileObject.
-	 * @return A predicate that returns true if the object's name contains the given string.
-	 */
-	public static <T extends TileObject> Predicate<T> nameMatches(String objectName)
-	{
-		return nameMatches(objectName, false);
-	}
+    /**
+     * Creates a predicate that matches TileObjects whose name contains the given name (case-insensitive).
+     *
+     * @param objectName The partial or full name to match against.
+     * @param <T>        A type that extends TileObject.
+     * @return A predicate that returns true if the object's name contains the given string.
+     */
+    public static <T extends TileObject> Predicate<T> nameMatches(String objectName)
+    {
+        return nameMatches(objectName, false);
+    }
 
-	/**
-	 * Creates a predicate that matches TileObjects whose name and one of the actions match the given values.
-	 * Matching can be exact or partial based on the 'exact' parameter.
-	 *
-	 * @param objectName The name of the object to match.
-	 * @param actionName The action text to match (e.g. "Open", "Climb").
-	 * @param exact      If true, both the name and action must match exactly (case-insensitive).
-	 *                   If false, both may partially match (case-insensitive).
-	 * @param <T>        A type that extends TileObject.
-	 * @return A predicate that returns true if both the name and action match.
-	 */
-	public static <T extends TileObject> Predicate<T> nameAndActionMatches(String objectName, String actionName, boolean exact)
-	{
-		Predicate<T> namePredicate = nameMatches(objectName, exact);
-		Predicate<T> actionPredicate = obj -> {
-			ObjectComposition comp = convertToObjectComposition(obj);
-			return hasAction(comp, actionName, exact);
-		};
+    /**
+     * Creates a predicate that matches TileObjects whose name and one of the actions match the given values.
+     * Matching can be exact or partial based on the 'exact' parameter.
+     *
+     * @param objectName The name of the object to match.
+     * @param actionName The action text to match (e.g. "Open", "Climb").
+     * @param exact      If true, both the name and action must match exactly (case-insensitive).
+     *                   If false, both may partially match (case-insensitive).
+     * @param <T>        A type that extends TileObject.
+     * @return A predicate that returns true if both the name and action match.
+     */
+    public static <T extends TileObject> Predicate<T> nameAndActionMatches(String objectName, String actionName, boolean exact)
+    {
+        Predicate<T> namePredicate = nameMatches(objectName, exact);
+        Predicate<T> actionPredicate = obj -> {
+            ObjectComposition comp = convertToObjectComposition(obj);
+            return hasAction(comp, actionName, exact);
+        };
 
-		return namePredicate.and(actionPredicate);
-	}
+        return namePredicate.and(actionPredicate);
+    }
 
-	/**
-	 * Creates a predicate that matches TileObjects by name and action using partial (contains) matching.
-	 *
-	 * @param objectName The name of the object to match.
-	 * @param actionName The action text to match (e.g. "Open", "Climb").
-	 * @param <T>        A type that extends TileObject.
-	 * @return A predicate that returns true if both the name and action partially match.
-	 */
-	public static <T extends TileObject> Predicate<T> nameAndActionMatches(String objectName, String actionName)
-	{
-		return nameAndActionMatches(objectName, actionName, false);
-	}
+    /**
+     * Creates a predicate that matches TileObjects by name and action using partial (contains) matching.
+     *
+     * @param objectName The name of the object to match.
+     * @param actionName The action text to match (e.g. "Open", "Climb").
+     * @param <T>        A type that extends TileObject.
+     * @return A predicate that returns true if both the name and action partially match.
+     */
+    public static <T extends TileObject> Predicate<T> nameAndActionMatches(String objectName, String actionName)
+    {
+        return nameAndActionMatches(objectName, actionName, false);
+    }
 
-	@SuppressWarnings("unchecked")
-	private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate, WorldPoint anchor, int distance) {
-		return (List<T>) getTileObjects((Predicate<TileObject>) predicate, anchor, distance);
-	}
+    @SuppressWarnings("unchecked")
+    private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate, WorldPoint anchor, int distance) {
+        return (List<T>) getTileObjects((Predicate<TileObject>) predicate, anchor, distance);
+    }
 
-	@SuppressWarnings("unchecked")
-	private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate, WorldPoint anchor, int distance) {
-		return (List<T>) getGameObjects((Predicate<GameObject>) predicate, anchor, distance);
-	}
+    @SuppressWarnings("unchecked")
+    private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate, WorldPoint anchor, int distance) {
+        return (List<T>) getGameObjects((Predicate<GameObject>) predicate, anchor, distance);
+    }
 
-	@SuppressWarnings("unchecked")
-	private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate, WorldPoint anchor) {
-		return fetchTileObjects(predicate, anchor, Constants.SCENE_SIZE);
-	}
+    @SuppressWarnings("unchecked")
+    private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate, WorldPoint anchor) {
+        return fetchTileObjects(predicate, anchor, Constants.SCENE_SIZE);
+    }
 
-	@SuppressWarnings("unchecked")
-	private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate, WorldPoint anchor) {
-		return fetchTileObjects(predicate, anchor, Constants.SCENE_SIZE);
-	}
+    @SuppressWarnings("unchecked")
+    private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate, WorldPoint anchor) {
+        return fetchTileObjects(predicate, anchor, Constants.SCENE_SIZE);
+    }
 
     @SuppressWarnings("unchecked")
     private static <T extends TileObject> List<T> fetchTileObjects(Predicate<? super T> predicate, int distance) {
-		Player player = Microbot.getClient().getLocalPlayer();
-		if (player == null) {
-			return Collections.emptyList();
-		}
+        Player player = Microbot.getClient().getLocalPlayer();
+        if (player == null) {
+            return Collections.emptyList();
+        }
         return fetchTileObjects(predicate, Rs2Player.getWorldLocation(), distance);
     }
 
     @SuppressWarnings("unchecked")
     private static <T extends TileObject> List<T> fetchGameObjects(Predicate<? super T> predicate, int distance) {
-		Player player = Microbot.getClient().getLocalPlayer();
-		if (player == null) {
-			return Collections.emptyList();
-		}
+        Player player = Microbot.getClient().getLocalPlayer();
+        if (player == null) {
+            return Collections.emptyList();
+        }
         return fetchGameObjects(predicate, Rs2Player.getWorldLocation(), distance);
     }
 
@@ -1825,17 +1826,17 @@ public class Rs2GameObject {
 
 
             Microbot.doInvoke(new NewMenuEntry()
-                    .param0(param0)
-                    .param1(param1)
-                    .opcode(menuAction.getId())
-                    .identifier(object.getId())
-                    .itemId(-1)
-                    .option(action)
-                    .target(objComp.getName())
-                    .gameObject(object)
-                    .worldViewId(worldViewId)
+                            .param0(param0)
+                            .param1(param1)
+                            .opcode(menuAction.getId())
+                            .identifier(object.getId())
+                            .itemId(-1)
+                            .option(action)
+                            .target(objComp.getName())
+                            .gameObject(object)
+                            .worldViewId(worldViewId)
                     ,
-                Rs2UiHelper.getObjectClickbox(object));
+                    Rs2UiHelper.getObjectClickbox(object));
 // MenuEntryImpl(getOption=Use, getTarget=Barrier, getIdentifier=43700, getType=GAME_OBJECT_THIRD_OPTION, getParam0=53, getParam1=51, getItemId=-1, isForceLeftClick=true, getWorldViewId=-1, isDeprioritized=false)
             //Rs2Reflection.invokeMenu(param0, param1, menuAction.getId(), object.getId(),-1, "", "", -1, -1);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -13,8 +13,8 @@ import net.runelite.api.kit.KitType;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.plugins.microbot.Microbot;
-import net.runelite.client.plugins.microbot.api.boat.Rs2BoatCache;
 import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
+import net.runelite.client.plugins.microbot.util.Rs2Cache;
 import net.runelite.client.plugins.microbot.util.coords.Rs2WorldPoint;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
@@ -139,7 +139,7 @@ public class Rs2Player {
     public static boolean hasStaminaBuffActive() {
         return staminaBuffTime > 0;
     }
-    
+
     public static boolean isTeleBlocked() {
         return teleBlockTime > 0;
     }
@@ -189,7 +189,7 @@ public class Rs2Player {
             }
         }
     }
-    
+
     /**
      * Handles updates to the teleblock timer based on changes to the {@link Varbits#TELEBLOCK} varbit.
      *
@@ -198,7 +198,7 @@ public class Rs2Player {
     public static void handleTeleblockTimer(VarbitChanged event){
         if (event.getVarbitId() == Varbits.TELEBLOCK) {
             int time = event.getValue();
-            
+
             if (time < 101) {
                 teleBlockTime = -1;
             } else {
@@ -528,7 +528,7 @@ public class Rs2Player {
     }
 
     /**
-     * Logs out the player if a specified number of players are detected, 
+     * Logs out the player if a specified number of players are detected,
      * triggering an immediate logout upon detection.
      *
      * @param amountOfPlayers The number of players to detect before triggering a logout.
@@ -627,11 +627,11 @@ public class Rs2Player {
         List<Rs2ItemModel> foods = Rs2Inventory.getInventoryFastFood();
         if (foods.isEmpty()) return false;
 
-		Optional<Rs2ItemModel> fastFood = foods.stream().findFirst();
+        Optional<Rs2ItemModel> fastFood = foods.stream().findFirst();
 
-		fastFood.ifPresent(rs2ItemModel -> Rs2Inventory.interact(rs2ItemModel, "eat"));
-		return true;
-	}
+        fastFood.ifPresent(rs2ItemModel -> Rs2Inventory.interact(rs2ItemModel, "eat"));
+        return true;
+    }
 
     /**
      * Finds and consumes the best available food item from the player's inventory.
@@ -698,12 +698,12 @@ public class Rs2Player {
     @Deprecated(since = "2.1.0 - Use Rs2PlayerCache/Rs2PlayerQueryable", forRemoval = true)
     public static Stream<Rs2PlayerModel> getPlayers(Predicate<Rs2PlayerModel> predicate, boolean includeLocalPlayer) {
         List<Rs2PlayerModel> players = Optional.of(Microbot.getClient().getTopLevelWorldView().players()
-                        .stream()
-                        .filter(Objects::nonNull)
-                        .map(Rs2PlayerModel::new)
-                        .filter(x -> includeLocalPlayer || x.getPlayer() != Microbot.getClient().getLocalPlayer())
-                        .filter(predicate)
-                        .collect(Collectors.toList())
+                .stream()
+                .filter(Objects::nonNull)
+                .map(Rs2PlayerModel::new)
+                .filter(x -> includeLocalPlayer || x.getPlayer() != Microbot.getClient().getLocalPlayer())
+                .filter(predicate)
+                .collect(Collectors.toList())
         ).orElse(new ArrayList<>());
 
         return players.stream();
@@ -751,7 +751,7 @@ public class Rs2Player {
     /**
      * Calculates the player's health as a percentage.
      *
-     * <p>The method retrieves the player's health ratio and scale, then calculates 
+     * <p>The method retrieves the player's health ratio and scale, then calculates
      * the percentage based on these values.</p>
      *
      * <p><b>Note:</b> If health information is unavailable (i.e., missing or invalid values),
@@ -826,7 +826,7 @@ public class Rs2Player {
         return equipment.values().stream()
                 .anyMatch(equippedItemId -> equippedItemId == itemId);
     }
-    
+
     /**
      * Checks if a player has any of the specified items equipped by their item IDs.
      *
@@ -914,7 +914,7 @@ public class Rs2Player {
     }
 
     /**
-     * Gets a list of Rs2PlayerModel objects representing players around the local player 
+     * Gets a list of Rs2PlayerModel objects representing players around the local player
      * within the combat level range and wilderness level where they can attack and be attacked.
      *
      * @return A list of Rs2PlayerModel objects within the combat range and attackable wilderness levels.
@@ -953,16 +953,7 @@ public class Rs2Player {
         });
     }
 
-    /**
-     * Retrieves the player's current world location as a {@link WorldPoint}.
-     *
-     * <p>If the player is in an instanced world, the method converts the local position 
-     * to an instanced {@link WorldPoint}. Otherwise, it returns the player's standard 
-     * world location.</p>
-     *
-     * @return The {@link WorldPoint} representing the player's current location.
-     */
-    public static WorldPoint getWorldLocation() {
+    public static WorldPoint getWorldLocation_Internal(){
         return Microbot.getClientThread().runOnClientThreadOptional(() -> {
             if (Microbot.getClient().getTopLevelWorldView().getScene().isInstance()) {
                 LocalPoint l = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), Microbot.getClient().getLocalPlayer().getWorldLocation());
@@ -970,6 +961,31 @@ public class Rs2Player {
             }
             return Microbot.getClient().getLocalPlayer().getWorldLocation();
         }).orElse(null);
+    }
+
+    public static WorldView getWorldView_Internal() {
+        return Microbot.getClientThread().runOnClientThreadOptional(() -> {
+            Player player = Microbot.getClient().getLocalPlayer();
+            if (player == null) return null;
+            return player.getWorldView();
+        }).orElse(null);
+    }
+
+    /**
+     * Retrieves the player's current world location as a {@link WorldPoint}.
+     *
+     * <p>If the player is in an instanced world, the method converts the local position
+     * to an instanced {@link WorldPoint}. Otherwise, it returns the player's standard
+     * world location.</p>
+     *
+     * @return The {@link WorldPoint} representing the player's current location.
+     */
+    public static WorldPoint getWorldLocation() {
+        return Rs2Cache.LOCAL_PLAYER_POSITION.getValue();
+    }
+
+    public static WorldView getWorldView() {
+        return Microbot.getClient().getTopLevelWorldView();
     }
 
     /**
@@ -1007,28 +1023,28 @@ public class Rs2Player {
         if (worldPoint == null) {
             return false;
         }
-        
+
         // Validate radius parameters (should be non-negative)
         if (xRadius < 0 || yRadius < 0) {
             return false;
         }
-        
+
         WorldPoint playerLocation = getWorldLocation();
-        
+
         // Null check for player location
         if (playerLocation == null) {
             return false;
         }
-        
+
         // Ensure both points are on the same plane
         if (worldPoint.getPlane() != playerLocation.getPlane()) {
             return false;
         }
-        
+
         // Simple distance check - check if player is within the rectangular radius
         int deltaX = Math.abs(playerLocation.getX() - worldPoint.getX());
         int deltaY = Math.abs(playerLocation.getY() - worldPoint.getY());
-        
+
         return deltaX <= xRadius && deltaY <= yRadius;
     }
 
@@ -1042,46 +1058,46 @@ public class Rs2Player {
      * @param playerYSpan    The total height (in tiles) of the area around the player's position.
      * @return {@code true} if the player's area intersects with the target area, {@code false} otherwise.
      */
-    public static boolean isPlayerAreaIntersecting(WorldPoint targetPoint, int targetXSpan, int targetYSpan, 
-                                             int playerXSpan, int playerYSpan) {
+    public static boolean isPlayerAreaIntersecting(WorldPoint targetPoint, int targetXSpan, int targetYSpan,
+                                                   int playerXSpan, int playerYSpan) {
         // Null check for target point
         if (targetPoint == null) {
             return false;
         }
-        
+
         // Validate span parameters (should be non-negative)
         if (targetXSpan < 0 || targetYSpan < 0 || playerXSpan < 0 || playerYSpan < 0) {
             return false;
         }
-        
+
         WorldPoint playerLocation = getWorldLocation();
-        
+
         // Null check for player location
         if (playerLocation == null) {
             return false;
         }
-        
+
         // Ensure both points are on the same plane
         if (targetPoint.getPlane() != playerLocation.getPlane()) {
             return false;
         }
-        
+
         // Create target area centered on targetPoint
         WorldPoint targetSouthWest = new WorldPoint(
-            targetPoint.getX() - (targetXSpan /2), 
-            targetPoint.getY() - (targetYSpan / 2), 
-            targetPoint.getPlane()
+                targetPoint.getX() - (targetXSpan /2),
+                targetPoint.getY() - (targetYSpan / 2),
+                targetPoint.getPlane()
         );
         WorldArea targetArea = new WorldArea(targetSouthWest, targetXSpan, targetYSpan);
-        
+
         // Create player area centered on player location
         WorldPoint playerSouthWest = new WorldPoint(
-            playerLocation.getX() - (playerXSpan / 2), 
-            playerLocation.getY() - (playerYSpan / 2), 
-            playerLocation.getPlane()
+                playerLocation.getX() - (playerXSpan / 2),
+                playerLocation.getY() - (playerYSpan / 2),
+                playerLocation.getPlane()
         );
         WorldArea playerArea = new WorldArea(playerSouthWest, playerXSpan, playerYSpan);
-        
+
         return targetArea.intersectsWith2D(playerArea);
     }
 
@@ -1308,7 +1324,7 @@ public class Rs2Player {
         }
         return usePotion(Rs2Potion.getGoadingPotion());
     }
-    
+
     /**
      * Helper method to check for the presence of any item in the provided IDs and interact with it.
      *
@@ -1319,9 +1335,9 @@ public class Rs2Player {
         Rs2ItemModel potion = Rs2Inventory.get(item ->
                 !item.isNoted() && Arrays.stream(itemIds).anyMatch(id -> id == item.getId())
         );
-        
+
         if (potion == null) return false;
-        
+
         return Rs2Inventory.interact(potion, "drink");
     }
 
@@ -1335,7 +1351,7 @@ public class Rs2Player {
         Rs2ItemModel potion = Rs2Inventory.get(item ->
                 !item.isNoted() && Arrays.stream(itemIds).anyMatch(id -> id == item.getId())
         );
-        
+
         return potion != null;
     }
 
@@ -1364,7 +1380,7 @@ public class Rs2Player {
 
         return Rs2Inventory.interact(potion, "drink");
     }
-    
+
     /**
      * Checks for the presence of any item in the provided names within the inventory.
      *
@@ -1385,7 +1401,7 @@ public class Rs2Player {
 
             return false;
         });
-        
+
         return potion != null;
     }
 
@@ -1604,7 +1620,7 @@ public class Rs2Player {
         return Rs2Player.getWorldLocation().getY() >= 6400
                 && !Microbot.getClient().getTopLevelWorldView().isInstance();
     }
-    
+
     /**
      * Checks whether the player is currently in an instanced world.
      *
@@ -1745,7 +1761,7 @@ public class Rs2Player {
     public static boolean use(Rs2PlayerModel rs2Player) {
         return invokeMenu(rs2Player, "use");
     }
-    
+
     /**
      * Selects the "CHALLENGE" option on a player for Soul Wars.
      *

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -13,6 +13,7 @@ import net.runelite.api.kit.KitType;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.api.boat.Rs2BoatCache;
 import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
 import net.runelite.client.plugins.microbot.util.Rs2Cache;
 import net.runelite.client.plugins.microbot.util.coords.Rs2WorldPoint;
@@ -953,6 +954,15 @@ public class Rs2Player {
 		});
 	}
 
+	/**
+	 * Retrieves the player's current world location as a {@link WorldPoint}.
+	 *
+	 * <p>If the player is in an instanced world, the method converts the local position
+	 * to an instanced {@link WorldPoint}. Otherwise, it returns the player's standard
+	 * world location.</p>
+	 *
+	 * @return The {@link WorldPoint} representing the player's current location, or {@code null} if it cannot be determined.
+	 */
 	public static WorldPoint getWorldLocation_Internal(){
 		return Microbot.getClientThread().runOnClientThreadOptional(() -> {
 			if (Microbot.getClient().getTopLevelWorldView().getScene().isInstance()) {
@@ -963,6 +973,11 @@ public class Rs2Player {
 		}).orElse(null);
 	}
 
+	/**
+	 * Retrieves the player's current {@link WorldView}.
+	 *
+	 * @return The {@link WorldView} representing the player's current world view, or {@code null} if it cannot be determined.
+	 */
 	public static WorldView getWorldView_Internal() {
 		return Microbot.getClientThread().runOnClientThreadOptional(() -> {
 			Player player = Microbot.getClient().getLocalPlayer();
@@ -984,6 +999,11 @@ public class Rs2Player {
 		return Rs2Cache.LOCAL_PLAYER_POSITION.getValue();
 	}
 
+	/**
+	 * Retrieves the player's current {@link WorldView}.
+	 *
+	 * @return The {@link WorldView} representing the player's current world view.
+	 */
 	public static WorldView getWorldView() {
 		return Microbot.getClient().getTopLevelWorldView();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -51,1809 +51,1809 @@ import static net.runelite.api.MenuAction.CC_OP;
 import static net.runelite.client.plugins.microbot.util.Global.*;
 
 public class Rs2Player {
-    static int VENOM_VALUE_CUTOFF = -38;
-    private static int antiFireTime = -1;
-    private static int superAntiFireTime = -1;
-    private static int divineRangedTime = -1;
-    private static int divineBastionTime = -1;
-    private static int divineCombatTime = -1;
-    private static int divineMagicTime = -1;
-    public static int antiVenomTime = -1;
-    public static int staminaBuffTime = -1;
-    public static int antiPoisonTime = -1;
-    public static int teleBlockTime = -1;
-    public static int goadingTime = -1;
-    public static int moonlightTime = -1;
-    public static Instant lastAnimationTime = null;
-    private static final long COMBAT_TIMEOUT_MS = 10000;
-    private static long lastCombatTime = 0;
-    @Getter
-    public static int lastAnimationID = AnimationID.IDLE;
-
-    public static boolean hasPrayerRegenerationActive() {
-        return (Microbot.getVarbitValue(VarbitID.PRAYER_REGENERATION_POTION_TIMER) > 0);
-    }
-
-    public static boolean hasAntiFireActive() {
-        return antiFireTime > 0 || hasSuperAntiFireActive();
-    }
-
-    public static boolean hasSuperAntiFireActive() {
-        return superAntiFireTime > 0;
-    }
-
-    public static boolean hasDivineRangedActive() {
-        return divineRangedTime > 0 || hasDivineBastionActive();
-    }
-
-    public static boolean hasRangingPotionActive(int threshold) {
-        return getBoostedSkillLevel(Skill.RANGED) - threshold > getRealSkillLevel(Skill.RANGED);
-    }
-
-    public static boolean hasDivineBastionActive() {
-        return divineBastionTime > 0;
-    }
-
-    public static boolean hasDivineCombatActive() {
-        return divineCombatTime > 0;
-    }
-
-    public static boolean hasDivineMagicActive() {
-        return divineMagicTime > 0;
-    }
-
-    public static boolean hasGoadingActive() {
-        return goadingTime > 0;
-    }
-
-    public static boolean hasMoonlightActive() {
-        return moonlightTime > 0;
-    }
-
-    public static boolean hasAttackActive(int threshold) {
-        return getBoostedSkillLevel(Skill.ATTACK) - threshold > getRealSkillLevel(Skill.ATTACK);
-    }
-
-    public static boolean hasStrengthActive(int threshold) {
-        return getBoostedSkillLevel(Skill.STRENGTH) - threshold > getRealSkillLevel(Skill.STRENGTH);
-    }
-
-    public static boolean hasDefenseActive(int threshold) {
-        return getBoostedSkillLevel(Skill.DEFENCE) - threshold > getRealSkillLevel(Skill.DEFENCE);
-    }
-
-    public static boolean hasMagicActive(int threshold) {
-        return getBoostedSkillLevel(Skill.MAGIC) - threshold > getRealSkillLevel(Skill.MAGIC);
-    }
-
-    public static boolean hasAntiVenomActive() {
-        if (Rs2Equipment.isWearing("serpentine helm")) {
-            return true;
-        } else return antiVenomTime < VENOM_VALUE_CUTOFF;
-    }
-
-    public static boolean hasAntiPoisonActive() {
-        return antiPoisonTime > 0;
-    }
-
-    public static boolean hasStaminaBuffActive() {
-        return staminaBuffTime > 0;
-    }
-
-    public static boolean isTeleBlocked() {
-        return teleBlockTime > 0;
-    }
-
-    private static final Map<Integer, Long> playerDetectionTimes = new ConcurrentHashMap<>();
-
-    public static void handlePotionTimers(VarbitChanged event) {
-        if (event.getVarbitId() == Varbits.ANTIFIRE) {
-            antiFireTime = event.getValue();
-        }
-        if (event.getVarbitId() == Varbits.SUPER_ANTIFIRE) {
-            superAntiFireTime = event.getValue();
-        }
-        if (event.getVarbitId() == Varbits.DIVINE_RANGING) {
-            divineRangedTime = event.getValue();
-        }
-        if (event.getVarbitId() == Varbits.DIVINE_BASTION) {
-            divineBastionTime = event.getValue();
-        }
-        if (event.getVarbitId() == Varbits.DIVINE_SUPER_COMBAT) {
-            divineCombatTime = event.getValue();
-        }
-        if (event.getVarbitId() == Varbits.STAMINA_EFFECT) {
-            staminaBuffTime = event.getValue();
-        }
-        if (event.getVarbitId() == Varbits.BUFF_GOADING_POTION) {
-            goadingTime = event.getValue();
-        }
-        if (event.getVarbitId() == Varbits.MOONLIGHT_POTION) {
-            moonlightTime = event.getValue();
-        }
-        if (event.getVarbitId() == Varbits.DIVINE_MAGIC) {
-            divineMagicTime = event.getValue();
-        }
-        if (event.getVarpId() == VarPlayer.POISON) {
-            if (event.getValue() >= VENOM_VALUE_CUTOFF) {
-                antiVenomTime = 0;
-            } else {
-                antiVenomTime = event.getValue();
-            }
-            final int poisonVarp = event.getValue();
-
-            if (poisonVarp == 0) {
-                antiPoisonTime = -1;
-            } else {
-                antiPoisonTime = poisonVarp;
-            }
-        }
-    }
-
-    /**
-     * Handles updates to the teleblock timer based on changes to the {@link Varbits#TELEBLOCK} varbit.
-     *
-     * @see Varbits#TELEBLOCK
-     */
-    public static void handleTeleblockTimer(VarbitChanged event){
-        if (event.getVarbitId() == Varbits.TELEBLOCK) {
-            int time = event.getValue();
-
-            if (time < 101) {
-                teleBlockTime = -1;
-            } else {
-                teleBlockTime = time;
-            }
-        }
-    }
-
-    public static void handleAnimationChanged(AnimationChanged event) {
-        if (!(event.getActor() instanceof Player)) {
-            return;
-        }
-
-        Player player = (Player) event.getActor();
-        if (player != Microbot.getClient().getLocalPlayer()) {
-            return;
-        }
-
-        if (player.getAnimation() != AnimationID.IDLE) {
-            lastAnimationTime = Instant.now();
-            lastAnimationID = player.getAnimation();
-        }
-    }
-
-    /**
-     * Wait for walking
-     */
-    public static void waitForWalking() {
-        boolean result = sleepUntilTrue(Rs2Player::isMoving, 100, 5000);
-        if (!result) return;
-        sleepUntil(() -> !Rs2Player.isMoving());
-    }
-
-    /**
-     * Waits for the player to start walking within the specified time limit.
-     * If the player starts walking, it then waits until the player stops walking.
-     *
-     * @param time The maximum time (in milliseconds) to wait for the player to start walking.
-     *             If the player does not start walking within this time, the method exits early.
-     */
-    public static void waitForWalking(int time) {
-        boolean result = sleepUntilTrue(Rs2Player::isMoving, 100, time);
-        if (!result) return;
-        sleepUntil(() -> !Rs2Player.isMoving(), time);
-    }
-
-    /**
-     * Waits for an XP drop in the specified skill within a default timeout of 5000 milliseconds.
-     *
-     * @param skill The skill to monitor for an XP drop.
-     * @return {@code true} if an XP drop was detected within the timeout, {@code false} otherwise.
-     */
-    public static boolean waitForXpDrop(Skill skill) {
-        return waitForXpDrop(skill, 5000, false);
-    }
-
-    /**
-     * Waits for an XP drop in the specified skill within a given timeout.
-     *
-     * @param skill The skill to monitor for an XP drop.
-     * @param time  The maximum time (in milliseconds) to wait for the XP drop.
-     * @return {@code true} if an XP drop was detected within the timeout, {@code false} otherwise.
-     */
-    public static boolean waitForXpDrop(Skill skill, int time) {
-        return waitForXpDrop(skill, time, false);
-    }
-
-    /**
-     * Waits for an XP drop in the specified skill or stops if the inventory is full.
-     *
-     * @param skill              The skill to monitor for an XP drop.
-     * @param inventoryFullCheck If {@code true}, also stops waiting if the inventory becomes full.
-     * @return {@code true} if an XP drop was detected or the inventory became full, {@code false} otherwise.
-     */
-    public static boolean waitForXpDrop(Skill skill, boolean inventoryFullCheck) {
-        return waitForXpDrop(skill, 5000, inventoryFullCheck);
-    }
-
-    /**
-     * Waits for an XP drop in the specified skill within a given timeout or stops if the inventory is full.
-     *
-     * @param skill              The skill to monitor for an XP drop.
-     * @param time               The maximum time (in milliseconds) to wait for the XP drop.
-     * @param inventoryFullCheck If {@code true}, also stops waiting if the inventory becomes full.
-     * @return {@code true} if an XP drop was detected or the inventory became full, {@code false} otherwise.
-     */
-    public static boolean waitForXpDrop(Skill skill, int time, boolean inventoryFullCheck) {
-        final int skillExp = Microbot.getClient().getSkillExperience(skill);
-        return sleepUntilTrue(() ->
-                        skillExp != Microbot.getClient().getSkillExperience(skill) ||
-                                (inventoryFullCheck && Rs2Inventory.isFull()),
-                100, time
-        );
-    }
-
-    /**
-     * Wait for animation
-     */
-    public static void waitForAnimation() {
-        boolean result = sleepUntilTrue(Rs2Player::isAnimating, 100, 5000);
-        if (!result) return;
-        sleepUntil(() -> !Rs2Player.isAnimating());
-    }
-
-    /**
-     * Waits for the player to start animating within a given time limit.
-     * If the player starts animating, it then waits until the animation stops.
-     *
-     * @param time The maximum time (in milliseconds) to wait for the player to start animating.
-     *             If the player does not start animating within this time, the method exits early.
-     */
-    public static void waitForAnimation(int time) {
-        boolean result = sleepUntilTrue(() -> Rs2Player.isAnimating(time), 100, 5000);
-        if (!result) return;
-        sleepUntil(() -> !Rs2Player.isAnimating(time));
-    }
-
-    /**
-     * Checks if the player has been animating within the past specified milliseconds.
-     *
-     * @param ms The time window (in milliseconds) to check for recent animations.
-     * @return {@code true} if the player has been animating within the last {@code ms} milliseconds,
-     *         or if the player's current animation is not {@code AnimationID.IDLE}, {@code false} otherwise.
-     */
-    public static boolean isAnimating(int ms) {
-        return (lastAnimationTime != null && Duration.between(lastAnimationTime, Instant.now()).toMillis() < ms)
-                || getAnimation() != AnimationID.IDLE;
-    }
-
-    /**
-     * Checks if the player has been animating within the past 600 milliseconds.
-     *
-     * @return {@code true} if the player has been animating within the last 600 milliseconds,
-     *         or if the player's current animation is not {@code AnimationID.IDLE}, {@code false} otherwise.
-     */
-    public static boolean isAnimating() {
-        return isAnimating(600);
-    }
-
-    /**
-     * Checks if the player is currently moving based on their pose animation.
-     * A player is considered moving if their pose animation is different from their idle pose animation.
-     *
-     * @return {@code true} if the player is moving, {@code false} if they are idle.
-     */
-    public static boolean isMoving() {
-        return Microbot.getClientThread().runOnClientThreadOptional(() -> {
-            Player localPlayer = Microbot.getClient().getLocalPlayer();
-            if (localPlayer == null) {
-                return false;
-            }
-            return localPlayer.getPoseAnimation() != localPlayer.getIdlePoseAnimation();
-        }).orElse(false);
-    }
-
-    /**
-     * Checks if the specified Rs2PlayerModel is currently moving based on its pose animation.
-     * The model is considered moving if its pose animation is different from its idle pose animation.
-     *
-     * @param playerModel The Rs2PlayerModel to check.
-     * @return {@code true} if the model is moving, {@code false} if it is idle.
-     */
-    public static boolean isMoving(Rs2PlayerModel playerModel) {
-        if (playerModel == null) {
-            return false;
-        }
-
-        return Microbot.getClientThread().runOnClientThreadOptional(() -> playerModel.getPoseAnimation() != playerModel.getIdlePoseAnimation()).orElse(false);
-    }
-
-    /**
-     * Checks if the player is currently interacting with another entity (NPC, player, or object).
-     *
-     * @return {@code true} if the player is interacting with another entity, {@code false} otherwise.
-     */
-    public static boolean isInteracting() {
-        if (Microbot.getClient().getLocalPlayer() == null) {
-            return false;
-        }
-        return Optional.of(Microbot.getClient().getLocalPlayer().isInteracting()).orElse(false);
-    }
-
-    /**
-     * Checks if the player has an active membership.
-     *
-     * @return {@code true} if the player is a member (has remaining membership days), {@code false} otherwise.
-     */
-    public static boolean isMember() {
-        return Microbot.getVarbitPlayerValue(VarPlayerID.ACCOUNT_CREDIT) > 0;
-    }
-
-    /**
-     * Checks if the player is currently in a members-only world.
-     *
-     * @return {@code true} if the player is in a members-only world, {@code false} otherwise.
-     */
-    public static boolean isInMemberWorld() {
-        WorldResult worldResult = Microbot.getWorldService().getWorlds();
-
-        if (worldResult != null) {
-            List<net.runelite.http.api.worlds.World> worlds = worldResult.getWorlds();
-            return worlds.stream()
-                    .anyMatch(x -> x.getId() == Microbot.getClient().getWorld() && x.getTypes().contains(WorldType.MEMBERS));
-        }
-
-        return false;
-    }
-
-    /**
-     * Toggles the player's run energy on or off.
-     *
-     * @param toggle {@code true} to enable running, {@code false} to disable it.
-     * @return {@code true} if the toggle action was performed successfully or was already in the desired state,
-     *         {@code false} if the run energy toggle widget was not found.
-     */
-    public static boolean toggleRunEnergy(boolean toggle) {
-        if (Microbot.getVarbitPlayerValue(173) == 0 && !toggle) return true;
-        if (Microbot.getVarbitPlayerValue(173) == 1 && toggle) return true;
-
-        Widget widget = Rs2Widget.getWidget(WidgetInfo.MINIMAP_TOGGLE_RUN_ORB.getId());
-        if (widget == null) return false;
-
-        Microbot.getMouse().click(widget.getCanvasLocation());
-        sleep(150, 300);
-
-        return true;
-    }
-
-    /**
-     * Checks if the player's run energy is currently enabled.
-     *
-     * @return {@code true} if run energy is enabled, {@code false} otherwise.
-     */
-    public static boolean isRunEnabled() {
-        return Microbot.getVarbitPlayerValue(173) == 1;
-    }
-
-    /**
-     * Logs the player out of the game
-     */
-    public static void logout() {
-        if (!Microbot.isLoggedIn()) return;
-
-        // Make sure jagex acount does not auto login
-        Rs2Keyboard.resetEnter();
-
-        Rs2Tab.switchTo(InterfaceTab.LOGOUT);
-
-        Widget currentWorldWidget = Rs2Widget.getWidget(69, 3);
-        if (currentWorldWidget != null) {
-            // From World Switcher
-            Microbot.doInvoke(new NewMenuEntry()
-                    .param0(-1)
-                    .param1(4522009)
-                    .opcode(CC_OP.getId())
-                    .identifier(1)
-                    .itemId(-1)
-                    .option("Logout"), new Rectangle(1, 1, Microbot.getClient().getCanvasWidth(), Microbot.getClient().getCanvasHeight()));
-        } else {
-            // From red logout button
-            Microbot.doInvoke(new NewMenuEntry()
-                    .param0(-1)
-                    .param1(11927560)
-                    .opcode(CC_OP.getId())
-                    .identifier(1)
-                    .itemId(-1)
-                    .option("Logout"), new Rectangle(1, 1, Microbot.getClient().getCanvasWidth(), Microbot.getClient().getCanvasHeight()));
-        }
-    }
-
-    /**
-     * Logs out the player if a specified number of players are detected within a given distance and time.
-     *
-     * @param amountOfPlayers The number of players to detect before triggering a logout.
-     * @param time            The duration (in milliseconds) that the players must remain detected before logging out.
-     *                         If {@code time <= 0}, the logout occurs immediately upon detection.
-     * @param distance        The maximum distance (in tiles) from the player to check for other players.
-     *                         If {@code distance <= 0}, all detected players are considered.
-     * @return {@code true} if the player logged out, {@code false} otherwise.
-     */
-    public static boolean logoutIfPlayerDetected(int amountOfPlayers, int time, int distance) {
-        List<Rs2PlayerModel> players = getPlayers(player -> true).collect(Collectors.toList());
-        long currentTime = System.currentTimeMillis();
-
-        if (distance > 0) {
-            players = players.stream()
-                    .filter(x -> x != null && x.getWorldLocation().distanceTo(Rs2Player.getWorldLocation()) <= distance)
-                    .collect(Collectors.toList());
-        }
-        if (time > 0 && players.size() >= amountOfPlayers) {
-            // Update detection times for currently detected players
-            for (Rs2PlayerModel player : players) {
-                playerDetectionTimes.putIfAbsent(player.getId(), currentTime);
-            }
-
-            // Remove players who are no longer detected
-            playerDetectionTimes.keySet().retainAll(players.stream().map(Rs2PlayerModel::getId).collect(Collectors.toSet()));
-
-            // Check if any player has been detected for longer than the specified time
-            for (Rs2PlayerModel player : players) {
-                long detectionTime = playerDetectionTimes.getOrDefault(player.getId(), 0L);
-                if (currentTime - detectionTime >= time) {
-                    logout();
-                    playerDetectionTimes.clear();
-                    return true;
-                }
-            }
-        } else if (time <= 0 && players.size() >= amountOfPlayers) {
-            logout();
-            playerDetectionTimes.clear();
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Logs out the player if a specified number of players are detected within a given time,
-     * checking all players regardless of distance.
-     *
-     * @param amountOfPlayers The number of players to detect before triggering a logout.
-     * @param time            The duration (in milliseconds) that the players must remain detected before logging out.
-     *                         If {@code time <= 0}, the logout occurs immediately upon detection.
-     * @return {@code true} if the player logged out, {@code false} otherwise.
-     */
-    public static boolean logoutIfPlayerDetected(int amountOfPlayers, int time) {
-        return logoutIfPlayerDetected(amountOfPlayers, time, 0);
-    }
-
-    /**
-     * Logs out the player if a specified number of players are detected,
-     * triggering an immediate logout upon detection.
-     *
-     * @param amountOfPlayers The number of players to detect before triggering a logout.
-     * @return {@code true} if the player logged out, {@code false} otherwise.
-     */
-    public static boolean logoutIfPlayerDetected(int amountOfPlayers) {
-        return logoutIfPlayerDetected(amountOfPlayers, 0, 0);
-    }
-
-    /**
-     * Hops to a random world if a specified number of players are detected within a given distance and time.
-     *
-     * @param amountOfPlayers The number of players to detect before triggering a world hop.
-     * @param time            The duration (in milliseconds) that the players must remain detected before hopping worlds.
-     *                         If {@code time <= 0}, the hop occurs immediately upon detection.
-     * @param distance        The maximum distance (in tiles) from the player to check for other players.
-     *                         If {@code distance <= 0}, all detected players are considered.
-     * @return {@code true} if the player detected and successfully hopped worlds, {@code false} otherwise.
-     */
-    public static boolean hopIfPlayerDetected(int amountOfPlayers, int time, int distance) {
-        List<Rs2PlayerModel> players = getPlayers(player -> true).collect(Collectors.toList());
-        long currentTime = System.currentTimeMillis();
-
-        if (distance > 0) {
-            players = players.stream()
-                    .filter(x -> x != null && x.getWorldLocation().distanceTo(Rs2Player.getWorldLocation()) <= distance)
-                    .collect(Collectors.toList());
-        }
-
-        if (time > 0 && players.size() >= amountOfPlayers) {
-            // Update detection times for currently detected players
-            for (Rs2PlayerModel player : players) {
-                playerDetectionTimes.putIfAbsent(player.getId(), currentTime);
-            }
-
-            // Remove players who are no longer detected
-            playerDetectionTimes.keySet().retainAll(players.stream().map(Rs2PlayerModel::getId).collect(Collectors.toSet()));
-
-            // Check if any player has been detected for longer than the specified time
-            for (Rs2PlayerModel player : players) {
-                long detectionTime = playerDetectionTimes.getOrDefault(player.getId(), 0L);
-                if (currentTime - detectionTime >= time) {
-                    int randomWorld = LoginManager.getRandomWorld(isMember());
-                    Microbot.hopToWorld(randomWorld);
-                    return true;
-                }
-            }
-        } else if (players.size() >= amountOfPlayers) {
-            int randomWorld = LoginManager.getRandomWorld(isMember());
-            Microbot.hopToWorld(randomWorld);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Consumes food when the player's health percentage falls below the specified threshold.
-     * Uses default food consumption behavior.
-     *
-     * @param percentage The health percentage at which food should be consumed.
-     * @return {@code true} if food was consumed, {@code false} if no action was taken.
-     */
-    public static boolean eatAt(int percentage) {
-        // Call the full method with a default value of false for fastFood
-        return eatAt(percentage, false);
-    }
-
-    /**
-     * Consumes food when the player's health percentage falls below the specified threshold.
-     * The method searches the inventory for the first available food item.
-     *
-     * @param percentage The health percentage at which food should be consumed.
-     * @param fastFood If true, prioritize faster food consumption behavior.
-     * @return {@code true} if food was consumed, {@code false} if no action was taken.
-     */
-    public static boolean eatAt(int percentage, boolean fastFood) {
-        double threshold = getHealthPercentage();
-        if (threshold <= percentage) {
-            if (fastFood && !Rs2Inventory.getInventoryFastFood().isEmpty()) {
-                return useFastFood();
-            }
-            return useFood(); // default method
-        }
-        return false;
-    }
-
-    /**
-     * Consumes the first available high-priority food item from the player's inventory.
-     *
-     * <p>Only food items defined in {@link Rs2Food} with a priority of {@code 1} are considered fast food.</p>
-     * <p>This method ignores noted items and will not attempt to drink items like Jug of Wine.</p>
-     *
-     * @return {@code true} if a fast food item was consumed, {@code false} if none were found.
-     */
-    public static boolean useFastFood() {
-        List<Rs2ItemModel> foods = Rs2Inventory.getInventoryFastFood();
-        if (foods.isEmpty()) return false;
-
-        Optional<Rs2ItemModel> fastFood = foods.stream().findFirst();
-
-        fastFood.ifPresent(rs2ItemModel -> Rs2Inventory.interact(rs2ItemModel, "eat"));
-        return true;
-    }
-
-    /**
-     * Finds and consumes the best available food item from the player's inventory.
-     *
-     * <p>If in the Wilderness, prioritizes blighted food items but falls back to regular food if none are available.</p>
-     * <p>If the selected food is a "Jug of Wine," the player will drink it instead of eating.</p>
-     *
-     * @return {@code true} if food was consumed, {@code false} if no food was available.
-     */
-    public static boolean useFood() {
-        List<Rs2ItemModel> foods = Rs2Inventory.getInventoryFood();
-        if (foods.isEmpty()) return false;
-
-        boolean inWilderness = Microbot.getVarbitValue(Varbits.IN_WILDERNESS) == 1;
-
-        // Separate blighted and non-blighted food
-        List<Rs2ItemModel> blightedFoods = foods.stream()
-                .filter(rs2Item -> !rs2Item.isNoted() && rs2Item.getName().toLowerCase().contains("blighted"))
-                .collect(Collectors.toList());
-
-        List<Rs2ItemModel> regularFoods = foods.stream()
-                .filter(rs2Item -> !rs2Item.isNoted() && !rs2Item.getName().toLowerCase().contains("blighted"))
-                .collect(Collectors.toList());
-
-        // Select food to use: prefer blighted in Wilderness, otherwise use any available food
-        Rs2ItemModel foodToUse = (inWilderness && !blightedFoods.isEmpty()) ? blightedFoods.get(0)
-                : !regularFoods.isEmpty() ? regularFoods.get(0) : null;
-
-        if (foodToUse == null) return false;
-
-        return foodToUse.getName().toLowerCase().contains("jug of wine")
-                ? Rs2Inventory.interact(foodToUse, "drink")
-                : Rs2Inventory.interact(foodToUse, "eat");
-    }
-
-    /**
-     * Calculates the player's current health as a percentage of their real (base) health.
-     *
-     * @return the health percentage as a double. For example:
-     *         150.0 if boosted, 80.0 if drained, or 100.0 if unchanged.
-     */
-    public static double getHealthPercentage() {
-        return (double) (getBoostedSkillLevel(Skill.HITPOINTS) * 100) / getRealSkillLevel(Skill.HITPOINTS);
-    }
-
-    /**
-     * Get a stream of players around you, optionally filtered by a predicate.
-     *
-     * @param predicate A condition to filter players (optional).
-     * @return A stream of Rs2PlayerModel objects representing nearby players.
-     */
-    @Deprecated(since = "2.1.0 - Use Rs2PlayerCache/Rs2PlayerQueryable", forRemoval = true)
-    public static Stream<Rs2PlayerModel> getPlayers(Predicate<Rs2PlayerModel> predicate) {
-        return getPlayers(predicate, false);
-    }
-
-    /**
-     * Get a stream of players around you, optionally filtered by a predicate.
-     *
-     * @param predicate A condition to filter players (optional).
-     * @param includeLocalPlayer a flag on whether to include the local player within the stream
-     * @return A stream of Rs2PlayerModel objects representing nearby players.
-     */
-    @Deprecated(since = "2.1.0 - Use Rs2PlayerCache/Rs2PlayerQueryable", forRemoval = true)
-    public static Stream<Rs2PlayerModel> getPlayers(Predicate<Rs2PlayerModel> predicate, boolean includeLocalPlayer) {
-        List<Rs2PlayerModel> players = Optional.of(Microbot.getClient().getTopLevelWorldView().players()
-                .stream()
-                .filter(Objects::nonNull)
-                .map(Rs2PlayerModel::new)
-                .filter(x -> includeLocalPlayer || x.getPlayer() != Microbot.getClient().getLocalPlayer())
-                .filter(predicate)
-                .collect(Collectors.toList())
-        ).orElse(new ArrayList<>());
-
-        return players.stream();
-    }
-
-    /**
-     * Retrieves a player by name with an optional exact match.
-     *
-     * @param playerName The name of the player to search for.
-     * @param exact      If {@code true}, performs an exact name match (case insensitive).
-     *                   If {@code false}, checks if the player name contains the given string.
-     * @return The first matching {@code Rs2PlayerModel}, or {@code null} if no player is found.
-     */
-    @Deprecated(since = "2.1.0 - Use Rs2PlayerCache/Rs2PlayerQueryable", forRemoval = true)
-    public static Rs2PlayerModel getPlayer(String playerName, boolean exact) {
-        return getPlayers(player -> {
-            String name = player.getName();
-            if (name == null) return false;
-            return exact ? name.equalsIgnoreCase(playerName) : name.toLowerCase().contains(playerName.toLowerCase());
-        }).findFirst().orElse(null);
-    }
-
-    /**
-     * Retrieves a player by name using a partial match.
-     *
-     * @param playerName The name of the player to search for.
-     * @return The first matching {@code Rs2PlayerModel}, or {@code null} if no player is found.
-     *         Uses {@code getPlayer(playerName, false)} to perform a case-insensitive partial match.
-     */
-    @Deprecated(since = "2.1.0 - Use Rs2PlayerCache/Rs2PlayerQueryable", forRemoval = true)
-    public static Rs2PlayerModel getPlayer(String playerName) {
-        return getPlayer(playerName, false);
-    }
-
-    /**
-     * Use this method to get a list of players that are in combat
-     *
-     * @return a list of players that are in combat
-     */
-    @Deprecated(since = "2.1.0 - Use Rs2PlayerCache/Rs2PlayerQueryable", forRemoval = true)
-    public static List<Rs2PlayerModel> getPlayersInCombat() {
-        return getPlayers(player -> player.getHealthRatio() != -1).collect(Collectors.toList());
-    }
-
-    /**
-     * Calculates the player's health as a percentage.
-     *
-     * <p>The method retrieves the player's health ratio and scale, then calculates
-     * the percentage based on these values.</p>
-     *
-     * <p><b>Note:</b> If health information is unavailable (i.e., missing or invalid values),
-     * the method returns {@code -1}.</p>
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} representing the player or actor to calculate health for.
-     * @return The health percentage (0-100), or {@code -1} if health information is unavailable.
-     */
-    public static int calculateHealthPercentage(Rs2PlayerModel rs2Player) {
-        int healthRatio = rs2Player.getHealthRatio();
-        int healthScale = rs2Player.getHealthScale();
-
-        // Check if health information is available
-        if (healthRatio == -1 || healthScale == -1 || healthScale == 0) {
-            return -1; // Health information is missing or invalid
-        }
-
-        // Calculate health percentage
-        return (int) ((healthRatio / (double) healthScale) * 100);
-    }
-
-    /**
-     * Retrieves a map of the player's equipped items, mapping {@link KitType} to their corresponding item IDs.
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment is to be retrieved.
-     * @return A {@code Map<KitType, Integer>} containing the equipment slot types as keys and the corresponding item IDs as values.
-     */
-    public static Map<KitType, Integer> getPlayerEquipmentIds(Rs2PlayerModel rs2Player) {
-        Map<KitType, Integer> equipmentMap = new HashMap<>();
-
-        for (KitType kitType : KitType.values()) {
-            int itemId = rs2Player.getPlayerComposition().getEquipmentId(kitType);
-            equipmentMap.put(kitType, itemId);
-        }
-
-        return equipmentMap;
-    }
-
-
-    /**
-     * Retrieves a map of the player's equipped items, mapping {@link KitType} to their corresponding item names.
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment names are to be retrieved.
-     * @return A {@code Map<KitType, String>} containing the equipment slot types as keys and the corresponding item names as values.
-     */
-    public static Map<KitType, String> getPlayerEquipmentNames(Rs2PlayerModel rs2Player) {
-        Map<KitType, String> equipmentMap = Microbot.getClientThread().runOnClientThreadOptional(() -> {
-            Map<KitType, String> tempMap = new HashMap<>();
-            for (KitType kitType : KitType.values()) {
-                String itemName = Microbot.getItemManager()
-                        .getItemComposition(rs2Player.getPlayerComposition().getEquipmentId(kitType))
-                        .getName();
-                tempMap.put(kitType, itemName);
-            }
-            return tempMap;
-        }).orElse(new HashMap<>());
-
-        return equipmentMap;
-    }
-
-
-    /**
-     * Checks if a player has a specific item equipped by its item ID.
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment is being checked.
-     * @param itemId    The ID of the item to check for.
-     * @return {@code true} if the player has the specified item equipped, {@code false} otherwise.
-     */
-    public static boolean hasPlayerEquippedItem(Rs2PlayerModel rs2Player, int itemId) {
-        Map<KitType, Integer> equipment = getPlayerEquipmentIds(rs2Player);
-
-        return equipment.values().stream()
-                .anyMatch(equippedItemId -> equippedItemId == itemId);
-    }
-
-    /**
-     * Checks if a player has any of the specified items equipped by their item IDs.
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment is being checked.
-     * @param itemIds   An array of item IDs to check for.
-     * @return {@code true} if the player has any of the specified items equipped, {@code false} otherwise.
-     */
-    public static boolean hasPlayerEquippedItem(Rs2PlayerModel rs2Player, int[] itemIds) {
-        Map<KitType, Integer> equipment = getPlayerEquipmentIds(rs2Player);
-
-        return equipment.values().stream()
-                .anyMatch(equippedItemId -> Arrays.stream(itemIds).anyMatch(id -> id == equippedItemId));
-    }
-
-
-    /**
-     * Checks if a player has a specific item equipped by its name.
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment is being checked.
-     * @param itemName  The name of the item to check for.
-     * @return {@code true} if the player has the specified item equipped, {@code false} otherwise.
-     */
-    public static boolean hasPlayerEquippedItem(Rs2PlayerModel rs2Player, String itemName) {
-        Map<KitType, String> equipment = getPlayerEquipmentNames(rs2Player);
-
-        return equipment.values().stream()
-                .anyMatch(equippedItem -> equippedItem.equalsIgnoreCase(itemName));
-    }
-
-
-    /**
-     * Checks if a player has any of the specified items equipped by their names.
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment is being checked.
-     * @param itemNames A list of item names to check for.
-     * @return {@code true} if the player has any of the specified items equipped, {@code false} otherwise.
-     */
-    public static boolean hasPlayerEquippedItem(Rs2PlayerModel rs2Player, List<String> itemNames) {
-        Map<KitType, String> equipment = getPlayerEquipmentNames(rs2Player);
-
-        return equipment.values().stream()
-                .anyMatch(equippedItem -> itemNames.stream().anyMatch(equippedItem::equalsIgnoreCase));
-    }
-
-
-    /**
-     * Retrieves the combat level of the local player.
-     *
-     * @return The combat level of the local player.
-     */
-    public static int getCombatLevel() {
-        return Microbot.getClientThread().runOnClientThreadOptional(() ->
-                Microbot.getClient().getLocalPlayer().getCombatLevel()
-        ).orElse(0);
-    }
-
-    /**
-     * Updates the last combat time when the player engages in or is hit during combat.
-     */
-    public static void updateCombatTime() {
-        Microbot.getClientThread().runOnClientThreadOptional(() -> {
-            Player localPlayer = Microbot.getClient().getLocalPlayer();
-            if (localPlayer != null) {
-                lastCombatTime = System.currentTimeMillis();
-            }
-            return null;
-        });
-    }
-    /**
-     * Get the local player as an {@link Rs2PlayerModel}.
-     *
-     * @return The local player wrapped in an {@link Rs2PlayerModel}.
-     */
-    public static Rs2PlayerModel getLocalPlayer() {
-        return getPlayers(player -> player.getId() == Microbot.getClient().getLocalPlayer().getId(), true).findFirst().orElse(null);
-    }
-
-    /**
-     * Checks if the player is in combat based on recent activity.
-     *
-     * @return True if the player is in combat, false otherwise.
-     */
-    public static boolean isInCombat() {
-        return System.currentTimeMillis() - lastCombatTime < COMBAT_TIMEOUT_MS;
-    }
-
-    /**
-     * Gets a list of Rs2PlayerModel objects representing players around the local player
-     * within the combat level range and wilderness level where they can attack and be attacked.
-     *
-     * @return A list of Rs2PlayerModel objects within the combat range and attackable wilderness levels.
-     */
-    public static List<Rs2PlayerModel> getPlayersInCombatLevelRange() {
-        return getPlayersMatchingCombatCriteria().collect(Collectors.toList());
-    }
-
-    /**
-     * Helper method that applies the combat level filtering and returns a Stream of Rs2PlayerModel.
-     *
-     * @return A Stream of Rs2PlayerModel objects that match the combat range criteria.
-     */
-    private static Stream<Rs2PlayerModel> getPlayersMatchingCombatCriteria() {
-        int localCombatLevel = getCombatLevel();
-        int localWildernessLevel = Rs2Pvp.getWildernessLevelFrom(Rs2Player.getWorldLocation());
-
-        if (localWildernessLevel == 0) return Stream.empty();
-
-        int localMinCombatLevel = Math.max(3, localCombatLevel - localWildernessLevel);
-        int localMaxCombatLevel = Math.min(126, localCombatLevel + localWildernessLevel);
-
-        return getPlayers(player -> {
-            int playerCombatLevel = player.getCombatLevel();
-            int playerWildernessLevel = Rs2Pvp.getWildernessLevelFrom(player.getWorldLocation());
-
-            if (playerWildernessLevel == 0) return false;
-
-            int playerMinCombatLevel = Math.max(3, playerCombatLevel - playerWildernessLevel);
-            int playerMaxCombatLevel = Math.min(126, playerCombatLevel + playerWildernessLevel);
-
-            boolean localCanAttackPlayer = playerCombatLevel >= localMinCombatLevel && playerCombatLevel <= localMaxCombatLevel;
-            boolean playerCanAttackLocal = localCombatLevel >= playerMinCombatLevel && localCombatLevel <= playerMaxCombatLevel;
-
-            return localCanAttackPlayer && playerCanAttackLocal;
-        });
-    }
-
-    public static WorldPoint getWorldLocation_Internal(){
-        return Microbot.getClientThread().runOnClientThreadOptional(() -> {
-            if (Microbot.getClient().getTopLevelWorldView().getScene().isInstance()) {
-                LocalPoint l = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), Microbot.getClient().getLocalPlayer().getWorldLocation());
-                return WorldPoint.fromLocalInstance(Microbot.getClient(), l);
-            }
-            return Microbot.getClient().getLocalPlayer().getWorldLocation();
-        }).orElse(null);
-    }
-
-    public static WorldView getWorldView_Internal() {
-        return Microbot.getClientThread().runOnClientThreadOptional(() -> {
-            Player player = Microbot.getClient().getLocalPlayer();
-            if (player == null) return null;
-            return player.getWorldView();
-        }).orElse(null);
-    }
-
-    /**
-     * Retrieves the player's current world location as a {@link WorldPoint}.
-     *
-     * <p>If the player is in an instanced world, the method converts the local position
-     * to an instanced {@link WorldPoint}. Otherwise, it returns the player's standard
-     * world location.</p>
-     *
-     * @return The {@link WorldPoint} representing the player's current location.
-     */
-    public static WorldPoint getWorldLocation() {
-        return Rs2Cache.LOCAL_PLAYER_POSITION.getValue();
-    }
-
-    public static WorldView getWorldView() {
-        return Microbot.getClient().getTopLevelWorldView();
-    }
-
-    /**
-     * Retrieves the player's current location as an {@link Rs2WorldPoint}.
-     *
-     * <p>This method wraps the player's {@link WorldPoint} location into an {@link Rs2WorldPoint}.</p>
-     *
-     * @return An {@link Rs2WorldPoint} representing the player's current world location.
-     */
-    public static Rs2WorldPoint getRs2WorldPoint() {
-        return new Rs2WorldPoint(getWorldLocation());
-    }
-
-    /**
-     * Checks if the player is within a specified distance of a given {@link WorldPoint}.
-     *
-     * @param worldPoint The {@link WorldPoint} to check proximity to.
-     * @param radius   The radius (in tiles) around the {@code worldPoint} to check.
-     * @return {@code true} if the player is within the specified distance, {@code false} otherwise.
-     */
-    public static boolean isInArea(WorldPoint worldPoint, int radius) {
-        return isInArea(worldPoint, radius, radius);
-    }
-
-    /**
-     * Checks if the player is within a specified area around a given {@link WorldPoint}.
-     *
-     * @param worldPoint The {@link WorldPoint} to check proximity to.
-     * @param xRadius    The horizontal radius (in tiles) around the {@code worldPoint}.
-     * @param yRadius    The vertical radius (in tiles) around the {@code worldPoint}.
-     * @return {@code true} if the player is within the specified area, {@code false} otherwise.
-     */
-    public static boolean isInArea(WorldPoint worldPoint, int xRadius, int yRadius) {
-        // Null check for world point
-        if (worldPoint == null) {
-            return false;
-        }
-
-        // Validate radius parameters (should be non-negative)
-        if (xRadius < 0 || yRadius < 0) {
-            return false;
-        }
-
-        WorldPoint playerLocation = getWorldLocation();
-
-        // Null check for player location
-        if (playerLocation == null) {
-            return false;
-        }
-
-        // Ensure both points are on the same plane
-        if (worldPoint.getPlane() != playerLocation.getPlane()) {
-            return false;
-        }
-
-        // Simple distance check - check if player is within the rectangular radius
-        int deltaX = Math.abs(playerLocation.getX() - worldPoint.getX());
-        int deltaY = Math.abs(playerLocation.getY() - worldPoint.getY());
-
-        return deltaX <= xRadius && deltaY <= yRadius;
-    }
-
-    /**
-     * Checks if two areas intersect - one centered on the player and another on a target {@link WorldPoint}.
-     *
-     * @param targetPoint    The {@link WorldPoint} to check intersection with.
-     * @param targetXSpan    The total width (in tiles) of the area around the {@code targetPoint}.
-     * @param targetYSpan    The total height (in tiles) of the area around the {@code targetPoint}.
-     * @param playerXSpan    The total width (in tiles) of the area around the player's position.
-     * @param playerYSpan    The total height (in tiles) of the area around the player's position.
-     * @return {@code true} if the player's area intersects with the target area, {@code false} otherwise.
-     */
-    public static boolean isPlayerAreaIntersecting(WorldPoint targetPoint, int targetXSpan, int targetYSpan,
-                                                   int playerXSpan, int playerYSpan) {
-        // Null check for target point
-        if (targetPoint == null) {
-            return false;
-        }
-
-        // Validate span parameters (should be non-negative)
-        if (targetXSpan < 0 || targetYSpan < 0 || playerXSpan < 0 || playerYSpan < 0) {
-            return false;
-        }
-
-        WorldPoint playerLocation = getWorldLocation();
-
-        // Null check for player location
-        if (playerLocation == null) {
-            return false;
-        }
-
-        // Ensure both points are on the same plane
-        if (targetPoint.getPlane() != playerLocation.getPlane()) {
-            return false;
-        }
-
-        // Create target area centered on targetPoint
-        WorldPoint targetSouthWest = new WorldPoint(
-                targetPoint.getX() - (targetXSpan /2),
-                targetPoint.getY() - (targetYSpan / 2),
-                targetPoint.getPlane()
-        );
-        WorldArea targetArea = new WorldArea(targetSouthWest, targetXSpan, targetYSpan);
-
-        // Create player area centered on player location
-        WorldPoint playerSouthWest = new WorldPoint(
-                playerLocation.getX() - (playerXSpan / 2),
-                playerLocation.getY() - (playerYSpan / 2),
-                playerLocation.getPlane()
-        );
-        WorldArea playerArea = new WorldArea(playerSouthWest, playerXSpan, playerYSpan);
-
-        return targetArea.intersectsWith2D(playerArea);
-    }
-
-    /**
-     * Retrieves the player's current {@link LocalPoint} location.
-     *
-     * <p>This is commonly used in instanced areas where world coordinates differ from local coordinates.</p>
-     *
-     * @return The {@link LocalPoint} representing the player's current position.
-     */
-    public static LocalPoint getLocalLocation() {
-        return Microbot.getClient().getLocalPlayer().getLocalLocation();
-    }
-
-    /**
-     * Checks if the player is at full health.
-     *
-     * @return {@code true} if the player's boosted hitpoints level is greater than or equal to their real hitpoints level,
-     *         {@code false} otherwise.
-     */
-    public static boolean isFullHealth() {
-        return getBoostedSkillLevel(Skill.HITPOINTS)
-                >= getRealSkillLevel(Skill.HITPOINTS);
-    }
-
-    /**
-     * Checks if the player is in a multi-combat area.
-     *
-     * @return {@code true} if the player is inside a multi-combat zone, {@code false} otherwise.
-     */
-    public static boolean isInMulti() {
-        return Microbot.getVarbitValue(VarbitID.MULTIWAY_INDICATOR)
-                == 1;
-    }
-
-    /**
-     * Checks if the player is currently inside their Player Owned House (POH).
-     *
-     * <p>This is detected by verifying two conditions:</p>
-     * <ul>
-     *     <li>The current scene is an instanced region (all POHs are instanced).</li>
-     *     <li>The {@link VarbitID#POH_HOUSE_LOCATION} varbit is non-zero, which is
-     *         set whenever the player is inside a POH. This distinguishes the POH from
-     *         other instanced regions such as the Gauntlet or Hallowed Sepulchre.</li>
-     * </ul>
-     *
-     * @return {@code true} if the player is inside a POH, {@code false} otherwise.
-     */
-    public static boolean isInPoh() {
-        return Microbot.getClient().getTopLevelWorldView().getScene().isInstance()
-                && Microbot.getVarbitValue(VarbitID.POH_HOUSE_LOCATION) > 0;
-    }
-
-    public static boolean drinkPrayerPotion() {
-        int maxPrayer = getRealSkillLevel(Skill.PRAYER);
-        int maxHerblore = getRealSkillLevel(Skill.HERBLORE);
-        int restoreAmount;
-
-        if (hasPotion("moonlight moth mix")) {
-            restoreAmount = 22;
-        } else if (hasPotion("moonlight potion")) {
-            int prayerRestore = (maxPrayer / 4) + 7;
-            int herbloreRestore = (int) Math.floor((maxHerblore * 3.0 / 10.0)) + 7;
-            restoreAmount = Math.max(prayerRestore, herbloreRestore);
-        } else if (hasPotion("super restore") || hasPotion("blighted super restore") ) {
-            restoreAmount = (maxPrayer / 4) + 8;
-        } else {
-            restoreAmount = (maxPrayer / 4) + 7;
-        }
-
-        int threshold = maxPrayer - restoreAmount;
-        int randomizedThreshold = Rs2Random.randomGaussian(threshold - 5, 3);
-        randomizedThreshold = Math.min(randomizedThreshold, threshold);
-        //System.out.println("Threshold: " + randomizedThreshold);
-
-        return drinkPrayerPotionAt(randomizedThreshold);
-    }
-
-    /**
-     * Drinks a prayer potion when the player's prayer points fall below the specified threshold.
-     *
-     * <p><b>Priority Order:</b></p>
-     * <ul>
-     *     <li>Uses a Prayer Regeneration Potion first, if its effect is not active.</li>
-     *     <li>If in the Wilderness or a PvP world, prioritizes a Blighted Super Restore.</li>
-     *     <li>If neither of the above is available, uses a standard prayer potion variant.</li>
-     * </ul>
-     *
-     * @param prayerPoints The prayer points threshold at which a potion should be consumed.
-     * @return {@code true} if a potion was successfully consumed, {@code false} if no applicable potion was used.
-     */
-    public static boolean drinkPrayerPotionAt(int prayerPoints) {
-        // Check if current prayer level is above the threshold
-        if (getBoostedSkillLevel(Skill.PRAYER) > prayerPoints) return false;
-
-        boolean inWilderness = Microbot.getVarbitValue(Varbits.IN_WILDERNESS) == 1;
-        boolean isInPVPWorld = Microbot.getClient().getWorldType().contains(WorldType.PVP);
-
-        // Prioritize Prayer Regeneration Potion if effect is not active
-        if (!Rs2Player.hasPrayerRegenerationActive() && usePotion(Rs2Potion.getPrayerRegenerationPotion())) return true;
-
-        // If in Wilderness or PvP world, prioritize Blighted Super Restore
-        if (inWilderness || isInPVPWorld)  {
-            if (hasPotion("blighted super restore")) {
-                return usePotion("blighted super restore");
-            }
-        }
-
-        // Use a standard prayer potion from available variants
-        return usePotion(Rs2Potion.getPrayerPotionsVariants().toArray(new String[0]));
-    }
-
-    /**
-     * Drinks a combat-related potion for the specified skill.
-     *
-     * <p>This method defaults to allowing super combat potions when applicable.</p>
-     *
-     * @param skill The {@link Skill} for which a potion should be consumed.
-     * @return {@code true} if a potion was successfully consumed, {@code false} otherwise.
-     */
-    public static boolean drinkCombatPotionAt(Skill skill) {
-        return drinkCombatPotionAt(skill, true);
-    }
-
-    /**
-     * Drinks a combat-related potion to boost the specified skill.
-     *
-     * <p><b>Priority Order:</b></p>
-     * <ul>
-     *     <li>If the current boosted level is already 5 or more above the real level, no potion is consumed.</li>
-     *     <li>If {@code superCombat} is {@code true} and the skill is Attack, Strength, or Defence,
-     *         a super combat potion is prioritized.</li>
-     *     <li>If a super combat potion is not available, the method falls back to a skill-specific potion.</li>
-     * </ul>
-     *
-     * @param skill       The {@link Skill} for which a potion should be consumed.
-     * @param superCombat If {@code true}, prioritizes using a super combat potion for melee skills.
-     * @return {@code true} if a potion was successfully consumed, {@code false} otherwise.
-     */
-    public static boolean drinkCombatPotionAt(Skill skill, boolean superCombat) {
-        int real = getRealSkillLevel(skill);
-        int boosted = getBoostedSkillLevel(skill);
-
-        // max boost per wiki: RealLevel * (15/100) + 5
-        double maxBoost = real * 0.15 + 5;
-
-        // threshold is 20% of that max
-        double threshold = maxBoost * 0.20;
-
-        if ((boosted - real) > threshold) {
-            return false;
-        }
-
-        // If superCombat is specified and the skill is Attack, Strength, or Defence, try super combat potions first
-        if (superCombat && (skill == Skill.ATTACK || skill == Skill.STRENGTH || skill == Skill.DEFENCE)) {
-            // for Defence, exclude the basic "combat potion"
-            List<String> combatVariants = new ArrayList<>(Rs2Potion.getCombatPotionsVariants());
-            if (skill == Skill.DEFENCE) {
-                combatVariants.remove("combat potion");
-            }
-            if (usePotion(combatVariants.toArray(new String[0]))) {
-                return true;
-            }
-        }
-
-        // Then fall back to skill-specific potions based on which skill is requested
-        switch (skill) {
-            case ATTACK:
-                return usePotion(Rs2Potion.getAttackPotionsVariants().toArray(new String[0]));
-
-            case STRENGTH:
-                return usePotion(Rs2Potion.getStrengthPotionsVariants().toArray(new String[0]));
-
-            case DEFENCE:
-                return usePotion(Rs2Potion.getDefencePotionsVariants().toArray(new String[0]));
-
-            case RANGED:
-                return usePotion(Rs2Potion.getRangePotionsVariants().toArray(new String[0]));
-
-            case MAGIC:
-                return usePotion(Rs2Potion.getMagicPotionsVariants().toArray(new String[0]));
-            default:
-                return false; // If the skill is not covered, return false
-        }
-    }
-
-    /**
-     * Drinks an anti-poison potion if the player does not have an active anti-poison effect.
-     *
-     * <p>If an anti-venom effect is active, no potion will be consumed.</p>
-     *
-     * @return {@code true} if an anti-poison potion was found and used, 
-     *         or if the player already has an anti-venom effect, {@code false} otherwise.
-     */
-    public static boolean drinkAntiPoisonPotion() {
-        if (!hasAntiPoisonActive() || hasAntiVenomActive()) {
-            return true;
-        }
-        return usePotion(Rs2Potion.getAntiPoisonVariants().toArray(new String[0]));
-    }
-
-    /**
-     * Drinks an anti-fire potion if the player does not have an active anti-fire effect.
-     *
-     * @return {@code true} if an anti-fire potion was found and used, 
-     *         or if the player already has an active anti-fire effect, {@code false} otherwise.
-     */
-    public static boolean drinkAntiFirePotion() {
-        if (hasAntiFireActive()) {
-            return true;
-        }
-        return usePotion(Rs2Potion.getAntifirePotionsVariants().toArray(new String[0]));
-    }
-
-    /**
-     * Drinks a goading potion if the player does not already have an active goading effect.
-     *
-     * @return {@code true} if a goading potion was found and used, 
-     *         {@code false} if the effect is already active or no potion was available.
-     */
-    public static boolean drinkGoadingPotion() {
-        if (hasGoadingActive()) {
-            return false;
-        }
-        return usePotion(Rs2Potion.getGoadingPotion());
-    }
-
-    /**
-     * Helper method to check for the presence of any item in the provided IDs and interact with it.
-     *
-     * @param itemIds Array of item IDs to check in the inventory.
-     * @return true if an item was found and interacted with; false otherwise.
-     */
-    private static boolean usePotion(Integer ...itemIds) {
-        Rs2ItemModel potion = Rs2Inventory.get(item ->
-                !item.isNoted() && Arrays.stream(itemIds).anyMatch(id -> id == item.getId())
-        );
-
-        if (potion == null) return false;
-
-        return Rs2Inventory.interact(potion, "drink");
-    }
-
-    /**
-     * Checks for the presence of any item in the provided IDs within the inventory.
-     *
-     * @param itemIds Array of item IDs to check in the inventory.
-     * @return true if an item matching the IDs exists; false otherwise.
-     */
-    private static boolean hasPotion(Integer... itemIds) {
-        Rs2ItemModel potion = Rs2Inventory.get(item ->
-                !item.isNoted() && Arrays.stream(itemIds).anyMatch(id -> id == item.getId())
-        );
-
-        return potion != null;
-    }
-
-    /**
-     * Helper method to check for the presence of any item in the provided names and interact with it.
-     *
-     * @param itemNames Array of item names to check in the inventory.
-     * @return true if an item was found and interacted with; false otherwise.
-     */
-    private static boolean usePotion(String... itemNames) {
-        Pattern usesRegexPattern = Pattern.compile("^(.*?)(?:\\(\\d+\\))?$");
-
-        Rs2ItemModel potion = Rs2Inventory.get(item -> {
-            if (item.isNoted()) return false;
-
-            Matcher matcher = usesRegexPattern.matcher(item.getName());
-            if (matcher.find()) {
-                String trimmedName = matcher.group(1).trim();
-                return Arrays.stream(itemNames).anyMatch(name -> name.equalsIgnoreCase(trimmedName));
-            }
-
-            return false;
-        });
-
-        if (potion == null) return false;
-
-        return Rs2Inventory.interact(potion, "drink");
-    }
-
-    /**
-     * Checks for the presence of any item in the provided names within the inventory.
-     *
-     * @param itemNames Array of item names to check in the inventory.
-     * @return true if an item matching the names exists; false otherwise.
-     */
-    private static boolean hasPotion(String... itemNames) {
-        Pattern usesRegexPattern = Pattern.compile("^(.*?)(?:\\(\\d+\\))?$");
-
-        Rs2ItemModel potion = Rs2Inventory.get(item -> {
-            if (item.isNoted()) return false;
-
-            Matcher matcher = usesRegexPattern.matcher(item.getName());
-            if (matcher.find()) {
-                String trimmedName = matcher.group(1).trim();
-                return Arrays.stream(itemNames).anyMatch(name -> name.equalsIgnoreCase(trimmedName));
-            }
-
-            return false;
-        });
-
-        return potion != null;
-    }
-
-    /**
-     * Checks if the player has any remaining prayer points.
-     *
-     * @return {@code true} if the player's boosted prayer level is greater than zero, {@code false} otherwise.
-     */
-    public static boolean hasPrayerPoints() {
-        return getBoostedSkillLevel(Skill.PRAYER) > 0;
-    }
-
-    /**
-     * Calculates the player's current prayer level as a percentage of their base prayer level.
-     *
-     * @return a value between 0 and 100 representing the percentage of prayer remaining.
-     */
-    public static int getPrayerPercentage() {
-        int current = getBoostedSkillLevel(Skill.PRAYER);
-        int base = getRealSkillLevel(Skill.PRAYER);
-
-        return (int) ((current / (double) base) * 100);
-    }
-
-    /**
-     * Checks if the player is currently standing on a game object.
-     *
-     * @return {@code true} if a game object exists at the player's current location, {@code false} otherwise.
-     */
-    public static boolean isStandingOnGameObject() {
-        WorldPoint playerPoint = getWorldLocation();
-        return Rs2GameObject.getGameObject(o -> Objects.equals(playerPoint, o.getWorldLocation())) != null || isStandingOnGroundItem();
-    }
-
-    /**
-     * Checks if the player is currently standing on a ground item.
-     *
-     * @return {@code true} if there are any ground items at the player's current location, {@code false} otherwise.
-     */
-    public static boolean isStandingOnGroundItem() {
-        WorldPoint playerPoint = getWorldLocation();
-        return Rs2GroundItem.getGroundItems().values().stream().anyMatch(x -> x.getLocation().equals(playerPoint));
-    }
-
-    /**
-     * Retrieves the player's current animation ID.
-     *
-     * @return The animation ID of the player's current action, or {@code -1} if the player is null.
-     */
-    public static int getAnimation() {
-        return Microbot.getClientThread().runOnClientThreadOptional(() -> {
-            if (Microbot.getClient() == null || Microbot.getClient().getLocalPlayer() == null) return -1;
-            return Microbot.getClient().getLocalPlayer().getAnimation();
-        }).orElse(-1);
-    }
-
-    /**
-     * Retrieves the player's current pose animation ID.
-     *
-     * @return The pose animation ID of the player.
-     */
-    public static int getPoseAnimation() {
-        return Microbot.getClientThread().runOnClientThreadOptional(() ->
-                Microbot.getClient().getLocalPlayer().getPoseAnimation()
-        ).orElse(-1);
-    }
-
-    /**
-     * Retrieves the current state of a specified quest.
-     *
-     * @param quest The {@link Quest} to check.
-     * @return The {@link QuestState} representing the player's progress in the quest.
-     */
-    public static QuestState getQuestState(Quest quest) {
-        return Microbot.getRs2PlayerStateCache().getQuestState(quest);
-    }
-
-    /**
-     * Retrieves the player's real (unboosted) level for a given skill.
-     *
-     * @param skill The {@link Skill} to check.
-     * @return The player's real level for the specified skill.
-     */
-    public static int getRealSkillLevel(Skill skill) {
-        return Microbot.getClientThread().runOnClientThreadOptional(() ->
-                Microbot.getClient().getRealSkillLevel(skill)
-        ).orElse(0);
-    }
-
-    /**
-     * Retrieves the player's current boosted level for a given skill.
-     *
-     * @param skill The {@link Skill} to check.
-     * @return The player's boosted level for the specified skill.
-     */
-    public static int getBoostedSkillLevel(Skill skill) {
-        return Microbot.getClientThread().runOnClientThreadOptional(() ->
-                Microbot.getClient().getBoostedSkillLevel(skill)
-        ).orElse(0);
-    }
-
-    /**
-     * Checks if the player meets the required level for a given skill.
-     *
-     * <p>The method allows checking against either the real skill level or the boosted skill level.</p>
-     *
-     * @param skill        The {@link Skill} to check.
-     * @param levelRequired The required level for the skill.
-     * @param isBoosted    {@code true} to check against the boosted skill level, {@code false} to check against the real skill level.
-     * @return {@code true} if the player meets or exceeds the required level, {@code false} otherwise.
-     */
-    public static boolean getSkillRequirement(Skill skill, int levelRequired, boolean isBoosted) {
-        if (isBoosted) return getBoostedSkillLevel(skill) >= levelRequired;
-        return getRealSkillLevel(skill) >= levelRequired;
-    }
-
-    /**
-     * Checks if the player meets the required real level for a given skill.
-     *
-     * <p>This method is a shorthand for {@code getSkillRequirement(skill, levelRequired, false)}.</p>
-     *
-     * @param skill        The {@link Skill} to check.
-     * @param levelRequired The required level for the skill.
-     * @return {@code true} if the player's real skill level meets or exceeds the required level, {@code false} otherwise.
-     */
-    public static boolean getSkillRequirement(Skill skill, int levelRequired) {
-        return getSkillRequirement(skill, levelRequired, false);
-    }
-
-    /**
-     * Checks if the player is an Ironman or Hardcore Ironman.
-     *
-     * <p>Account types are determined based on the {@link Varbits#ACCOUNT_TYPE} value:</p>
-     * <ul>
-     *     <li>1 - Ironman</li>
-     *     <li>2 - Hardcore Ironman</li>
-     *     <li>3 - Ultimate Ironman</li>
-     * </ul>
-     *
-     * @return {@code true} if the player is an Ironman, Hardcore Ironman, or Ultimate Ironman, {@code false} otherwise.
-     */
-    public static boolean isIronman() {
-        int accountType = Microbot.getVarbitValue(Varbits.ACCOUNT_TYPE);
-        return accountType > 0 && accountType <= 3;
-    }
-
-    /**
-     * Checks if the player is a Group Ironman.
-     *
-     * <p>Group Ironman account types are determined based on the {@link Varbits#ACCOUNT_TYPE} value:</p>
-     * <ul>
-     *     <li>4 - Group Ironman</li>
-     *     <li>5 - Hardcore Group Ironman</li>
-     * </ul>
-     *
-     * @return {@code true} if the player is a Group Ironman or Hardcore Group Ironman, {@code false} otherwise.
-     */
-    public static boolean isGroupIronman() {
-        int accountType = Microbot.getVarbitValue(Varbits.ACCOUNT_TYPE);
-        return accountType >= 4;
-    }
-
-    /**
-     * Retrieves the player's current world.
-     *
-     * @return The world number the player is currently in.
-     */
-    public static int getWorld() {
-        return Microbot.getClient().getWorld();
-    }
-
-    /**
-     * Calculates the distance from the player's current location to a specified endpoint.
-     *
-     * <p><b>Note:</b> This method uses the ShortestPath algorithm and does not work in instanced regions.
-     * If the player is in an instance, it falls back to a direct {@link WorldPoint#distanceTo(WorldPoint)} calculation.</p>
-     *
-     * @param endpoint The target {@link WorldPoint} to measure the distance to.
-     * @return The distance between the player's current location and the endpoint.
-     */
-    public static int distanceTo(WorldPoint endpoint) {
-        if (Microbot.getClient().getTopLevelWorldView().getScene().isInstance()) {
-            return getWorldLocation().distanceTo(endpoint);
-        }
-        return Rs2Walker.getDistanceBetween(getWorldLocation(), endpoint);
-    }
-
-    /**
-     * Checks if the player is at risk of logging out due to inactivity.
-     *
-     * <p>This method determines the lowest idle time between mouse and keyboard activity
-     * and compares it to the client's idle timeout, factoring in a specified random delay.</p>
-     *
-     * @param randomDelay The time (in ticks) to subtract from the client's idle timeout 
-     *                    to introduce variability in detecting inactivity.
-     * @return {@code true} if the player's idle time exceeds or equals the adjusted timeout, {@code false} otherwise.
-     */
-    public static boolean checkIdleLogout(long randomDelay) {
-        long idleClientTicks = Long.min(
-                Microbot.getClient().getMouseIdleTicks(),
-                Microbot.getClient().getKeyboardIdleTicks()
-        );
-
-        return idleClientTicks >= Microbot.getClient().getIdleTimeout() - randomDelay;
-    }
-
-    /**
-     * Checks whether the player is in a cave.
-     *
-     * <p>A player is considered to be in a cave if their {@link WorldPoint#getY()} coordinate
-     * is 6400 or higher and they are not in an instanced world.</p>
-     *
-     * @return {@code true} if the player is inside a cave, {@code false} otherwise.
-     */
-    public static boolean isInCave() {
-        return Rs2Player.getWorldLocation().getY() >= 6400
-                && !Microbot.getClient().getTopLevelWorldView().isInstance();
-    }
-
-    /**
-     * Checks whether the player is currently in an instanced world.
-     *
-     * @return {@code true} if the player is in an instanced world, {@code false} otherwise.
-     */
-    public static boolean IsInInstance() {
-        return Microbot.getClient().getTopLevelWorldView().getScene().isInstance();
-    }
-
-    /**
-     * Retrieves the player's current run energy as a percentage.
-     *
-     * <p>Run energy is stored in the client as an integer value (e.g., 7500 for 75.00%).
-     * This method converts it to a whole number percentage.</p>
-     *
-     * @return The player's run energy as an integer percentage (0-100).
-     */
-    public static int getRunEnergy() {
-        return Microbot.getClient().getEnergy() / 100;
-    }
-
-    /**
-     * Checks if the player has an active stamina effect.
-     *
-     * <p>A stamina effect reduces the rate at which run energy depletes.
-     * This method checks the {@link Varbits#RUN_SLOWED_DEPLETION_ACTIVE} value.</p>
-     *
-     * @return {@code true} if the stamina effect is active, {@code false} otherwise.
-     */
-    public static boolean hasStaminaActive() {
-        return Microbot.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE) != 0;
-    }
-
-    /**
-     * Retrieves the current graphic ID of the local player.
-     *
-     * <p>This ID represents the graphical effect currently applied to the player, 
-     * such as spell casts or special attack animations.</p>
-     *
-     * @return The graphic ID of the local player.
-     */
-    public static int getGraphicId() {
-        return Microbot.getClient().getLocalPlayer().getGraphic();
-    }
-
-    /**
-     * Checks if the local player has a specific spot animation active.
-     *
-     * <p>Spot animations (also known as graphics IDs) are special visual effects 
-     * applied to the player, such as teleportation effects or status conditions.</p>
-     *
-     * @param graphicId The graphic ID of the spot animation to check. See {@link GraphicID} for predefined values.
-     * @return {@code true} if the local player has the specified spot animation, {@code false} otherwise.
-     */
-    public static boolean hasSpotAnimation(int graphicId) {
-        return Microbot.getClient().getLocalPlayer().hasSpotAnim(graphicId);
-    }
-
-    /**
-     * Checks if the local player is currently stunned.
-     *
-     * <p>A player is considered stunned if they have the spot animation with graphic ID {@code 245} active.</p>
-     *
-     * @return {@code true} if the player is stunned, {@code false} otherwise.
-     */
-    public static boolean isStunned() {
-        return hasSpotAnimation(245);
-    }
-
-    /**
-     * Invokes the "attack" action on the specified player.
-     *
-     * <p>This method interacts with the specified {@link Rs2PlayerModel} to initiate an attack.</p>
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} representing the player to attack.
-     * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
-     */
-    public static boolean attack(Rs2PlayerModel rs2Player) {
-        return invokeMenu(rs2Player, "attack");
-    }
-
-    /**
-     * Invokes the "walk here" action to move to the same location as the specified player.
-     *
-     * <p>This method interacts with the specified {@link Rs2PlayerModel} to initiate movement to their position.</p>
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} representing the player under whose position to walk.
-     * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
-     */
-    public static boolean walkUnder(Rs2PlayerModel rs2Player) {
-        return invokeMenu(rs2Player, "walk here");
-    }
-
-    /**
-     * Invokes the "trade with" action on the specified player.
-     *
-     * <p>This method interacts with the specified {@link Rs2PlayerModel} to initiate a trade.</p>
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} representing the player to trade with.
-     * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
-     */
-    public static boolean trade(Rs2PlayerModel rs2Player) {
-        return invokeMenu(rs2Player, "trade with");
-    }
-
-    /**
-     * Invokes the "follow" action on the specified player.
-     *
-     * <p>This method interacts with the specified {@link Rs2PlayerModel} to initiate following them.</p>
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} representing the player to follow.
-     * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
-     */
-    public static boolean follow(Rs2PlayerModel rs2Player) {
-        return invokeMenu(rs2Player, "follow");
-    }
-
-    /**
-     * Invokes the "cast" action on the specified player.
-     *
-     * <p>This method interacts with the specified {@link Rs2PlayerModel} to cast a spell or ability on them.</p>
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} to cast on.
-     * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
-     */
-    public static boolean cast(Rs2PlayerModel rs2Player) {
-        return invokeMenu(rs2Player, "cast");
-    }
-
-    /**
-     * Selects the "USE" option on a player for an item that is already selected via {@code Rs2Inventory.use(item)}.
-     *
-     * <p>This method interacts with the specified {@link Rs2PlayerModel} to use the selected item on them.</p>
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} to use the item on.
-     * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
-     */
-    public static boolean use(Rs2PlayerModel rs2Player) {
-        return invokeMenu(rs2Player, "use");
-    }
-
-    /**
-     * Selects the "CHALLENGE" option on a player for Soul Wars.
-     *
-     * <p>This method interacts with the specified {@link Rs2PlayerModel} to issue a challenge.</p>
-     *
-     * @param rs2Player The {@link Rs2PlayerModel} to challenge.
-     * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
-     */
-    public static boolean challenge(Rs2PlayerModel rs2Player) {
-        return invokeMenu(rs2Player, "challenge");
-    }
-
-    /**
-     * Executes a specific menu action on a given player.
-     *
-     * @param rs2Player the player to interact with
-     * @param action the action to invoke (e.g., "attack", "walk here", "trade with", "follow")
-     * @return true if the action was invoked successfully, false otherwise
-     */
-
-    private static boolean invokeMenu(Rs2PlayerModel rs2Player, String action) {
-        if (rs2Player == null) return false;
-
-        // Set the current status for the action being performed
-        Microbot.status = action + " " + rs2Player.getName();
-
-        // Determine the appropriate menu action based on the action string
-        MenuAction menuAction = MenuAction.CC_OP;
-
-        if(action.equalsIgnoreCase("attack")) {
-            menuAction = MenuAction.PLAYER_SECOND_OPTION;
-        } else if (action.equalsIgnoreCase("walk here")) {
-            menuAction = MenuAction.WALK;
-        } else if (action.equalsIgnoreCase("follow")) {
-            menuAction = MenuAction.PLAYER_THIRD_OPTION;
-        } else if (action.equalsIgnoreCase("challenge")) {
-            menuAction = MenuAction.PLAYER_FIRST_OPTION;
-        } else if (action.equalsIgnoreCase("trade with")) {
-            menuAction = MenuAction.PLAYER_FOURTH_OPTION;
-        } else if (action.equalsIgnoreCase("cast")) {
-            menuAction = MenuAction.WIDGET_TARGET_ON_PLAYER;
-        }else if (action.equalsIgnoreCase("use")) {
-            menuAction = MenuAction.WIDGET_TARGET_ON_PLAYER;
-        }
-
-        // Invoke the menu entry using the selected action
-        Microbot.doInvoke(
-                new NewMenuEntry()
-                        .param0(0)
-                        .param1(0)
-                        .opcode(menuAction.getId())
-                        .identifier(rs2Player.getId())
-                        .itemId(-1)
-                        .target(rs2Player.getName())
-                        .actor(rs2Player),
-                Rs2UiHelper.getActorClickbox(rs2Player)
-        );
-
-        return true;
-    }
-
-    /**
-     * Retrieves the actor that the local player is currently interacting with.
-     *
-     * @return The interacting actor as an {@link Actor} object. If the interacting actor is an NPC,
-     *         it returns an {@link Rs2NpcModel} object. If the local player is not interacting with anyone,
-     *         or if the local player is null, it returns null.
-     */
-    public static Actor getInteracting() {
-        Optional<Actor> result = Microbot.getClientThread().runOnClientThreadOptional(() -> {
-            if (Microbot.getClient().getLocalPlayer() == null) return null;
-
-            var interactingActor = Microbot.getClient().getLocalPlayer().getInteracting();
-
-            if (interactingActor instanceof net.runelite.api.NPC) {
-                return new Rs2NpcModel((NPC) interactingActor);
-            }
-
-            return interactingActor;
-        });
-
-        return result.orElse(null);
-    }
-    /**
-     * Checks if the player has finished Tutorial Island.
-     *
-     * <p>This method checks the player's progress on Tutorial Island by retrieving the value of Varbit 281.
-     * If the value is greater than or equal to 1000, it indicates that the player has completed Tutorial Island.</p>
-     *
-     * @return {@code true} if the player has finished Tutorial Island, {@code false} otherwise.
-     */
-    public static boolean hasCompletedTutorialIsland() {
-        return Microbot.getVarbitPlayerValue(281) >= 1000;
-    }
+	static int VENOM_VALUE_CUTOFF = -38;
+	private static int antiFireTime = -1;
+	private static int superAntiFireTime = -1;
+	private static int divineRangedTime = -1;
+	private static int divineBastionTime = -1;
+	private static int divineCombatTime = -1;
+	private static int divineMagicTime = -1;
+	public static int antiVenomTime = -1;
+	public static int staminaBuffTime = -1;
+	public static int antiPoisonTime = -1;
+	public static int teleBlockTime = -1;
+	public static int goadingTime = -1;
+	public static int moonlightTime = -1;
+	public static Instant lastAnimationTime = null;
+	private static final long COMBAT_TIMEOUT_MS = 10000;
+	private static long lastCombatTime = 0;
+	@Getter
+	public static int lastAnimationID = AnimationID.IDLE;
+
+	public static boolean hasPrayerRegenerationActive() {
+		return (Microbot.getVarbitValue(VarbitID.PRAYER_REGENERATION_POTION_TIMER) > 0);
+	}
+
+	public static boolean hasAntiFireActive() {
+		return antiFireTime > 0 || hasSuperAntiFireActive();
+	}
+
+	public static boolean hasSuperAntiFireActive() {
+		return superAntiFireTime > 0;
+	}
+
+	public static boolean hasDivineRangedActive() {
+		return divineRangedTime > 0 || hasDivineBastionActive();
+	}
+
+	public static boolean hasRangingPotionActive(int threshold) {
+		return getBoostedSkillLevel(Skill.RANGED) - threshold > getRealSkillLevel(Skill.RANGED);
+	}
+
+	public static boolean hasDivineBastionActive() {
+		return divineBastionTime > 0;
+	}
+
+	public static boolean hasDivineCombatActive() {
+		return divineCombatTime > 0;
+	}
+
+	public static boolean hasDivineMagicActive() {
+		return divineMagicTime > 0;
+	}
+
+	public static boolean hasGoadingActive() {
+		return goadingTime > 0;
+	}
+
+	public static boolean hasMoonlightActive() {
+		return moonlightTime > 0;
+	}
+
+	public static boolean hasAttackActive(int threshold) {
+		return getBoostedSkillLevel(Skill.ATTACK) - threshold > getRealSkillLevel(Skill.ATTACK);
+	}
+
+	public static boolean hasStrengthActive(int threshold) {
+		return getBoostedSkillLevel(Skill.STRENGTH) - threshold > getRealSkillLevel(Skill.STRENGTH);
+	}
+
+	public static boolean hasDefenseActive(int threshold) {
+		return getBoostedSkillLevel(Skill.DEFENCE) - threshold > getRealSkillLevel(Skill.DEFENCE);
+	}
+
+	public static boolean hasMagicActive(int threshold) {
+		return getBoostedSkillLevel(Skill.MAGIC) - threshold > getRealSkillLevel(Skill.MAGIC);
+	}
+
+	public static boolean hasAntiVenomActive() {
+		if (Rs2Equipment.isWearing("serpentine helm")) {
+			return true;
+		} else return antiVenomTime < VENOM_VALUE_CUTOFF;
+	}
+
+	public static boolean hasAntiPoisonActive() {
+		return antiPoisonTime > 0;
+	}
+
+	public static boolean hasStaminaBuffActive() {
+		return staminaBuffTime > 0;
+	}
+
+	public static boolean isTeleBlocked() {
+		return teleBlockTime > 0;
+	}
+
+	private static final Map<Integer, Long> playerDetectionTimes = new ConcurrentHashMap<>();
+
+	public static void handlePotionTimers(VarbitChanged event) {
+		if (event.getVarbitId() == Varbits.ANTIFIRE) {
+			antiFireTime = event.getValue();
+		}
+		if (event.getVarbitId() == Varbits.SUPER_ANTIFIRE) {
+			superAntiFireTime = event.getValue();
+		}
+		if (event.getVarbitId() == Varbits.DIVINE_RANGING) {
+			divineRangedTime = event.getValue();
+		}
+		if (event.getVarbitId() == Varbits.DIVINE_BASTION) {
+			divineBastionTime = event.getValue();
+		}
+		if (event.getVarbitId() == Varbits.DIVINE_SUPER_COMBAT) {
+			divineCombatTime = event.getValue();
+		}
+		if (event.getVarbitId() == Varbits.STAMINA_EFFECT) {
+			staminaBuffTime = event.getValue();
+		}
+		if (event.getVarbitId() == Varbits.BUFF_GOADING_POTION) {
+			goadingTime = event.getValue();
+		}
+		if (event.getVarbitId() == Varbits.MOONLIGHT_POTION) {
+			moonlightTime = event.getValue();
+		}
+		if (event.getVarbitId() == Varbits.DIVINE_MAGIC) {
+			divineMagicTime = event.getValue();
+		}
+		if (event.getVarpId() == VarPlayer.POISON) {
+			if (event.getValue() >= VENOM_VALUE_CUTOFF) {
+				antiVenomTime = 0;
+			} else {
+				antiVenomTime = event.getValue();
+			}
+			final int poisonVarp = event.getValue();
+
+			if (poisonVarp == 0) {
+				antiPoisonTime = -1;
+			} else {
+				antiPoisonTime = poisonVarp;
+			}
+		}
+	}
+
+	/**
+	 * Handles updates to the teleblock timer based on changes to the {@link Varbits#TELEBLOCK} varbit.
+	 *
+	 * @see Varbits#TELEBLOCK
+	 */
+	public static void handleTeleblockTimer(VarbitChanged event){
+		if (event.getVarbitId() == Varbits.TELEBLOCK) {
+			int time = event.getValue();
+
+			if (time < 101) {
+				teleBlockTime = -1;
+			} else {
+				teleBlockTime = time;
+			}
+		}
+	}
+
+	public static void handleAnimationChanged(AnimationChanged event) {
+		if (!(event.getActor() instanceof Player)) {
+			return;
+		}
+
+		Player player = (Player) event.getActor();
+		if (player != Microbot.getClient().getLocalPlayer()) {
+			return;
+		}
+
+		if (player.getAnimation() != AnimationID.IDLE) {
+			lastAnimationTime = Instant.now();
+			lastAnimationID = player.getAnimation();
+		}
+	}
+
+	/**
+	 * Wait for walking
+	 */
+	public static void waitForWalking() {
+		boolean result = sleepUntilTrue(Rs2Player::isMoving, 100, 5000);
+		if (!result) return;
+		sleepUntil(() -> !Rs2Player.isMoving());
+	}
+
+	/**
+	 * Waits for the player to start walking within the specified time limit.
+	 * If the player starts walking, it then waits until the player stops walking.
+	 *
+	 * @param time The maximum time (in milliseconds) to wait for the player to start walking.
+	 *             If the player does not start walking within this time, the method exits early.
+	 */
+	public static void waitForWalking(int time) {
+		boolean result = sleepUntilTrue(Rs2Player::isMoving, 100, time);
+		if (!result) return;
+		sleepUntil(() -> !Rs2Player.isMoving(), time);
+	}
+
+	/**
+	 * Waits for an XP drop in the specified skill within a default timeout of 5000 milliseconds.
+	 *
+	 * @param skill The skill to monitor for an XP drop.
+	 * @return {@code true} if an XP drop was detected within the timeout, {@code false} otherwise.
+	 */
+	public static boolean waitForXpDrop(Skill skill) {
+		return waitForXpDrop(skill, 5000, false);
+	}
+
+	/**
+	 * Waits for an XP drop in the specified skill within a given timeout.
+	 *
+	 * @param skill The skill to monitor for an XP drop.
+	 * @param time  The maximum time (in milliseconds) to wait for the XP drop.
+	 * @return {@code true} if an XP drop was detected within the timeout, {@code false} otherwise.
+	 */
+	public static boolean waitForXpDrop(Skill skill, int time) {
+		return waitForXpDrop(skill, time, false);
+	}
+
+	/**
+	 * Waits for an XP drop in the specified skill or stops if the inventory is full.
+	 *
+	 * @param skill              The skill to monitor for an XP drop.
+	 * @param inventoryFullCheck If {@code true}, also stops waiting if the inventory becomes full.
+	 * @return {@code true} if an XP drop was detected or the inventory became full, {@code false} otherwise.
+	 */
+	public static boolean waitForXpDrop(Skill skill, boolean inventoryFullCheck) {
+		return waitForXpDrop(skill, 5000, inventoryFullCheck);
+	}
+
+	/**
+	 * Waits for an XP drop in the specified skill within a given timeout or stops if the inventory is full.
+	 *
+	 * @param skill              The skill to monitor for an XP drop.
+	 * @param time               The maximum time (in milliseconds) to wait for the XP drop.
+	 * @param inventoryFullCheck If {@code true}, also stops waiting if the inventory becomes full.
+	 * @return {@code true} if an XP drop was detected or the inventory became full, {@code false} otherwise.
+	 */
+	public static boolean waitForXpDrop(Skill skill, int time, boolean inventoryFullCheck) {
+		final int skillExp = Microbot.getClient().getSkillExperience(skill);
+		return sleepUntilTrue(() ->
+						skillExp != Microbot.getClient().getSkillExperience(skill) ||
+								(inventoryFullCheck && Rs2Inventory.isFull()),
+				100, time
+		);
+	}
+
+	/**
+	 * Wait for animation
+	 */
+	public static void waitForAnimation() {
+		boolean result = sleepUntilTrue(Rs2Player::isAnimating, 100, 5000);
+		if (!result) return;
+		sleepUntil(() -> !Rs2Player.isAnimating());
+	}
+
+	/**
+	 * Waits for the player to start animating within a given time limit.
+	 * If the player starts animating, it then waits until the animation stops.
+	 *
+	 * @param time The maximum time (in milliseconds) to wait for the player to start animating.
+	 *             If the player does not start animating within this time, the method exits early.
+	 */
+	public static void waitForAnimation(int time) {
+		boolean result = sleepUntilTrue(() -> Rs2Player.isAnimating(time), 100, 5000);
+		if (!result) return;
+		sleepUntil(() -> !Rs2Player.isAnimating(time));
+	}
+
+	/**
+	 * Checks if the player has been animating within the past specified milliseconds.
+	 *
+	 * @param ms The time window (in milliseconds) to check for recent animations.
+	 * @return {@code true} if the player has been animating within the last {@code ms} milliseconds,
+	 *         or if the player's current animation is not {@code AnimationID.IDLE}, {@code false} otherwise.
+	 */
+	public static boolean isAnimating(int ms) {
+		return (lastAnimationTime != null && Duration.between(lastAnimationTime, Instant.now()).toMillis() < ms)
+				|| getAnimation() != AnimationID.IDLE;
+	}
+
+	/**
+	 * Checks if the player has been animating within the past 600 milliseconds.
+	 *
+	 * @return {@code true} if the player has been animating within the last 600 milliseconds,
+	 *         or if the player's current animation is not {@code AnimationID.IDLE}, {@code false} otherwise.
+	 */
+	public static boolean isAnimating() {
+		return isAnimating(600);
+	}
+
+	/**
+	 * Checks if the player is currently moving based on their pose animation.
+	 * A player is considered moving if their pose animation is different from their idle pose animation.
+	 *
+	 * @return {@code true} if the player is moving, {@code false} if they are idle.
+	 */
+	public static boolean isMoving() {
+		return Microbot.getClientThread().runOnClientThreadOptional(() -> {
+			Player localPlayer = Microbot.getClient().getLocalPlayer();
+			if (localPlayer == null) {
+				return false;
+			}
+			return localPlayer.getPoseAnimation() != localPlayer.getIdlePoseAnimation();
+		}).orElse(false);
+	}
+
+	/**
+	 * Checks if the specified Rs2PlayerModel is currently moving based on its pose animation.
+	 * The model is considered moving if its pose animation is different from its idle pose animation.
+	 *
+	 * @param playerModel The Rs2PlayerModel to check.
+	 * @return {@code true} if the model is moving, {@code false} if it is idle.
+	 */
+	public static boolean isMoving(Rs2PlayerModel playerModel) {
+		if (playerModel == null) {
+			return false;
+		}
+
+		return Microbot.getClientThread().runOnClientThreadOptional(() -> playerModel.getPoseAnimation() != playerModel.getIdlePoseAnimation()).orElse(false);
+	}
+
+	/**
+	 * Checks if the player is currently interacting with another entity (NPC, player, or object).
+	 *
+	 * @return {@code true} if the player is interacting with another entity, {@code false} otherwise.
+	 */
+	public static boolean isInteracting() {
+		if (Microbot.getClient().getLocalPlayer() == null) {
+			return false;
+		}
+		return Optional.of(Microbot.getClient().getLocalPlayer().isInteracting()).orElse(false);
+	}
+
+	/**
+	 * Checks if the player has an active membership.
+	 *
+	 * @return {@code true} if the player is a member (has remaining membership days), {@code false} otherwise.
+	 */
+	public static boolean isMember() {
+		return Microbot.getVarbitPlayerValue(VarPlayerID.ACCOUNT_CREDIT) > 0;
+	}
+
+	/**
+	 * Checks if the player is currently in a members-only world.
+	 *
+	 * @return {@code true} if the player is in a members-only world, {@code false} otherwise.
+	 */
+	public static boolean isInMemberWorld() {
+		WorldResult worldResult = Microbot.getWorldService().getWorlds();
+
+		if (worldResult != null) {
+			List<net.runelite.http.api.worlds.World> worlds = worldResult.getWorlds();
+			return worlds.stream()
+					.anyMatch(x -> x.getId() == Microbot.getClient().getWorld() && x.getTypes().contains(WorldType.MEMBERS));
+		}
+
+		return false;
+	}
+
+	/**
+	 * Toggles the player's run energy on or off.
+	 *
+	 * @param toggle {@code true} to enable running, {@code false} to disable it.
+	 * @return {@code true} if the toggle action was performed successfully or was already in the desired state,
+	 *         {@code false} if the run energy toggle widget was not found.
+	 */
+	public static boolean toggleRunEnergy(boolean toggle) {
+		if (Microbot.getVarbitPlayerValue(173) == 0 && !toggle) return true;
+		if (Microbot.getVarbitPlayerValue(173) == 1 && toggle) return true;
+
+		Widget widget = Rs2Widget.getWidget(WidgetInfo.MINIMAP_TOGGLE_RUN_ORB.getId());
+		if (widget == null) return false;
+
+		Microbot.getMouse().click(widget.getCanvasLocation());
+		sleep(150, 300);
+
+		return true;
+	}
+
+	/**
+	 * Checks if the player's run energy is currently enabled.
+	 *
+	 * @return {@code true} if run energy is enabled, {@code false} otherwise.
+	 */
+	public static boolean isRunEnabled() {
+		return Microbot.getVarbitPlayerValue(173) == 1;
+	}
+
+	/**
+	 * Logs the player out of the game
+	 */
+	public static void logout() {
+		if (!Microbot.isLoggedIn()) return;
+
+		// Make sure jagex acount does not auto login
+		Rs2Keyboard.resetEnter();
+
+		Rs2Tab.switchTo(InterfaceTab.LOGOUT);
+
+		Widget currentWorldWidget = Rs2Widget.getWidget(69, 3);
+		if (currentWorldWidget != null) {
+			// From World Switcher
+			Microbot.doInvoke(new NewMenuEntry()
+					.param0(-1)
+					.param1(4522009)
+					.opcode(CC_OP.getId())
+					.identifier(1)
+					.itemId(-1)
+					.option("Logout"), new Rectangle(1, 1, Microbot.getClient().getCanvasWidth(), Microbot.getClient().getCanvasHeight()));
+		} else {
+			// From red logout button
+			Microbot.doInvoke(new NewMenuEntry()
+					.param0(-1)
+					.param1(11927560)
+					.opcode(CC_OP.getId())
+					.identifier(1)
+					.itemId(-1)
+					.option("Logout"), new Rectangle(1, 1, Microbot.getClient().getCanvasWidth(), Microbot.getClient().getCanvasHeight()));
+		}
+	}
+
+	/**
+	 * Logs out the player if a specified number of players are detected within a given distance and time.
+	 *
+	 * @param amountOfPlayers The number of players to detect before triggering a logout.
+	 * @param time            The duration (in milliseconds) that the players must remain detected before logging out.
+	 *                         If {@code time <= 0}, the logout occurs immediately upon detection.
+	 * @param distance        The maximum distance (in tiles) from the player to check for other players.
+	 *                         If {@code distance <= 0}, all detected players are considered.
+	 * @return {@code true} if the player logged out, {@code false} otherwise.
+	 */
+	public static boolean logoutIfPlayerDetected(int amountOfPlayers, int time, int distance) {
+		List<Rs2PlayerModel> players = getPlayers(player -> true).collect(Collectors.toList());
+		long currentTime = System.currentTimeMillis();
+
+		if (distance > 0) {
+			players = players.stream()
+					.filter(x -> x != null && x.getWorldLocation().distanceTo(Rs2Player.getWorldLocation()) <= distance)
+					.collect(Collectors.toList());
+		}
+		if (time > 0 && players.size() >= amountOfPlayers) {
+			// Update detection times for currently detected players
+			for (Rs2PlayerModel player : players) {
+				playerDetectionTimes.putIfAbsent(player.getId(), currentTime);
+			}
+
+			// Remove players who are no longer detected
+			playerDetectionTimes.keySet().retainAll(players.stream().map(Rs2PlayerModel::getId).collect(Collectors.toSet()));
+
+			// Check if any player has been detected for longer than the specified time
+			for (Rs2PlayerModel player : players) {
+				long detectionTime = playerDetectionTimes.getOrDefault(player.getId(), 0L);
+				if (currentTime - detectionTime >= time) {
+					logout();
+					playerDetectionTimes.clear();
+					return true;
+				}
+			}
+		} else if (time <= 0 && players.size() >= amountOfPlayers) {
+			logout();
+			playerDetectionTimes.clear();
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Logs out the player if a specified number of players are detected within a given time,
+	 * checking all players regardless of distance.
+	 *
+	 * @param amountOfPlayers The number of players to detect before triggering a logout.
+	 * @param time            The duration (in milliseconds) that the players must remain detected before logging out.
+	 *                         If {@code time <= 0}, the logout occurs immediately upon detection.
+	 * @return {@code true} if the player logged out, {@code false} otherwise.
+	 */
+	public static boolean logoutIfPlayerDetected(int amountOfPlayers, int time) {
+		return logoutIfPlayerDetected(amountOfPlayers, time, 0);
+	}
+
+	/**
+	 * Logs out the player if a specified number of players are detected,
+	 * triggering an immediate logout upon detection.
+	 *
+	 * @param amountOfPlayers The number of players to detect before triggering a logout.
+	 * @return {@code true} if the player logged out, {@code false} otherwise.
+	 */
+	public static boolean logoutIfPlayerDetected(int amountOfPlayers) {
+		return logoutIfPlayerDetected(amountOfPlayers, 0, 0);
+	}
+
+	/**
+	 * Hops to a random world if a specified number of players are detected within a given distance and time.
+	 *
+	 * @param amountOfPlayers The number of players to detect before triggering a world hop.
+	 * @param time            The duration (in milliseconds) that the players must remain detected before hopping worlds.
+	 *                         If {@code time <= 0}, the hop occurs immediately upon detection.
+	 * @param distance        The maximum distance (in tiles) from the player to check for other players.
+	 *                         If {@code distance <= 0}, all detected players are considered.
+	 * @return {@code true} if the player detected and successfully hopped worlds, {@code false} otherwise.
+	 */
+	public static boolean hopIfPlayerDetected(int amountOfPlayers, int time, int distance) {
+		List<Rs2PlayerModel> players = getPlayers(player -> true).collect(Collectors.toList());
+		long currentTime = System.currentTimeMillis();
+
+		if (distance > 0) {
+			players = players.stream()
+					.filter(x -> x != null && x.getWorldLocation().distanceTo(Rs2Player.getWorldLocation()) <= distance)
+					.collect(Collectors.toList());
+		}
+
+		if (time > 0 && players.size() >= amountOfPlayers) {
+			// Update detection times for currently detected players
+			for (Rs2PlayerModel player : players) {
+				playerDetectionTimes.putIfAbsent(player.getId(), currentTime);
+			}
+
+			// Remove players who are no longer detected
+			playerDetectionTimes.keySet().retainAll(players.stream().map(Rs2PlayerModel::getId).collect(Collectors.toSet()));
+
+			// Check if any player has been detected for longer than the specified time
+			for (Rs2PlayerModel player : players) {
+				long detectionTime = playerDetectionTimes.getOrDefault(player.getId(), 0L);
+				if (currentTime - detectionTime >= time) {
+					int randomWorld = LoginManager.getRandomWorld(isMember());
+					Microbot.hopToWorld(randomWorld);
+					return true;
+				}
+			}
+		} else if (players.size() >= amountOfPlayers) {
+			int randomWorld = LoginManager.getRandomWorld(isMember());
+			Microbot.hopToWorld(randomWorld);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Consumes food when the player's health percentage falls below the specified threshold.
+	 * Uses default food consumption behavior.
+	 *
+	 * @param percentage The health percentage at which food should be consumed.
+	 * @return {@code true} if food was consumed, {@code false} if no action was taken.
+	 */
+	public static boolean eatAt(int percentage) {
+		// Call the full method with a default value of false for fastFood
+		return eatAt(percentage, false);
+	}
+
+	/**
+	 * Consumes food when the player's health percentage falls below the specified threshold.
+	 * The method searches the inventory for the first available food item.
+	 *
+	 * @param percentage The health percentage at which food should be consumed.
+	 * @param fastFood If true, prioritize faster food consumption behavior.
+	 * @return {@code true} if food was consumed, {@code false} if no action was taken.
+	 */
+	public static boolean eatAt(int percentage, boolean fastFood) {
+		double threshold = getHealthPercentage();
+		if (threshold <= percentage) {
+			if (fastFood && !Rs2Inventory.getInventoryFastFood().isEmpty()) {
+				return useFastFood();
+			}
+			return useFood(); // default method
+		}
+		return false;
+	}
+
+	/**
+	 * Consumes the first available high-priority food item from the player's inventory.
+	 *
+	 * <p>Only food items defined in {@link Rs2Food} with a priority of {@code 1} are considered fast food.</p>
+	 * <p>This method ignores noted items and will not attempt to drink items like Jug of Wine.</p>
+	 *
+	 * @return {@code true} if a fast food item was consumed, {@code false} if none were found.
+	 */
+	public static boolean useFastFood() {
+		List<Rs2ItemModel> foods = Rs2Inventory.getInventoryFastFood();
+		if (foods.isEmpty()) return false;
+
+		Optional<Rs2ItemModel> fastFood = foods.stream().findFirst();
+
+		fastFood.ifPresent(rs2ItemModel -> Rs2Inventory.interact(rs2ItemModel, "eat"));
+		return true;
+	}
+
+	/**
+	 * Finds and consumes the best available food item from the player's inventory.
+	 *
+	 * <p>If in the Wilderness, prioritizes blighted food items but falls back to regular food if none are available.</p>
+	 * <p>If the selected food is a "Jug of Wine," the player will drink it instead of eating.</p>
+	 *
+	 * @return {@code true} if food was consumed, {@code false} if no food was available.
+	 */
+	public static boolean useFood() {
+		List<Rs2ItemModel> foods = Rs2Inventory.getInventoryFood();
+		if (foods.isEmpty()) return false;
+
+		boolean inWilderness = Microbot.getVarbitValue(Varbits.IN_WILDERNESS) == 1;
+
+		// Separate blighted and non-blighted food
+		List<Rs2ItemModel> blightedFoods = foods.stream()
+				.filter(rs2Item -> !rs2Item.isNoted() && rs2Item.getName().toLowerCase().contains("blighted"))
+				.collect(Collectors.toList());
+
+		List<Rs2ItemModel> regularFoods = foods.stream()
+				.filter(rs2Item -> !rs2Item.isNoted() && !rs2Item.getName().toLowerCase().contains("blighted"))
+				.collect(Collectors.toList());
+
+		// Select food to use: prefer blighted in Wilderness, otherwise use any available food
+		Rs2ItemModel foodToUse = (inWilderness && !blightedFoods.isEmpty()) ? blightedFoods.get(0)
+				: !regularFoods.isEmpty() ? regularFoods.get(0) : null;
+
+		if (foodToUse == null) return false;
+
+		return foodToUse.getName().toLowerCase().contains("jug of wine")
+				? Rs2Inventory.interact(foodToUse, "drink")
+				: Rs2Inventory.interact(foodToUse, "eat");
+	}
+
+	/**
+	 * Calculates the player's current health as a percentage of their real (base) health.
+	 *
+	 * @return the health percentage as a double. For example:
+	 *         150.0 if boosted, 80.0 if drained, or 100.0 if unchanged.
+	 */
+	public static double getHealthPercentage() {
+		return (double) (getBoostedSkillLevel(Skill.HITPOINTS) * 100) / getRealSkillLevel(Skill.HITPOINTS);
+	}
+
+	/**
+	 * Get a stream of players around you, optionally filtered by a predicate.
+	 *
+	 * @param predicate A condition to filter players (optional).
+	 * @return A stream of Rs2PlayerModel objects representing nearby players.
+	 */
+	@Deprecated(since = "2.1.0 - Use Rs2PlayerCache/Rs2PlayerQueryable", forRemoval = true)
+	public static Stream<Rs2PlayerModel> getPlayers(Predicate<Rs2PlayerModel> predicate) {
+		return getPlayers(predicate, false);
+	}
+
+	/**
+	 * Get a stream of players around you, optionally filtered by a predicate.
+	 *
+	 * @param predicate A condition to filter players (optional).
+	 * @param includeLocalPlayer a flag on whether to include the local player within the stream
+	 * @return A stream of Rs2PlayerModel objects representing nearby players.
+	 */
+	@Deprecated(since = "2.1.0 - Use Rs2PlayerCache/Rs2PlayerQueryable", forRemoval = true)
+	public static Stream<Rs2PlayerModel> getPlayers(Predicate<Rs2PlayerModel> predicate, boolean includeLocalPlayer) {
+		List<Rs2PlayerModel> players = Optional.of(Microbot.getClient().getTopLevelWorldView().players()
+				.stream()
+				.filter(Objects::nonNull)
+				.map(Rs2PlayerModel::new)
+				.filter(x -> includeLocalPlayer || x.getPlayer() != Microbot.getClient().getLocalPlayer())
+				.filter(predicate)
+				.collect(Collectors.toList())
+		).orElse(new ArrayList<>());
+
+		return players.stream();
+	}
+
+	/**
+	 * Retrieves a player by name with an optional exact match.
+	 *
+	 * @param playerName The name of the player to search for.
+	 * @param exact      If {@code true}, performs an exact name match (case insensitive).
+	 *                   If {@code false}, checks if the player name contains the given string.
+	 * @return The first matching {@code Rs2PlayerModel}, or {@code null} if no player is found.
+	 */
+	@Deprecated(since = "2.1.0 - Use Rs2PlayerCache/Rs2PlayerQueryable", forRemoval = true)
+	public static Rs2PlayerModel getPlayer(String playerName, boolean exact) {
+		return getPlayers(player -> {
+			String name = player.getName();
+			if (name == null) return false;
+			return exact ? name.equalsIgnoreCase(playerName) : name.toLowerCase().contains(playerName.toLowerCase());
+		}).findFirst().orElse(null);
+	}
+
+	/**
+	 * Retrieves a player by name using a partial match.
+	 *
+	 * @param playerName The name of the player to search for.
+	 * @return The first matching {@code Rs2PlayerModel}, or {@code null} if no player is found.
+	 *         Uses {@code getPlayer(playerName, false)} to perform a case-insensitive partial match.
+	 */
+	@Deprecated(since = "2.1.0 - Use Rs2PlayerCache/Rs2PlayerQueryable", forRemoval = true)
+	public static Rs2PlayerModel getPlayer(String playerName) {
+		return getPlayer(playerName, false);
+	}
+
+	/**
+	 * Use this method to get a list of players that are in combat
+	 *
+	 * @return a list of players that are in combat
+	 */
+	@Deprecated(since = "2.1.0 - Use Rs2PlayerCache/Rs2PlayerQueryable", forRemoval = true)
+	public static List<Rs2PlayerModel> getPlayersInCombat() {
+		return getPlayers(player -> player.getHealthRatio() != -1).collect(Collectors.toList());
+	}
+
+	/**
+	 * Calculates the player's health as a percentage.
+	 *
+	 * <p>The method retrieves the player's health ratio and scale, then calculates
+	 * the percentage based on these values.</p>
+	 *
+	 * <p><b>Note:</b> If health information is unavailable (i.e., missing or invalid values),
+	 * the method returns {@code -1}.</p>
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} representing the player or actor to calculate health for.
+	 * @return The health percentage (0-100), or {@code -1} if health information is unavailable.
+	 */
+	public static int calculateHealthPercentage(Rs2PlayerModel rs2Player) {
+		int healthRatio = rs2Player.getHealthRatio();
+		int healthScale = rs2Player.getHealthScale();
+
+		// Check if health information is available
+		if (healthRatio == -1 || healthScale == -1 || healthScale == 0) {
+			return -1; // Health information is missing or invalid
+		}
+
+		// Calculate health percentage
+		return (int) ((healthRatio / (double) healthScale) * 100);
+	}
+
+	/**
+	 * Retrieves a map of the player's equipped items, mapping {@link KitType} to their corresponding item IDs.
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment is to be retrieved.
+	 * @return A {@code Map<KitType, Integer>} containing the equipment slot types as keys and the corresponding item IDs as values.
+	 */
+	public static Map<KitType, Integer> getPlayerEquipmentIds(Rs2PlayerModel rs2Player) {
+		Map<KitType, Integer> equipmentMap = new HashMap<>();
+
+		for (KitType kitType : KitType.values()) {
+			int itemId = rs2Player.getPlayerComposition().getEquipmentId(kitType);
+			equipmentMap.put(kitType, itemId);
+		}
+
+		return equipmentMap;
+	}
+
+
+	/**
+	 * Retrieves a map of the player's equipped items, mapping {@link KitType} to their corresponding item names.
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment names are to be retrieved.
+	 * @return A {@code Map<KitType, String>} containing the equipment slot types as keys and the corresponding item names as values.
+	 */
+	public static Map<KitType, String> getPlayerEquipmentNames(Rs2PlayerModel rs2Player) {
+		Map<KitType, String> equipmentMap = Microbot.getClientThread().runOnClientThreadOptional(() -> {
+			Map<KitType, String> tempMap = new HashMap<>();
+			for (KitType kitType : KitType.values()) {
+				String itemName = Microbot.getItemManager()
+						.getItemComposition(rs2Player.getPlayerComposition().getEquipmentId(kitType))
+						.getName();
+				tempMap.put(kitType, itemName);
+			}
+			return tempMap;
+		}).orElse(new HashMap<>());
+
+		return equipmentMap;
+	}
+
+
+	/**
+	 * Checks if a player has a specific item equipped by its item ID.
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment is being checked.
+	 * @param itemId    The ID of the item to check for.
+	 * @return {@code true} if the player has the specified item equipped, {@code false} otherwise.
+	 */
+	public static boolean hasPlayerEquippedItem(Rs2PlayerModel rs2Player, int itemId) {
+		Map<KitType, Integer> equipment = getPlayerEquipmentIds(rs2Player);
+
+		return equipment.values().stream()
+				.anyMatch(equippedItemId -> equippedItemId == itemId);
+	}
+
+	/**
+	 * Checks if a player has any of the specified items equipped by their item IDs.
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment is being checked.
+	 * @param itemIds   An array of item IDs to check for.
+	 * @return {@code true} if the player has any of the specified items equipped, {@code false} otherwise.
+	 */
+	public static boolean hasPlayerEquippedItem(Rs2PlayerModel rs2Player, int[] itemIds) {
+		Map<KitType, Integer> equipment = getPlayerEquipmentIds(rs2Player);
+
+		return equipment.values().stream()
+				.anyMatch(equippedItemId -> Arrays.stream(itemIds).anyMatch(id -> id == equippedItemId));
+	}
+
+
+	/**
+	 * Checks if a player has a specific item equipped by its name.
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment is being checked.
+	 * @param itemName  The name of the item to check for.
+	 * @return {@code true} if the player has the specified item equipped, {@code false} otherwise.
+	 */
+	public static boolean hasPlayerEquippedItem(Rs2PlayerModel rs2Player, String itemName) {
+		Map<KitType, String> equipment = getPlayerEquipmentNames(rs2Player);
+
+		return equipment.values().stream()
+				.anyMatch(equippedItem -> equippedItem.equalsIgnoreCase(itemName));
+	}
+
+
+	/**
+	 * Checks if a player has any of the specified items equipped by their names.
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} representing the player whose equipment is being checked.
+	 * @param itemNames A list of item names to check for.
+	 * @return {@code true} if the player has any of the specified items equipped, {@code false} otherwise.
+	 */
+	public static boolean hasPlayerEquippedItem(Rs2PlayerModel rs2Player, List<String> itemNames) {
+		Map<KitType, String> equipment = getPlayerEquipmentNames(rs2Player);
+
+		return equipment.values().stream()
+				.anyMatch(equippedItem -> itemNames.stream().anyMatch(equippedItem::equalsIgnoreCase));
+	}
+
+
+	/**
+	 * Retrieves the combat level of the local player.
+	 *
+	 * @return The combat level of the local player.
+	 */
+	public static int getCombatLevel() {
+		return Microbot.getClientThread().runOnClientThreadOptional(() ->
+				Microbot.getClient().getLocalPlayer().getCombatLevel()
+		).orElse(0);
+	}
+
+	/**
+	 * Updates the last combat time when the player engages in or is hit during combat.
+	 */
+	public static void updateCombatTime() {
+		Microbot.getClientThread().runOnClientThreadOptional(() -> {
+			Player localPlayer = Microbot.getClient().getLocalPlayer();
+			if (localPlayer != null) {
+				lastCombatTime = System.currentTimeMillis();
+			}
+			return null;
+		});
+	}
+	/**
+	 * Get the local player as an {@link Rs2PlayerModel}.
+	 *
+	 * @return The local player wrapped in an {@link Rs2PlayerModel}.
+	 */
+	public static Rs2PlayerModel getLocalPlayer() {
+		return getPlayers(player -> player.getId() == Microbot.getClient().getLocalPlayer().getId(), true).findFirst().orElse(null);
+	}
+
+	/**
+	 * Checks if the player is in combat based on recent activity.
+	 *
+	 * @return True if the player is in combat, false otherwise.
+	 */
+	public static boolean isInCombat() {
+		return System.currentTimeMillis() - lastCombatTime < COMBAT_TIMEOUT_MS;
+	}
+
+	/**
+	 * Gets a list of Rs2PlayerModel objects representing players around the local player
+	 * within the combat level range and wilderness level where they can attack and be attacked.
+	 *
+	 * @return A list of Rs2PlayerModel objects within the combat range and attackable wilderness levels.
+	 */
+	public static List<Rs2PlayerModel> getPlayersInCombatLevelRange() {
+		return getPlayersMatchingCombatCriteria().collect(Collectors.toList());
+	}
+
+	/**
+	 * Helper method that applies the combat level filtering and returns a Stream of Rs2PlayerModel.
+	 *
+	 * @return A Stream of Rs2PlayerModel objects that match the combat range criteria.
+	 */
+	private static Stream<Rs2PlayerModel> getPlayersMatchingCombatCriteria() {
+		int localCombatLevel = getCombatLevel();
+		int localWildernessLevel = Rs2Pvp.getWildernessLevelFrom(Rs2Player.getWorldLocation());
+
+		if (localWildernessLevel == 0) return Stream.empty();
+
+		int localMinCombatLevel = Math.max(3, localCombatLevel - localWildernessLevel);
+		int localMaxCombatLevel = Math.min(126, localCombatLevel + localWildernessLevel);
+
+		return getPlayers(player -> {
+			int playerCombatLevel = player.getCombatLevel();
+			int playerWildernessLevel = Rs2Pvp.getWildernessLevelFrom(player.getWorldLocation());
+
+			if (playerWildernessLevel == 0) return false;
+
+			int playerMinCombatLevel = Math.max(3, playerCombatLevel - playerWildernessLevel);
+			int playerMaxCombatLevel = Math.min(126, playerCombatLevel + playerWildernessLevel);
+
+			boolean localCanAttackPlayer = playerCombatLevel >= localMinCombatLevel && playerCombatLevel <= localMaxCombatLevel;
+			boolean playerCanAttackLocal = localCombatLevel >= playerMinCombatLevel && localCombatLevel <= playerMaxCombatLevel;
+
+			return localCanAttackPlayer && playerCanAttackLocal;
+		});
+	}
+
+	public static WorldPoint getWorldLocation_Internal(){
+		return Microbot.getClientThread().runOnClientThreadOptional(() -> {
+			if (Microbot.getClient().getTopLevelWorldView().getScene().isInstance()) {
+				LocalPoint l = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), Microbot.getClient().getLocalPlayer().getWorldLocation());
+				return WorldPoint.fromLocalInstance(Microbot.getClient(), l);
+			}
+			return Microbot.getClient().getLocalPlayer().getWorldLocation();
+		}).orElse(null);
+	}
+
+	public static WorldView getWorldView_Internal() {
+		return Microbot.getClientThread().runOnClientThreadOptional(() -> {
+			Player player = Microbot.getClient().getLocalPlayer();
+			if (player == null) return null;
+			return player.getWorldView();
+		}).orElse(null);
+	}
+
+	/**
+	 * Retrieves the player's current world location as a {@link WorldPoint}.
+	 *
+	 * <p>If the player is in an instanced world, the method converts the local position
+	 * to an instanced {@link WorldPoint}. Otherwise, it returns the player's standard
+	 * world location.</p>
+	 *
+	 * @return The {@link WorldPoint} representing the player's current location.
+	 */
+	public static WorldPoint getWorldLocation() {
+		return Rs2Cache.LOCAL_PLAYER_POSITION.getValue();
+	}
+
+	public static WorldView getWorldView() {
+		return Microbot.getClient().getTopLevelWorldView();
+	}
+
+	/**
+	 * Retrieves the player's current location as an {@link Rs2WorldPoint}.
+	 *
+	 * <p>This method wraps the player's {@link WorldPoint} location into an {@link Rs2WorldPoint}.</p>
+	 *
+	 * @return An {@link Rs2WorldPoint} representing the player's current world location.
+	 */
+	public static Rs2WorldPoint getRs2WorldPoint() {
+		return new Rs2WorldPoint(getWorldLocation());
+	}
+
+	/**
+	 * Checks if the player is within a specified distance of a given {@link WorldPoint}.
+	 *
+	 * @param worldPoint The {@link WorldPoint} to check proximity to.
+	 * @param radius   The radius (in tiles) around the {@code worldPoint} to check.
+	 * @return {@code true} if the player is within the specified distance, {@code false} otherwise.
+	 */
+	public static boolean isInArea(WorldPoint worldPoint, int radius) {
+		return isInArea(worldPoint, radius, radius);
+	}
+
+	/**
+	 * Checks if the player is within a specified area around a given {@link WorldPoint}.
+	 *
+	 * @param worldPoint The {@link WorldPoint} to check proximity to.
+	 * @param xRadius    The horizontal radius (in tiles) around the {@code worldPoint}.
+	 * @param yRadius    The vertical radius (in tiles) around the {@code worldPoint}.
+	 * @return {@code true} if the player is within the specified area, {@code false} otherwise.
+	 */
+	public static boolean isInArea(WorldPoint worldPoint, int xRadius, int yRadius) {
+		// Null check for world point
+		if (worldPoint == null) {
+			return false;
+		}
+
+		// Validate radius parameters (should be non-negative)
+		if (xRadius < 0 || yRadius < 0) {
+			return false;
+		}
+
+		WorldPoint playerLocation = getWorldLocation();
+
+		// Null check for player location
+		if (playerLocation == null) {
+			return false;
+		}
+
+		// Ensure both points are on the same plane
+		if (worldPoint.getPlane() != playerLocation.getPlane()) {
+			return false;
+		}
+
+		// Simple distance check - check if player is within the rectangular radius
+		int deltaX = Math.abs(playerLocation.getX() - worldPoint.getX());
+		int deltaY = Math.abs(playerLocation.getY() - worldPoint.getY());
+
+		return deltaX <= xRadius && deltaY <= yRadius;
+	}
+
+	/**
+	 * Checks if two areas intersect - one centered on the player and another on a target {@link WorldPoint}.
+	 *
+	 * @param targetPoint    The {@link WorldPoint} to check intersection with.
+	 * @param targetXSpan    The total width (in tiles) of the area around the {@code targetPoint}.
+	 * @param targetYSpan    The total height (in tiles) of the area around the {@code targetPoint}.
+	 * @param playerXSpan    The total width (in tiles) of the area around the player's position.
+	 * @param playerYSpan    The total height (in tiles) of the area around the player's position.
+	 * @return {@code true} if the player's area intersects with the target area, {@code false} otherwise.
+	 */
+	public static boolean isPlayerAreaIntersecting(WorldPoint targetPoint, int targetXSpan, int targetYSpan,
+												   int playerXSpan, int playerYSpan) {
+		// Null check for target point
+		if (targetPoint == null) {
+			return false;
+		}
+
+		// Validate span parameters (should be non-negative)
+		if (targetXSpan < 0 || targetYSpan < 0 || playerXSpan < 0 || playerYSpan < 0) {
+			return false;
+		}
+
+		WorldPoint playerLocation = getWorldLocation();
+
+		// Null check for player location
+		if (playerLocation == null) {
+			return false;
+		}
+
+		// Ensure both points are on the same plane
+		if (targetPoint.getPlane() != playerLocation.getPlane()) {
+			return false;
+		}
+
+		// Create target area centered on targetPoint
+		WorldPoint targetSouthWest = new WorldPoint(
+				targetPoint.getX() - (targetXSpan /2),
+				targetPoint.getY() - (targetYSpan / 2),
+				targetPoint.getPlane()
+		);
+		WorldArea targetArea = new WorldArea(targetSouthWest, targetXSpan, targetYSpan);
+
+		// Create player area centered on player location
+		WorldPoint playerSouthWest = new WorldPoint(
+				playerLocation.getX() - (playerXSpan / 2),
+				playerLocation.getY() - (playerYSpan / 2),
+				playerLocation.getPlane()
+		);
+		WorldArea playerArea = new WorldArea(playerSouthWest, playerXSpan, playerYSpan);
+
+		return targetArea.intersectsWith2D(playerArea);
+	}
+
+	/**
+	 * Retrieves the player's current {@link LocalPoint} location.
+	 *
+	 * <p>This is commonly used in instanced areas where world coordinates differ from local coordinates.</p>
+	 *
+	 * @return The {@link LocalPoint} representing the player's current position.
+	 */
+	public static LocalPoint getLocalLocation() {
+		return Microbot.getClient().getLocalPlayer().getLocalLocation();
+	}
+
+	/**
+	 * Checks if the player is at full health.
+	 *
+	 * @return {@code true} if the player's boosted hitpoints level is greater than or equal to their real hitpoints level,
+	 *         {@code false} otherwise.
+	 */
+	public static boolean isFullHealth() {
+		return getBoostedSkillLevel(Skill.HITPOINTS)
+				>= getRealSkillLevel(Skill.HITPOINTS);
+	}
+
+	/**
+	 * Checks if the player is in a multi-combat area.
+	 *
+	 * @return {@code true} if the player is inside a multi-combat zone, {@code false} otherwise.
+	 */
+	public static boolean isInMulti() {
+		return Microbot.getVarbitValue(VarbitID.MULTIWAY_INDICATOR)
+				== 1;
+	}
+
+	/**
+	 * Checks if the player is currently inside their Player Owned House (POH).
+	 *
+	 * <p>This is detected by verifying two conditions:</p>
+	 * <ul>
+	 *     <li>The current scene is an instanced region (all POHs are instanced).</li>
+	 *     <li>The {@link VarbitID#POH_HOUSE_LOCATION} varbit is non-zero, which is
+	 *         set whenever the player is inside a POH. This distinguishes the POH from
+	 *         other instanced regions such as the Gauntlet or Hallowed Sepulchre.</li>
+	 * </ul>
+	 *
+	 * @return {@code true} if the player is inside a POH, {@code false} otherwise.
+	 */
+	public static boolean isInPoh() {
+		return Microbot.getClient().getTopLevelWorldView().getScene().isInstance()
+				&& Microbot.getVarbitValue(VarbitID.POH_HOUSE_LOCATION) > 0;
+	}
+
+	public static boolean drinkPrayerPotion() {
+		int maxPrayer = getRealSkillLevel(Skill.PRAYER);
+		int maxHerblore = getRealSkillLevel(Skill.HERBLORE);
+		int restoreAmount;
+
+		if (hasPotion("moonlight moth mix")) {
+			restoreAmount = 22;
+		} else if (hasPotion("moonlight potion")) {
+			int prayerRestore = (maxPrayer / 4) + 7;
+			int herbloreRestore = (int) Math.floor((maxHerblore * 3.0 / 10.0)) + 7;
+			restoreAmount = Math.max(prayerRestore, herbloreRestore);
+		} else if (hasPotion("super restore") || hasPotion("blighted super restore") ) {
+			restoreAmount = (maxPrayer / 4) + 8;
+		} else {
+			restoreAmount = (maxPrayer / 4) + 7;
+		}
+
+		int threshold = maxPrayer - restoreAmount;
+		int randomizedThreshold = Rs2Random.randomGaussian(threshold - 5, 3);
+		randomizedThreshold = Math.min(randomizedThreshold, threshold);
+		//System.out.println("Threshold: " + randomizedThreshold);
+
+		return drinkPrayerPotionAt(randomizedThreshold);
+	}
+
+	/**
+	 * Drinks a prayer potion when the player's prayer points fall below the specified threshold.
+	 *
+	 * <p><b>Priority Order:</b></p>
+	 * <ul>
+	 *     <li>Uses a Prayer Regeneration Potion first, if its effect is not active.</li>
+	 *     <li>If in the Wilderness or a PvP world, prioritizes a Blighted Super Restore.</li>
+	 *     <li>If neither of the above is available, uses a standard prayer potion variant.</li>
+	 * </ul>
+	 *
+	 * @param prayerPoints The prayer points threshold at which a potion should be consumed.
+	 * @return {@code true} if a potion was successfully consumed, {@code false} if no applicable potion was used.
+	 */
+	public static boolean drinkPrayerPotionAt(int prayerPoints) {
+		// Check if current prayer level is above the threshold
+		if (getBoostedSkillLevel(Skill.PRAYER) > prayerPoints) return false;
+
+		boolean inWilderness = Microbot.getVarbitValue(Varbits.IN_WILDERNESS) == 1;
+		boolean isInPVPWorld = Microbot.getClient().getWorldType().contains(WorldType.PVP);
+
+		// Prioritize Prayer Regeneration Potion if effect is not active
+		if (!Rs2Player.hasPrayerRegenerationActive() && usePotion(Rs2Potion.getPrayerRegenerationPotion())) return true;
+
+		// If in Wilderness or PvP world, prioritize Blighted Super Restore
+		if (inWilderness || isInPVPWorld)  {
+			if (hasPotion("blighted super restore")) {
+				return usePotion("blighted super restore");
+			}
+		}
+
+		// Use a standard prayer potion from available variants
+		return usePotion(Rs2Potion.getPrayerPotionsVariants().toArray(new String[0]));
+	}
+
+	/**
+	 * Drinks a combat-related potion for the specified skill.
+	 *
+	 * <p>This method defaults to allowing super combat potions when applicable.</p>
+	 *
+	 * @param skill The {@link Skill} for which a potion should be consumed.
+	 * @return {@code true} if a potion was successfully consumed, {@code false} otherwise.
+	 */
+	public static boolean drinkCombatPotionAt(Skill skill) {
+		return drinkCombatPotionAt(skill, true);
+	}
+
+	/**
+	 * Drinks a combat-related potion to boost the specified skill.
+	 *
+	 * <p><b>Priority Order:</b></p>
+	 * <ul>
+	 *     <li>If the current boosted level is already 5 or more above the real level, no potion is consumed.</li>
+	 *     <li>If {@code superCombat} is {@code true} and the skill is Attack, Strength, or Defence,
+	 *         a super combat potion is prioritized.</li>
+	 *     <li>If a super combat potion is not available, the method falls back to a skill-specific potion.</li>
+	 * </ul>
+	 *
+	 * @param skill       The {@link Skill} for which a potion should be consumed.
+	 * @param superCombat If {@code true}, prioritizes using a super combat potion for melee skills.
+	 * @return {@code true} if a potion was successfully consumed, {@code false} otherwise.
+	 */
+	public static boolean drinkCombatPotionAt(Skill skill, boolean superCombat) {
+		int real = getRealSkillLevel(skill);
+		int boosted = getBoostedSkillLevel(skill);
+
+		// max boost per wiki: RealLevel * (15/100) + 5
+		double maxBoost = real * 0.15 + 5;
+
+		// threshold is 20% of that max
+		double threshold = maxBoost * 0.20;
+
+		if ((boosted - real) > threshold) {
+			return false;
+		}
+
+		// If superCombat is specified and the skill is Attack, Strength, or Defence, try super combat potions first
+		if (superCombat && (skill == Skill.ATTACK || skill == Skill.STRENGTH || skill == Skill.DEFENCE)) {
+			// for Defence, exclude the basic "combat potion"
+			List<String> combatVariants = new ArrayList<>(Rs2Potion.getCombatPotionsVariants());
+			if (skill == Skill.DEFENCE) {
+				combatVariants.remove("combat potion");
+			}
+			if (usePotion(combatVariants.toArray(new String[0]))) {
+				return true;
+			}
+		}
+
+		// Then fall back to skill-specific potions based on which skill is requested
+		switch (skill) {
+			case ATTACK:
+				return usePotion(Rs2Potion.getAttackPotionsVariants().toArray(new String[0]));
+
+			case STRENGTH:
+				return usePotion(Rs2Potion.getStrengthPotionsVariants().toArray(new String[0]));
+
+			case DEFENCE:
+				return usePotion(Rs2Potion.getDefencePotionsVariants().toArray(new String[0]));
+
+			case RANGED:
+				return usePotion(Rs2Potion.getRangePotionsVariants().toArray(new String[0]));
+
+			case MAGIC:
+				return usePotion(Rs2Potion.getMagicPotionsVariants().toArray(new String[0]));
+			default:
+				return false; // If the skill is not covered, return false
+		}
+	}
+
+	/**
+	 * Drinks an anti-poison potion if the player does not have an active anti-poison effect.
+	 *
+	 * <p>If an anti-venom effect is active, no potion will be consumed.</p>
+	 *
+	 * @return {@code true} if an anti-poison potion was found and used,
+	 *         or if the player already has an anti-venom effect, {@code false} otherwise.
+	 */
+	public static boolean drinkAntiPoisonPotion() {
+		if (!hasAntiPoisonActive() || hasAntiVenomActive()) {
+			return true;
+		}
+		return usePotion(Rs2Potion.getAntiPoisonVariants().toArray(new String[0]));
+	}
+
+	/**
+	 * Drinks an anti-fire potion if the player does not have an active anti-fire effect.
+	 *
+	 * @return {@code true} if an anti-fire potion was found and used,
+	 *         or if the player already has an active anti-fire effect, {@code false} otherwise.
+	 */
+	public static boolean drinkAntiFirePotion() {
+		if (hasAntiFireActive()) {
+			return true;
+		}
+		return usePotion(Rs2Potion.getAntifirePotionsVariants().toArray(new String[0]));
+	}
+
+	/**
+	 * Drinks a goading potion if the player does not already have an active goading effect.
+	 *
+	 * @return {@code true} if a goading potion was found and used,
+	 *         {@code false} if the effect is already active or no potion was available.
+	 */
+	public static boolean drinkGoadingPotion() {
+		if (hasGoadingActive()) {
+			return false;
+		}
+		return usePotion(Rs2Potion.getGoadingPotion());
+	}
+
+	/**
+	 * Helper method to check for the presence of any item in the provided IDs and interact with it.
+	 *
+	 * @param itemIds Array of item IDs to check in the inventory.
+	 * @return true if an item was found and interacted with; false otherwise.
+	 */
+	private static boolean usePotion(Integer ...itemIds) {
+		Rs2ItemModel potion = Rs2Inventory.get(item ->
+				!item.isNoted() && Arrays.stream(itemIds).anyMatch(id -> id == item.getId())
+		);
+
+		if (potion == null) return false;
+
+		return Rs2Inventory.interact(potion, "drink");
+	}
+
+	/**
+	 * Checks for the presence of any item in the provided IDs within the inventory.
+	 *
+	 * @param itemIds Array of item IDs to check in the inventory.
+	 * @return true if an item matching the IDs exists; false otherwise.
+	 */
+	private static boolean hasPotion(Integer... itemIds) {
+		Rs2ItemModel potion = Rs2Inventory.get(item ->
+				!item.isNoted() && Arrays.stream(itemIds).anyMatch(id -> id == item.getId())
+		);
+
+		return potion != null;
+	}
+
+	/**
+	 * Helper method to check for the presence of any item in the provided names and interact with it.
+	 *
+	 * @param itemNames Array of item names to check in the inventory.
+	 * @return true if an item was found and interacted with; false otherwise.
+	 */
+	private static boolean usePotion(String... itemNames) {
+		Pattern usesRegexPattern = Pattern.compile("^(.*?)(?:\\(\\d+\\))?$");
+
+		Rs2ItemModel potion = Rs2Inventory.get(item -> {
+			if (item.isNoted()) return false;
+
+			Matcher matcher = usesRegexPattern.matcher(item.getName());
+			if (matcher.find()) {
+				String trimmedName = matcher.group(1).trim();
+				return Arrays.stream(itemNames).anyMatch(name -> name.equalsIgnoreCase(trimmedName));
+			}
+
+			return false;
+		});
+
+		if (potion == null) return false;
+
+		return Rs2Inventory.interact(potion, "drink");
+	}
+
+	/**
+	 * Checks for the presence of any item in the provided names within the inventory.
+	 *
+	 * @param itemNames Array of item names to check in the inventory.
+	 * @return true if an item matching the names exists; false otherwise.
+	 */
+	private static boolean hasPotion(String... itemNames) {
+		Pattern usesRegexPattern = Pattern.compile("^(.*?)(?:\\(\\d+\\))?$");
+
+		Rs2ItemModel potion = Rs2Inventory.get(item -> {
+			if (item.isNoted()) return false;
+
+			Matcher matcher = usesRegexPattern.matcher(item.getName());
+			if (matcher.find()) {
+				String trimmedName = matcher.group(1).trim();
+				return Arrays.stream(itemNames).anyMatch(name -> name.equalsIgnoreCase(trimmedName));
+			}
+
+			return false;
+		});
+
+		return potion != null;
+	}
+
+	/**
+	 * Checks if the player has any remaining prayer points.
+	 *
+	 * @return {@code true} if the player's boosted prayer level is greater than zero, {@code false} otherwise.
+	 */
+	public static boolean hasPrayerPoints() {
+		return getBoostedSkillLevel(Skill.PRAYER) > 0;
+	}
+
+	/**
+	 * Calculates the player's current prayer level as a percentage of their base prayer level.
+	 *
+	 * @return a value between 0 and 100 representing the percentage of prayer remaining.
+	 */
+	public static int getPrayerPercentage() {
+		int current = getBoostedSkillLevel(Skill.PRAYER);
+		int base = getRealSkillLevel(Skill.PRAYER);
+
+		return (int) ((current / (double) base) * 100);
+	}
+
+	/**
+	 * Checks if the player is currently standing on a game object.
+	 *
+	 * @return {@code true} if a game object exists at the player's current location, {@code false} otherwise.
+	 */
+	public static boolean isStandingOnGameObject() {
+		WorldPoint playerPoint = getWorldLocation();
+		return Rs2GameObject.getGameObject(o -> Objects.equals(playerPoint, o.getWorldLocation())) != null || isStandingOnGroundItem();
+	}
+
+	/**
+	 * Checks if the player is currently standing on a ground item.
+	 *
+	 * @return {@code true} if there are any ground items at the player's current location, {@code false} otherwise.
+	 */
+	public static boolean isStandingOnGroundItem() {
+		WorldPoint playerPoint = getWorldLocation();
+		return Rs2GroundItem.getGroundItems().values().stream().anyMatch(x -> x.getLocation().equals(playerPoint));
+	}
+
+	/**
+	 * Retrieves the player's current animation ID.
+	 *
+	 * @return The animation ID of the player's current action, or {@code -1} if the player is null.
+	 */
+	public static int getAnimation() {
+		return Microbot.getClientThread().runOnClientThreadOptional(() -> {
+			if (Microbot.getClient() == null || Microbot.getClient().getLocalPlayer() == null) return -1;
+			return Microbot.getClient().getLocalPlayer().getAnimation();
+		}).orElse(-1);
+	}
+
+	/**
+	 * Retrieves the player's current pose animation ID.
+	 *
+	 * @return The pose animation ID of the player.
+	 */
+	public static int getPoseAnimation() {
+		return Microbot.getClientThread().runOnClientThreadOptional(() ->
+				Microbot.getClient().getLocalPlayer().getPoseAnimation()
+		).orElse(-1);
+	}
+
+	/**
+	 * Retrieves the current state of a specified quest.
+	 *
+	 * @param quest The {@link Quest} to check.
+	 * @return The {@link QuestState} representing the player's progress in the quest.
+	 */
+	public static QuestState getQuestState(Quest quest) {
+		return Microbot.getRs2PlayerStateCache().getQuestState(quest);
+	}
+
+	/**
+	 * Retrieves the player's real (unboosted) level for a given skill.
+	 *
+	 * @param skill The {@link Skill} to check.
+	 * @return The player's real level for the specified skill.
+	 */
+	public static int getRealSkillLevel(Skill skill) {
+		return Microbot.getClientThread().runOnClientThreadOptional(() ->
+				Microbot.getClient().getRealSkillLevel(skill)
+		).orElse(0);
+	}
+
+	/**
+	 * Retrieves the player's current boosted level for a given skill.
+	 *
+	 * @param skill The {@link Skill} to check.
+	 * @return The player's boosted level for the specified skill.
+	 */
+	public static int getBoostedSkillLevel(Skill skill) {
+		return Microbot.getClientThread().runOnClientThreadOptional(() ->
+				Microbot.getClient().getBoostedSkillLevel(skill)
+		).orElse(0);
+	}
+
+	/**
+	 * Checks if the player meets the required level for a given skill.
+	 *
+	 * <p>The method allows checking against either the real skill level or the boosted skill level.</p>
+	 *
+	 * @param skill        The {@link Skill} to check.
+	 * @param levelRequired The required level for the skill.
+	 * @param isBoosted    {@code true} to check against the boosted skill level, {@code false} to check against the real skill level.
+	 * @return {@code true} if the player meets or exceeds the required level, {@code false} otherwise.
+	 */
+	public static boolean getSkillRequirement(Skill skill, int levelRequired, boolean isBoosted) {
+		if (isBoosted) return getBoostedSkillLevel(skill) >= levelRequired;
+		return getRealSkillLevel(skill) >= levelRequired;
+	}
+
+	/**
+	 * Checks if the player meets the required real level for a given skill.
+	 *
+	 * <p>This method is a shorthand for {@code getSkillRequirement(skill, levelRequired, false)}.</p>
+	 *
+	 * @param skill        The {@link Skill} to check.
+	 * @param levelRequired The required level for the skill.
+	 * @return {@code true} if the player's real skill level meets or exceeds the required level, {@code false} otherwise.
+	 */
+	public static boolean getSkillRequirement(Skill skill, int levelRequired) {
+		return getSkillRequirement(skill, levelRequired, false);
+	}
+
+	/**
+	 * Checks if the player is an Ironman or Hardcore Ironman.
+	 *
+	 * <p>Account types are determined based on the {@link Varbits#ACCOUNT_TYPE} value:</p>
+	 * <ul>
+	 *     <li>1 - Ironman</li>
+	 *     <li>2 - Hardcore Ironman</li>
+	 *     <li>3 - Ultimate Ironman</li>
+	 * </ul>
+	 *
+	 * @return {@code true} if the player is an Ironman, Hardcore Ironman, or Ultimate Ironman, {@code false} otherwise.
+	 */
+	public static boolean isIronman() {
+		int accountType = Microbot.getVarbitValue(Varbits.ACCOUNT_TYPE);
+		return accountType > 0 && accountType <= 3;
+	}
+
+	/**
+	 * Checks if the player is a Group Ironman.
+	 *
+	 * <p>Group Ironman account types are determined based on the {@link Varbits#ACCOUNT_TYPE} value:</p>
+	 * <ul>
+	 *     <li>4 - Group Ironman</li>
+	 *     <li>5 - Hardcore Group Ironman</li>
+	 * </ul>
+	 *
+	 * @return {@code true} if the player is a Group Ironman or Hardcore Group Ironman, {@code false} otherwise.
+	 */
+	public static boolean isGroupIronman() {
+		int accountType = Microbot.getVarbitValue(Varbits.ACCOUNT_TYPE);
+		return accountType >= 4;
+	}
+
+	/**
+	 * Retrieves the player's current world.
+	 *
+	 * @return The world number the player is currently in.
+	 */
+	public static int getWorld() {
+		return Microbot.getClient().getWorld();
+	}
+
+	/**
+	 * Calculates the distance from the player's current location to a specified endpoint.
+	 *
+	 * <p><b>Note:</b> This method uses the ShortestPath algorithm and does not work in instanced regions.
+	 * If the player is in an instance, it falls back to a direct {@link WorldPoint#distanceTo(WorldPoint)} calculation.</p>
+	 *
+	 * @param endpoint The target {@link WorldPoint} to measure the distance to.
+	 * @return The distance between the player's current location and the endpoint.
+	 */
+	public static int distanceTo(WorldPoint endpoint) {
+		if (Microbot.getClient().getTopLevelWorldView().getScene().isInstance()) {
+			return getWorldLocation().distanceTo(endpoint);
+		}
+		return Rs2Walker.getDistanceBetween(getWorldLocation(), endpoint);
+	}
+
+	/**
+	 * Checks if the player is at risk of logging out due to inactivity.
+	 *
+	 * <p>This method determines the lowest idle time between mouse and keyboard activity
+	 * and compares it to the client's idle timeout, factoring in a specified random delay.</p>
+	 *
+	 * @param randomDelay The time (in ticks) to subtract from the client's idle timeout
+	 *                    to introduce variability in detecting inactivity.
+	 * @return {@code true} if the player's idle time exceeds or equals the adjusted timeout, {@code false} otherwise.
+	 */
+	public static boolean checkIdleLogout(long randomDelay) {
+		long idleClientTicks = Long.min(
+				Microbot.getClient().getMouseIdleTicks(),
+				Microbot.getClient().getKeyboardIdleTicks()
+		);
+
+		return idleClientTicks >= Microbot.getClient().getIdleTimeout() - randomDelay;
+	}
+
+	/**
+	 * Checks whether the player is in a cave.
+	 *
+	 * <p>A player is considered to be in a cave if their {@link WorldPoint#getY()} coordinate
+	 * is 6400 or higher and they are not in an instanced world.</p>
+	 *
+	 * @return {@code true} if the player is inside a cave, {@code false} otherwise.
+	 */
+	public static boolean isInCave() {
+		return Rs2Player.getWorldLocation().getY() >= 6400
+				&& !Microbot.getClient().getTopLevelWorldView().isInstance();
+	}
+
+	/**
+	 * Checks whether the player is currently in an instanced world.
+	 *
+	 * @return {@code true} if the player is in an instanced world, {@code false} otherwise.
+	 */
+	public static boolean IsInInstance() {
+		return Microbot.getClient().getTopLevelWorldView().getScene().isInstance();
+	}
+
+	/**
+	 * Retrieves the player's current run energy as a percentage.
+	 *
+	 * <p>Run energy is stored in the client as an integer value (e.g., 7500 for 75.00%).
+	 * This method converts it to a whole number percentage.</p>
+	 *
+	 * @return The player's run energy as an integer percentage (0-100).
+	 */
+	public static int getRunEnergy() {
+		return Microbot.getClient().getEnergy() / 100;
+	}
+
+	/**
+	 * Checks if the player has an active stamina effect.
+	 *
+	 * <p>A stamina effect reduces the rate at which run energy depletes.
+	 * This method checks the {@link Varbits#RUN_SLOWED_DEPLETION_ACTIVE} value.</p>
+	 *
+	 * @return {@code true} if the stamina effect is active, {@code false} otherwise.
+	 */
+	public static boolean hasStaminaActive() {
+		return Microbot.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE) != 0;
+	}
+
+	/**
+	 * Retrieves the current graphic ID of the local player.
+	 *
+	 * <p>This ID represents the graphical effect currently applied to the player,
+	 * such as spell casts or special attack animations.</p>
+	 *
+	 * @return The graphic ID of the local player.
+	 */
+	public static int getGraphicId() {
+		return Microbot.getClient().getLocalPlayer().getGraphic();
+	}
+
+	/**
+	 * Checks if the local player has a specific spot animation active.
+	 *
+	 * <p>Spot animations (also known as graphics IDs) are special visual effects
+	 * applied to the player, such as teleportation effects or status conditions.</p>
+	 *
+	 * @param graphicId The graphic ID of the spot animation to check. See {@link GraphicID} for predefined values.
+	 * @return {@code true} if the local player has the specified spot animation, {@code false} otherwise.
+	 */
+	public static boolean hasSpotAnimation(int graphicId) {
+		return Microbot.getClient().getLocalPlayer().hasSpotAnim(graphicId);
+	}
+
+	/**
+	 * Checks if the local player is currently stunned.
+	 *
+	 * <p>A player is considered stunned if they have the spot animation with graphic ID {@code 245} active.</p>
+	 *
+	 * @return {@code true} if the player is stunned, {@code false} otherwise.
+	 */
+	public static boolean isStunned() {
+		return hasSpotAnimation(245);
+	}
+
+	/**
+	 * Invokes the "attack" action on the specified player.
+	 *
+	 * <p>This method interacts with the specified {@link Rs2PlayerModel} to initiate an attack.</p>
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} representing the player to attack.
+	 * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
+	 */
+	public static boolean attack(Rs2PlayerModel rs2Player) {
+		return invokeMenu(rs2Player, "attack");
+	}
+
+	/**
+	 * Invokes the "walk here" action to move to the same location as the specified player.
+	 *
+	 * <p>This method interacts with the specified {@link Rs2PlayerModel} to initiate movement to their position.</p>
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} representing the player under whose position to walk.
+	 * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
+	 */
+	public static boolean walkUnder(Rs2PlayerModel rs2Player) {
+		return invokeMenu(rs2Player, "walk here");
+	}
+
+	/**
+	 * Invokes the "trade with" action on the specified player.
+	 *
+	 * <p>This method interacts with the specified {@link Rs2PlayerModel} to initiate a trade.</p>
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} representing the player to trade with.
+	 * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
+	 */
+	public static boolean trade(Rs2PlayerModel rs2Player) {
+		return invokeMenu(rs2Player, "trade with");
+	}
+
+	/**
+	 * Invokes the "follow" action on the specified player.
+	 *
+	 * <p>This method interacts with the specified {@link Rs2PlayerModel} to initiate following them.</p>
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} representing the player to follow.
+	 * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
+	 */
+	public static boolean follow(Rs2PlayerModel rs2Player) {
+		return invokeMenu(rs2Player, "follow");
+	}
+
+	/**
+	 * Invokes the "cast" action on the specified player.
+	 *
+	 * <p>This method interacts with the specified {@link Rs2PlayerModel} to cast a spell or ability on them.</p>
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} to cast on.
+	 * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
+	 */
+	public static boolean cast(Rs2PlayerModel rs2Player) {
+		return invokeMenu(rs2Player, "cast");
+	}
+
+	/**
+	 * Selects the "USE" option on a player for an item that is already selected via {@code Rs2Inventory.use(item)}.
+	 *
+	 * <p>This method interacts with the specified {@link Rs2PlayerModel} to use the selected item on them.</p>
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} to use the item on.
+	 * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
+	 */
+	public static boolean use(Rs2PlayerModel rs2Player) {
+		return invokeMenu(rs2Player, "use");
+	}
+
+	/**
+	 * Selects the "CHALLENGE" option on a player for Soul Wars.
+	 *
+	 * <p>This method interacts with the specified {@link Rs2PlayerModel} to issue a challenge.</p>
+	 *
+	 * @param rs2Player The {@link Rs2PlayerModel} to challenge.
+	 * @return {@code true} if the action was invoked successfully, {@code false} otherwise.
+	 */
+	public static boolean challenge(Rs2PlayerModel rs2Player) {
+		return invokeMenu(rs2Player, "challenge");
+	}
+
+	/**
+	 * Executes a specific menu action on a given player.
+	 *
+	 * @param rs2Player the player to interact with
+	 * @param action the action to invoke (e.g., "attack", "walk here", "trade with", "follow")
+	 * @return true if the action was invoked successfully, false otherwise
+	 */
+
+	private static boolean invokeMenu(Rs2PlayerModel rs2Player, String action) {
+		if (rs2Player == null) return false;
+
+		// Set the current status for the action being performed
+		Microbot.status = action + " " + rs2Player.getName();
+
+		// Determine the appropriate menu action based on the action string
+		MenuAction menuAction = MenuAction.CC_OP;
+
+		if(action.equalsIgnoreCase("attack")) {
+			menuAction = MenuAction.PLAYER_SECOND_OPTION;
+		} else if (action.equalsIgnoreCase("walk here")) {
+			menuAction = MenuAction.WALK;
+		} else if (action.equalsIgnoreCase("follow")) {
+			menuAction = MenuAction.PLAYER_THIRD_OPTION;
+		} else if (action.equalsIgnoreCase("challenge")) {
+			menuAction = MenuAction.PLAYER_FIRST_OPTION;
+		} else if (action.equalsIgnoreCase("trade with")) {
+			menuAction = MenuAction.PLAYER_FOURTH_OPTION;
+		} else if (action.equalsIgnoreCase("cast")) {
+			menuAction = MenuAction.WIDGET_TARGET_ON_PLAYER;
+		}else if (action.equalsIgnoreCase("use")) {
+			menuAction = MenuAction.WIDGET_TARGET_ON_PLAYER;
+		}
+
+		// Invoke the menu entry using the selected action
+		Microbot.doInvoke(
+				new NewMenuEntry()
+						.param0(0)
+						.param1(0)
+						.opcode(menuAction.getId())
+						.identifier(rs2Player.getId())
+						.itemId(-1)
+						.target(rs2Player.getName())
+						.actor(rs2Player),
+				Rs2UiHelper.getActorClickbox(rs2Player)
+		);
+
+		return true;
+	}
+
+	/**
+	 * Retrieves the actor that the local player is currently interacting with.
+	 *
+	 * @return The interacting actor as an {@link Actor} object. If the interacting actor is an NPC,
+	 *         it returns an {@link Rs2NpcModel} object. If the local player is not interacting with anyone,
+	 *         or if the local player is null, it returns null.
+	 */
+	public static Actor getInteracting() {
+		Optional<Actor> result = Microbot.getClientThread().runOnClientThreadOptional(() -> {
+			if (Microbot.getClient().getLocalPlayer() == null) return null;
+
+			var interactingActor = Microbot.getClient().getLocalPlayer().getInteracting();
+
+			if (interactingActor instanceof net.runelite.api.NPC) {
+				return new Rs2NpcModel((NPC) interactingActor);
+			}
+
+			return interactingActor;
+		});
+
+		return result.orElse(null);
+	}
+	/**
+	 * Checks if the player has finished Tutorial Island.
+	 *
+	 * <p>This method checks the player's progress on Tutorial Island by retrieving the value of Varbit 281.
+	 * If the value is greater than or equal to 1000, it indicates that the player has completed Tutorial Island.</p>
+	 *
+	 * @return {@code true} if the player has finished Tutorial Island, {@code false} otherwise.
+	 */
+	public static boolean hasCompletedTutorialIsland() {
+		return Microbot.getVarbitPlayerValue(281) >= 1000;
+	}
 }


### PR DESCRIPTION
Many of the recent methods that need to now be run on the client thread are used as if they are free in many places currently.  From my observations any attempt to run anything on the client thread is now an automatic 50ms cost.  

To help facilitate faster scripts this change adds a global caching mechanism.  This change was specifically targeted at the WebWalker that currently is not able to keep up with a player running.  From my eye ball measurements caching just these 2 methods results in roughly a 3.5x speedup (350ms -> 100ms) for the processWalk loop.

For more efficiency we should really consider a system that caches all "common" values on the first time we go to the client thread for any value instead of going for each one, but this naive approach was good enough for the part I cared about.