### PR TITLE
fix(breakhandlerv2): don't treat LOADING transitions as unexpected logout

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2Plugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2Plugin.java
@@ -32,7 +32,7 @@ import java.awt.*;
  * - Retry mechanism with configurable attempts and delays
  * - In-game overlay showing break status and timers
  *
- * @version 2.0.0
+ * @version 2.0.1
  */
 @PluginDescriptor(
     name = PluginDescriptor.Default + "BreakHandler V2",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2Script.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2Script.java
@@ -78,7 +78,7 @@ public class BreakHandlerV2Script extends Script {
     private static final int MAX_SAFETY_CHECK_ATTEMPTS = 60;
     private static final int SAFETY_CHECK_DELAY_MS = 5000; // 5 seconds between checks
 
-    public static String version = "2.0.0";
+    public static String version = "2.0.1";
 
     /**
      * Run the break handler script
@@ -525,8 +525,16 @@ public class BreakHandlerV2Script extends Script {
             return;
         }
 
+        // Transient game states during region/plane transitions (e.g. climbing the Mining Guild
+        // ladder to bank) briefly report !isLoggedIn() with GameState LOADING/HOPPING/LOGGING_IN.
+        // Those are NOT logouts; treating them as one fires a false break cycle that reschedules
+        // the next break and can starve real breaks entirely. Only act on a genuine logged-out
+        // GameState (LOGIN_SCREEN / CONNECTION_LOST), not the transition states.
+        GameState gameState = Microbot.getClient() != null ? Microbot.getClient().getGameState() : null;
+        boolean genuinelyLoggedOut = gameState == GameState.LOGIN_SCREEN || gameState == GameState.CONNECTION_LOST;
+
         // Check if player is logged out unexpectedly
-        if (!Microbot.isLoggedIn() && !unexpectedLogoutDetected) {
+        if (genuinelyLoggedOut && !unexpectedLogoutDetected) {
             long secondsUntilBreak = Instant.now().until(nextBreakTime, ChronoUnit.SECONDS);
 
             if (secondsUntilBreak > 0) {


### PR DESCRIPTION
## Problem

`BreakHandlerV2Script.detectUnexpectedLogout()` decided a logout occurred with:

```java
if (!Microbot.isLoggedIn() && !unexpectedLogoutDetected) { ... }
```

`Microbot.isLoggedIn()` is `GameState == LOGGED_IN`, so it is also false during **transient** game states: `LOADING`, `HOPPING`, `LOGGING_IN`. Any region/plane transition (for example climbing the Mining Guild ladder to bank) briefly hits `LOADING`, so the handler logs a false `Unexpected logout detected`. Auto-login then "recovers" a session that was never lost, and that recovery path reschedules the next break (`Next break in N minutes`).

Because those transitions happen on **every bank trip** (more often than the break interval), the break countdown keeps getting reset and **real scheduled breaks never fire**. Observed symptom: the "Next break" timer ratchets *up* (e.g. 40m -> 44m) across ladder transitions instead of counting down.

### Evidence (5.5h F2P Mining Guild session)
- 13 `Unexpected logout detected` warnings
- **0** `LOGIN_SCREEN`, **0** `CONNECTION_LOST`, **0** disconnects in the entire log
- The break state machine **never once entered a real break**; every "break cycle" was a 2-3 second false recovery triggered by a ladder transition (one even resolved as `Already logged in`).

## Fix

Only treat a genuine logged-out `GameState` (`LOGIN_SCREEN` / `CONNECTION_LOST`) as an unexpected logout; ignore the transient transition states.

```java
GameState gameState = Microbot.getClient() != null ? Microbot.getClient().getGameState() : null;
boolean genuinelyLoggedOut = gameState == GameState.LOGIN_SCREEN || gameState == GameState.CONNECTION_LOST;
if (genuinelyLoggedOut && !unexpectedLogoutDetected) { ... }
```

Strictly narrower than the previous `!isLoggedIn()` check, so it cannot miss a real logout (a real kick/disconnect lands on `LOGIN_SCREEN`/`CONNECTION_LOST`), while transient transitions no longer trip it. `GameState` is already imported. Version bumped 2.0.0 -> 2.0.1.

## Repro
F2P Mining Guild coal (or any underground spot that banks via a ladder) with BreakHandler V2 + auto-login enabled. Watch for `Unexpected logout detected` on each ladder climb and the "Next break" timer resetting instead of counting down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
