### PR TITLE
fix(events): re-queue blocking event on concurrent CAS failure

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEventManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/BlockingEventManager.java
@@ -175,7 +175,8 @@ public class BlockingEventManager
 
         if (!isRunning.compareAndSet(false, true))
         {
-            // if somebody else started in the meantime, we consider it “busy”
+            // if somebody else started in the meantime, re-queue the event and report busy
+            eventQueue.offer(event);
             return true;
         }
 


### PR DESCRIPTION
When two threads call shouldBlockAndProcess() concurrently, the second thread dequeues an event but fails the compareAndSet. The event was silently lost — never executed, never re-queued. Now the event is offered back to the queue before returning.