### PR TITLE
refactor(util): migrate util/* off deprecated Rs2GameObject and Rs2Npc

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/tileobject/models/Rs2TileObjectModel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/tileobject/models/Rs2TileObjectModel.java
@@ -50,6 +50,7 @@ public class Rs2TileObjectModel implements TileObject, IEntity {
 
     @Getter
     private final TileObjectType tileObjectType;
+    @Getter
     private final TileObject tileObject;
     private String[] actions;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DeathEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/events/DeathEvent.java
@@ -8,7 +8,6 @@ import net.runelite.client.plugins.microbot.BlockingEventPriority;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.Global;
 import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
-import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 
 import java.util.List;
@@ -44,7 +43,9 @@ public class DeathEvent implements BlockingEvent {
                         .collect(Collectors.toList());
 
                 if (completedDialogueOptions.size() >= 4) {
-                    Rs2GameObject.interact(DEATHS_PORTAL, "use");
+                    Microbot.getRs2TileObjectCache().query()
+                            .withId(DEATHS_PORTAL)
+                            .interact("use");
                     return Global.sleepUntil(() -> Rs2Player.getWorldLocation().getRegionID() != DEATH_DOMAIN_REGION_ID, 10000);
                 }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2Cannon.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/gameobject/Rs2Cannon.java
@@ -1,11 +1,11 @@
 package net.runelite.client.plugins.microbot.util.gameobject;
 
 import net.runelite.api.ObjectID;
-import net.runelite.api.TileObject;
 import net.runelite.api.VarPlayer;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.client.plugins.cannon.CannonPlugin;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
@@ -16,22 +16,24 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 public class Rs2Cannon {
 
     public static boolean repair() {
-        TileObject brokenCannon = Rs2GameObject.findObject(new Integer[]{ObjectID.BROKEN_MULTICANNON_14916, ObjectID.BROKEN_MULTICANNON_43028});
+        Rs2TileObjectModel brokenCannon = Microbot.getRs2TileObjectCache().query()
+                .withIds(ObjectID.BROKEN_MULTICANNON_14916, ObjectID.BROKEN_MULTICANNON_43028)
+                .nearest();
 
         if (brokenCannon == null) return false;
 
         // Create centered WorldArea (3x3 area with cannon at center)
         WorldArea cannonLocation = new WorldArea(
-            brokenCannon.getWorldLocation().getX() - 1, 
-            brokenCannon.getWorldLocation().getY() - 1, 
-            3, 3, 
+            brokenCannon.getWorldLocation().getX() - 1,
+            brokenCannon.getWorldLocation().getY() - 1,
+            3, 3,
             brokenCannon.getWorldLocation().getPlane()
         );
         if (!cannonLocation.toWorldPoint().equals(CannonPlugin.getCannonPosition().toWorldPoint())) return false;
 
         Microbot.status = "Repairing Cannon";
 
-        Rs2GameObject.interact(brokenCannon, "Repair");
+        brokenCannon.click("Repair");
         return true;
     }
 
@@ -51,22 +53,24 @@ public class Rs2Cannon {
 
         Microbot.status = "Refilling Cannon";
 
-        TileObject cannon = Rs2GameObject.findObject(new Integer[]{ObjectID.DWARF_MULTICANNON, ObjectID.DWARF_MULTICANNON_43027});
+        Rs2TileObjectModel cannon = Microbot.getRs2TileObjectCache().query()
+                .withIds(ObjectID.DWARF_MULTICANNON, ObjectID.DWARF_MULTICANNON_43027)
+                .nearest();
         if (cannon == null) return false;
 
         // Create centered WorldArea (3x3 area with cannon at center)
         WorldArea cannonLocation = new WorldArea(
-            cannon.getWorldLocation().getX() - 1, 
-            cannon.getWorldLocation().getY() - 1, 
-            3, 3, 
+            cannon.getWorldLocation().getX() - 1,
+            cannon.getWorldLocation().getY() - 1,
+            3, 3,
             cannon.getWorldLocation().getPlane()
         );
         if (!cannonLocation.toWorldPoint().equals(CannonPlugin.getCannonPosition().toWorldPoint())) return false;
 		Microbot.pauseAllScripts.compareAndSet(false, true);
-        Rs2GameObject.interact(cannon, "Fire");
+        cannon.click("Fire");
         Rs2Player.waitForWalking();
         sleep(1200);
-        Rs2GameObject.interact(cannon, "Fire");
+        cannon.click("Fire");
         sleepUntil(() -> Microbot.getClientThread().runOnClientThreadOptional(() -> Microbot.getClient().getVarpValue(VarPlayer.CANNON_AMMO)).orElse(0) > Rs2Random.between(10, 15));
 		Microbot.pauseAllScripts.compareAndSet(true, false);
         return true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
@@ -21,8 +21,7 @@ import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
 import net.runelite.client.plugins.microbot.util.misc.Rs2UiHelper;
-import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
-import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.security.Encryption;
 import net.runelite.client.plugins.microbot.util.security.LoginManager;
@@ -123,11 +122,13 @@ public class Rs2GrandExchange {
             if (isOpen()) {
                 return true;
             }
-            Rs2NpcModel npc = Rs2Npc.getNpc("Grand Exchange Clerk");
+            Rs2NpcModel npc = Microbot.getRs2NpcCache().query()
+                    .withName("Grand Exchange Clerk")
+                    .nearest();
             if (npc == null) {
                 return false;
             }
-            Rs2Npc.interact(npc, "exchange");
+            npc.click("exchange");
             if (Rs2Bank.isBankPinWidgetVisible()) {
                 ConfigProfile activeProfile = LoginManager.getActiveProfile();
                 if (activeProfile == null) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/inventory/Rs2Inventory.java
@@ -12,8 +12,8 @@ import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
 import net.runelite.client.plugins.microbot.pouch.Pouch;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
-import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
@@ -21,7 +21,6 @@ import net.runelite.client.plugins.microbot.util.misc.Rs2Food;
 import net.runelite.client.plugins.microbot.util.misc.Rs2Potion;
 import net.runelite.client.plugins.microbot.util.misc.Rs2UiHelper;
 import net.runelite.client.plugins.microbot.util.mouse.naturalmouse.util.Pair;
-import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.shop.Rs2Shop;
@@ -1727,7 +1726,7 @@ public class Rs2Inventory {
     public static boolean useUnNotedItemOnObject(String item, int objectID) {
         if (Rs2Bank.isOpen()) return false;
         useUnNoted(item);
-        Rs2GameObject.interact(objectID);
+        Microbot.getRs2TileObjectCache().query().interact(objectID);
         return true;
     }
 
@@ -1743,7 +1742,7 @@ public class Rs2Inventory {
         if (Rs2Bank.isOpen()) return false;
         if (!useUnNoted(item)) return false;
         sleep(100);
-        return isItemSelected() && Rs2GameObject.interact(object);
+        return isItemSelected() && new Rs2TileObjectModel(object).click();
     }
 
     /**
@@ -1758,7 +1757,7 @@ public class Rs2Inventory {
         if (Rs2Bank.isOpen()) return false;
         if (!use(item)) return false;
         sleep(100);
-        return isItemSelected() && Rs2GameObject.interact(objectID);
+        return isItemSelected() && Microbot.getRs2TileObjectCache().query().interact(objectID);
     }
 
     /**
@@ -1771,7 +1770,7 @@ public class Rs2Inventory {
         if (Rs2Bank.isOpen()) return false;
         if (!use(itemId)) return false;
         sleep(100);
-        return isItemSelected() && Rs2Npc.interact(npcID);
+        return isItemSelected() && Microbot.getRs2NpcCache().query().interact(npcID);
     }
 
     /**
@@ -1790,7 +1789,10 @@ public class Rs2Inventory {
         if (Rs2Bank.isOpen()) return false;
         if (!use(item)) return false;
         if (!sleepUntil(Rs2Inventory::isItemSelected, 1_000)) return false;
-        return Rs2Npc.interact(npc);
+        if (npc == null) return false;
+        return Microbot.getRs2NpcCache().query()
+                .where(n -> n.getIndex() == npc.getIndex())
+                .interact();
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/data/MountedDigsite.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/data/MountedDigsite.java
@@ -7,7 +7,8 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.ObjectID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import net.runelite.client.plugins.worldmap.TeleportLocationData;
 
@@ -30,17 +31,22 @@ public enum MountedDigsite implements PohTeleport {
 
     @Override
     public boolean execute() {
-        DecorativeObject pendant = getObject();
+        Rs2TileObjectModel pendant = getObject();
         if (pendant == null) {
             return false;
         }
         if (pendant.getId() == objectId) {
             // The correct id for the object means it has the right left click option, so we can just use that.
-            return Rs2GameObject.interact(pendant, destinationName);
+            return Microbot.getRs2TileObjectCache().query()
+                    .withIds(IDS)
+                    .interact(destinationName);
         }
         Widget widget = getWidget();
         if (widget == null) {
-            if (Rs2GameObject.interact(pendant, "Teleport menu")) {
+            boolean clicked = Microbot.getRs2TileObjectCache().query()
+                    .withIds(IDS)
+                    .interact("Teleport menu");
+            if (clicked) {
                 if (!sleepUntil(() -> getWidget() != null, 10000)) {
                     return false;
                 }
@@ -53,10 +59,12 @@ public enum MountedDigsite implements PohTeleport {
         return Rs2Widget.getWidget(InterfaceID.MENU, 3);
     }
 
-    public static final Integer[] IDS = {ObjectID.POH_AMULET_DIGSITE, ObjectID.POH_AMULET_DIG_LITHKREN, ObjectID.POH_AMULET_DIG_FOSSIL, ObjectID.POH_AMULET_DIG_DIGSITE};
+    public static final int[] IDS = {ObjectID.POH_AMULET_DIGSITE, ObjectID.POH_AMULET_DIG_LITHKREN, ObjectID.POH_AMULET_DIG_FOSSIL, ObjectID.POH_AMULET_DIG_DIGSITE};
 
-    public static DecorativeObject getObject() {
-        return Rs2GameObject.getDecorativeObject(IDS);
+    public static Rs2TileObjectModel getObject() {
+        return Microbot.getRs2TileObjectCache().query()
+                .withIds(IDS)
+                .first();
     }
 
     public static boolean isMountedDigsite(DecorativeObject go) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/data/MountedGlory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/data/MountedGlory.java
@@ -5,7 +5,8 @@ import lombok.RequiredArgsConstructor;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ObjectID;
-import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
 import net.runelite.client.plugins.worldmap.TeleportLocationData;
 
 import java.util.Arrays;
@@ -29,11 +30,15 @@ public enum MountedGlory implements PohTeleport {
 
     @Override
     public boolean execute() {
-        return Rs2GameObject.interact(getObject(), destinationName);
+        return Microbot.getRs2TileObjectCache().query()
+                .withId(ObjectID.POH_TROPHY_AMULETOFGLORY_4)
+                .interact(destinationName);
     }
 
-    public static DecorativeObject getObject() {
-        return Rs2GameObject.getDecorativeObject(ObjectID.POH_TROPHY_AMULETOFGLORY_4);
+    public static Rs2TileObjectModel getObject() {
+        return Microbot.getRs2TileObjectCache().query()
+                .withId(ObjectID.POH_TROPHY_AMULETOFGLORY_4)
+                .first();
     }
 
     public static List<PohTeleport> getTransports() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/data/MountedMythical.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/data/MountedMythical.java
@@ -5,7 +5,8 @@ import lombok.RequiredArgsConstructor;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ObjectID;
-import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
 import net.runelite.client.plugins.worldmap.TeleportLocationData;
 
 
@@ -23,15 +24,15 @@ public enum MountedMythical implements PohTeleport {
 
     @Override
     public boolean execute() {
-        DecorativeObject cape = getObject();
-        if (cape == null) {
-            return false;
-        }
-        return Rs2GameObject.interact(cape, "Teleport");
+        return Microbot.getRs2TileObjectCache().query()
+                .withId(MYTHS_GUILD.getObjectId())
+                .interact("Teleport");
     }
 
-    public static DecorativeObject getObject() {
-        return Rs2GameObject.getDecorativeObject(MYTHS_GUILD.getObjectId());
+    public static Rs2TileObjectModel getObject() {
+        return Microbot.getRs2TileObjectCache().query()
+                .withId(MYTHS_GUILD.getObjectId())
+                .first();
     }
 
     public static boolean isMountedMythsCape(DecorativeObject go) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/data/MountedXerics.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/data/MountedXerics.java
@@ -3,13 +3,12 @@ package net.runelite.client.plugins.microbot.util.poh.data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.runelite.api.DecorativeObject;
-import net.runelite.api.GameObject;
-import net.runelite.api.TileObject;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.ObjectID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import net.runelite.client.plugins.worldmap.TeleportLocationData;
 
@@ -34,17 +33,22 @@ public enum MountedXerics implements PohTeleport {
 
     @Override
     public boolean execute() {
-        DecorativeObject talisman = getObject();
+        Rs2TileObjectModel talisman = getObject();
         if (talisman == null) {
             return false;
         }
         if (talisman.getId() == objectId) {
             //The correct id for the object means it has the right left click option, so we can just use that.
-            return Rs2GameObject.interact(talisman, destinationName);
+            return Microbot.getRs2TileObjectCache().query()
+                    .withIds(IDS)
+                    .interact(destinationName);
         }
         Widget widget = getWidget();
         if (widget == null) {
-            if (Rs2GameObject.interact(talisman, "Teleport menu")) {
+            boolean clicked = Microbot.getRs2TileObjectCache().query()
+                    .withIds(IDS)
+                    .interact("Teleport menu");
+            if (clicked) {
                 if (!sleepUntil(() -> getWidget() != null, 10000)) {
                     return false;
                 }
@@ -53,10 +57,12 @@ public enum MountedXerics implements PohTeleport {
         return Rs2Widget.clickWidget(destinationName);
     }
 
-    public static final Integer[] IDS = {ObjectID.POH_AMULET_XERIC, ObjectID.POH_AMULET_XERIC_LOOKOUT, ObjectID.POH_AMULET_XERIC_GLADE, ObjectID.POH_AMULET_XERIC_INFERNO, ObjectID.POH_AMULET_XERIC_HEART, ObjectID.POH_AMULET_XERIC_HONOUR};
+    public static final int[] IDS = {ObjectID.POH_AMULET_XERIC, ObjectID.POH_AMULET_XERIC_LOOKOUT, ObjectID.POH_AMULET_XERIC_GLADE, ObjectID.POH_AMULET_XERIC_INFERNO, ObjectID.POH_AMULET_XERIC_HEART, ObjectID.POH_AMULET_XERIC_HONOUR};
 
-    public static DecorativeObject getObject() {
-        return Rs2GameObject.getDecorativeObject(IDS);
+    public static Rs2TileObjectModel getObject() {
+        return Microbot.getRs2TileObjectCache().query()
+                .withIds(IDS)
+                .first();
     }
 
     public static boolean isMountedXerics(DecorativeObject go) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.Point;
 import net.runelite.api.annotations.Component;
+import net.runelite.api.Perspective;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
@@ -29,6 +30,13 @@ import net.runelite.client.plugins.microbot.util.coords.Rs2WorldArea;
 import net.runelite.client.plugins.microbot.util.coords.Rs2WorldPoint;
 import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
+import net.runelite.client.plugins.microbot.api.tileobject.models.TileObjectType;
+// Rs2GameObject is still referenced by ~70 helper methods (getAll, hasLineOfSight, hasAction,
+// getObjectIdsByName, findObjectById, etc.) that have no direct equivalent on the new
+// queryable cache API yet. The high-traffic interact / point lookups have been migrated
+// above; the remaining static helpers stay until those utilities land on Rs2TileObjectModel
+// / Rs2TileObjectCache. @SuppressWarnings("removal") on the class scope keeps the build clean.
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
@@ -95,6 +103,7 @@ import static net.runelite.client.plugins.microbot.util.Global.*;
  * Seasonal handlers ({@link Rs2LeaguesTransport#tryHandleLeaguesAreaTransport}, MoA) must not run on the client thread — same contract as {@link Rs2LeaguesTransport#leaguesTeleport}.
  */
 @Slf4j
