### PR TITLE
feat(cache): implement global per-tick value caching mechanism

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/Rs2Cache.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/Rs2Cache.java
@@ -1,0 +1,95 @@
+package net.runelite.client.plugins.microbot.util;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Global per-tick value cache.
+ *
+ * <p>Each entry stores its own populator. Calling {@link #getValue()} returns the
+ * cached value when the stored tick matches the current game tick; otherwise the
+ * populator is invoked, the result is stored with the current tick, and then returned.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * List<NPC> npcs = Rs2Cache.NPCS.getValue();
+ * Player local = Rs2Cache.LOCAL_PLAYER.getValue();
+ * }</pre>
+ */
+public enum Rs2Cache {
+
+    LOCAL_PLAYER_POSITION(Rs2Player::getWorldLocation_Internal),
+    LOCAL_PLAYER_WORLD_VIEW(Rs2Player::getWorldView_Internal),
+    ;
+
+    // ---------------------------------------------------------------------------
+    // Internal state
+    // ---------------------------------------------------------------------------
+
+    private static final Map<Rs2Cache, Entry> CACHE = new EnumMap<>(Rs2Cache.class);
+
+    private final Supplier<Object> populator;
+
+    Rs2Cache(Supplier<Object> populator) {
+        this.populator = populator;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Public API
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Returns the cached value for this entry.
+     *
+     * <p>If the value was already computed on the current game tick it is returned
+     * directly. Otherwise the populator is called, the result is cached alongside
+     * the current tick, and then returned.
+     *
+     * @param <T> expected return type
+     * @return the (possibly freshly populated) cached value
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getValue() {
+        int currentTick = Microbot.getClient().getTickCount();
+        Entry entry = CACHE.get(this);
+        if (entry != null && entry.tick == currentTick) {
+            return (T) entry.value;
+        }
+        Object value = populator.get();
+        CACHE.put(this, new Entry(value, currentTick));
+        return (T) value;
+    }
+
+    /**
+     * Invalidates the cached value for this entry, forcing a fresh call to the
+     * populator on the next {@link #getValue()} invocation.
+     */
+    public void invalidate() {
+        CACHE.remove(this);
+    }
+
+    /**
+     * Invalidates all cached entries.
+     */
+    public static void invalidateAll() {
+        CACHE.clear();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Internal helpers
+    // ---------------------------------------------------------------------------
+
+    private static final class Entry {
+        final Object value;
+        final int tick;
+
+        Entry(Object value, int tick) {
+            this.value = value;
+            this.tick = tick;
+        }
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/Rs2Cache.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/Rs2Cache.java
@@ -3,8 +3,8 @@ package net.runelite.client.plugins.microbot.util;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 
-import java.util.EnumMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 /**
@@ -30,7 +30,7 @@ public enum Rs2Cache {
     // Internal state
     // ---------------------------------------------------------------------------
 
-    private static final Map<Rs2Cache, Entry> CACHE = new EnumMap<>(Rs2Cache.class);
+    private static final Map<Rs2Cache, Entry> CACHE = new ConcurrentHashMap<>();
 
     private final Supplier<Object> populator;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
@@ -1563,11 +1563,11 @@ public class Rs2GameObject {
     }
 
 	private static LocalPoint localPointFromWorldSafe(WorldPoint anchor) {
-		if(Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.getValue() == null){
+		WorldView worldView = Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.getValue();
+		if (worldView == null) {
 			return null;
 		}
-
-		return LocalPoint.fromWorld(Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.<WorldView>getValue(), anchor);
+		return LocalPoint.fromWorld(worldView, anchor);
 	}
 
     public static Optional<String> getCompositionName(TileObject obj) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
@@ -7,6 +7,7 @@ import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.Rs2Cache;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.bank.enums.BankLocation;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
@@ -1561,13 +1562,13 @@ public class Rs2GameObject {
         return to -> isWithinTiles(anchor, to.getLocalLocation(), distance);
     }
 
-    private static LocalPoint localPointFromWorldSafe(WorldPoint anchor) {
-        return Microbot.getClientThread().runOnClientThreadOptional(() -> {
-            Player player = Microbot.getClient().getLocalPlayer();
-            if (player == null) return null;
-            return LocalPoint.fromWorld(player.getWorldView(), anchor);
-        }).orElse(null);
-    }
+	private static LocalPoint localPointFromWorldSafe(WorldPoint anchor) {
+		if(Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.getValue() == null){
+			return null;
+		}
+
+		return LocalPoint.fromWorld(Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.<WorldView>getValue(), anchor);
+	}
 
     public static Optional<String> getCompositionName(TileObject obj) {
         ObjectComposition comp = convertToObjectComposition(obj);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -15,6 +15,7 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.api.boat.Rs2BoatCache;
 import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
+import net.runelite.client.plugins.microbot.util.Rs2Cache;
 import net.runelite.client.plugins.microbot.util.coords.Rs2WorldPoint;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
@@ -953,24 +954,59 @@ public class Rs2Player {
         });
     }
 
-    /**
-     * Retrieves the player's current world location as a {@link WorldPoint}.
-     *
-     * <p>If the player is in an instanced world, the method converts the local position 
-     * to an instanced {@link WorldPoint}. Otherwise, it returns the player's standard 
-     * world location.</p>
-     *
-     * @return The {@link WorldPoint} representing the player's current location.
-     */
-    public static WorldPoint getWorldLocation() {
-        return Microbot.getClientThread().runOnClientThreadOptional(() -> {
-            if (Microbot.getClient().getTopLevelWorldView().getScene().isInstance()) {
-                LocalPoint l = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), Microbot.getClient().getLocalPlayer().getWorldLocation());
-                return WorldPoint.fromLocalInstance(Microbot.getClient(), l);
-            }
-            return Microbot.getClient().getLocalPlayer().getWorldLocation();
-        }).orElse(null);
-    }
+	/**
+	 * Retrieves the player's current world location as a {@link WorldPoint} from the client thread.
+	 *
+	 * <p>If the player is in an instanced world, the method converts the local position
+	 * to an instanced {@link WorldPoint}. Otherwise, it returns the player's standard
+	 * world location.</p>
+	 *
+	 * @return The {@link WorldPoint} representing the player's current location, or {@code null} if unavailable.
+	 */
+	public static WorldPoint getWorldLocation_Internal(){
+		return Microbot.getClientThread().runOnClientThreadOptional(() -> {
+			if (Microbot.getClient().getTopLevelWorldView().getScene().isInstance()) {
+				LocalPoint l = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), Microbot.getClient().getLocalPlayer().getWorldLocation());
+				return WorldPoint.fromLocalInstance(Microbot.getClient(), l);
+			}
+			return Microbot.getClient().getLocalPlayer().getWorldLocation();
+		}).orElse(null);
+	}
+
+	/**
+	 * Retrieves the player's current {@link WorldView} from the client thread.
+	 *
+	 * @return The {@link WorldView} representing the player's current world view, or {@code null} if unavailable.
+	 */
+	public static WorldView getWorldView_Internal() {
+		return Microbot.getClientThread().runOnClientThreadOptional(() -> {
+			Player player = Microbot.getClient().getLocalPlayer();
+			if (player == null) return null;
+			return player.getWorldView();
+		}).orElse(null);
+	}
+
+	/**
+	 * Retrieves the player's current world location as a {@link WorldPoint}.
+	 *
+	 * <p>If the player is in an instanced world, the method converts the local position
+	 * to an instanced {@link WorldPoint}. Otherwise, it returns the player's standard
+	 * world location.</p>
+	 *
+	 * @return The {@link WorldPoint} representing the player's current location.
+	 */
+	public static WorldPoint getWorldLocation() {
+		return Rs2Cache.LOCAL_PLAYER_POSITION.getValue();
+	}
+
+	/**
+	 * Retrieves the player's current {@link WorldView}.
+	 *
+	 * @return The {@link WorldView} representing the player's current world view, or {@code null} if unavailable.
+	 */
+	public static WorldView getWorldView() {
+		return Microbot.getClient().getTopLevelWorldView();
+	}
 
     /**
      * Retrieves the player's current location as an {@link Rs2WorldPoint}.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -1005,7 +1005,7 @@ public class Rs2Player {
 	 * @return The {@link WorldView} representing the player's current world view, or {@code null} if unavailable.
 	 */
 	public static WorldView getWorldView() {
-		return Microbot.getClient().getTopLevelWorldView();
+		return Rs2Cache.LOCAL_PLAYER_WORLD_VIEW.getValue();
 	}
 
     /**


### PR DESCRIPTION
Many of the recent methods that need to now be run on the client thread are used as if they are free in many places currently.  From my observations any attempt to run anything on the client thread is now an automatic 50ms cost.  

To help facilitate faster scripts this change adds a global caching mechanism.  This change was specifically targeted at the WebWalker that currently is not able to keep up with a player running.  From my eye ball measurements caching just these 2 methods results in roughly a 3.5x speedup (350ms -> 100ms) for the processWalk loop.

For more efficiency we should really consider a system that caches all "common" values on the first time we go to the client thread for any value instead of going for each one, but this naive approach was good enough for the part I cared about.