### PR TITLE
Promote development with RuneLite startup and looting fixes

### DIFF
--- a/docs/entity-guides/items.md
+++ b/docs/entity-guides/items.md
@@ -133,3 +133,22 @@ Set JVM flag `-Dmicrobot.bank.validateInventorySetup=true` so `Rs2InventorySetup
 ---
 
 <!-- Add new gotchas here as numbered entries (## 8, ## 9, ...). -->
+
+## 8. Ground-item action reflection must fail closed to `Take`, not `CANCEL`
+
+`Rs2GroundItem` and `Rs2TileItemModel` recover ground-item actions from the injected client's `ItemComposition`. That backing layout is obfuscated and can shift on RuneLite bumps. If reflection cannot find a real action list, treat the ground item as exposing `Take` in the injected client's third ground-item slot instead of returning an empty action array.
+
+**Why this matters:** After the RuneLite 1.12.30 bump, the reflection path returned `[]` for ordinary loot such as Cowhide. Loot helpers then failed to map `"Take"` to `GROUND_ITEM_THIRD_OPTION`, silently dispatched a no-op/cancel action, and ExampleScript's drop-and-loot smoke test failed even though the dropped item was visible and lootable.
+
+**Pattern to follow:**
+
+```java
+String[] actions = Rs2Reflection.getGroundItemActions(itemComposition);
+// If reflection cannot recover actions, this must still contain "Take" at index 2.
+```
+
+Do not make call sites compensate by assuming `index == 0` when the action array is empty; keep the fallback centralized in `Rs2Reflection.getGroundItemActions`.
+
+**Where this applies:** `Rs2Reflection.getGroundItemActions`, `Rs2GroundItem.interact`, `Rs2TileItemModel.click`, and any future ground-item interaction helper that derives a `MenuAction` from item actions.
+
+**Defensive check:** Live smoke with ExampleScript's "Drop and loot item" check after any RuneLite or injected-client version bump.

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ project.build.version=1.12.30
 runelite.injected-client.version=1.12.30
 
 glslang.path=
-microbot.version=2.6.7
+microbot.version=2.6.8
 microbot.commit.sha=nogit
 microbot.repo.url=http://138.201.81.246:8081/repository/microbot-snapshot/
 microbot.repo.username=

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -236,7 +236,7 @@ public interface Client extends OAuthApi, GameEngine
 	 * @see #getCameraX()
 	 * @return
 	 */
-	double getCameraFpX();
+	float getCameraFpX();
 
 	/**
 	 * Gets the y-axis coordinate of the camera.
@@ -253,7 +253,7 @@ public interface Client extends OAuthApi, GameEngine
 	 * @see #getCameraY()
 	 * @return
 	 */
-	double getCameraFpY();
+	float getCameraFpY();
 
 	/**
 	 * Gets the z-axis coordinate of the camera.
@@ -270,7 +270,7 @@ public interface Client extends OAuthApi, GameEngine
 	 * @see #getCameraZ()
 	 * @return
 	 */
-	double getCameraFpZ();
+	float getCameraFpZ();
 
 	/**
 	 * Gets the pitch of the camera.
@@ -287,7 +287,7 @@ public interface Client extends OAuthApi, GameEngine
 	 * @see #getCameraPitch()
 	 * @return
 	 */
-	double getCameraFpPitch();
+	float getCameraFpPitch();
 
 	/**
 	 * Gets the yaw of the camera.
@@ -301,7 +301,7 @@ public interface Client extends OAuthApi, GameEngine
 	 * @see #getCameraYaw()
 	 * @return
 	 */
-	double getCameraFpYaw();
+	float getCameraFpYaw();
 
 	/**
 	 * Gets the current world number of the logged in player.

--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -46,16 +46,6 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import org.jetbrains.annotations.ApiStatus;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.awt.*;
-import java.awt.geom.Rectangle2D;
-import java.awt.image.BufferedImage;
-import java.util.ArrayList;
-import java.util.List;
-
-import static net.runelite.api.Constants.TILE_FLAG_BRIDGE;
-
 /**
  * A utility class containing methods to help with conversion between
  * in-game features to canvas areas.
@@ -64,6 +54,7 @@ public class Perspective
 {
 	// How much of the unit circle each unit of SINE/COSINE is
 	public static final double UNIT = 0.0030679615d; // ~pi/1024
+	public static final double UNIT14 = 3.834951969714103E-4D; // ~pi/8192
 
 	public static final int LOCAL_COORD_BITS = 7;
 	public static final int LOCAL_TILE_SIZE = 1 << LOCAL_COORD_BITS; // 128 - size of a tile in local coordinates
@@ -74,8 +65,14 @@ public class Perspective
 	public static final int[] SINE = new int[2048]; // sine angles for each of the 2048 units, * 65536 and stored as an int
 	public static final int[] COSINE = new int[2048]; // cosine
 
-	private static final float[] SINF = new float[2048];
-	private static final float[] COSF = new float[2048];
+	public static final float[] SINEF = new float[2048];
+	public static final float[] COSINEF = new float[2048];
+
+	public static final int[] SINE14 = new int[0x4000];
+	public static final int[] COSINE14 = new int[0x4000];
+
+	public static final float[] SINEF14 = new float[0x4000];
+	public static final float[] COSINEF14 = new float[0x4000];
 
 	private static final int ESCENE_OFFSET = (Constants.EXTENDED_SCENE_SIZE - Constants.SCENE_SIZE) / 2;
 
@@ -85,10 +82,19 @@ public class Perspective
 		{
 			double s = Math.sin((double) i * UNIT);
 			double c = Math.cos((double) i * UNIT);
-			SINF[i] = (float) s;
-			COSF[i] = (float) c;
+			SINEF[i] = (float) s;
+			COSINEF[i] = (float) c;
 			SINE[i] = (int) (65536.0 * s);
 			COSINE[i] = (int) (65536.0 * c);
+		}
+		for (int i = 0; i < 0x4000; ++i)
+		{
+			double s = Math.sin((double) i * UNIT14);
+			double c = Math.cos((double) i * UNIT14);
+			SINEF14[i] = (float) s;
+			COSINEF14[i] = (float) c;
+			SINE14[i] = (int) (65536.0 * s);
+			COSINE14[i] = (int) (65536.0 * c);
 		}
 	}
 
@@ -217,10 +223,10 @@ public class Perspective
 			final int cameraPitch = client.getCameraPitch();
 			final int cameraYaw = client.getCameraYaw();
 
-			final int pitchSin = SINE[cameraPitch];
-			final int pitchCos = COSINE[cameraPitch];
-			final int yawSin = SINE[cameraYaw];
-			final int yawCos = COSINE[cameraYaw];
+			final int pitchSin = SINE14[cameraPitch];
+			final int pitchCos = COSINE14[cameraPitch];
+			final int yawSin = SINE14[cameraYaw];
+			final int yawCos = COSINE14[cameraYaw];
 
 			final int
 				x1 = x * yawCos + y * yawSin >> 16,
@@ -253,9 +259,9 @@ public class Perspective
 				cameraYaw = client.getCameraFpYaw();
 
 			final float
-				fx = x - (float) client.getCameraFpX(),
-				fy = y - (float) client.getCameraFpY(),
-				fz = z - (float) client.getCameraFpZ(),
+				fx = x - client.getCameraFpX(),
+				fy = y - client.getCameraFpY(),
+				fz = z - client.getCameraFpZ(),
 				pitchSin = (float) Math.sin(cameraPitch),
 				pitchCos = (float) Math.cos(cameraPitch),
 				yawSin = (float) Math.sin(cameraYaw),
@@ -381,9 +387,9 @@ public class Perspective
 			rotateSin = SINE[rotate] / 65536.0f,
 			rotateCos = COSINE[rotate] / 65536.0f,
 
-			cx = x3dCenter - (float) client.getCameraFpX(),
-			cy = y3dCenter - (float) client.getCameraFpY(),
-			cz = z3dCenter - (float) client.getCameraFpZ(),
+			cx = x3dCenter - client.getCameraFpX(),
+			cy = y3dCenter - client.getCameraFpY(),
+			cz = z3dCenter - client.getCameraFpZ(),
 
 			viewportXMiddle = client.getViewportWidth() / 2f,
 			viewportYMiddle = client.getViewportHeight() / 2f,
@@ -440,12 +446,12 @@ public class Perspective
 			cameraYaw = client.getCameraYaw();
 
 		final float
-			pitchSin = SINF[cameraPitch],
-			pitchCos = COSF[cameraPitch],
-			yawSin = SINF[cameraYaw],
-			yawCos = COSF[cameraYaw],
-			rotateSin = SINF[rotate],
-			rotateCos = COSF[rotate];
+			pitchSin = SINEF14[cameraPitch],
+			pitchCos = COSINEF14[cameraPitch],
+			yawSin = SINEF14[cameraYaw],
+			yawCos = COSINEF14[cameraYaw],
+			rotateSin = SINEF[rotate],
+			rotateCos = COSINEF[rotate];
 
 		final int
 			cx = x3dCenter - client.getCameraX(),
@@ -592,14 +598,14 @@ public class Perspective
 			return null;
 		}
 
-			final double zoom = (client.getMinimapZoom() - 0.5) / LOCAL_TILE_SIZE;
-			final int x = (int) (dx * zoom);
-			final int y = (int) (dy * zoom);
+		final double zoom = client.getMinimapZoom() / LOCAL_TILE_SIZE;
+		final int x = (int) (dx * zoom);
+		final int y = (int) (dy * zoom);
 
-		final int angle = client.getCameraYawTarget() & 0x7FF;
+		final int angle = client.getCameraYawTarget() & 0x3fff;
 
-		final int sin = SINE[angle];
-		final int cos = COSINE[angle];
+		final int sin = SINE14[angle];
+		final int cos = COSINE14[angle];
 
 		final int rx = cos * x + sin * y >> 16;
 		final int ry = sin * x - cos * y >> 16;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/tileitem/models/Rs2TileItemModel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/tileitem/models/Rs2TileItemModel.java
@@ -7,7 +7,7 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.api.IEntity;
-import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
+import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.reflection.Rs2Reflection;
 
@@ -248,38 +248,53 @@ public class Rs2TileItemModel implements TileItem, IEntity {
             } else if (index == 4) {
                 menuAction = MenuAction.GROUND_ITEM_FIFTH_OPTION;
             }
-            LocalPoint localPoint1 = getLocalLocation();
-            if (localPoint1 != null) {
-                Polygon canvas = Perspective.getCanvasTilePoly(Microbot.getClient(), localPoint1);
-                if (canvas != null) {
-                    Microbot.doInvoke(new NewMenuEntry()
-                            .option(action)
-                            .param0(param0)
-                            .param1(param1)
-                            .opcode(menuAction.getId())
-                            .identifier(identifier)
-                            .itemId(-1)
-                            .target(target)
-                            ,
-                canvas.getBounds());
-                }
-            } else {
-                Microbot.doInvoke(new NewMenuEntry()
-                        .option(action)
-                        .param0(param0)
-                        .param1(param1)
-                        .opcode(menuAction.getId())
-                        .identifier(identifier)
-                        .itemId(-1)
-                        .target(target)
-                        ,
-                new Rectangle(1, 1, Microbot.getClient().getCanvasWidth(), Microbot.getClient().getCanvasHeight()));
-
+            if (menuAction == MenuAction.CANCEL) {
+                log.warn("Unable to interact with ground item '{}' using action '{}'; actions={}", getName(), action, java.util.Arrays.toString(groundActions));
+                return false;
             }
+            LocalPoint localPoint1 = getLocalLocation();
+            if (localPoint1 == null) {
+                return false;
+            }
+            if (!Rs2Camera.isTileOnScreen(localPoint1)) {
+                Rs2Camera.turnTo(localPoint1);
+            }
+            Polygon canvas = Perspective.getCanvasTilePoly(Microbot.getClient(), localPoint1);
+            Rectangle bounds = canvas == null
+                    ? new Rectangle(1, 1, Microbot.getClient().getCanvasWidth(), Microbot.getClient().getCanvasHeight())
+                    : canvas.getBounds();
+            MenuAction selectedMenuAction = menuAction;
+            String selectedAction = action;
+            int worldViewId = localPoint1.getWorldView();
+            Microbot.getClientThread().runOnClientThreadOptional(() -> {
+                MenuEntry entry = Microbot.getClient().getMenu().createMenuEntry(-1)
+                        .setOption(selectedAction)
+                        .setTarget(target)
+                        .setIdentifier(identifier)
+                        .setType(selectedMenuAction)
+                        .setParam0(param0)
+                        .setParam1(param1)
+                        .setItemId(-1)
+                        .setWorldViewId(worldViewId);
+                Microbot.getClient().setMenuEntries(new MenuEntry[]{entry});
+                return true;
+            });
+            Rs2Reflection.invokeMenu(
+                    param0,
+                    param1,
+                    menuAction.getId(),
+                    identifier,
+                    -1,
+                    worldViewId,
+                    action,
+                    target,
+                    (int) bounds.getCenterX(),
+                    (int) bounds.getCenterY());
+            return true;
         } catch (Exception ex) {
             Microbot.log(ex.getMessage());
             ex.printStackTrace();
+            return false;
         }
-        return true;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/example/ExampleScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/example/ExampleScript.java
@@ -53,8 +53,8 @@ public class ExampleScript extends Script {
                 checkWidgets();
                 checkWalker();
                 checkDialogue();
-                checkHomeTeleport();
                 checkLooting();
+                checkHomeTeleport();
 
                 printSummary();
                 shutdown();
@@ -318,7 +318,9 @@ public class ExampleScript extends Script {
         int countAfterDrop = Rs2Inventory.count(itemId);
 
         check("Loot item from ground", () -> {
-            sleep(600);
+            boolean itemAppeared = sleepUntil(() -> Rs2GroundItem.exists(itemName, 5), 5000);
+            assertTrue(itemAppeared, "item did not appear on ground after drop");
+            sleepUntil(() -> !Rs2Player.isAnimating() && !Rs2Player.isMoving(), 5000);
             boolean looted = Rs2GroundItem.loot(itemName, 5);
             assertTrue(looted, "Rs2GroundItem.loot() returned false");
             boolean pickedUp = sleepUntil(() -> Rs2Inventory.count(itemId) > countAfterDrop, 5000);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItem.java
@@ -8,9 +8,9 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.grounditems.GroundItem;
 import net.runelite.client.plugins.grounditems.GroundItemsPlugin;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
-import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
 import net.runelite.client.plugins.microbot.util.models.RS2Item;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.reflection.Rs2Reflection;
@@ -105,39 +105,51 @@ public class Rs2GroundItem {
             } else if (index == 4) {
                 menuAction = MenuAction.GROUND_ITEM_FIFTH_OPTION;
             }
-            LocalPoint localPoint1 = localPoint;
-            if (localPoint1 != null) {
-                Polygon canvas = Perspective.getCanvasTilePoly(Microbot.getClient(), localPoint1);
-                if (canvas != null) {
-                    Microbot.doInvoke(new NewMenuEntry()
-                            .option(action)
-                            .param0(param0)
-                            .param1(param1)
-                            .opcode(menuAction.getId())
-                            .identifier(identifier)
-                            .itemId(-1)
-                            .target(target)
-                            ,
-                canvas.getBounds());
-                }
-            } else {
-                Microbot.doInvoke(new NewMenuEntry()
-                        .option(action)
-                        .param0(param0)
-                        .param1(param1)
-                        .opcode(menuAction.getId())
-                        .identifier(identifier)
-                        .itemId(-1)
-                        .target(target)
-                        ,
-                new Rectangle(1, 1, Microbot.getClient().getCanvasWidth(), Microbot.getClient().getCanvasHeight()));
-
+            if (menuAction == MenuAction.CANCEL) {
+                log.warn("Unable to interact with ground item '{}' using action '{}'; actions={}", groundItem.getName(), action, Arrays.toString(groundActions));
+                return false;
             }
+            LocalPoint localPoint1 = localPoint;
+            if (!Rs2Camera.isTileOnScreen(localPoint1)) {
+                Rs2Camera.turnTo(localPoint1);
+            }
+            Polygon canvas = Perspective.getCanvasTilePoly(Microbot.getClient(), localPoint1);
+            Rectangle bounds = canvas == null
+                    ? new Rectangle(1, 1, Microbot.getClient().getCanvasWidth(), Microbot.getClient().getCanvasHeight())
+                    : canvas.getBounds();
+            MenuAction selectedMenuAction = menuAction;
+            String selectedAction = action;
+            int worldViewId = localPoint1.getWorldView();
+            Microbot.getClientThread().runOnClientThreadOptional(() -> {
+                MenuEntry entry = Microbot.getClient().getMenu().createMenuEntry(-1)
+                        .setOption(selectedAction)
+                        .setTarget(target)
+                        .setIdentifier(identifier)
+                        .setType(selectedMenuAction)
+                        .setParam0(param0)
+                        .setParam1(param1)
+                        .setItemId(-1)
+                        .setWorldViewId(worldViewId);
+                Microbot.getClient().setMenuEntries(new MenuEntry[]{entry});
+                return true;
+            });
+            Rs2Reflection.invokeMenu(
+                    param0,
+                    param1,
+                    menuAction.getId(),
+                    identifier,
+                    -1,
+                    worldViewId,
+                    action,
+                    target,
+                    (int) bounds.getCenterX(),
+                    (int) bounds.getCenterY());
+            return true;
         } catch (Exception ex) {
             Microbot.log(ex.getMessage());
             ex.printStackTrace();
+            return false;
         }
-        return true;
     }
 
     public static boolean interact(GroundItem groundItem) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/reflection/Rs2Reflection.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/reflection/Rs2Reflection.java
@@ -121,7 +121,7 @@ public class Rs2Reflection {
                         cachedOuterField = outerField;
                         cachedListField = listField;
                         cachedStringField = null;
-                        return toStringArray(list);
+                        return groundItemActionsOrDefault(toStringArray(list));
                     }
 
                     Field stringField = null;
@@ -133,12 +133,12 @@ public class Rs2Reflection {
                     cachedOuterField = outerField;
                     cachedListField = listField;
                     cachedStringField = stringField;
-                    return extractFromBeans(list, stringField);
+                    return groundItemActionsOrDefault(extractFromBeans(list, stringField));
                 }
             }
         }
 
-        return new String[]{};
+        return defaultGroundItemActions();
     }
 
     private static String[] extractWithCache(ItemComposition item) throws Exception {
@@ -153,8 +153,23 @@ public class Rs2Reflection {
         if (!(listObj instanceof ArrayList)) return new String[]{};
 
         ArrayList<?> list = (ArrayList<?>) listObj;
-        if (cachedStringField == null) return toStringArray(list);
-        return extractFromBeans(list, cachedStringField);
+        if (cachedStringField == null) return groundItemActionsOrDefault(toStringArray(list));
+        return groundItemActionsOrDefault(extractFromBeans(list, cachedStringField));
+    }
+
+    private static String[] groundItemActionsOrDefault(String[] actions) {
+        if (actions != null) {
+            for (String action : actions) {
+                if (action != null && !action.isBlank()) {
+                    return actions;
+                }
+            }
+        }
+        return defaultGroundItemActions();
+    }
+
+    private static String[] defaultGroundItemActions() {
+        return new String[]{null, null, "Take", null, null};
     }
 
     private static String[] toStringArray(ArrayList<?> list) {
@@ -190,4 +205,3 @@ public class Rs2Reflection {
                 .invoke(menuEntry, itemId); //use the setItemId method through reflection
     }
 }
-

--- a/runelite-client/src/test/resources/threadsafety/client-thread-guardrail-baseline.txt
+++ b/runelite-client/src/test/resources/threadsafety/client-thread-guardrail-baseline.txt
@@ -395,18 +395,18 @@ net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#interact(Inte
 net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#interact(RS2Item, String): boolean  ->  net.runelite.api.ItemComposition#getName(): String
 net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#interact(RS2Item, String): boolean  ->  net.runelite.api.Tile#getWorldLocation(): WorldPoint
 net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#interact(RS2Item, String): boolean  ->  net.runelite.api.TileItem#getId(): int
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$exists$28(int, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getId(): int
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$exists$29(String, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getName(): String
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$getAllAt$1(Tile, TileItem): RS2Item  ->  net.runelite.api.TileItem#getId(): int
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$getAllFromWorldPoint$4(RS2Item): int  ->  net.runelite.api.Client#getLocalPlayer(): Player
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$getAllFromWorldPoint$4(RS2Item): int  ->  net.runelite.api.Player#getLocalLocation(): LocalPoint
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$getAllFromWorldPoint$4(RS2Item): int  ->  net.runelite.api.Tile#getLocalLocation(): LocalPoint
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$interact$26(String, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getName(): String
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$interact$27(int, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getId(): int
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$loot$25(int, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getId(): int
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$loot$30(int, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getId(): int
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$loot$7(String, int, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getName(): String
-net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$loot$7(String, int, RS2Item): boolean  ->  net.runelite.api.TileItem#getQuantity(): int
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$exists$29(int, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getId(): int
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$exists$30(String, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getName(): String
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$getAllAt$2(Tile, TileItem): RS2Item  ->  net.runelite.api.TileItem#getId(): int
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$getAllFromWorldPoint$5(RS2Item): int  ->  net.runelite.api.Client#getLocalPlayer(): Player
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$getAllFromWorldPoint$5(RS2Item): int  ->  net.runelite.api.Player#getLocalLocation(): LocalPoint
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$getAllFromWorldPoint$5(RS2Item): int  ->  net.runelite.api.Tile#getLocalLocation(): LocalPoint
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$interact$27(String, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getName(): String
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$interact$28(int, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getId(): int
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$loot$26(int, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getId(): int
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$loot$31(int, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getId(): int
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$loot$8(String, int, RS2Item): boolean  ->  net.runelite.api.ItemComposition#getName(): String
+net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lambda$loot$8(String, int, RS2Item): boolean  ->  net.runelite.api.TileItem#getQuantity(): int
 net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem#lootAllItemBasedOnValue(int, int): boolean  ->  net.runelite.api.ItemComposition#getName(): String
 net.runelite.client.plugins.microbot.util.grounditem.models.Rs2SpawnLocation#getItemName(): String  ->  net.runelite.api.ItemComposition#getName(): String
 net.runelite.client.plugins.microbot.util.huntkit.Rs2HuntKit#depositActionIndex(Rs2ItemModel, String): int  ->  net.runelite.api.widgets.Widget#getActions(): String[]


### PR DESCRIPTION
## Summary
- promote the latest development branch to main
- bump Microbot to 2.6.8
- fix RuneLite 1.12.30 startup compatibility for float camera/trig fields
- fix Microbot ground-item pickup fallback so `Take` maps to `GROUND_ITEM_THIRD_OPTION`
- tighten ExampleScript looting smoke coverage and document the ground-item action-slot gotcha

## Validation
- `./gradlew :client:compileJava`
- live `:client:run` startup reached RuneLite 1.12.30 without the previous `NoSuchFieldError: SINE14`
- ExampleScript live smoke: `Drop item from inventory` passed, `Loot item from ground` passed, full result `35/35 PASSED`
- observed Cowhide pickup path dispatching action 20 (`GROUND_ITEM_THIRD_OPTION`) with tile params matching the successful runtime log