### PR TITLE
feat(agent-server): add quest-helper and /logout endpoints

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/AgentServerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/AgentServerPlugin.java
@@ -142,6 +142,7 @@ public class AgentServerPlugin extends Plugin {
 				new SkillsHandler(gson, client),
 				new ScriptHandler(gson),
 				new LoginHandler(gson, client),
+				new LogoutHandler(gson, client),
 				new ScreenshotHandler(gson, client, drawManager),
 				new VarbitHandler(gson),
 				new VarpHandler(gson),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/LogoutHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/LogoutHandler.java
@@ -71,8 +71,19 @@ public class LogoutHandler extends AgentHandler {
 				wait = Boolean.TRUE.equals(body.get("wait"));
 			}
 			if (body.containsKey("timeout")) {
-				timeoutSeconds = Math.min(((Number) body.get("timeout")).intValue(), MAX_TIMEOUT_SECONDS);
-				if (timeoutSeconds <= 0) timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+				Object raw = body.get("timeout");
+				int parsed = 0;
+				if (raw instanceof Number) {
+					parsed = ((Number) raw).intValue();
+				} else if (raw instanceof String) {
+					try {
+						parsed = Integer.parseInt(((String) raw).trim());
+					} catch (NumberFormatException ignored) {
+					}
+				}
+				if (parsed > 0) {
+					timeoutSeconds = Math.min(parsed, MAX_TIMEOUT_SECONDS);
+				}
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/LogoutHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/LogoutHandler.java
@@ -1,0 +1,145 @@
+package net.runelite.client.plugins.microbot.agentserver.handler;
+
+import com.google.gson.Gson;
+import com.sun.net.httpserver.HttpExchange;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Slf4j
+public class LogoutHandler extends AgentHandler {
+
+	private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+	private static final int MAX_TIMEOUT_SECONDS = 120;
+	private static final int POLL_INTERVAL_MS = 600;
+
+	private final Client client;
+
+	public LogoutHandler(Gson gson, Client client) {
+		super(gson);
+		this.client = client;
+	}
+
+	@Override
+	public String getPath() {
+		return "/logout";
+	}
+
+	@Override
+	protected void handleRequest(HttpExchange exchange) throws IOException {
+		String method = exchange.getRequestMethod().toUpperCase();
+
+		if ("GET".equals(method)) {
+			handleStatus(exchange);
+		} else if ("POST".equals(method)) {
+			handleLogout(exchange);
+		} else {
+			sendJson(exchange, 405, errorResponse("Use GET or POST"));
+		}
+	}
+
+	private void handleStatus(HttpExchange exchange) throws IOException {
+		Map<String, Object> result = new LinkedHashMap<>();
+		result.put("loggedIn", Microbot.isLoggedIn());
+		result.put("gameState", client.getGameState().name());
+		sendJson(exchange, 200, result);
+	}
+
+	private void handleLogout(HttpExchange exchange) throws IOException {
+		if (!Microbot.isLoggedIn()) {
+			Map<String, Object> result = new LinkedHashMap<>();
+			result.put("success", true);
+			result.put("message", "Already logged out");
+			result.put("gameState", client.getGameState().name());
+			sendJson(exchange, 200, result);
+			return;
+		}
+
+		Map<String, Object> body = readJsonBody(exchange);
+
+		boolean wait = true;
+		int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+
+		if (body != null) {
+			if (body.containsKey("wait")) {
+				wait = Boolean.TRUE.equals(body.get("wait"));
+			}
+			if (body.containsKey("timeout")) {
+				timeoutSeconds = Math.min(((Number) body.get("timeout")).intValue(), MAX_TIMEOUT_SECONDS);
+				if (timeoutSeconds <= 0) timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+			}
+		}
+
+		long startTime = System.currentTimeMillis();
+
+		try {
+			Rs2Player.logout();
+		} catch (Exception e) {
+			log.error("Logout attempt failed", e);
+			sendJson(exchange, 500, errorResponse("Logout failed: " + e.getMessage()));
+			return;
+		}
+
+		if (!wait) {
+			Map<String, Object> result = new LinkedHashMap<>();
+			result.put("success", true);
+			result.put("message", "Logout initiated");
+			sendJson(exchange, 200, result);
+			return;
+		}
+
+		LogoutResult logoutResult = waitForLogoutResult(timeoutSeconds);
+		long durationMs = System.currentTimeMillis() - startTime;
+
+		Map<String, Object> result = new LinkedHashMap<>();
+		result.put("success", logoutResult.success);
+		result.put("gameState", client.getGameState().name());
+		result.put("durationMs", durationMs);
+		result.put("message", logoutResult.message);
+
+		sendJson(exchange, logoutResult.success ? 200 : 408, result);
+	}
+
+	private LogoutResult waitForLogoutResult(int timeoutSeconds) {
+		long deadline = System.currentTimeMillis() + (timeoutSeconds * 1000L);
+
+		while (System.currentTimeMillis() < deadline) {
+			if (!Microbot.isLoggedIn() && client.getGameState() == GameState.LOGIN_SCREEN) {
+				return LogoutResult.ok("Logout successful");
+			}
+
+			try {
+				Thread.sleep(POLL_INTERVAL_MS);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return LogoutResult.fail("Logout interrupted");
+			}
+		}
+
+		return LogoutResult.fail("Logout timed out after " + timeoutSeconds + "s");
+	}
+
+	private static class LogoutResult {
+		final boolean success;
+		final String message;
+
+		LogoutResult(boolean success, String message) {
+			this.success = success;
+			this.message = message;
+		}
+
+		static LogoutResult ok(String message) {
+			return new LogoutResult(true, message);
+		}
+
+		static LogoutResult fail(String message) {
+			return new LogoutResult(false, message);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/QuestHelperHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/QuestHelperHandler.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import net.runelite.api.Client;
+import net.runelite.api.QuestState;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.questhelper.QuestHelperConfig;
@@ -50,6 +52,9 @@ public class QuestHelperHandler extends AgentHandler
 			case "":
 			case "/":
 				handleList(exchange);
+				break;
+			case "/states":
+				handleStates(exchange);
 				break;
 			default:
 				sendJson(exchange, 404, errorResponse("Unknown endpoint: " + BASE_PATH + sub));
@@ -199,6 +204,56 @@ public class QuestHelperHandler extends AgentHandler
 		Map<String, Object> result = new LinkedHashMap<>();
 		result.put("count", quests.size());
 		result.put("quests", quests);
+		sendJson(exchange, 200, result);
+	}
+
+	private void handleStates(HttpExchange exchange) throws IOException
+	{
+		try
+		{
+			requireGet(exchange);
+		}
+		catch (HttpMethodException e)
+		{
+			sendJson(exchange, 405, errorResponse(e.getMessage()));
+			return;
+		}
+
+		Client client = Microbot.getClient();
+		if (client == null)
+		{
+			sendJson(exchange, 503, errorResponse("Client not available"));
+			return;
+		}
+
+		List<Map<String, Object>> states = Microbot.getClientThread()
+			.runOnClientThreadOptional(() ->
+			{
+				List<Map<String, Object>> out = new ArrayList<>();
+				for (QuestHelperQuest qhq : QuestHelperQuest.values())
+				{
+					Map<String, Object> entry = new LinkedHashMap<>();
+					entry.put("enum", qhq.name());
+					entry.put("displayName", qhq.getName());
+					try
+					{
+						QuestState state = qhq.getState(client);
+						entry.put("state", state != null ? state.name() : "UNKNOWN");
+					}
+					catch (Exception ex)
+					{
+						entry.put("state", "ERROR");
+						entry.put("error", ex.getClass().getSimpleName() + ": " + ex.getMessage());
+					}
+					out.add(entry);
+				}
+				return out;
+			})
+			.orElse(new ArrayList<>());
+
+		Map<String, Object> result = new LinkedHashMap<>();
+		result.put("count", states.size());
+		result.put("quests", states);
 		sendJson(exchange, 200, result);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/QuestHelperHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/agentserver/handler/QuestHelperHandler.java
@@ -3,13 +3,16 @@ package net.runelite.client.plugins.microbot.agentserver.handler;
 import com.google.gson.Gson;
 import com.sun.net.httpserver.HttpExchange;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.questhelper.QuestHelperConfig;
 import net.runelite.client.plugins.microbot.questhelper.QuestHelperPlugin;
 import net.runelite.client.plugins.microbot.questhelper.questhelpers.QuestHelper;
+import net.runelite.client.plugins.microbot.questhelper.questinfo.QuestHelperQuest;
 import net.runelite.client.plugins.microbot.questhelper.steps.QuestStep;
 
 public class QuestHelperHandler extends AgentHandler
@@ -39,6 +42,14 @@ public class QuestHelperHandler extends AgentHandler
 				break;
 			case "/start":
 				handleStart(exchange);
+				break;
+			case "/stop":
+				handleStop(exchange);
+				break;
+			case "/list":
+			case "":
+			case "/":
+				handleList(exchange);
 				break;
 			default:
 				sendJson(exchange, 404, errorResponse("Unknown endpoint: " + BASE_PATH + sub));
@@ -135,6 +146,59 @@ public class QuestHelperHandler extends AgentHandler
 		Map<String, Object> result = new LinkedHashMap<>();
 		result.put("success", true);
 		result.put("questName", name);
+		sendJson(exchange, 200, result);
+	}
+
+	private void handleStop(HttpExchange exchange) throws IOException
+	{
+		try
+		{
+			requirePost(exchange);
+		}
+		catch (HttpMethodException e)
+		{
+			sendJson(exchange, 405, errorResponse(e.getMessage()));
+			return;
+		}
+
+		QuestHelperPlugin plugin = Microbot.getPlugin(QuestHelperPlugin.class);
+		if (plugin == null)
+		{
+			sendJson(exchange, 404, errorResponse("Quest Helper plugin not found"));
+			return;
+		}
+
+		plugin.getQuestManager().shutDownQuest(true);
+
+		Map<String, Object> result = new LinkedHashMap<>();
+		result.put("success", true);
+		sendJson(exchange, 200, result);
+	}
+
+	private void handleList(HttpExchange exchange) throws IOException
+	{
+		try
+		{
+			requireGet(exchange);
+		}
+		catch (HttpMethodException e)
+		{
+			sendJson(exchange, 405, errorResponse(e.getMessage()));
+			return;
+		}
+
+		List<Map<String, Object>> quests = new ArrayList<>();
+		for (QuestHelperQuest qhq : QuestHelperQuest.values())
+		{
+			Map<String, Object> entry = new LinkedHashMap<>();
+			entry.put("enum", qhq.name());
+			entry.put("displayName", qhq.getName());
+			quests.add(entry);
+		}
+
+		Map<String, Object> result = new LinkedHashMap<>();
+		result.put("count", quests.size());
+		result.put("quests", quests);
 		sendJson(exchange, 200, result);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
@@ -1298,7 +1298,7 @@ public class QuestScript extends Script {
         // doesn't mean a direct click will succeed. Require line-of-sight too, or we walk instead.
         if (npc != null && npc.getLocalLocation() != null && Rs2Camera.isTileOnScreen(npc.getLocalLocation())
                 && (Microbot.getClient().isInInstancedRegion() || (Rs2Walker.canReach(npc.getWorldLocation()) && npc.hasLineOfSight()))) {
-             Rs2Walker.clearWalkingRoute("quest-helper:npc-step-visible-interact");
+            Rs2Walker.clearWalkingRoute("quest-helper:npc-step-visible-interact");
 
             if (step.getText().stream().anyMatch(x -> x.toLowerCase().contains("kill"))) {
                 if (!Rs2Combat.inCombat()) {


### PR DESCRIPTION
## Summary
- Expands the agent server to expose Quest Helper control + state introspection so external agents can drive and observe quest progress.
- Adds a `/logout` endpoint mirroring the existing `/login` handler so an agent can end a session cleanly.

## Endpoints added
**`/quest-helper`** (`QuestHelperHandler`)
- `/quest-helper/list` — list available quests
- `/quest-helper/start` — start a quest
- `/quest-helper/stop` — stop the quest helper
- `/quest-helper/status` — status of the current quest run
- `/quest-helper/states` — bulk state read across all quests in a single response

**`/logout`** (`LogoutHandler`)
- Mirrors `LoginHandler` semantics; registered alongside it in `AgentServerPlugin.buildHandlers`.

## Other changes
- `QuestScript.java`: 1-line whitespace fix on the line introduced by the recent `clearWalkingRoute(...)` migration. No behavior change; the fix is a side-effect of resolving the cherry-pick against the older `Rs2Walker.setTarget(null)` call this branch was built on.

## Test plan
- [ ] Start the client with the agent server enabled and a valid token
- [ ] `GET /quest-helper/list` returns the available quests
- [ ] `POST /quest-helper/start` with a known quest name starts the helper
- [ ] `GET /quest-helper/status` reflects the running quest
- [ ] `POST /quest-helper/stop` halts the helper cleanly
- [ ] `GET /quest-helper/states` returns the full per-quest state map in one response
- [ ] `POST /logout` ends the session in the same way `/login` begins it