### PR TITLE
fix(shop): add missing break in Value switch case

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/shop/Rs2Shop.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/shop/Rs2Shop.java
@@ -389,6 +389,7 @@ public class Rs2Shop {
                 // Logic to check Value of item
                 identifier = 1;
                 param1 = 19660816;
+                break;
             case "Buy 1":
                 // Logic to sell one item
                 identifier = 2;


### PR DESCRIPTION
The "Value" case was missing a break statement, causing fall-through into "Buy 1" which overwrote the identifier from 1 to 2. This made the Value action always perform Buy 1 instead.