+@SuppressWarnings("removal") // Many static Rs2GameObject helpers (getAll, hasLineOfSight, hasAction, ...) are still used; the queryable cache doesn't expose equivalents yet.
 public class Rs2Walker {
     @Setter
     public static ShortestPathConfig config;
@@ -2040,7 +2049,7 @@ public class Rs2Walker {
     }
 
     public static boolean walkNextTo(GameObject target) {
-        Rs2WorldArea gameObjectArea = new Rs2WorldArea(Objects.requireNonNull(Rs2GameObject.getWorldArea(target)));
+        Rs2WorldArea gameObjectArea = new Rs2WorldArea(Objects.requireNonNull(computeWorldArea(target)));
         List<WorldPoint> interactablePoints = gameObjectArea.getInteractable();
 
         if (interactablePoints.isEmpty()) {
@@ -2060,7 +2069,7 @@ public class Rs2Walker {
     }
 
     public static void walkNextToInstance(GameObject target) {
-        Rs2WorldArea gameObjectArea = new Rs2WorldArea(Objects.requireNonNull(Rs2GameObject.getWorldArea(target)));
+        Rs2WorldArea gameObjectArea = new Rs2WorldArea(Objects.requireNonNull(computeWorldArea(target)));
         List<WorldPoint> interactablePoints = gameObjectArea.getInteractable();
 
         if (interactablePoints.isEmpty()) {
@@ -2862,19 +2871,17 @@ public class Rs2Walker {
         for (int rockIndex = index; rockIndex < index + 2; rockIndex++) {
             var point = path.get(rockIndex);
 
-            TileObject object = null;
-            var tile = Rs2GameObject.getTiles(3).stream()
-                    .filter(x -> x.getWorldLocation().equals(point))
-                    .findFirst().orElse(null);
-
-            if (tile != null)
-                object = Rs2GameObject.getGameObject(point);
+            Rs2TileObjectModel object = Microbot.getRs2TileObjectCache().query()
+                    .where(o -> o.getWorldLocation().equals(point))
+                    .first();
 
             if (object == null) continue;
 
             if (object.getId() == ObjectID.MOTHERLODE_ROCKFALL_1 || object.getId() == ObjectID.MOTHERLODE_ROCKFALL_2) {
-                Rs2GameObject.interact(object, "mine");
-                return sleepUntil(() -> Rs2GameObject.getGameObject(point) == null);
+                object.click("mine");
+                return sleepUntil(() -> Microbot.getRs2TileObjectCache().query()
+                        .where(o -> o.getWorldLocation().equals(point))
+                        .first() == null);
             }
         }
 
@@ -3397,8 +3404,31 @@ public class Rs2Walker {
         return dx * dx + dy * dy;
     }
 
+    /**
+     * Computes the world-space bounding area for a multi-tile GameObject from its
+     * local center and size. Mirrors the helper that used to live on the deprecated
+     * Rs2GameObject class.
+     */
+    private static WorldArea computeWorldArea(GameObject gameObject) {
+        if (!gameObject.getLocalLocation().isInScene()) {
+            return null;
+        }
+        LocalPoint sw = new LocalPoint(
+                gameObject.getLocalLocation().getX() - (gameObject.sizeX() - 1) * Perspective.LOCAL_TILE_SIZE / 2,
+                gameObject.getLocalLocation().getY() - (gameObject.sizeY() - 1) * Perspective.LOCAL_TILE_SIZE / 2
+        );
+        LocalPoint ne = new LocalPoint(
+                gameObject.getLocalLocation().getX() + (gameObject.sizeX() - 1) * Perspective.LOCAL_TILE_SIZE / 2,
+                gameObject.getLocalLocation().getY() + (gameObject.sizeY() - 1) * Perspective.LOCAL_TILE_SIZE / 2
+        );
+        return new Rs2WorldArea(
+                net.runelite.api.coords.WorldPoint.fromLocal(Microbot.getClient(), sw),
+                net.runelite.api.coords.WorldPoint.fromLocal(Microbot.getClient(), ne)
+        );
+    }
+
     private static ObjectComposition resolveCompositionForDoorProbe(TileObject object) {
-        ObjectComposition comp = Rs2GameObject.convertToObjectComposition(object);
+        ObjectComposition comp = new Rs2TileObjectModel(object).getObjectComposition();
         if (comp == null) {
             return null;
         }
@@ -3570,20 +3600,40 @@ public class Rs2Walker {
                 // WallObjects can report their world location as an adjacent tile depending on
                 // orientation / scene representation. Use exact match first, then allow a small
                 // adjacency fallback so door handling triggers reliably.
-                WallObject wall = Rs2GameObject.getWallObject(o -> o.getWorldLocation().equals(probe), probe, 3);
-                if (wall == null) {
-                    wall = Rs2GameObject.getWallObject(o -> o.getWorldLocation().distanceTo2D(probe) <= 1, probe, 3);
+                Rs2TileObjectModel wallModel = Microbot.getRs2TileObjectCache().query()
+                        .where(o -> o.getTileObjectType() == TileObjectType.WALL)
+                        .where(o -> o.getWorldLocation().equals(probe))
+                        .within(probe, 3)
+                        .first();
+                if (wallModel == null) {
+                    wallModel = Microbot.getRs2TileObjectCache().query()
+                            .where(o -> o.getTileObjectType() == TileObjectType.WALL)
+                            .where(o -> o.getWorldLocation().distanceTo2D(probe) <= 1)
+                            .within(probe, 3)
+                            .first();
                 }
 
-                TileObject object = (wall != null)
-                        ? wall
-                        : Rs2GameObject.getGameObject(o -> o.getWorldLocation().equals(probe), probe, 3);
-                if (object == null) {
-                    object = Rs2GameObject.getGameObject(o -> o.getWorldLocation().distanceTo2D(probe) <= 1, probe, 3);
+                Rs2TileObjectModel objectModel = wallModel;
+                if (objectModel == null) {
+                    objectModel = Microbot.getRs2TileObjectCache().query()
+                            .where(o -> o.getTileObjectType() == TileObjectType.GAME)
+                            .where(o -> o.getWorldLocation().equals(probe))
+                            .within(probe, 3)
+                            .first();
                 }
-                if (object == null) continue;
+                if (objectModel == null) {
+                    objectModel = Microbot.getRs2TileObjectCache().query()
+                            .where(o -> o.getTileObjectType() == TileObjectType.GAME)
+                            .where(o -> o.getWorldLocation().distanceTo2D(probe) <= 1)
+                            .within(probe, 3)
+                            .first();
+                }
+                if (objectModel == null) continue;
 
-                ObjectComposition baseComp = Rs2GameObject.convertToObjectComposition(object);
+                TileObject object = objectModel.getTileObject();
+                WallObject wall = wallModel != null ? (WallObject) wallModel.getTileObject() : null;
+
+                ObjectComposition baseComp = objectModel.getObjectComposition();
                 ObjectComposition comp = resolveCompositionForDoorProbe(object);
                 if (comp == null) {
                     Telemetry.recordDoorReject("composition-null");
@@ -3670,7 +3720,7 @@ public class Rs2Walker {
                         WorldPoint posBefore = Rs2Player.getWorldLocation();
                         boolean interacted;
                         try {
-                            interacted = Rs2GameObject.interact(object, action);
+                            interacted = objectModel.click(action);
                         } catch (Exception ex) {
                             WebWalkLog.spInfo("door_interact_exception | mode=segment-door probe={} from={} to={} ex={}",
                                     compactWorldPoint(probe), compactWorldPoint(fromWp), compactWorldPoint(toWp), ex.getClass().getSimpleName());


### PR DESCRIPTION
## Summary

  `Rs2GameObject` (use `Rs2TileObjectQueryable`) and `Rs2Npc` (use `Rs2NpcCache` / `Rs2NpcQuery`)
   helpers are marked for removal in 2.1.0. This migrates the internal `util/*` call sites that
  still depend on them onto the queryable cache API documented in `api/QUERYABLE_API.md`, so
  removing the deprecated classes won't require a follow-up sweep of `util/*`.
  
  ## Migrated
  
  - **`poh/data/Mounted{Glory,Xerics,Digsite,Mythical}`** — `getObject()` now returns
  `Rs2TileObjectModel`; `execute()` interacts via
  `Microbot.getRs2TileObjectCache().query().withId(s).interact(action)`. External callers in
  `shortestpath` only null-check the result, so the return-type change is compatible.
  - **`gameobject/Rs2Cannon`** — `repair()` and `refill()` resolve the cannon through the
  tile-object cache and `.click()` on the model.
  - **`events/DeathEvent`** — `DEATHS_PORTAL` interaction goes through the cache.
  - **`inventory/Rs2Inventory`** — `useItemOnObject(int|TileObject)` and
  `useItemOnNpc(int|Rs2NpcModel)` use the cache; the `Rs2NpcModel` overload resolves the cached
  model via `getIndex()` so behavior is preserved.
  - **`grandexchange/Rs2GrandExchange`** — `openExchange()` uses the npc cache and
  `.click("exchange")` on the model. Import switched to the new `api.npc.models.Rs2NpcModel`.
  - **`walker/Rs2Walker`** — high-traffic interact / point lookups and door composition
  resolution migrated. `computeWorldArea(GameObject)` is inlined so we don't depend on
  `Rs2GameObject.getWorldArea`. The remaining ~70 calls in this file use helpers that have no
  queryable equivalent yet (`getAll`, `hasLineOfSight`, `hasAction`, `getObjectIdsByName`,
  `getWallObjects` / `getGameObjects`, `exists`, `canWalkTo`, …); the file gets
  `@SuppressWarnings("removal")` with a comment so the build stays clean until those land on the
  cache API.
  
  ## API surface

  - **`api/tileobject/models/Rs2TileObjectModel`** — expose the wrapped `TileObject` via a
  `@Getter` so callers that need a concrete subtype (e.g. `WallObject` for orientation) can
  downcast without going back through the deprecated helpers.

  ## Verification
  
  - [x] `./gradlew :client:compileJava` builds clean.
  - [x] Files in the original deprecation report no longer emit `[removal]` warnings.
  - [ ] (Reviewer / me) Smoke test in-game: POH teleports (Glory / Xerics / Digsite / Mythical),
  cannon repair + fire, GE clerk interaction, death-domain portal, inventory-on-object / npc,
  walker pathing through doors and rockfalls.
