### PR TITLE
fix(gameobject): remove redundant double filtering in findObjectById

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject.java
@@ -230,7 +230,7 @@ public class Rs2GameObject {
 	@Deprecated
     public static TileObject findObjectById(int id) {
         var list = getAll(o -> o.getId() == id);
-        return list.stream().filter(x -> x.getId() == id).findFirst().orElse(null);
+        return list.stream().findFirst().orElse(null);
     }
 
     @Deprecated


### PR DESCRIPTION
Removes the redundant .filter(x -> x.getId() == id) in Rs2GameObject.findObjectById() since getAll() already applies that filter.