### PR TITLE
fix(antiban): prevent action-cooldown stall when play-style tick intervals cross

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/Rs2Antiban.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/Rs2Antiban.java
@@ -295,8 +295,9 @@ public class Rs2Antiban {
         else
             TIMEOUT = playStyle.getPrimaryTickInterval();
 
-        // Pause and set the active flag together, only after TIMEOUT is computed. If computing the
-        // interval ever throws, scripts must not be left paused with no countdown to clear them.
+        // The pause (universal antiban only) and the always-set active flag both happen only after
+        // TIMEOUT is computed: if computing the interval ever throws, scripts must not be left
+        // paused with no countdown to clear them.
         if (Rs2AntibanSettings.universalAntiban)
 			Microbot.pauseAllScripts.compareAndSet(false, true);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/Rs2Antiban.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/Rs2Antiban.java
@@ -287,9 +287,6 @@ public class Rs2Antiban {
     }
 
     private static void performActionCooldown() {
-        if (Rs2AntibanSettings.universalAntiban)
-			Microbot.pauseAllScripts.compareAndSet(false, true);
-
         if (Rs2AntibanSettings.nonLinearIntervals)
             playStyle.evolvePlayStyle();
 
@@ -297,6 +294,11 @@ public class Rs2Antiban {
             TIMEOUT = playStyle.getRandomTickInterval();
         else
             TIMEOUT = playStyle.getPrimaryTickInterval();
+
+        // Pause and set the active flag together, only after TIMEOUT is computed. If computing the
+        // interval ever throws, scripts must not be left paused with no countdown to clear them.
+        if (Rs2AntibanSettings.universalAntiban)
+			Microbot.pauseAllScripts.compareAndSet(false, true);
 
         Rs2AntibanSettings.actionCooldownActive = true;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/enums/PlayStyle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/enums/PlayStyle.java
@@ -111,7 +111,12 @@ public enum PlayStyle {
     }
 
     public int getRandomTickInterval() {
-        return ThreadLocalRandom.current().nextInt(primaryTickInterval, secondaryTickInterval + 1);
+        // primaryTickInterval and secondaryTickInterval drift independently in evolvePlayStyle()
+        // and can cross (primary > secondary). nextInt(origin, bound) requires bound > origin, so
+        // order the bounds defensively to avoid IllegalArgumentException.
+        int lo = Math.min(primaryTickInterval, secondaryTickInterval);
+        int hi = Math.max(primaryTickInterval, secondaryTickInterval);
+        return ThreadLocalRandom.current().nextInt(lo, hi + 1);
     }
 
     public void evolvePlayStyle() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/enums/PlayStyle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/enums/PlayStyle.java
@@ -113,10 +113,11 @@ public enum PlayStyle {
     public int getRandomTickInterval() {
         // primaryTickInterval and secondaryTickInterval drift independently in evolvePlayStyle()
         // and can cross (primary > secondary). nextInt(origin, bound) requires bound > origin, so
-        // order the bounds defensively to avoid IllegalArgumentException.
+        // order the bounds defensively to avoid IllegalArgumentException. The bound is computed in
+        // long so an inclusive upper bound of Integer.MAX_VALUE cannot overflow.
         int lo = Math.min(primaryTickInterval, secondaryTickInterval);
         int hi = Math.max(primaryTickInterval, secondaryTickInterval);
-        return ThreadLocalRandom.current().nextInt(lo, hi + 1);
+        return (int) ThreadLocalRandom.current().nextLong(lo, (long) hi + 1L);
     }
 
     public void evolvePlayStyle() {

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/antiban/enums/PlayStyleRandomTickIntervalTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/antiban/enums/PlayStyleRandomTickIntervalTest.java
@@ -32,7 +32,10 @@ public class PlayStyleRandomTickIntervalTest {
 
 	@Test
 	public void getRandomTickIntervalDoesNotThrowWhenIntervalsCross() throws Exception {
-		PlayStyle style = PlayStyle.values()[0];
+		// A specific constant (not values()[0]) so enum reordering cannot change what is tested.
+		// The intervals are restored in the finally block, so the shared enum singleton is left
+		// untouched for other tests; the unit-test suite runs single-threaded.
+		PlayStyle style = PlayStyle.MODERATE;
 		int origPrimary = getInterval(style, "primaryTickInterval");
 		int origSecondary = getInterval(style, "secondaryTickInterval");
 		try {

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/antiban/enums/PlayStyleRandomTickIntervalTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/antiban/enums/PlayStyleRandomTickIntervalTest.java
@@ -1,0 +1,58 @@
+package net.runelite.client.plugins.microbot.util.antiban.enums;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Regression test for the action-cooldown stall.
+ *
+ * <p>evolvePlayStyle() drifts primaryTickInterval and secondaryTickInterval independently, so over
+ * time they can cross (primary greater than secondary). getRandomTickInterval() must not throw
+ * IllegalArgumentException from ThreadLocalRandom.nextInt(origin, bound) when that happens; before
+ * the fix it did, which left Microbot.pauseAllScripts stuck true and froze running scripts.
+ */
+public class PlayStyleRandomTickIntervalTest {
+
+	private static void setInterval(PlayStyle style, String field, int value) throws Exception {
+		Field f = PlayStyle.class.getDeclaredField(field);
+		f.setAccessible(true);
+		f.setInt(style, value);
+	}
+
+	private static int getInterval(PlayStyle style, String field) throws Exception {
+		Field f = PlayStyle.class.getDeclaredField(field);
+		f.setAccessible(true);
+		return f.getInt(style);
+	}
+
+	@Test
+	public void getRandomTickIntervalDoesNotThrowWhenIntervalsCross() throws Exception {
+		PlayStyle style = PlayStyle.values()[0];
+		int origPrimary = getInterval(style, "primaryTickInterval");
+		int origSecondary = getInterval(style, "secondaryTickInterval");
+		try {
+			// Crossed bounds (primary greater than secondary): this is what previously threw.
+			setInterval(style, "primaryTickInterval", 10);
+			setInterval(style, "secondaryTickInterval", 5);
+			for (int i = 0; i < 10_000; i++) {
+				int v = style.getRandomTickInterval();
+				assertTrue("interval " + v + " must fall within [5,10]", v >= 5 && v <= 10);
+			}
+
+			// Equal bounds edge case (primary == secondary).
+			setInterval(style, "primaryTickInterval", 7);
+			setInterval(style, "secondaryTickInterval", 7);
+			assertEquals(7, style.getRandomTickInterval());
+		} catch (IllegalArgumentException e) {
+			fail("getRandomTickInterval threw on crossed intervals: " + e.getMessage());
+		} finally {
+			setInterval(style, "primaryTickInterval", origPrimary);
+			setInterval(style, "secondaryTickInterval", origSecondary);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

With "Use Non-Linear Intervals" enabled (which the per-skill antiban setup templates turn on by default), `PlayStyle.evolvePlayStyle()` random-walks `primaryTickInterval` and `secondaryTickInterval` independently, so over time they can cross (primary greater than secondary). Once that happens, `PlayStyle.getRandomTickInterval()` calls `ThreadLocalRandom.nextInt(origin, bound)` with origin above bound and throws on every stat change:

```
java.lang.IllegalArgumentException: bound must be greater than origin
    at java.base/java.util.concurrent.ThreadLocalRandom.nextInt(ThreadLocalRandom.java:337)
    at net.runelite.client.plugins.microbot.util.antiban.enums.PlayStyle.getRandomTickInterval(PlayStyle.java:114)
    at net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban.performActionCooldown(Rs2Antiban.java:297)
    at net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban.actionCooldown(Rs2Antiban.java:277)
    at net.runelite.client.plugins.microbot.util.antiban.AntibanPlugin.onStatChanged(AntibanPlugin.java:345)
```

Captured live on 2.6.5 while high alching.

The impact is worse than the exception: `performActionCooldown()` sets `Microbot.pauseAllScripts = true` BEFORE computing the interval, and `actionCooldownActive = true` only after. The throw lands between the two, so the cooldown clearer (`AntibanPlugin.performActionBreak`, gated on `actionCooldownActive`) never runs and every running script stays frozen until the interval random-walk happens to uncross (observed multi-minute stalls). Any script using a templated antiban setup is exposed.

## Fix

1. `PlayStyle.getRandomTickInterval()`: order the bounds with min/max before calling `nextInt(lo, hi + 1)`, so crossed intervals can never throw.
2. `Rs2Antiban.performActionCooldown()`: compute the interval first, then set `pauseAllScripts` and `actionCooldownActive` together, so no exception path can leave scripts paused with nothing to release them.
3. New regression test `PlayStyleRandomTickIntervalTest` forces the crossed-interval state (which deterministically threw before the fix) plus the equal-bounds edge case.

## Testing

- `./gradlew :client:runUnitTests --tests "*PlayStyleRandomTickIntervalTest"` passes (failed before the fix).
- `./gradlew :client:compileJava` green.
- Patched client boots and runs clean; normal action-cooldown pause and resume behavior unchanged.
- Workaround for affected users until this lands: disable "Use Non-Linear Intervals" in the Antiban panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
