### PR TITLE
fix(loot): use dead player's location in onPlayerDespawned

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/LootManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/LootManager.java
@@ -66,7 +66,6 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ServerNpcLoot;
 import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.events.PlayerLootReceived;
-import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.util.Text;
 
 @Singleton
@@ -162,7 +161,7 @@ public class LootManager
 			return;
 		}
 
-		final WorldPoint worldPoint = Rs2Player.getWorldLocation();
+		final WorldPoint worldPoint = player.getWorldLocation();
 		final LocalPoint location = LocalPoint.fromWorld(client, worldPoint);
 		if (location == null || killPoints.contains(worldPoint))
 		{


### PR DESCRIPTION
The getWorldLocation() refactor incorrectly replaced player.getWorldLocation() (the despawned player) with Rs2Player.getWorldLocation() (the local player). This caused PvP loot tracking to record loot at the wrong position.