### PR TITLE
[BREAKING FOR SOME PLUGINS] Remove auto-run, stamina pot usage from base client

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/Microbot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/Microbot.java
@@ -99,10 +99,6 @@ public class Microbot {
     public static AtomicBoolean pauseAllScripts = new AtomicBoolean(false);
     public static String status = "IDLE";
 
-    // Feature Flags
-    public static boolean enableAutoRunOn = true;
-    public static boolean useStaminaPotsIfNeeded = true;
-    public static int runEnergyThreshold = 1000;
     public static boolean isCantReachTargetDetectionEnabled = false;
 
     @Getter

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/Script.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/Script.java
@@ -7,7 +7,6 @@ import net.runelite.client.plugins.microbot.shortestpath.ShortestPathPlugin;
 import net.runelite.client.plugins.microbot.util.Global;
 import net.runelite.client.plugins.microbot.agentserver.handler.ScriptHeartbeatRegistry;
 import net.runelite.client.plugins.microbot.util.antiban.SessionFatigue;
-import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import org.jetbrains.annotations.NotNull;
@@ -93,14 +92,6 @@ public abstract class Script extends Global implements IScript {
         if (Thread.currentThread().isInterrupted())
             return false;
 
-        if (Microbot.isLoggedIn()) {
-            boolean hasRunEnergy = Microbot.getClientThread().runOnClientThreadOptional(() -> Microbot.getClient().getEnergy()).orElse(0) > Microbot.runEnergyThreshold;
-            if (Microbot.enableAutoRunOn && hasRunEnergy)
-                Rs2Player.toggleRunEnergy(true);
-            if (!hasRunEnergy && Microbot.useStaminaPotsIfNeeded && Rs2Player.isMoving()) {
-                Rs2Inventory.useRestoreEnergyItem();
-            }
-        }
         return true;
     }
 }


### PR DESCRIPTION
In my opinion the client shouldn't be handling this logic inside its main loop, the plugins that are using:

- Microbot.enableAutoRunOn
- Microbot.useStaminaPotsIfNeeded
- Microbot.runEnergyThreshold

Should update and just write their own running logic instead using `Rs2Player.toggleRunEnergy(true);` and `Rs2Inventory.useRestoreEnergyItem();`

This logic belongs inside plugins and not inside Script.java

If this is something you're willing to merge i can go through the hub plugins and check for usages of these and try fixing them, from what ive seen there actually arent THAT many, but it's bound to break some private plugins


Walker already correctly handles the run/walk cycle without using these