### PR TITLE
Improve potion and canoe functionalities

### DIFF
--- a/docs/AGENT_SERVER.md
+++ b/docs/AGENT_SERVER.md
@@ -328,18 +328,57 @@ Body: `{"name": "Dragon bones"}` or `{"id": 536}`
 
 #### POST /walk
 
-Body: `{"x": 3100, "y": 3500, "plane": 0}` (plane defaults to 0)
+Body: `{"x": 3100, "y": 3500, "plane": 0, "wait": false, "timeout": 30}`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `x`, `y` | required | Destination world coordinates |
+| `plane` | `0` | Destination plane |
+| `wait` | `false` | If `true`, blocks until the walk arrives or `timeout` elapses. If `false`, returns immediately after kicking the walk off on a background thread. |
+| `timeout` | `30` (max `600`) | Seconds to wait when `wait=true` |
+
+Walking is non-blocking by default — long routes used to exceed the CLI's curl timeout and produce broken-pipe errors. Poll `/state` to check the player's position, or pass `--wait` to block.
 
 ```bash
 ./microbot-cli walk 3100 3500
 ./microbot-cli walk 3100 3500 1
+./microbot-cli walk 3100 3500 --wait --timeout 120
 ```
+
+Non-blocking response:
 
 ```json
 {
-  "success": true,
   "destination": {"x": 3100, "y": 3500, "plane": 0},
+  "success": true,
+  "walking": true,
+  "message": "Walk initiated",
+  "playerPosition": {"x": 3200, "y": 3400, "plane": 0}
+}
+```
+
+Blocking response (`wait=true`):
+
+```json
+{
+  "destination": {"x": 3100, "y": 3500, "plane": 0},
+  "success": true,
+  "walking": false,
+  "state": "ARRIVED",
   "playerPosition": {"x": 3100, "y": 3500, "plane": 0}
+}
+```
+
+Blocking timeout response:
+
+```json
+{
+  "destination": {"x": 3100, "y": 3500, "plane": 0},
+  "success": false,
+  "walking": true,
+  "timedOut": true,
+  "message": "Walk did not complete within 30s; still in progress",
+  "playerPosition": {"x": 3150, "y": 3450, "plane": 0}
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ project.build.group=net.runelite
 project.build.version=1.12.23
 
 glslang.path=
-microbot.version=2.2.0
+microbot.version=2.2.1
 microbot.commit.sha=nogit
 microbot.repo.url=http://138.201.81.246:8081/repository/microbot-snapshot/
 microbot.repo.username=

--- a/microbot-cli
+++ b/microbot-cli
@@ -45,7 +45,9 @@ Ground Items:
   ground-items pickup <name>             Pick up nearest ground item
 
 Movement:
-  walk <x> <y> [plane]                   Walk to coordinates
+  walk <x> <y> [plane] [--wait] [--timeout SECONDS]
+                                         Walk to coordinates (non-blocking by default;
+                                         --wait blocks until arrival or timeout, default 30s)
 
 Banking:
   bank                                   Bank status (open/closed, items)
@@ -309,9 +311,32 @@ case "$1" in
         ;;
 
     walk)
-        [[ $# -lt 3 ]] && { echo '{"error":"Usage: microbot-cli walk <x> <y> [plane]"}'; exit 1; }
-        plane="${4:-0}"
-        do_post "${BASE}/walk" "{\"x\":$2,\"y\":$3,\"plane\":${plane}}"
+        [[ $# -lt 3 ]] && { echo '{"error":"Usage: microbot-cli walk <x> <y> [plane] [--wait] [--timeout SECONDS]"}'; exit 1; }
+        walk_x="$2"
+        walk_y="$3"
+        walk_plane=0
+        walk_wait="false"
+        walk_timeout=30
+        shift 3
+        if [[ $# -gt 0 ]] && [[ "$1" != --* ]]; then
+            walk_plane="$1"
+            shift
+        fi
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --wait) walk_wait="true"; shift ;;
+                --timeout) walk_timeout="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        walk_body="{\"x\":${walk_x},\"y\":${walk_y},\"plane\":${walk_plane},\"wait\":${walk_wait},\"timeout\":${walk_timeout}}"
+        if [[ "$walk_wait" == "true" ]]; then
+            curl_timeout=$((walk_timeout + 5))
+            curl -sf --max-time "$curl_timeout" -X POST -H "Content-Type: application/json" -d "$walk_body" "${BASE}/walk" 2>/dev/null \
+                || { echo '{"error":"Connection refused - is the Agent Server plugin enabled?"}'; exit 1; }
+        else
+            do_post "${BASE}/walk" "$walk_body"
+        fi
         ;;
 
     bank)

--- a/microbot-cli
+++ b/microbot-cli
@@ -33,15 +33,15 @@ Inventory:
   inventory drop <name> [--all]          Drop item(s)
 
 NPCs:
-  npcs [--name Guard] [--distance 20] [--limit N]
+  npcs [--name Guard] [--name-contains Guar] [--id 3265] [--distance 20] [--limit N]
   npcs interact <name> <action>          Interact with nearest NPC
 
 Objects:
-  objects [--name "Oak tree"] [--distance 20] [--limit N]
+  objects [--name "Oak tree"] [--name-contains Oak] [--id 1278] [--distance 20] [--limit N]
   objects interact <name> <action>       Interact with nearest object
 
 Ground Items:
-  ground-items [--name Bones] [--distance 20] [--limit N]
+  ground-items [--name Bones] [--name-contains Bone] [--id 526] [--distance 20] [--limit N]
   ground-items pickup <name>             Pick up nearest ground item
 
 Movement:
@@ -119,13 +119,15 @@ build_query() {
 }
 
 parse_named_args() {
-    NAME_OUT="" DISTANCE_OUT="" LIMIT_OUT=""
+    NAME_OUT="" DISTANCE_OUT="" LIMIT_OUT="" ID_OUT="" NAME_CONTAINS_OUT=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --name) NAME_OUT="$2"; shift 2 ;;
+            --name-contains) NAME_CONTAINS_OUT="$2"; shift 2 ;;
+            --id) ID_OUT="$2"; shift 2 ;;
             --distance) DISTANCE_OUT="$2"; shift 2 ;;
             --limit) LIMIT_OUT="$2"; shift 2 ;;
-            *) shift ;;
+            *) echo "{\"error\":\"Unknown flag: $1\"}" >&2; shift ;;
         esac
     done
 }
@@ -258,7 +260,7 @@ case "$1" in
         [[ $# -lt 2 ]] || [[ "$2" == --* ]] && {
             shift
             parse_named_args "$@"
-            q=$(build_query "name" "${NAME_OUT}" "maxDistance" "${DISTANCE_OUT}" "limit" "${LIMIT_OUT}")
+            q=$(build_query "name" "${NAME_OUT}" "nameContains" "${NAME_CONTAINS_OUT}" "id" "${ID_OUT}" "maxDistance" "${DISTANCE_OUT}" "limit" "${LIMIT_OUT}")
             do_get "${BASE}/npcs${q}"
             exit 0
         }
@@ -277,7 +279,7 @@ case "$1" in
         [[ $# -lt 2 ]] || [[ "$2" == --* ]] && {
             shift
             parse_named_args "$@"
-            q=$(build_query "name" "${NAME_OUT}" "maxDistance" "${DISTANCE_OUT}" "limit" "${LIMIT_OUT}")
+            q=$(build_query "name" "${NAME_OUT}" "nameContains" "${NAME_CONTAINS_OUT}" "id" "${ID_OUT}" "maxDistance" "${DISTANCE_OUT}" "limit" "${LIMIT_OUT}")
             do_get "${BASE}/objects${q}"
             exit 0
         }
@@ -296,7 +298,7 @@ case "$1" in
         [[ $# -lt 2 ]] || [[ "$2" == --* ]] && {
             shift
             parse_named_args "$@"
-            q=$(build_query "name" "${NAME_OUT}" "maxDistance" "${DISTANCE_OUT}" "limit" "${LIMIT_OUT}")
+            q=$(build_query "name" "${NAME_OUT}" "nameContains" "${NAME_CONTAINS_OUT}" "id" "${ID_OUT}" "maxDistance" "${DISTANCE_OUT}" "limit" "${LIMIT_OUT}")
             do_get "${BASE}/ground-items${q}"
             exit 0
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/AgentServerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/AgentServerPlugin.java
@@ -71,10 +71,9 @@ public class AgentServerPlugin extends Plugin {
 		try {
 			server = HttpServer.create(new InetSocketAddress("127.0.0.1", port), 0);
 		} catch (java.net.BindException e) {
-			log.warn("Port {} already in use, killing existing process", port);
-			killProcessOnPort(port);
-			Thread.sleep(500);
-			server = HttpServer.create(new InetSocketAddress("127.0.0.1", port), 0);
+			log.warn("Agent server port {} is already in use (likely another Microbot client). Skipping agent server startup for this instance.", port);
+			stopServer();
+			return;
 		}
 
 		server.setExecutor(executor);
@@ -141,21 +140,4 @@ public class AgentServerPlugin extends Plugin {
 		}
 	}
 
-	private void killProcessOnPort(int port) {
-		try {
-			String os = System.getProperty("os.name", "").toLowerCase();
-			ProcessBuilder pb;
-			if (os.contains("win")) {
-				pb = new ProcessBuilder("cmd", "/c",
-						"for /f \"tokens=5\" %a in ('netstat -aon ^| findstr :" + port + "') do taskkill /PID %a /F");
-			} else {
-				pb = new ProcessBuilder("bash", "-c", "fuser -k " + port + "/tcp 2>/dev/null || lsof -ti:" + port + " | xargs kill 2>/dev/null");
-			}
-			Process p = pb.start();
-			p.waitFor(5, TimeUnit.SECONDS);
-			log.info("Killed process on port {}", port);
-		} catch (Exception e) {
-			log.warn("Failed to kill process on port {}: {}", port, e.getMessage());
-		}
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/AgentHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/AgentHandler.java
@@ -43,9 +43,39 @@ public abstract class AgentHandler implements HttpHandler {
 		try {
 			handleRequest(exchange);
 		} catch (Exception e) {
+			if (isClientDisconnect(e)) {
+				log.debug("Client disconnected before {} response could be sent", exchange.getRequestURI());
+				return;
+			}
 			log.error("Error handling {}", exchange.getRequestURI(), e);
-			sendJson(exchange, 500, errorResponse("Internal server error: " + e.getMessage()));
+			try {
+				sendJson(exchange, 500, errorResponse("Internal server error: " + e.getMessage()));
+			} catch (IOException ioe) {
+				if (!isClientDisconnect(ioe)) {
+					throw ioe;
+				}
+				log.debug("Client disconnected before error response could be sent for {}", exchange.getRequestURI());
+			}
 		}
+	}
+
+	protected static boolean isClientDisconnect(Throwable t) {
+		while (t != null) {
+			if (t instanceof java.io.IOException) {
+				String msg = t.getMessage();
+				if (msg != null) {
+					String lower = msg.toLowerCase();
+					if (lower.contains("broken pipe")
+							|| lower.contains("connection reset")
+							|| lower.contains("connection closed")
+							|| lower.contains("insufficient bytes written")) {
+						return true;
+					}
+				}
+			}
+			t = t.getCause();
+		}
+		return false;
 	}
 
 	protected void requireGet(HttpExchange exchange) throws HttpMethodException {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/GroundItemHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/GroundItemHandler.java
@@ -51,12 +51,19 @@ public class GroundItemHandler extends AgentHandler {
 
 		Map<String, String> params = parseQuery(exchange.getRequestURI());
 		String name = params.get("name");
+		String nameContains = params.get("nameContains");
+		int id = getIntParam(params, "id", -1);
 		int maxDistance = getIntParam(params, "maxDistance", 20);
 		int limit = getIntParam(params, "limit", defaultLimit);
 
 		var query = Microbot.getRs2TileItemCache().query();
+		if (id >= 0) {
+			query = query.withId(id);
+		}
 		if (name != null && !name.isEmpty()) {
 			query = query.withName(name);
+		} else if (nameContains != null && !nameContains.isEmpty()) {
+			query = query.withNameContains(nameContains);
 		}
 		query = query.within(maxDistance);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/NpcHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/NpcHandler.java
@@ -51,12 +51,19 @@ public class NpcHandler extends AgentHandler {
 
 		Map<String, String> params = parseQuery(exchange.getRequestURI());
 		String name = params.get("name");
+		String nameContains = params.get("nameContains");
+		int id = getIntParam(params, "id", -1);
 		int maxDistance = getIntParam(params, "maxDistance", 20);
 		int limit = getIntParam(params, "limit", defaultLimit);
 
 		var query = Microbot.getRs2NpcCache().query();
+		if (id >= 0) {
+			query = query.withId(id);
+		}
 		if (name != null && !name.isEmpty()) {
 			query = query.withName(name);
+		} else if (nameContains != null && !nameContains.isEmpty()) {
+			query = query.withNameContains(nameContains);
 		}
 		query = query.within(maxDistance);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/ObjectHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/ObjectHandler.java
@@ -51,12 +51,19 @@ public class ObjectHandler extends AgentHandler {
 
 		Map<String, String> params = parseQuery(exchange.getRequestURI());
 		String name = params.get("name");
+		String nameContains = params.get("nameContains");
+		int id = getIntParam(params, "id", -1);
 		int maxDistance = getIntParam(params, "maxDistance", 20);
 		int limit = getIntParam(params, "limit", defaultLimit);
 
 		var query = Microbot.getRs2TileObjectCache().query();
+		if (id >= 0) {
+			query = query.withId(id);
+		}
 		if (name != null && !name.isEmpty()) {
 			query = query.withName(name);
+		} else if (nameContains != null && !nameContains.isEmpty()) {
+			query = query.withNameContains(nameContains);
 		}
 		query = query.within(maxDistance);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/WalkHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/WalkHandler.java
@@ -2,15 +2,37 @@ package net.runelite.client.plugins.microbot.agentserver.handler;
 
 import com.google.gson.Gson;
 import com.sun.net.httpserver.HttpExchange;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.walker.WalkerState;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
+@Slf4j
 public class WalkHandler extends AgentHandler {
+
+	private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+	private static final int MAX_TIMEOUT_SECONDS = 600;
+
+	private static final AtomicInteger WALK_THREAD_COUNT = new AtomicInteger(1);
+	private static final ExecutorService WALK_EXECUTOR = Executors.newSingleThreadExecutor(r -> {
+		Thread t = new Thread(r, "AgentServer-Walk-" + WALK_THREAD_COUNT.getAndIncrement());
+		t.setDaemon(true);
+		return t;
+	});
+
+	private static volatile Future<WalkerState> activeWalk;
+	private static volatile WorldPoint activeWalkTarget;
 
 	public WalkHandler(Gson gson) {
 		super(gson);
@@ -48,20 +70,75 @@ public class WalkHandler extends AgentHandler {
 		Number planeNum = (Number) body.get("plane");
 		int plane = planeNum != null ? planeNum.intValue() : 0;
 
-		WorldPoint destination = new WorldPoint(xNum.intValue(), yNum.intValue(), plane);
-		boolean success = Rs2Walker.walkTo(destination);
+		boolean wait = Boolean.TRUE.equals(body.get("wait"));
+		int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+		if (body.get("timeout") instanceof Number) {
+			timeoutSeconds = ((Number) body.get("timeout")).intValue();
+			if (timeoutSeconds <= 0) timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+			if (timeoutSeconds > MAX_TIMEOUT_SECONDS) timeoutSeconds = MAX_TIMEOUT_SECONDS;
+		}
 
-		WorldPoint playerPos = Microbot.getRs2PlayerStateCache().getLocalPlayerPosition();
+		WorldPoint destination = new WorldPoint(xNum.intValue(), yNum.intValue(), plane);
+
+		Future<WalkerState> walkFuture = submitWalk(destination);
 
 		Map<String, Object> response = new LinkedHashMap<>();
-		response.put("success", success);
-
 		Map<String, Integer> dest = new LinkedHashMap<>();
 		dest.put("x", destination.getX());
 		dest.put("y", destination.getY());
 		dest.put("plane", destination.getPlane());
 		response.put("destination", dest);
 
+		if (!wait) {
+			response.put("success", true);
+			response.put("walking", true);
+			response.put("message", "Walk initiated");
+			addPlayerPosition(response);
+			sendJson(exchange, 200, response);
+			return;
+		}
+
+		WalkerState state;
+		boolean timedOut = false;
+		try {
+			state = walkFuture.get(timeoutSeconds, TimeUnit.SECONDS);
+		} catch (TimeoutException te) {
+			state = null;
+			timedOut = true;
+		} catch (Exception e) {
+			log.warn("Walk failed: {}", e.toString());
+			response.put("success", false);
+			response.put("error", "Walk failed: " + e.getMessage());
+			addPlayerPosition(response);
+			sendJson(exchange, 500, response);
+			return;
+		}
+
+		if (timedOut) {
+			response.put("success", false);
+			response.put("walking", true);
+			response.put("timedOut", true);
+			response.put("message", "Walk did not complete within " + timeoutSeconds + "s; still in progress");
+		} else {
+			response.put("success", state == WalkerState.ARRIVED);
+			response.put("walking", false);
+			response.put("state", state == null ? "UNKNOWN" : state.name());
+		}
+		addPlayerPosition(response);
+		sendJson(exchange, 200, response);
+	}
+
+	private static synchronized Future<WalkerState> submitWalk(WorldPoint destination) {
+		if (activeWalk != null && !activeWalk.isDone() && destination.equals(activeWalkTarget)) {
+			return activeWalk;
+		}
+		activeWalkTarget = destination;
+		activeWalk = WALK_EXECUTOR.submit(() -> Rs2Walker.walkWithState(destination));
+		return activeWalk;
+	}
+
+	private static void addPlayerPosition(Map<String, Object> response) {
+		WorldPoint playerPos = Microbot.getRs2PlayerStateCache().getLocalPlayerPosition();
 		if (playerPos != null) {
 			Map<String, Integer> pos = new LinkedHashMap<>();
 			pos.put("x", playerPos.getX());
@@ -69,7 +146,5 @@ public class WalkHandler extends AgentHandler {
 			pos.put("plane", playerPos.getPlane());
 			response.put("playerPosition", pos);
 		}
-
-		sendJson(exchange, 200, response);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/AbstractEntityQueryable.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/AbstractEntityQueryable.java
@@ -96,6 +96,23 @@ public abstract class AbstractEntityQueryable<
 
     @SuppressWarnings("unchecked")
     @Override
+    public Q withNameContains(String substring) {
+        if (substring == null || substring.isEmpty()) {
+            this.source = Stream.empty();
+            return (Q) this;
+        }
+
+        String needle = substring.toLowerCase();
+        this.source = this.source.filter(x -> {
+            String n = x.getName();
+            return n != null && n.toLowerCase().contains(needle);
+        });
+
+        return (Q) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
     public Q withNames(String... names) {
         if (names == null || names.length == 0) {
             this.source = Stream.empty();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/IEntityQueryable.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/IEntityQueryable.java
@@ -16,6 +16,8 @@ public interface IEntityQueryable<Q extends IEntityQueryable<Q, E>, E extends IE
 
     Q withName(String name);
 
+    Q withNameContains(String substring);
+
     Q withNames(String... names);
 
     Q withId(int id);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/misc/Rs2Potion.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/misc/Rs2Potion.java
@@ -31,6 +31,7 @@ public class Rs2Potion
                 "Super restore",
                 "Moonlight potion",
                 "Moonlight moth mix",
+                "Moonlight moth",
                 "Egniol potion",
                 "Tears of elidinis",
                 "Sanfew serum"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -1178,7 +1178,7 @@ public class Rs2Player {
 
         if (hasPotion("moonlight moth mix")) {
             restoreAmount = 22;
-        } else if (hasPotion("moonlight potion")) {
+        } else if (hasPotion("moonlight potion") || hasPotion("moonlight moth")) {
             int prayerRestore = (maxPrayer / 4) + 7;
             int herbloreRestore = (int) Math.floor((maxHerblore * 3.0 / 10.0)) + 7;
             restoreAmount = Math.max(prayerRestore, herbloreRestore);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -2299,9 +2299,6 @@ public class Rs2Walker {
                     return Arrays.stream(composition.getActions()).filter(Objects::nonNull).noneMatch(currentAction::equals) && !Rs2Player.isAnimating();
                 }, 300, 10000);
             case "Paddle Canoe":
-                @Component final int DESTINATION_MAP_PARENT = 42401792; // 647.3
-                @Component final int DESTINATION_LIST = 42401795; // 647.13
-
                 if (!Rs2GameObject.interact(transport.getObjectId(), "Paddle Canoe")) {
                     log.error("Failed to interact with canoe station");
                     return false;
@@ -2313,15 +2310,24 @@ public class Rs2Walker {
                 sleepUntil(Rs2Player::isMoving, 2000);
                 sleepUntilTrue(() -> !Rs2Player.isMoving(), 100, 30000);
 
-                boolean isDestinationMapVisible = sleepUntilTrue(() -> Rs2Widget.isWidgetVisible(DESTINATION_MAP_PARENT), 100, 10000);
+                // OSRS update moved the canoe destination map from group 647 to
+                // CanoeMapLum (953) for the river Lum chain. CanoeMapDougne (952)
+                // is for a different chain not currently used by canoes.tsv.
+                boolean isDestinationMapVisible = sleepUntilTrue(
+                        () -> Rs2Widget.isWidgetVisible(InterfaceID.CanoeMapLum.MAIN_MAP),
+                        100, 10000);
                 if (!isDestinationMapVisible) {
-                    log.error("Destination map is not visible within timeout period");
+                    log.error("Canoe destination map (CanoeMapLum) not visible within timeout period");
                     return false;
                 }
 
-                Widget destinationListWidget = Rs2Widget.getWidget(DESTINATION_LIST);
+                Widget destinationListWidget = Rs2Widget.getWidget(InterfaceID.CanoeMapLum.DESTINATIONS);
                 if (destinationListWidget == null) return false;
                 Widget destination = Rs2Widget.findWidget("Travel to " + displayInfo, List.of(destinationListWidget), false);
+                if (destination == null) {
+                    log.error("Could not find canoe destination widget for: {}", displayInfo);
+                    return false;
+                }
                 Rs2Widget.clickWidget(destination);
 
                 Rs2Dialogue.waitForCutScene(100, 15000);

--- a/scripts/test-loop.sh
+++ b/scripts/test-loop.sh
@@ -42,6 +42,21 @@ IMPORTANT RULES:
    Use the CLI to observe actual game state (widgets, inventory, position) and take screenshots
    to visually confirm. Reading a config file or checking a boolean is NOT verification.
 
+3. IF YOU NOTICE A BUG IN THE MICROBOT CLI API, FIX IT BEFORE CONTINUING. While using the
+   microbot-cli, if a command returns wrong data, crashes, hangs, mis-parses arguments, has
+   broken output formatting, or otherwise behaves incorrectly, STOP using the CLI to verify
+   your original goal. First:
+   - Locate the offending CLI command source (typically under runelite-client/.../agentserver/
+     or the microbot-cli script + its server-side handler).
+   - Fix the bug at the root cause — do not work around it, do not switch to a different CLI
+     command just to bypass it, and do not silently tolerate the broken behavior.
+   - Recompile (./gradlew :client:compileJava), relaunch the client, and confirm the CLI
+     command now works.
+   - Only then resume verifying your original goal.
+   Reason: a broken CLI poisons every subsequent verification step in the loop. Leaving it
+   broken means future iterations (and other agents) will hit the same bug. Fixing it once
+   pays for itself immediately.
+
 You have up to $MAX_ITER iterations to achieve the goal.
 
 ## Step-by-step workflow


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the agent server's walking API, enhances CLI usability, and addresses minor issues with potion handling and canoe travel. The most significant changes are grouped below.

### Agent Server Walking API and CLI Enhancements

* The `/walk` API now supports non-blocking and blocking modes with new `wait` and `timeout` parameters. Non-blocking is now the default, allowing long walks without hitting curl timeouts; blocking mode waits for arrival or times out as specified. The API responses are updated to clearly indicate walk status and player position. (`docs/AGENT_SERVER.md`, `microbot-cli`, `runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/WalkHandler.java`) [[1]](diffhunk://#diff-9c43217d3e73c1709f59cb4f0fd619c8b277a3204388bed8492145f2a3823d36L331-R384) [[2]](diffhunk://#diff-80a87c064d760b9e86ead3ab7f3ed29c17abdf6cb63967eb2697d9198987d9e5L48-R50) [[3]](diffhunk://#diff-80a87c064d760b9e86ead3ab7f3ed29c17abdf6cb63967eb2697d9198987d9e5L312-R339) [[4]](diffhunk://#diff-c76d84f06e432b4409a73b5654a60c4b2e6e0a828d3a09d4a2651b73c9b05d87R5-R36) [[5]](diffhunk://#diff-c76d84f06e432b4409a73b5654a60c4b2e6e0a828d3a09d4a2651b73c9b05d87R73-L73)

* The CLI `walk` command now accepts `[--wait] [--timeout SECONDS]` options, matching the API changes. Non-blocking is default; `--wait` blocks until arrival or timeout. Usage and help text are updated accordingly. (`microbot-cli`) [[1]](diffhunk://#diff-80a87c064d760b9e86ead3ab7f3ed29c17abdf6cb63967eb2697d9198987d9e5L48-R50) [[2]](diffhunk://#diff-80a87c064d760b9e86ead3ab7f3ed29c17abdf6cb63967eb2697d9198987d9e5L312-R339)

### Server Stability and Error Handling

* Improved error handling for client disconnects in the agent server: broken pipe and connection reset errors are now logged at debug level and do not trigger error responses. (`runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/AgentHandler.java`)

* The agent server will no longer attempt to kill processes on port conflicts; instead, it logs a warning and skips startup for that instance, avoiding potentially disruptive behavior. (`runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/AgentServerPlugin.java`) [[1]](diffhunk://#diff-f255806ab2789c6e3b5ac2f35928ca6b4f2763b93315f8ba1986fe981aabecbeL74-R76) [[2]](diffhunk://#diff-f255806ab2789c6e3b5ac2f35928ca6b4f2763b93315f8ba1986fe981aabecbeL144-L160)

### Game Logic Fixes and Updates

* Added "Moonlight moth" to the list of prayer potion variants and ensured it is properly handled for prayer restoration. (`runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/misc/Rs2Potion.java`, `runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java`) [[1]](diffhunk://#diff-828133a6b98fc7d5b3296edf926d1da0f2d12318046293c479111588d1ed9f51R34) [[2]](diffhunk://#diff-c8d91e0689ac63a80e21760dbd0d3498ad0a82426223fc3d933d6be700a2f0ffL1181-R1181)

* Updated canoe travel logic to support the new OSRS canoe map interface (`CanoeMapLum`), fixing destination selection after a game update. Improved error logging if the destination widget is not found. (`runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java`) [[1]](diffhunk://#diff-94eaddcc7725fe69050c28838a9325bfb8bea2de9fe8fa4904d8c6ec0ad14b4bL2302-L2304) [[2]](diffhunk://#diff-94eaddcc7725fe69050c28838a9325bfb8bea2de9fe8fa4904d8c6ec0ad14b4bL2316-R2330)