### PR TITLE
[codex] update runelite and microbot versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,11 +28,11 @@ org.gradle.parallel=true
 org.gradle.caching=false
 
 project.build.group=net.runelite
-project.build.version=1.12.28
-runelite.injected-client.version=1.12.28
+project.build.version=1.12.30
+runelite.injected-client.version=1.12.30
 
 glslang.path=
-microbot.version=2.6.6
+microbot.version=2.6.7
 microbot.commit.sha=nogit
 microbot.repo.url=http://138.201.81.246:8081/repository/microbot-snapshot/
 microbot.repo.username=

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/util/reflection/menu-action-info.properties
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/util/reflection/menu-action-info.properties
@@ -1,7 +1,7 @@
 #Build-time pre-seed for MenuActionInfoCache (do not edit by hand; regenerate via :client:seedMenuActionInfo)
-#Tue Jun 16 21:33:16 CEST 2026
-menuAction.garbageValue=910500823
+#Wed Jun 24 20:37:30 CEST 2026
+menuAction.garbageValue=-1612500198
 menuAction.descriptor=(IIIIIILjava/lang/String;Ljava/lang/String;III)V
-menuAction.methodName=fa
-menuAction.ownerClass=qd
+menuAction.methodName=fu
+menuAction.ownerClass=ek
 menuAction.garbageKind=Integer


### PR DESCRIPTION
## Summary

Updates the pinned RuneLite release and Microbot distribution version.

- Bumps `project.build.version` from `1.12.28` to `1.12.30`
- Bumps `runelite.injected-client.version` from `1.12.28` to `1.12.30`
- Bumps `microbot.version` from `2.6.6` to `2.6.7`

## Impact

Builds now resolve against the latest stable RuneLite artifacts available from the RuneLite Maven repository, while producing Microbot artifacts under the next patch version.

## Validation

- `./gradlew :client:compileJava`