### PR TITLE
fix(rs2walker): unblock long indoor paths — filtered-edge guard, exhaustion bail, scene doors

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Transport.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/Transport.java
@@ -119,6 +119,19 @@ public class Transport {
     @Getter
     private boolean isMembers = false;
 
+    /**
+     * True for runtime virtual edges injected by PathfinderConfig.discoverSceneDoors
+     * (Patch H). These represent scene WallObjects so BFS can route through doors
+     * not in transports.tsv. handleTransports must skip them — handleDoors opens
+     * the actual wall via orientation-checked WallObject scan, which is the only
+     * path-edge-aware way to interact with these doors. Letting handleTransports
+     * fire on a scene-discovered transport opens any door whose two tiles both
+     * appear on the path even when the path doesn't actually traverse it.
+     */
+    @Getter
+    @Setter
+    private boolean sceneDiscovered = false;
+
 
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/Pathfinder.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/Pathfinder.java
@@ -58,6 +58,15 @@ public class Pathfinder implements Runnable {
     private volatile boolean pathNeedsUpdate = false;
     private volatile boolean smoothed = false;
     private volatile Node bestLastNode;
+    // True when the BFS exhausted both boundary and pending without reaching a
+    // target — the destination is genuinely unreachable from the source given
+    // the current transport graph. Distinguished from cutoff timeout (queues
+    // still hold candidates) and target-found (loop broke early). Walker uses
+    // this to bail UNREACHABLE instead of walking a partial path toward the
+    // closest-by-heuristic node, which on a quest-locked area produced a
+    // 60-second tour around the locked region in the wild.
+    @Getter
+    private volatile boolean searchExhausted = false;
     /**
      * Teleportation transports are updated when this changes.
      * Can be either:
@@ -295,6 +304,11 @@ public class Pathfinder implements Runnable {
                 addNeighbors(node);
             }
 
+            // Capture exhaustion before finally clears the queues. Both empty
+            // after the while loop means BFS terminated by the loop condition
+            // (no more nodes to expand) — i.e. dest is unreachable. Cutoff and
+            // target-reached exits leave queues non-empty.
+            searchExhausted = !cancelled && boundary.isEmpty() && pending.isEmpty();
             log.info("[Pathfinder] Loop exited. cancelled={}, boundaryEmpty={}, pendingEmpty={}, bestLastNode={}",
                     cancelled, boundary.isEmpty(), pending.isEmpty(),
                     bestLastNode == null ? "null" : WorldPointUtil.toString(bestLastNode.packedPosition));
@@ -311,6 +325,45 @@ public class Pathfinder implements Runnable {
 
             log.info("[Pathfinder] run() completed. done={}, cancelled={}, stats={}",
                     done, cancelled, getStats() != null ? getStats().toString() : "null");
+
+            // Diagnostic: walk the bestLastNode chain and log every transport hop in
+            // the final path. Lets us prove which transports BFS actually selected
+            // (e.g., distinguishes a palace door from an agility-shortcut trellis at
+            // adjacent tiles). Cheap — only walks the linked list once per run.
+            if (bestLastNode != null) {
+                int hops = 0;
+                Node cur = bestLastNode;
+                while (cur != null && cur.previous != null) {
+                    if (cur instanceof TransportNode) {
+                        log.info("[Pathfinder] transport hop in path: {} -> {} cost={}",
+                                WorldPointUtil.toString(cur.previous.packedPosition),
+                                WorldPointUtil.toString(cur.packedPosition),
+                                cur.cost);
+                        hops++;
+                    }
+                    cur = cur.previous;
+                }
+                if (hops == 0) {
+                    log.info("[Pathfinder] transport hops in path: 0 (walking-only)");
+                }
+
+                // Dump the full raw path (pre-smoother) for diagnosis. Tells us the
+                // actual tile sequence BFS picked, so we can spot illegal wall steps
+                // (e.g., (3228,3470) -> (3228,3471) without a transport — which would
+                // be the trellis fence walked through as if it weren't there).
+                java.util.List<WorldPoint> rawPath = bestLastNode.getPath();
+                int sz = rawPath.size();
+                log.info("[Pathfinder] raw path: {} tiles", sz);
+                if (sz > 0) {
+                    StringBuilder sb = new StringBuilder("[Pathfinder] raw path tiles: ");
+                    for (int i = 0; i < sz; i++) {
+                        WorldPoint p = rawPath.get(i);
+                        sb.append("(").append(p.getX()).append(",").append(p.getY()).append(",").append(p.getPlane()).append(")");
+                        if (i < sz - 1) sb.append(" ");
+                    }
+                    log.info(sb.toString());
+                }
+            }
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/Pathfinder.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/Pathfinder.java
@@ -325,45 +325,6 @@ public class Pathfinder implements Runnable {
 
             log.info("[Pathfinder] run() completed. done={}, cancelled={}, stats={}",
                     done, cancelled, getStats() != null ? getStats().toString() : "null");
-
-            // Diagnostic: walk the bestLastNode chain and log every transport hop in
-            // the final path. Lets us prove which transports BFS actually selected
-            // (e.g., distinguishes a palace door from an agility-shortcut trellis at
-            // adjacent tiles). Cheap — only walks the linked list once per run.
-            if (bestLastNode != null) {
-                int hops = 0;
-                Node cur = bestLastNode;
-                while (cur != null && cur.previous != null) {
-                    if (cur instanceof TransportNode) {
-                        log.info("[Pathfinder] transport hop in path: {} -> {} cost={}",
-                                WorldPointUtil.toString(cur.previous.packedPosition),
-                                WorldPointUtil.toString(cur.packedPosition),
-                                cur.cost);
-                        hops++;
-                    }
-                    cur = cur.previous;
-                }
-                if (hops == 0) {
-                    log.info("[Pathfinder] transport hops in path: 0 (walking-only)");
-                }
-
-                // Dump the full raw path (pre-smoother) for diagnosis. Tells us the
-                // actual tile sequence BFS picked, so we can spot illegal wall steps
-                // (e.g., (3228,3470) -> (3228,3471) without a transport — which would
-                // be the trellis fence walked through as if it weren't there).
-                java.util.List<WorldPoint> rawPath = bestLastNode.getPath();
-                int sz = rawPath.size();
-                log.info("[Pathfinder] raw path: {} tiles", sz);
-                if (sz > 0) {
-                    StringBuilder sb = new StringBuilder("[Pathfinder] raw path tiles: ");
-                    for (int i = 0; i < sz; i++) {
-                        WorldPoint p = rawPath.get(i);
-                        sb.append("(").append(p.getX()).append(",").append(p.getY()).append(",").append(p.getPlane()).append(")");
-                        if (i < sz - 1) sb.append(" ");
-                    }
-                    log.info(sb.toString());
-                }
-            }
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/Pathfinder.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/Pathfinder.java
@@ -245,6 +245,8 @@ public class Pathfinder implements Runnable {
             long cutoffDurationMillis = config.getCalculationCutoffMillis();
             long cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
             config.refreshTeleports(start, 31);
+            boolean reachedTarget = false;
+            boolean cutoffHit = false;
             while (!cancelled && (!boundary.isEmpty() || !pending.isEmpty())) {
                 Node b = boundary.peek();
                 Node p = pending.peek();
@@ -294,9 +296,13 @@ public class Pathfinder implements Runnable {
                         cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
                     }
                 }
-                if (reached) break;
+                if (reached) {
+                    reachedTarget = true;
+                    break;
+                }
 
                 if (System.currentTimeMillis() > cutoffTimeMillis) {
+                    cutoffHit = true;
                     log.info("[Pathfinder] Cutoff reached. bestDistance={}, nodesChecked={}", bestDistance, stats.getNodesChecked());
                     break;
                 }
@@ -304,11 +310,14 @@ public class Pathfinder implements Runnable {
                 addNeighbors(node);
             }
 
-            // Capture exhaustion before finally clears the queues. Both empty
-            // after the while loop means BFS terminated by the loop condition
-            // (no more nodes to expand) — i.e. dest is unreachable. Cutoff and
-            // target-reached exits leave queues non-empty.
-            searchExhausted = !cancelled && boundary.isEmpty() && pending.isEmpty();
+            // Capture exhaustion before finally clears the queues. Gate on
+            // !reachedTarget && !cutoffHit so polling the last queued node and
+            // then exiting via target-found or cutoff isn't misread as the BFS
+            // running out of frontier — those leave the queues empty for a
+            // benign reason and would otherwise trip a spurious UNREACHABLE
+            // downstream.
+            searchExhausted = !cancelled && !reachedTarget && !cutoffHit
+                    && boundary.isEmpty() && pending.isEmpty();
             log.info("[Pathfinder] Loop exited. cancelled={}, boundaryEmpty={}, pendingEmpty={}, bestLastNode={}",
                     cancelled, boundary.isEmpty(), pending.isEmpty(),
                     bestLastNode == null ? "null" : WorldPointUtil.toString(bestLastNode.packedPosition));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -127,6 +127,16 @@ public class PathfinderConfig {
     private final Set<Integer> restrictedPointsPacked;
     private final Set<Integer> internalRestrictedPointsPacked;
     private volatile boolean useNpcs;
+
+    // Runtime blacklist of transport origin tiles whose interaction failed to deliver
+    // the player to the destination. The static eligibility checks (member flag, levels,
+    // quests, varbits) can't capture every server-side gate (region unlocks, sub-quest
+    // progression, etc.), so a transport can pass plan-time and still no-op at click
+    // time. Without this, the pathfinder keeps emitting the same broken edge and the
+    // walker re-attempts it forever. TTL clears stale entries so the player can retry
+    // after world hops or unlock progression.
+    private final Map<Integer, Long> failedTransportOriginsPacked = new ConcurrentHashMap<>();
+    private static final long FAILED_TRANSPORT_TTL_MS = 5L * 60L * 1000L;
     //END microbot variables
     private volatile TeleportationItem useTeleportationItems;
 
@@ -714,6 +724,27 @@ public class PathfinderConfig {
                 .orElse(0);
     }
 
+    public void addFailedTransportRestriction(WorldPoint origin) {
+        if (origin == null) return;
+        failedTransportOriginsPacked.put(WorldPointUtil.packWorldPoint(origin), System.currentTimeMillis());
+    }
+
+    public void clearFailedTransportRestrictions() {
+        failedTransportOriginsPacked.clear();
+    }
+
+    private boolean isRecentlyFailedOrigin(WorldPoint origin) {
+        if (origin == null) return false;
+        int packed = WorldPointUtil.packWorldPoint(origin);
+        Long failedAt = failedTransportOriginsPacked.get(packed);
+        if (failedAt == null) return false;
+        if (System.currentTimeMillis() - failedAt > FAILED_TRANSPORT_TTL_MS) {
+            failedTransportOriginsPacked.remove(packed);
+            return false;
+        }
+        return true;
+    }
+
     private boolean useTransport(Transport transport) {
         boolean traceMoa = transport.getType() == TransportType.SEASONAL_TRANSPORT
                 && transport.getDisplayInfo() != null
@@ -741,6 +772,14 @@ public class PathfinderConfig {
                     return false;
                 }
             }
+        }
+
+        // Runtime blacklist for transports whose origin tile recently failed to deliver
+        // the player. Skip before any other check so a broken edge stops re-emerging
+        // from the next pathfinder run (see addFailedTransportRestriction comment).
+        if (isRecentlyFailedOrigin(transport.getOrigin())) {
+            log.debug("Transport ( O: {} D: {} ) skipped: origin recently failed", transport.getOrigin(), transport.getDestination());
+            return false;
         }
 
         // Check if the feature flag is disabled

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -137,6 +137,16 @@ public class PathfinderConfig {
     // after world hops or unlock progression.
     private final Map<Integer, Long> failedTransportOriginsPacked = new ConcurrentHashMap<>();
     private static final long FAILED_TRANSPORT_TTL_MS = 5L * 60L * 1000L;
+
+    // Walking edges that the BFS must treat as walls because the only known way to
+    // cross them is a transport that's currently filtered out (member flag, quest, F2P
+    // gate, etc.). Trellis at (3228,3470)<->(3228,3471) is the canonical case: the
+    // upstream collision map omits the fence, relying on the agility-shortcut transport
+    // to imply the obstacle. Without this set, BFS happily walks across the fence as if
+    // it were open ground when the transport is excluded — producing paths that look
+    // valid but require climbing an obstacle the player can't use. Encoded as
+    // (fromPacked << 32) | toPacked. Rebuilt every refreshTransports().
+    private final Set<Long> blockedWalkingEdges = ConcurrentHashMap.newKeySet();
     //END microbot variables
     private volatile TeleportationItem useTeleportationItems;
 
@@ -307,6 +317,7 @@ public class PathfinderConfig {
         blockedTransportEdgesPacked.clear();
         addStaticBlockedEdges();
         usableTeleports.clear();
+        blockedWalkingEdges.clear();
 
         long mergeStart = System.currentTimeMillis();
         Map<WorldPoint, Set<Transport>> mergedList = createMergedList();
@@ -722,6 +733,21 @@ public class PathfinderConfig {
         return Microbot.getClientThread()
                 .runOnClientThreadOptional(() -> client.getVarpValue(varplayerId))
                 .orElse(0);
+    }
+
+    private static long packEdge(int fromPacked, int toPacked) {
+        return ((long) fromPacked << 32) | (toPacked & 0xFFFFFFFFL);
+    }
+
+    /**
+     * True when the walking edge from {@code fromPacked} to {@code toPacked} is
+     * blocked by an excluded transport — i.e. the only known way to traverse this
+     * edge is a transport the player can't currently use (quest/skill/F2P gate).
+     * Used by {@link CollisionMap#getNeighbors} to prevent BFS from walking across
+     * fences whose only crossing is a filtered agility shortcut etc.
+     */
+    public boolean isWalkingEdgeBlocked(int fromPacked, int toPacked) {
+        return !blockedWalkingEdges.isEmpty() && blockedWalkingEdges.contains(packEdge(fromPacked, toPacked));
     }
 
     public void addFailedTransportRestriction(WorldPoint origin) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -414,6 +414,19 @@ public class PathfinderConfig {
         }
         long similarTime = System.currentTimeMillis() - similarStart;
 
+        // Patch H: scene-discovered doors. The TSV is incomplete (palace internal
+        // doors, throne rooms, etc.) — without these, BFS can't route through them
+        // and bails UNREACHABLE for destinations a human player could trivially
+        // reach. Scan loaded scene for door WallObjects and inject as virtual
+        // transports so BFS plans through them. handleDoors() in the walker opens
+        // them at click time.
+        long doorStart = System.currentTimeMillis();
+        int doorsAdded = discoverSceneDoors();
+        long doorTime = System.currentTimeMillis() - doorStart;
+        if (doorsAdded > 0) {
+            log.info("[refreshTransports] scene doors: added={}, time={}ms", doorsAdded, doorTime);
+        }
+
         refreshAvailableItemIds = null;
         refreshBoostedLevels = null;
         refreshCurrencyCache = null;
@@ -748,6 +761,130 @@ public class PathfinderConfig {
      */
     public boolean isWalkingEdgeBlocked(int fromPacked, int toPacked) {
         return !blockedWalkingEdges.isEmpty() && blockedWalkingEdges.contains(packEdge(fromPacked, toPacked));
+    }
+
+    /**
+     * Patch H: enumerate door WallObjects in the loaded scene and inject them as
+     * virtual Transport edges so BFS can route through doors not present in
+     * transports.tsv (palace internal chambers, generic interior doors, etc.).
+     *
+     * Only WallObjects whose ObjectComposition exposes an "Open" action are
+     * added — gated actions (Pay-toll, Pick-lock) imply quest/skill requirements
+     * that the TSV captures more accurately, so we defer to the TSV for those.
+     * Existing transports at the same edge are not overridden.
+     *
+     * @return number of door edges added (one direction == 1, bidirectional adds 2)
+     */
+    private int discoverSceneDoors() {
+        if (!GameState.LOGGED_IN.equals(client.getGameState())) return 0;
+
+        // Whole scan on client thread in one hop. Each WallObject requires an
+        // ObjectComposition lookup which itself needs the client thread; doing
+        // them individually from a background thread costs ~26s for ~200 walls
+        // because every lookup blocks waiting for a thread switch.
+        Integer result = Microbot.getClientThread().runOnClientThreadOptional(this::discoverSceneDoorsOnClientThread)
+                .orElse(0);
+        return result != null ? result : 0;
+    }
+
+    private int discoverSceneDoorsOnClientThread() {
+        try {
+            if (client.getTopLevelWorldView().getScene().isInstance()) return 0;
+        } catch (Exception e) {
+            return 0;
+        }
+
+        Player player = client.getLocalPlayer();
+        if (player == null) return 0;
+        WorldPoint playerLoc = player.getWorldLocation();
+        if (playerLoc == null) return 0;
+        int playerX = playerLoc.getX();
+        int playerY = playerLoc.getY();
+        int playerPlane = playerLoc.getPlane();
+
+        Scene scene = player.getWorldView().getScene();
+        Tile[][][] tiles = scene.getTiles();
+        if (tiles == null) return 0;
+
+        int added = 0;
+        for (int z = 0; z < tiles.length; z++) {
+            Tile[][] plane = tiles[z];
+            if (plane == null) continue;
+            for (int x = 0; x < plane.length; x++) {
+                Tile[] col = plane[x];
+                if (col == null) continue;
+                for (int y = 0; y < col.length; y++) {
+                    Tile tile = col[y];
+                    if (tile == null) continue;
+                    WallObject wall = tile.getWallObject();
+                    if (wall == null) continue;
+
+                    WorldPoint probe = wall.getWorldLocation();
+                    if (probe == null || probe.getPlane() != playerPlane) continue;
+                    // Same scene-radius cap as the rest of the walker (52 tiles).
+                    if (Math.max(Math.abs(probe.getX() - playerX), Math.abs(probe.getY() - playerY)) > 52) continue;
+                    if (Rs2Walker.sessionBlacklistedDoors.contains(probe)) continue;
+
+                    ObjectComposition comp = client.getObjectDefinition(wall.getId());
+                    if (comp == null || comp.getImpostorIds() != null) continue;
+                    String name = comp.getName();
+                    if (name == null || "null".equals(name)) continue;
+
+                    String[] actions = comp.getActions();
+                    if (actions == null) continue;
+                    String action = null;
+                    for (String a : actions) {
+                        if (a == null) continue;
+                        if (a.toLowerCase().startsWith("open")) {
+                            action = a;
+                            break;
+                        }
+                    }
+                    if (action == null) continue;
+
+                    int dx, dy;
+                    switch (wall.getOrientationA()) {
+                        case 1:   dx = -1; dy =  0; break;
+                        case 2:   dx =  0; dy =  1; break;
+                        case 4:   dx =  1; dy =  0; break;
+                        case 8:   dx =  0; dy = -1; break;
+                        default: continue;
+                    }
+
+                    WorldPoint neighbor = new WorldPoint(probe.getX() + dx, probe.getY() + dy, probe.getPlane());
+                    if (Rs2Walker.sessionBlacklistedDoors.contains(neighbor)) continue;
+
+                    int objectId = comp.getId();
+                    String displayInfo = "Door (" + name + ") @ " + probe;
+                    added += addRuntimeDoorEdge(probe, neighbor, displayInfo, action, name, objectId);
+                    added += addRuntimeDoorEdge(neighbor, probe, displayInfo, action, name, objectId);
+                }
+            }
+        }
+        return added;
+    }
+
+    private int addRuntimeDoorEdge(WorldPoint origin, WorldPoint destination,
+                                   String displayInfo, String action, String name, int objectId) {
+        Set<Transport> existing = transports.get(origin);
+        if (existing != null) {
+            for (Transport t : existing) {
+                if (destination.equals(t.getDestination())) {
+                    return 0; // TSV already covers this edge
+                }
+            }
+        }
+        Transport door = new Transport(origin, destination, displayInfo,
+                TransportType.TRANSPORT, false, action, name, objectId);
+        // Per refreshTransports invariant, transports and transportsPacked share
+        // the same Set reference per origin — add once via the shared reference.
+        Set<Transport> set = transports.computeIfAbsent(origin, k -> new HashSet<>());
+        int packedOrigin = WorldPointUtil.packWorldPoint(origin);
+        if (transportsPacked.get(packedOrigin) == null) {
+            transportsPacked.put(packedOrigin, set);
+        }
+        set.add(door);
+        return 1;
     }
 
     public void addFailedTransportRestriction(WorldPoint origin) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -876,6 +876,9 @@ public class PathfinderConfig {
         }
         Transport door = new Transport(origin, destination, displayInfo,
                 TransportType.TRANSPORT, false, action, name, objectId);
+        // Tag for handleTransports to skip — handleDoors opens these via the
+        // WallObject orientation check, which is the only edge-aware mechanism.
+        door.setSceneDiscovered(true);
         // Per refreshTransports invariant, transports and transportsPacked share
         // the same Set reference per origin — add once via the shared reference.
         Set<Transport> set = transports.computeIfAbsent(origin, k -> new HashSet<>());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -191,7 +191,6 @@ public class PathfinderConfig {
     }
 
     public void refresh(WorldPoint target) {
-        diagAgilityShortcutLogged.set(false);
         calculationCutoffMillis = (long) config.calculationCutoff() * Constants.GAME_TICK_LENGTH;
         avoidWilderness = ShortestPathPlugin.override("avoidWilderness", config.avoidWilderness());
         useAgilityShortcuts = ShortestPathPlugin.override("useAgilityShortcuts", config.useAgilityShortcuts());
@@ -1109,23 +1108,10 @@ public class PathfinderConfig {
         return true;
     }
 
-    // Diagnostic one-shot — logs the world type set + agility shortcut decision the
-    // first time isFeatureEnabled sees an AGILITY_SHORTCUT after each refresh().
-    // Used to investigate whether the F2P gate is actually filtering trellises etc.
-    // Reset to false at the top of refresh() so each cache rebuild logs once.
-    private final java.util.concurrent.atomic.AtomicBoolean diagAgilityShortcutLogged =
-            new java.util.concurrent.atomic.AtomicBoolean(false);
-
     private boolean isFeatureEnabled(Transport transport) {
         TransportType type = transport.getType();
 
-        boolean membersWorld = client.getWorldType().contains(WorldType.MEMBERS);
-        if (type == TransportType.AGILITY_SHORTCUT && diagAgilityShortcutLogged.compareAndSet(false, true)) {
-            log.warn("[F2P diag] AGILITY_SHORTCUT useTransport probe: worldTypes={} membersFlag={} useAgilityShortcuts={} transport.isMembers={} origin={} dest={}",
-                    client.getWorldType(), membersWorld, useAgilityShortcuts, transport.isMembers(), transport.getOrigin(), transport.getDestination());
-        }
-
-        if (!membersWorld) {
+        if (!client.getWorldType().contains(WorldType.MEMBERS)) {
             // Transport types that require membership
             switch (type) {
                 case AGILITY_SHORTCUT:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/pathfinder/PathfinderConfig.java
@@ -191,6 +191,7 @@ public class PathfinderConfig {
     }
 
     public void refresh(WorldPoint target) {
+        diagAgilityShortcutLogged.set(false);
         calculationCutoffMillis = (long) config.calculationCutoff() * Constants.GAME_TICK_LENGTH;
         avoidWilderness = ShortestPathPlugin.override("avoidWilderness", config.avoidWilderness());
         useAgilityShortcuts = ShortestPathPlugin.override("useAgilityShortcuts", config.useAgilityShortcuts());
@@ -234,8 +235,11 @@ public class PathfinderConfig {
             refreshRestrictionData();
             long t2 = System.currentTimeMillis();
 
-            // Do not switch back to inventory tab if we are inside of the telekinetic room in Mage Training Arena
-            if (Rs2Player.getWorldLocation().getRegionID() != 13463) {
+            // Do not switch back to inventory tab if we are inside of the telekinetic room in Mage Training Arena.
+            // Skip the tab switch entirely when LocalPlayer isn't hydrated yet (refresh can fire on a tick before
+            // the player object is available post-login, NPE'd the client during startup).
+            WorldPoint playerLoc = Rs2Player.getWorldLocation();
+            if (playerLoc != null && playerLoc.getRegionID() != 13463) {
                 Rs2Tab.switchTo(InterfaceTab.INVENTORY);
             }
             long t3 = System.currentTimeMillis();
@@ -1105,10 +1109,23 @@ public class PathfinderConfig {
         return true;
     }
 
+    // Diagnostic one-shot — logs the world type set + agility shortcut decision the
+    // first time isFeatureEnabled sees an AGILITY_SHORTCUT after each refresh().
+    // Used to investigate whether the F2P gate is actually filtering trellises etc.
+    // Reset to false at the top of refresh() so each cache rebuild logs once.
+    private final java.util.concurrent.atomic.AtomicBoolean diagAgilityShortcutLogged =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
+
     private boolean isFeatureEnabled(Transport transport) {
         TransportType type = transport.getType();
 
-        if (!client.getWorldType().contains(WorldType.MEMBERS)) {
+        boolean membersWorld = client.getWorldType().contains(WorldType.MEMBERS);
+        if (type == TransportType.AGILITY_SHORTCUT && diagAgilityShortcutLogged.compareAndSet(false, true)) {
+            log.warn("[F2P diag] AGILITY_SHORTCUT useTransport probe: worldTypes={} membersFlag={} useAgilityShortcuts={} transport.isMembers={} origin={} dest={}",
+                    client.getWorldType(), membersWorld, useAgilityShortcuts, transport.isMembers(), transport.getOrigin(), transport.getDestination());
+        }
+
+        if (!membersWorld) {
             // Transport types that require membership
             switch (type) {
                 case AGILITY_SHORTCUT:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/tile/Rs2Tile.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/tile/Rs2Tile.java
@@ -415,6 +415,13 @@ public abstract class Rs2Tile implements Tile {
             startX = playerLoc.getX() - Microbot.getClient().getBaseX();
             startY = playerLoc.getY() - Microbot.getClient().getBaseY();
         }
+        // Player can be outside the loaded scene grid (instance transitions, stale
+        // worldview, base mismatch in non-top-level views). Without this guard the
+        // visited[startX][startY] write throws ArrayIndexOutOfBoundsException and
+        // crashes the walker thread mid-loop.
+        if (!isWithinBounds(startX, startY)) {
+            return false;
+        }
         final int startPoint = (startX << 16) | startY;
 
         ArrayDeque<Integer> queue = new ArrayDeque<>();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1830,7 +1830,7 @@ public class Rs2Walker {
     // Session-local set of door tiles the walker detected as quest/stat-locked after a
     // failed interact. Cleared when the client restarts. Prevents infinite retry loops
     // through the same restricted door when the restriction isn't in restrictions.tsv.
-    static final Set<WorldPoint> sessionBlacklistedDoors = ConcurrentHashMap.newKeySet();
+    public static final Set<WorldPoint> sessionBlacklistedDoors = ConcurrentHashMap.newKeySet();
     private static final Map<WorldPoint, Long> recentlyOpenedStationaryDoors = new ConcurrentHashMap<>();
     private static final long STATIONARY_DOOR_SUPPRESS_MS = 10_000;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -581,6 +581,43 @@ public class Rs2Walker {
                                 wp -> inInstance || isKnownWalkableOrUnloaded(wp));
                     }
 
+                    // Pre-scan the path segment we're about to skip past for any closed
+                    // door. handleDoors() per-iteration only inspects the current tile
+                    // boundary, but `i = targetIdx` jumps ahead after the click, so any
+                    // door between i and targetIdx never gets opened — the server then
+                    // strands the player against the closed door that BFS treated as a
+                    // normal walking edge. Open it here before the click goes through.
+                    // Walk j ascending — path tiles are in walking order, so the first
+                    // door we find is the nearest closed door between the player and
+                    // wherever the OSRS server will route them on this click. handleDoors()
+                    // opens it and returns; we break and let processWalk recurse so the
+                    // next iteration starts from the player's new position past the door
+                    // (and catches any further-out doors on its own next pre-scan).
+                    //
+                    // Bounded by HANDLER_RANGE distance, NOT by targetIdx — when the
+                    // walker uses an interpolated click target (the targetIdx < i path
+                    // above sets targetIdx = i - 1), the indexed range is empty but the
+                    // actual click destination is far, so the relevant doors live along
+                    // path[i..end] within Euclidean reach. Iterate until a door is found
+                    // or every tile in scene-range has been checked.
+                    boolean preDoorHandled = false;
+                    int preDoorAt = -1;
+                    for (int j = i; j < path.size(); j++) {
+                        int distFromPlayer = path.get(j).distanceTo2D(Rs2Player.getWorldLocation());
+                        if (distFromPlayer > HANDLER_RANGE) continue; // out of scene; handle when closer
+                        if (handleDoors(path, j)) {
+                            preDoorHandled = true;
+                            preDoorAt = j;
+                            break;
+                        }
+                    }
+                    if (preDoorHandled) {
+                        log.info("[Walker pre-scan] opened door at path idx {} ({}) before clicking past — re-evaluating",
+                                preDoorAt, path.get(preDoorAt));
+                        exitReason = "door-prescan";
+                        break;
+                    }
+
                     WorldPoint posBefore = playerLoc;
                     WorldPoint clickTarget = inInstance ? targetWp : getPointWithWallDistance(targetWp);
                     if (!inInstance && !Rs2Tile.isTileReachable(clickTarget)) {
@@ -598,6 +635,8 @@ public class Rs2Walker {
                     if (isWalkCancelled(target)) {
                         return WalkerState.EXIT;
                     }
+                    log.info("[Walker click] target={} pathIdx={} playerBefore={} clicked={}",
+                            targetWp, targetIdx, posBefore, clicked);
                     if (clicked) {
                         final WorldPoint b = targetWp;
                         final WorldPoint before = posBefore;
@@ -642,6 +681,12 @@ public class Rs2Walker {
                                 break;
                             }
                         }
+                        WorldPoint posAfter = Rs2Player.getWorldLocation();
+                        int moved = posAfter == null ? -1 : posBefore.distanceTo2D(posAfter);
+                        int distLeft = posAfter == null ? -1 : b.distanceTo2D(posAfter);
+                        long elapsedMs = System.currentTimeMillis() - clickedAt;
+                        log.info("[Walker click] result moved={} tiles posAfter={} distFromTarget={} elapsedMs={} reachedProximity={}",
+                                moved, posAfter, distLeft, elapsedMs, distLeft >= 0 && distLeft <= proximityWake);
                     }
                     // Keep stuck-detection honest: observed movement resets the movement timer.
                     // Without this, isStuckTooLong() fires after long successful walks because
@@ -2008,6 +2053,7 @@ public class Rs2Walker {
         boolean diagonal = Math.abs(fromWp.getX() - toWp.getX()) > 0
                 && Math.abs(fromWp.getY() - toWp.getY()) > 0;
 
+
         for (int offset = 0; offset <= 1; offset++) {
             int doorIdx = index + offset;
             if (doorIdx >= path.size()) continue;
@@ -2017,12 +2063,14 @@ public class Rs2Walker {
                     ? Rs2WorldPoint.convertInstancedWorldPoint(rawDoorWp)
                     : rawDoorWp;
 
+            // Only probe the path tiles themselves (fromWp and toWp via the offset
+            // loop). Diagonal corner probes were opening doors on shoulder tiles
+            // that don't actually block the fromWp↔toWp edge — a wall at the
+            // corner facing one of the path tiles passes the orientation check but
+            // is on a different edge entirely. The OSRS server picks a shoulder
+            // for diagonals; opening the wrong shoulder's door is wasted action.
             List<WorldPoint> probes = new ArrayList<>();
             probes.add(doorWp);
-            if (diagonal) {
-                probes.add(new WorldPoint(toWp.getX(), fromWp.getY(), doorWp.getPlane()));
-                probes.add(new WorldPoint(fromWp.getX(), toWp.getY(), doorWp.getPlane()));
-            }
 
             for (WorldPoint probe : probes) {
                 if (recentlyOpenedStationaryDoorOnSegment(fromWp, toWp)) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -635,7 +635,7 @@ public class Rs2Walker {
                     if (isWalkCancelled(target)) {
                         return WalkerState.EXIT;
                     }
-                    log.info("[Walker click] target={} pathIdx={} playerBefore={} clicked={}",
+                    log.debug("[Walker click] target={} pathIdx={} playerBefore={} clicked={}",
                             targetWp, targetIdx, posBefore, clicked);
                     if (clicked) {
                         final WorldPoint b = targetWp;
@@ -685,7 +685,7 @@ public class Rs2Walker {
                         int moved = posAfter == null ? -1 : posBefore.distanceTo2D(posAfter);
                         int distLeft = posAfter == null ? -1 : b.distanceTo2D(posAfter);
                         long elapsedMs = System.currentTimeMillis() - clickedAt;
-                        log.info("[Walker click] result moved={} tiles posAfter={} distFromTarget={} elapsedMs={} reachedProximity={}",
+                        log.debug("[Walker click] result moved={} tiles posAfter={} distFromTarget={} elapsedMs={} reachedProximity={}",
                                 moved, posAfter, distLeft, elapsedMs, distLeft >= 0 && distLeft <= proximityWake);
                     }
                     // Keep stuck-detection honest: observed movement resets the movement timer.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -330,6 +330,25 @@ public class Rs2Walker {
                 dst = path.get(path.size()-1);
             }
 
+            // BFS exhausted both queues without reaching the target — destination is
+            // genuinely unreachable (quest-locked gate, walled-off area, etc.). Bail
+            // ONLY if endpoint is outside the caller's proximity threshold: when
+            // dst is within `distance` of target, the partial path lands the player
+            // close enough to satisfy the request (e.g., NPCs accept 1-tile reach,
+            // BFS commonly exhausts at adjacent-to-target when the final tile is a
+            // throne/altar/object the player can't stand on). Walking the path is
+            // correct in that case. Bailing only matters when the closest-found tile
+            // is genuinely far — that's what produced the 25+ tile palace tour.
+            if (pathfinder.isSearchExhausted()
+                    && (dst == null || dst.distanceTo(target) > distance)) {
+                log.warn("[Walker] Pathfinder exhausted search without reaching target {} (best endpoint {}, dist={}, threshold={}) — bailing UNREACHABLE",
+                        target, dst, dst == null ? -1 : dst.distanceTo(target), distance);
+                Telemetry.recordUnreachable("search-exhausted", Rs2Player.getWorldLocation(),
+                        target, dst, path == null ? 0 : path.size(), distance, pathfinder);
+                setTarget(null);
+                return WalkerState.UNREACHABLE;
+            }
+
             boolean partialPath = false;
             if (dst == null || dst.distanceTo(target) > distance) {
                 if (path != null && path.size() > 1) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -270,10 +270,18 @@ public class Rs2Walker {
      * @param distance
      */
     private static WalkerState processWalk(WorldPoint target, int distance) {
-        return processWalk(target, distance, 0);
+        return processWalk(target, distance, 0, 0, Integer.MAX_VALUE);
     }
 
-    private static WalkerState processWalk(WorldPoint target, int distance, int partialRetries) {
+    // Bound for the no-progress recursion path (line where finalDist >= distance and we
+    // re-enter). Each retry can burn ~10s on a failed transport interaction or a stuck
+    // mini-map click, so 5 retries caps the worst-case stuck loop at ~50s before the
+    // walker bails to UNREACHABLE. Without this, a transport that passes plan-time but
+    // fails at click-time put the walker into an unbounded loop (3h+ in the wild).
+    private static final int MAX_NO_PROGRESS_RETRIES = 5;
+
+    private static WalkerState processWalk(WorldPoint target, int distance, int partialRetries,
+                                           int noProgressRetries, int prevFinalDist) {
         if (debug) {
             return WalkerState.EXIT;
         }
@@ -358,7 +366,7 @@ public class Rs2Walker {
                 lastMovedTimeMs = System.currentTimeMillis();
                 stuckCount = 0;
                 setTarget(target);
-                return processWalk(target, distance, partialRetries);
+                return processWalk(target, distance, partialRetries, noProgressRetries, prevFinalDist);
             }
             if (stuckCount > 10) {
                 var reachable = Rs2Tile.getReachableTilesFromTile(Rs2Player.getWorldLocation(), 5).keySet();
@@ -676,7 +684,7 @@ public class Rs2Walker {
                     log.info("[Walker] Walked partial path ({} tiles remaining), retrying from current position (attempt {}/3)",
                             finalDist, partialRetries + 1);
                     recalculatePath();
-                    return processWalk(target, distance, partialRetries + 1);
+                    return processWalk(target, distance, partialRetries + 1, noProgressRetries, prevFinalDist);
                 }
                 log.info("[Walker] Walked partial path, exhausted retries. final distance to target: {}", finalDist);
                 Telemetry.recordUnreachable("partial-retries-exhausted", Rs2Player.getWorldLocation(),
@@ -692,7 +700,16 @@ public class Rs2Walker {
                         return WalkerState.EXIT;
                     }
                 }
-                return processWalk(target, distance, partialRetries);
+                int nextNoProgress = (finalDist >= prevFinalDist) ? noProgressRetries + 1 : 0;
+                if (nextNoProgress > MAX_NO_PROGRESS_RETRIES) {
+                    log.warn("[Walker] No progress after {} retries (finalDist={}, prevFinalDist={}, exitReason={}) — bailing UNREACHABLE",
+                            nextNoProgress, finalDist, prevFinalDist, exitReason);
+                    Telemetry.recordUnreachable("no-progress-retries-exhausted", Rs2Player.getWorldLocation(),
+                            target, Rs2Player.getWorldLocation(), 0, distance, ShortestPathPlugin.getPathfinder());
+                    setTarget(null);
+                    return WalkerState.UNREACHABLE;
+                }
+                return processWalk(target, distance, partialRetries, nextNoProgress, finalDist);
             }
         } catch (Exception ex) {
             if (ex instanceof InterruptedException || ex.getCause() instanceof InterruptedException) {
@@ -2930,6 +2947,18 @@ public class Rs2Walker {
                             markAdjacentSamePlaneTransportHandled(transport, object);
                             return finishHandledTransport(transport);
                         }
+                        // Static eligibility (member flag, levels, quest, varbits) said this
+                        // transport was usable, but the click produced no movement within
+                        // the arrival window. Hidden server-side gate (region unlock,
+                        // sub-quest progression, etc.). Blacklist the origin so the next
+                        // pathfinder run routes around it instead of re-emitting the same
+                        // broken edge — the unbounded retry loop this prevented produced
+                        // ~3 hours of position oscillation in the wild (240 STALL_RECALC
+                        // events on one Varrock palace shortcut).
+                        log.warn("[Walker] Transport {} (type={} origin={} dest={}) failed to deliver player after click — blacklisting origin",
+                                transport.getDisplayInfo(), transport.getType(), transport.getOrigin(), transport.getDestination());
+                        ShortestPathPlugin.getPathfinderConfig().addFailedTransportRestriction(transport.getOrigin());
+                        setTarget(null);
                         return false;
                     }
                 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -2656,6 +2656,17 @@ public class Rs2Walker {
         }
 
         for (Transport transport : transports) {
+            // Patch H virtual door edges exist purely so BFS can route through scene
+            // doors not in transports.tsv. The actual click is owned by handleDoors,
+            // which probes wall orientation against the consecutive fromWp↔toWp edge
+            // and only opens doors that block that specific step. handleTransports
+            // here would open any door whose origin matches path[i] and whose
+            // destination is anywhere later on the path — so a scene wall whose two
+            // tiles both happen to land on the path (common in Varrock palace where
+            // the path winds past multiple doors) gets opened off-edge.
+            if (transport.isSceneDiscovered()) {
+                continue;
+            }
             Collection<WorldPoint> worldPointCollections;
             //in some cases the getOrigin is null, for teleports that start the player location
             if (transport.getOrigin() == null) {

--- a/runelite-client/src/test/resources/threadsafety/client-thread-guardrail-baseline.txt
+++ b/runelite-client/src/test/resources/threadsafety/client-thread-guardrail-baseline.txt
@@ -67,12 +67,14 @@ net.runelite.client.plugins.microbot.api.tileobject.Rs2TileObjectCache#getStream
 net.runelite.client.plugins.microbot.api.tileobject.Rs2TileObjectCache#getStream(): Stream  ->  net.runelite.api.Client#getWorldView(int): WorldView
 net.runelite.client.plugins.microbot.api.tileobject.Rs2TileObjectCache#getStream(): Stream  ->  net.runelite.api.Scene#getTiles(): Tile[][][]
 net.runelite.client.plugins.microbot.api.tileobject.Rs2TileObjectCache#getStream(): Stream  ->  net.runelite.api.Tile#getGameObjects(): GameObject[]
+net.runelite.client.plugins.microbot.api.tileobject.Rs2TileObjectCache#getStream(): Stream  ->  net.runelite.api.Tile#getWallObject(): WallObject
 net.runelite.client.plugins.microbot.api.tileobject.Rs2TileObjectCache#getStream(): Stream  ->  net.runelite.api.WorldView#getId(): int
 net.runelite.client.plugins.microbot.api.tileobject.Rs2TileObjectCache#getStream(): Stream  ->  net.runelite.api.WorldView#getPlane(): int
 net.runelite.client.plugins.microbot.api.tileobject.Rs2TileObjectCache#getStream(): Stream  ->  net.runelite.api.WorldView#getScene(): Scene
 net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.Client#isWidgetSelected(): boolean
 net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.GameObject#sizeX(): int
 net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.GameObject#sizeY(): int
+net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.ObjectComposition#getImpostor(): ObjectComposition
 net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.ObjectComposition#getImpostorIds(): int[]
 net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.ObjectComposition#getName(): String
@@ -181,6 +183,7 @@ net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#clickObject(T
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#clickObject(TileObject, String): boolean  ->  net.runelite.api.Client#isWidgetSelected(): boolean
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#clickObject(TileObject, String): boolean  ->  net.runelite.api.GameObject#sizeX(): int
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#clickObject(TileObject, String): boolean  ->  net.runelite.api.GameObject#sizeY(): int
+net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#clickObject(TileObject, String): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#clickObject(TileObject, String): boolean  ->  net.runelite.api.ObjectComposition#getImpostor(): ObjectComposition
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#clickObject(TileObject, String): boolean  ->  net.runelite.api.ObjectComposition#getImpostorIds(): int[]
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#clickObject(TileObject, String): boolean  ->  net.runelite.api.ObjectComposition#getName(): String
@@ -255,6 +258,7 @@ net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#getWallObject
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#getWorldArea(GameObject): WorldArea  ->  net.runelite.api.GameObject#sizeX(): int
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#getWorldArea(GameObject): WorldArea  ->  net.runelite.api.GameObject#sizeY(): int
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#getWorldArea(GameObject): WorldArea  ->  net.runelite.api.coords.WorldPoint#fromLocal(Client, LocalPoint): WorldPoint
+net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#hasAction(ObjectComposition, String, boolean): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#hasLineOfSight(WorldPoint, TileObject): boolean  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#hasLineOfSight(WorldPoint, TileObject): boolean  ->  net.runelite.api.GameObject#sizeX(): int
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#hasLineOfSight(WorldPoint, TileObject): boolean  ->  net.runelite.api.GameObject#sizeY(): int
@@ -266,6 +270,7 @@ net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$findBa
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$findDepositBox$20(GameObject): boolean  ->  net.runelite.api.GameObject#getId(): int
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$findGameObjectByLocation$7(WorldPoint, GameObject): boolean  ->  net.runelite.api.GameObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$findGrandExchangeBooth$21(WallObject): boolean  ->  net.runelite.api.WallObject#getId(): int
+net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$findGrandExchangeBooth$21(WallObject): boolean  ->  net.runelite.api.WallObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$findObject$10(int, WorldPoint, GameObject): boolean  ->  net.runelite.api.GameObject#getId(): int
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$findObject$10(int, WorldPoint, GameObject): boolean  ->  net.runelite.api.GameObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$findObject$37(Set, GameObject): boolean  ->  net.runelite.api.GameObject#getId(): int
@@ -294,11 +299,15 @@ net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$getWal
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$getWallObject$60(Set, WallObject): boolean  ->  net.runelite.api.WallObject#getId(): int
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$nameMatches$85(Set, boolean, String, String, TileObject): boolean  ->  net.runelite.api.TileObject#getId(): int
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$static$0(Tile): Collection  ->  net.runelite.api.Tile#getGameObjects(): GameObject[]
+net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$static$3(Tile): Collection  ->  net.runelite.api.Tile#getWallObject(): WallObject
+net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#lambda$static$4(Tile): Collection  ->  net.runelite.api.Tile#getWallObject(): WallObject
 net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject#localPointFromWorldSafe(WorldPoint): LocalPoint  ->  net.runelite.api.coords.LocalPoint#fromWorld(WorldView, WorldPoint): LocalPoint
 net.runelite.client.plugins.microbot.util.gameobject.Rs2ObjectModel#<init>(TileObject, Tile): void  ->  net.runelite.api.Client#getTickCount(): int
 net.runelite.client.plugins.microbot.util.gameobject.Rs2ObjectModel#<init>(TileObject, Tile): void  ->  net.runelite.api.GameObject#sizeX(): int
 net.runelite.client.plugins.microbot.util.gameobject.Rs2ObjectModel#<init>(TileObject, Tile): void  ->  net.runelite.api.GameObject#sizeY(): int
+net.runelite.client.plugins.microbot.util.gameobject.Rs2ObjectModel#blocksLineOfSight(): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.gameobject.Rs2ObjectModel#blocksLineOfSight(): boolean  ->  net.runelite.api.ObjectComposition#getName(): String
+net.runelite.client.plugins.microbot.util.gameobject.Rs2ObjectModel#getActions(): String[]  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.gameobject.Rs2ObjectModel#getCanonicalLocation(): WorldPoint  ->  net.runelite.api.Tile#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.gameobject.Rs2ObjectModel#getCanonicalLocation(): WorldPoint  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.gameobject.Rs2ObjectModel#getId(): int  ->  net.runelite.api.TileObject#getId(): int
@@ -681,6 +690,7 @@ net.runelite.client.plugins.microbot.util.tile.Rs2Tile#isVisited(WorldPoint, boo
 net.runelite.client.plugins.microbot.util.tile.Rs2Tile#isWalkable(WorldPoint): boolean  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
 net.runelite.client.plugins.microbot.util.tile.Rs2Tile#isWalkable(WorldPoint): boolean  ->  net.runelite.api.coords.LocalPoint#fromWorld(WorldView, WorldPoint): LocalPoint
 net.runelite.client.plugins.microbot.util.tile.Rs2Tile#lambda$isBankBooth$20(WorldPoint, GameObject): boolean  ->  net.runelite.api.GameObject#getWorldLocation(): WorldPoint
+net.runelite.client.plugins.microbot.util.tile.Rs2Tile#lambda$tileHasWalls$19(WorldPoint, WallObject): boolean  ->  net.runelite.api.WallObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.tile.Rs2Tile#pathTo(Tile, Tile): List  ->  net.runelite.api.Client#getScene(): Scene
 net.runelite.client.plugins.microbot.util.tile.Rs2Tile#pathTo(Tile, Tile): List  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
 net.runelite.client.plugins.microbot.util.tile.Rs2Tile#pathTo(Tile, Tile): List  ->  net.runelite.api.CollisionData#getFlags(): int[][]
@@ -690,6 +700,7 @@ net.runelite.client.plugins.microbot.util.tileobject.Rs2TileObjectModel#click(St
 net.runelite.client.plugins.microbot.util.tileobject.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.Client#isWidgetSelected(): boolean
 net.runelite.client.plugins.microbot.util.tileobject.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.GameObject#sizeX(): int
 net.runelite.client.plugins.microbot.util.tileobject.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.GameObject#sizeY(): int
+net.runelite.client.plugins.microbot.util.tileobject.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.tileobject.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.ObjectComposition#getImpostor(): ObjectComposition
 net.runelite.client.plugins.microbot.util.tileobject.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.ObjectComposition#getImpostorIds(): int[]
 net.runelite.client.plugins.microbot.util.tileobject.Rs2TileObjectModel#click(String): boolean  ->  net.runelite.api.ObjectComposition#getName(): String
@@ -708,6 +719,7 @@ net.runelite.client.plugins.microbot.util.walker.Rs2Walker#adjacentSamePlaneTran
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#closeWorldMap(): boolean  ->  net.runelite.api.widgets.Widget#getBounds(): Rectangle
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#distanceToRegion(int, int): int  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#distanceToRegion(int, int): int  ->  net.runelite.api.WorldView#getPlane(): int
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#getDoorAction(ObjectComposition, List): String  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#getPointWithWallDistance(WorldPoint): WorldPoint  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#getPointWithWallDistance(WorldPoint): WorldPoint  ->  net.runelite.api.CollisionData#getFlags(): int[][]
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#getPointWithWallDistance(WorldPoint): WorldPoint  ->  net.runelite.api.WorldView#getCollisionMaps(): CollisionData[]
@@ -718,6 +730,7 @@ net.runelite.client.plugins.microbot.util.walker.Rs2Walker#getTile(WorldPoint): 
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#getTile(WorldPoint): Tile  ->  net.runelite.api.WorldView#getScene(): Scene
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#getTile(WorldPoint): Tile  ->  net.runelite.api.coords.LocalPoint#fromWorld(WorldView, WorldPoint): LocalPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#getTransportsForPath(List, int, TransportType, boolean): List  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleCanoe(Transport): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleCharterShip(Transport): boolean  ->  net.runelite.api.widgets.Widget#getDynamicChildren(): Widget[]
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleCharterShip(Transport): boolean  ->  net.runelite.api.widgets.Widget#getId(): int
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleCharterShip(Transport): boolean  ->  net.runelite.api.widgets.Widget#getIndex(): int
@@ -742,6 +755,7 @@ net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleRockfall(List, 
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleRockfall(List, int): boolean  ->  net.runelite.api.TileObject#getId(): int
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleSpiritTree(Transport): boolean  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleTransports(List, int): boolean  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleTransports(List, int): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleTransports(List, int): boolean  ->  net.runelite.api.ObjectComposition#getName(): String
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleTransports(List, int): boolean  ->  net.runelite.api.Scene#isInstance(): boolean
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleTransports(List, int): boolean  ->  net.runelite.api.TileObject#getId(): int
@@ -749,15 +763,21 @@ net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleTransports(List
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#handleTransports(List, int): boolean  ->  net.runelite.api.WorldView#getScene(): Scene
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#isCloseToRegion(int, int, int): boolean  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#isCloseToRegion(int, int, int): boolean  ->  net.runelite.api.WorldView#getPlane(): int
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#isDoorComposition(ObjectComposition, List): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#isDoorComposition(ObjectComposition, List): boolean  ->  net.runelite.api.ObjectComposition#getImpostorIds(): int[]
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#isDoorComposition(ObjectComposition, List): boolean  ->  net.runelite.api.ObjectComposition#getName(): String
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#isDoorOnSegment(TileObject, WorldPoint, WorldPoint): boolean  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#isKnownWalkableOrUnloaded(WorldPoint): boolean  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#isKnownWalkableOrUnloaded(WorldPoint): boolean  ->  net.runelite.api.coords.LocalPoint#fromWorld(WorldView, WorldPoint): LocalPoint
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$doorStillHasAction$34(WorldPoint, WallObject): boolean  ->  net.runelite.api.WallObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$doorStillHasAction$35(WorldPoint, GameObject): boolean  ->  net.runelite.api.GameObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$findDoorNearSegment$32(WorldPoint, WorldPoint, WorldPoint, List, TileObject): boolean  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$findDoorNearSegment$33(WorldPoint, TileObject): int  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleCanoe$131(Transport, String): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleCanoe$134(Transport, String): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleCanoe$136(Transport, String): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleCharterShip$146(Widget): boolean  ->  net.runelite.api.widgets.Widget#getActions(): String[]
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleDoors$30(WorldPoint, WallObject): boolean  ->  net.runelite.api.WallObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleDoors$31(WorldPoint, GameObject): boolean  ->  net.runelite.api.GameObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleFairyRing$152(Transport, TileObject): boolean  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleMinigameTeleport$125(Widget, Object[]): boolean  ->  net.runelite.api.widgets.Widget#getOnOpListener(): Object[]
@@ -770,18 +790,21 @@ net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleObjectEx
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleRockfall$17(WorldPoint, Tile): boolean  ->  net.runelite.api.Tile#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleTransports$74(int, TileObject): boolean  ->  net.runelite.api.TileObject#getId(): int
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleTransports$76(Transport, TileObject): int  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleTransports$78(TileObject): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleTransports$78(TileObject): boolean  ->  net.runelite.api.ObjectComposition#getName(): String
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleTransports$79(Transport, TileObject): int  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleTransports$80(TileObject): boolean  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleTransports$81(Transport, Object): Integer  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleTransports$82(Transport, Object): Integer  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleTransports$84(int, List, TileObject): boolean  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleTransports$84(int, List, TileObject): boolean  ->  net.runelite.api.TileObject#getId(): int
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleTransports$85(Transport, TileObject): int  ->  net.runelite.api.TileObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleWildernessObelisk$111(Transport, GameObject): boolean  ->  net.runelite.api.GameObject#getId(): int
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$handleWildernessObelisk$112(Transport, GameObject): boolean  ->  net.runelite.api.GameObject#getId(): int
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$processWalk$0(): boolean  ->  net.runelite.api.widgets.Widget#getSpriteId(): int
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#lambda$processWalk$1(): boolean  ->  net.runelite.api.widgets.Widget#getSpriteId(): int
-net.runelite.client.plugins.microbot.util.walker.Rs2Walker#processWalk(WorldPoint, int, int): WalkerState  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#processWalk(WorldPoint, int, int, int, int): WalkerState  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#resolveTransportObjectAction(TileObject, List): Optional  ->  net.runelite.api.ObjectComposition#getActions(): String[]
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#restartPathfinding(WorldPoint, Set): boolean  ->  net.runelite.api.Client#isClientThread(): boolean
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#setStart(WorldPoint): void  ->  net.runelite.api.Client#isClientThread(): boolean
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#setTarget(WorldPoint): void  ->  net.runelite.api.Client#getLocalPlayer(): Player
@@ -791,6 +814,7 @@ net.runelite.client.plugins.microbot.util.walker.Rs2Walker#setTarget(WorldPoint)
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#staminaThreshold(): int  ->  net.runelite.api.Client#getLocalPlayer(): Player
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#staminaThreshold(): int  ->  net.runelite.api.Player#getName(): String
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#tryHandleDoorObject(TileObject, WorldPoint, WorldPoint, WorldPoint, List, boolean): boolean  ->  net.runelite.api.ObjectComposition#getName(): String
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#tryHandleDoorObject(TileObject, WorldPoint, WorldPoint, WorldPoint, List, boolean): boolean  ->  net.runelite.api.WallObject#getOrientationA(): int
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#walkCanvas(WorldPoint): WorldPoint  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#walkCanvas(WorldPoint): WorldPoint  ->  net.runelite.api.WorldView#getPlane(): int
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#walkCanvas(WorldPoint): WorldPoint  ->  net.runelite.api.coords.LocalPoint#fromWorld(WorldView, WorldPoint): LocalPoint
@@ -807,6 +831,8 @@ net.runelite.client.plugins.microbot.util.walker.Rs2Walker#walkWithBankedTranspo
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#walkWithStateInternal(WorldPoint, int): WalkerState  ->  net.runelite.api.Client#getTopLevelWorldView(): WorldView
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#walkWithStateInternal(WorldPoint, int): WalkerState  ->  net.runelite.api.Client#isClientThread(): boolean
 net.runelite.client.plugins.microbot.util.walker.Rs2Walker#walkWithStateInternal(WorldPoint, int): WalkerState  ->  net.runelite.api.coords.LocalPoint#fromWorld(WorldView, WorldPoint): LocalPoint
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#wallDoorTouchesSegment(WallObject, WorldPoint, WorldPoint): boolean  ->  net.runelite.api.WallObject#getOrientationA(): int
+net.runelite.client.plugins.microbot.util.walker.Rs2Walker#wallDoorTouchesSegment(WallObject, WorldPoint, WorldPoint): boolean  ->  net.runelite.api.WallObject#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.widget.Rs2Widget#checkBoundsOverlapWidgetInMainModal(Rectangle, int, int): boolean  ->  net.runelite.api.widgets.Widget#isHidden(): boolean
 net.runelite.client.plugins.microbot.util.widget.Rs2Widget#checkWidgetAndDescendantsForOverlapCanvas(Widget, Rectangle, int, int): boolean  ->  net.runelite.api.widgets.Widget#getBounds(): Rectangle
 net.runelite.client.plugins.microbot.util.widget.Rs2Widget#checkWidgetAndDescendantsForOverlapCanvas(Widget, Rectangle, int, int): boolean  ->  net.runelite.api.widgets.Widget#getDynamicChildren(): Widget[]


### PR DESCRIPTION
## Summary

Fixes for Rs2Walker getting stuck, retrying forever, or clicking the wrong door on long indoor paths (Varrock palace was the canonical case driving the work). Builds on the prior Round-1 commit ([330485ef33](https://github.com/chsami/Microbot/commit/330485ef33)) which already covered failed-transport blacklisting, bounded recursion, and Rs2Tile bounds-checking.

Six commits, each landing one fix:

- **`fix(pathfinder): block walking edges whose only crossing is a filtered transport`** — when a transport is filtered out (member-only, quest gate, F2P), the upstream collision map can still permit walking across the underlying obstacle. Track those edges in a per-refresh blocked-edge set; CollisionMap consults it during neighbor expansion.
- **`fix(walker): bail UNREACHABLE on BFS exhaustion outside proximity threshold`** — Pathfinder records a \`searchExhausted\` flag when both queues drain without target reach; walker bails UNREACHABLE only when the best endpoint is farther than the caller's \`distance\` threshold (preserves valid one-tile-short approaches at NPCs/altars).
- **`feat(pathfinder): inject scene-discovered doors as virtual transports for BFS`** — transports.tsv is incomplete (palace internal doors etc.). On every refresh, scan the loaded scene for door WallObjects and inject bidirectional virtual TRANSPORT edges so BFS can route through them. Whole scan in a single client-thread hop (~20ms vs ~26s for per-wall hops).
- **`fix(walker): skip scene-discovered transports in handleTransports`** — handleTransports' destIdx >= originIdx ordering check was not consecutive; scene-discovered virtuals fired silently for any door whose two endpoints both landed somewhere on the path. Tag the virtuals with \`sceneDiscovered=true\` and skip them — handleDoors owns the actual click via WallObject orientation against \`path[i]→path[i+1]\`. Adds INFO log before any handleObject open.
- **`chore(pathfinder): null-guard refresh tab switch + AGILITY_SHORTCUT F2P diagnostic`** — refresh() can fire pre-LocalPlayer-hydration on login and NPE'd. Skip tab switch when player loc is null. One-shot F2P diagnostic on first AGILITY_SHORTCUT seen each refresh.
- **`fix(walker): pre-scan path for closed doors before skip-clicking, drop wrong diagonal probes`** — skip-clicks past closed doors stranded the player; pre-scan ascending from i for the nearest in-range closed path tile and open it before the click. Also drops handleDoors' diagonal corner probes that were opening shoulder-tile doors not actually blocking the fromWp↔toWp edge.

## Test plan

- [x] \`:client:compileJava\` clean (already verified locally)
- [x] Walk Varrock entrance → throne \`(3224,3488,0)\` on F2P: opens exactly 2 on-path doors, no off-path opens, walker reaches throne
- [x] Long minimap-skip walks past closed doors: pre-scan opens the door before the click, no stranded-against-door state
- [x] Quest-locked region (e.g. Rogues' Den without thieving level): bails UNREACHABLE quickly instead of touring the locked area
- [x] F2P trellis at \`(3228,3470)\`: BFS routes around it instead of walking through
- [x] Members AGILITY_SHORTCUT still selectable (F2P diag does not gate, only logs)