### PR TITLE
fix(walker): clarify compound assignment in isNearPath()

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -2071,7 +2071,9 @@ public class Rs2Walker {
         final WorldPoint loc = Rs2Player.getWorldLocation();
         if (loc == null) return true;
 
-        if (config.recalculateDistance() < 0 || lastPosition.equals(lastPosition = loc)) {
+        boolean positionUnchanged = lastPosition != null && lastPosition.equals(loc);
+        lastPosition = loc;
+        if (config.recalculateDistance() < 0 || positionUnchanged) {
             return true;
         }
 


### PR DESCRIPTION
Replace the confusing expression `lastPosition.equals(lastPosition = loc)` with explicit steps: check equality first, then assign. Also adds a null check for lastPosition to prevent a potential NPE if isNearPath() is called before lastPosition is initialized.