### PR TITLE
fix(mouse): preserve chat-input focus in VirtualMouse.dispatchWithoutFocusGrab

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/mouse/VirtualMouse.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/mouse/VirtualMouse.java
@@ -87,19 +87,26 @@ public class VirtualMouse extends Mouse {
         dispatchWithoutFocusGrab(canvas, event);
     }
 
-    // Jagex's MOUSE_PRESSED listener calls canvas.requestFocus() when the event source is the Canvas,
-    // which yanks OS keyboard focus away from whatever app the user is typing in. Flip focusable off
-    // for the duration of the synthetic dispatch so requestFocus is a no-op; mouse delivery itself is
-    // unaffected by focusable state.
+    // Jagex's MOUSE_PRESSED listener calls canvas.requestFocus() when the event source is the
+    // Canvas, which yanks OS keyboard focus away from whatever app the user is typing in. Flip
+    // focusable off for the duration of the synthetic dispatch so requestFocus is a no-op; mouse
+    // delivery itself is unaffected by focusable state.
+    //
+    // IMPORTANT: only do this when the canvas is NOT currently the focus owner. If the user is
+    // actively typing in the in-game chat (which lives inside the canvas), the canvas IS the focus
+    // owner, and setFocusable(false) immediately yanks focus away to the parent container — exactly
+    // the opposite of what this method is trying to prevent. Detect that case and skip the toggle.
     private void dispatchWithoutFocusGrab(Canvas canvas, AWTEvent event) {
+        boolean canvasIsFocused = canvas.isFocusOwner();
         boolean wasFocusable = canvas.isFocusable();
-        if (wasFocusable) canvas.setFocusable(false);
+        boolean shouldGuard = wasFocusable && !canvasIsFocused;
+        if (shouldGuard) canvas.setFocusable(false);
         BotEventGuard.begin();
         try {
             canvas.dispatchEvent(event);
         } finally {
             BotEventGuard.end();
-            if (wasFocusable) canvas.setFocusable(true);
+            if (shouldGuard) canvas.setFocusable(true);
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes a focus-management polarity bug in `VirtualMouse.dispatchWithoutFocusGrab` that yanked OS keyboard focus away from the in-game chat the moment a synthetic click was dispatched — making it impossible to type while any script was clicking.

## Changes
- `VirtualMouse.dispatchWithoutFocusGrab` now checks `canvas.isFocusOwner()` before toggling `setFocusable(false)`
- Skips the toggle entirely when the canvas already owns focus (i.e. the user is typing in chat)
- Expanded the inline comment to document why the guard condition matters

## Why
The original guard called `canvas.setFocusable(false)` on every synthetic dispatch to neuter Jagex's `MOUSE_PRESSED` listener (which calls `canvas.requestFocus()` and steals OS keyboard focus from whatever app the user was typing in). That works when the canvas is **not** the focus owner. But when the user is typing into the in-game chat, the canvas **is** the focus owner — and `setFocusable(false)` on a focused component immediately transfers focus away to the parent container. Result: every single bot-click dropped the chat-input focus mid-keystroke, exactly the opposite of the method's intent. Reported symptom: "whenever a mouse click happens, I can no longer type into chat."

## Testing
- Started a Microbot script and confirmed continuous chat typing remained uninterrupted across hundreds of synthetic clicks
- Verified original behavior preserved when the canvas is **not** the focus owner (focus still does not get stolen back to the client by Jagex's `MOUSE_PRESSED` handler when the user is in another app)
- No change to mouse event delivery (`canvas.dispatchEvent(event)` is unaffected by `focusable` state)
- `BotEventGuard.begin()/end()` lifecycle preserved
- Confirmed naturalMouse pathing still works correctly with the patch
- Build succeeds (`./gradlew :client:compileJava`)

## Checklist
- [x] Code compiles
- [x] No unused imports
- [x] Follows existing code style
- [x] Tested in-game
- [x] No debug logs left behind
- [x] No breaking API changes

## Notes
The 4-line behavioral change is small but worth landing because the previous behavior makes the client effectively unusable for any user who wants to chat / type while a script runs. The expanded comment block exists so the next reader doesn't "simplify" the guard back into the original shape.

Diff is purely additive on the comment side and a one-condition narrowing on the runtime side — no API surface changes, no detection-surface changes (a `setFocusable` toggle is not something the gamepack instruments).