### PR TITLE
fix: harden ground item action reflection

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/tileitem/models/Rs2TileItemModel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/tileitem/models/Rs2TileItemModel.java
@@ -226,9 +226,15 @@ public class Rs2TileItemModel implements TileItem, IEntity {
 
             int index = -1;
             if (action.isEmpty()) {
-                if (groundActions.length == 0 || groundActions[0] == null) return false;
-                action = groundActions[0];
-                index = 0;
+                for (int i = 0; i < groundActions.length; i++) {
+                    if (groundActions[i] == null) {
+                        continue;
+                    }
+                    action = groundActions[i];
+                    index = i;
+                    break;
+                }
+                if (index == -1) return false;
             } else {
                 for (int i = 0; i < groundActions.length; i++) {
                     String groundAction = groundActions[i];

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/tileitem/models/Rs2TileItemModel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/api/tileitem/models/Rs2TileItemModel.java
@@ -12,6 +12,7 @@ import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.reflection.Rs2Reflection;
 
 import java.awt.*;
+import java.util.Arrays;
 import java.util.function.Supplier;
 
 @Slf4j
@@ -207,7 +208,7 @@ public class Rs2TileItemModel implements TileItem, IEntity {
             int param1;
             int identifier;
             String target;
-            MenuAction menuAction = MenuAction.CANCEL;
+            MenuAction menuAction;
             ItemComposition item;
 
             item = Microbot.getClientThread().runOnClientThreadOptional(() -> Microbot.getClient().getItemDefinition(getId())).orElse(null);
@@ -225,6 +226,7 @@ public class Rs2TileItemModel implements TileItem, IEntity {
 
             int index = -1;
             if (action.isEmpty()) {
+                if (groundActions.length == 0 || groundActions[0] == null) return false;
                 action = groundActions[0];
                 index = 0;
             } else {
@@ -232,25 +234,18 @@ public class Rs2TileItemModel implements TileItem, IEntity {
                     String groundAction = groundActions[i];
                     if (groundAction == null || !groundAction.equalsIgnoreCase(action)) continue;
                     index = i;
+                    break;
                 }
             }
 
             if (Microbot.getClient().isWidgetSelected()) {
                 menuAction = MenuAction.WIDGET_TARGET_ON_GROUND_ITEM;
-            } else if (index == 0) {
-                menuAction = MenuAction.GROUND_ITEM_FIRST_OPTION;
-            } else if (index == 1) {
-                menuAction = MenuAction.GROUND_ITEM_SECOND_OPTION;
-            } else if (index == 2) {
-                menuAction = MenuAction.GROUND_ITEM_THIRD_OPTION;
-            } else if (index == 3) {
-                menuAction = MenuAction.GROUND_ITEM_FOURTH_OPTION;
-            } else if (index == 4) {
-                menuAction = MenuAction.GROUND_ITEM_FIFTH_OPTION;
-            }
-            if (menuAction == MenuAction.CANCEL) {
-                log.warn("Unable to interact with ground item '{}' using action '{}'; actions={}", getName(), action, java.util.Arrays.toString(groundActions));
-                return false;
+            } else {
+                menuAction = groundItemMenuAction(index);
+                if (menuAction == null) {
+                    log.warn("Unable to interact with ground item '{}' using action '{}'; actions={}", getName(), action, Arrays.toString(groundActions));
+                    return false;
+                }
             }
             LocalPoint localPoint1 = getLocalLocation();
             if (localPoint1 == null) {
@@ -292,9 +287,19 @@ public class Rs2TileItemModel implements TileItem, IEntity {
                     (int) bounds.getCenterY());
             return true;
         } catch (Exception ex) {
-            Microbot.log(ex.getMessage());
-            ex.printStackTrace();
+            Microbot.logStackTrace("Rs2TileItemModel", ex);
             return false;
+        }
+    }
+
+    private static MenuAction groundItemMenuAction(int index) {
+        switch (index) {
+            case 0: return MenuAction.GROUND_ITEM_FIRST_OPTION;
+            case 1: return MenuAction.GROUND_ITEM_SECOND_OPTION;
+            case 2: return MenuAction.GROUND_ITEM_THIRD_OPTION;
+            case 3: return MenuAction.GROUND_ITEM_FOURTH_OPTION;
+            case 4: return MenuAction.GROUND_ITEM_FIFTH_OPTION;
+            default: return null;
         }
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItem.java
@@ -69,7 +69,7 @@ public class Rs2GroundItem {
             int param1;
             int identifier;
             String target;
-            MenuAction menuAction = MenuAction.CANCEL;
+            MenuAction menuAction;
             ItemComposition item;
 
             item = Microbot.getClientThread().runOnClientThreadOptional(() -> Microbot.getClient().getItemDefinition(groundItem.getId())).orElse(null);
@@ -90,24 +90,17 @@ public class Rs2GroundItem {
                 String groundAction = groundActions[i];
                 if (groundAction == null || !groundAction.equalsIgnoreCase(action)) continue;
                 index = i;
+                break;
             }
 
             if (Microbot.getClient().isWidgetSelected()) {
                 menuAction = MenuAction.WIDGET_TARGET_ON_GROUND_ITEM;
-            } else if (index == 0) {
-                menuAction = MenuAction.GROUND_ITEM_FIRST_OPTION;
-            } else if (index == 1) {
-                menuAction = MenuAction.GROUND_ITEM_SECOND_OPTION;
-            } else if (index == 2) {
-                menuAction = MenuAction.GROUND_ITEM_THIRD_OPTION;
-            } else if (index == 3) {
-                menuAction = MenuAction.GROUND_ITEM_FOURTH_OPTION;
-            } else if (index == 4) {
-                menuAction = MenuAction.GROUND_ITEM_FIFTH_OPTION;
-            }
-            if (menuAction == MenuAction.CANCEL) {
-                log.warn("Unable to interact with ground item '{}' using action '{}'; actions={}", groundItem.getName(), action, Arrays.toString(groundActions));
-                return false;
+            } else {
+                menuAction = groundItemMenuAction(index);
+                if (menuAction == null) {
+                    log.warn("Unable to interact with ground item '{}' using action '{}'; actions={}", groundItem.getName(), action, Arrays.toString(groundActions));
+                    return false;
+                }
             }
             LocalPoint localPoint1 = localPoint;
             if (!Rs2Camera.isTileOnScreen(localPoint1)) {
@@ -146,9 +139,19 @@ public class Rs2GroundItem {
                     (int) bounds.getCenterY());
             return true;
         } catch (Exception ex) {
-            Microbot.log(ex.getMessage());
-            ex.printStackTrace();
+            Microbot.logStackTrace("Rs2GroundItem", ex);
             return false;
+        }
+    }
+
+    private static MenuAction groundItemMenuAction(int index) {
+        switch (index) {
+            case 0: return MenuAction.GROUND_ITEM_FIRST_OPTION;
+            case 1: return MenuAction.GROUND_ITEM_SECOND_OPTION;
+            case 2: return MenuAction.GROUND_ITEM_THIRD_OPTION;
+            case 3: return MenuAction.GROUND_ITEM_FOURTH_OPTION;
+            case 4: return MenuAction.GROUND_ITEM_FIFTH_OPTION;
+            default: return null;
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/reflection/Rs2Reflection.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/reflection/Rs2Reflection.java
@@ -14,8 +14,9 @@ import java.awt.event.KeyEvent;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -76,21 +77,27 @@ public class Rs2Reflection {
     private static volatile Field cachedListField;
     private static volatile Field cachedStringField;
 
-    @SneakyThrows
     public static String[] getGroundItemActions(ItemComposition item) {
+        return getGroundItemActionsFromObject(item);
+    }
+
+    @SneakyThrows
+    static String[] getGroundItemActionsFromObject(Object item) {
+        if (item == null) return new String[]{};
+
         if (cachedOuterField != null && cachedListField != null) {
             try {
                 return extractWithCache(item);
             } catch (Exception e) {
                 log.warn("Ground item action cache invalidated, re-discovering");
-                cachedOuterField = null;
-                cachedListField = null;
-                cachedStringField = null;
+                resetGroundItemActionCache();
             }
         }
 
         for (Class<?> clazz = item.getClass(); clazz != null && clazz != Object.class; clazz = clazz.getSuperclass()) {
             for (Field outerField : clazz.getDeclaredFields()) {
+                if (Modifier.isStatic(outerField.getModifiers()) || outerField.isSynthetic()) continue;
+
                 Class<?> type = outerField.getType();
                 if (type.isPrimitive() || type == String.class || type.isArray()
                         || type.getName().startsWith("java.") || type.getName().startsWith("net.runelite.")) continue;
@@ -101,14 +108,15 @@ public class Rs2Reflection {
                 if (outerValue == null) continue;
 
                 for (Field listField : outerValue.getClass().getDeclaredFields()) {
-                    if (listField.getType() != ArrayList.class) continue;
+                    if (Modifier.isStatic(listField.getModifiers()) || listField.isSynthetic()) continue;
+                    if (!List.class.isAssignableFrom(listField.getType())) continue;
 
                     listField.setAccessible(true);
                     Object listObj = listField.get(outerValue);
                     listField.setAccessible(false);
-                    if (!(listObj instanceof ArrayList)) continue;
+                    if (!(listObj instanceof List)) continue;
 
-                    ArrayList<?> list = (ArrayList<?>) listObj;
+                    List<?> list = (List<?>) listObj;
                     if (list.isEmpty()) continue;
 
                     Object first = null;
@@ -121,27 +129,36 @@ public class Rs2Reflection {
                         cachedOuterField = outerField;
                         cachedListField = listField;
                         cachedStringField = null;
-                        return groundItemActionsOrDefault(toStringArray(list));
+                        return toStringArray(list);
                     }
 
                     Field stringField = null;
                     for (Field f : first.getClass().getDeclaredFields()) {
-                        if (f.getType() == String.class) { stringField = f; break; }
+                        if (!Modifier.isStatic(f.getModifiers()) && !f.isSynthetic() && f.getType() == String.class) {
+                            stringField = f;
+                            break;
+                        }
                     }
                     if (stringField == null) continue;
 
                     cachedOuterField = outerField;
                     cachedListField = listField;
                     cachedStringField = stringField;
-                    return groundItemActionsOrDefault(extractFromBeans(list, stringField));
+                    return extractFromBeans(list, stringField);
                 }
             }
         }
 
-        return defaultGroundItemActions();
+        return new String[]{};
     }
 
-    private static String[] extractWithCache(ItemComposition item) throws Exception {
+    static void resetGroundItemActionCache() {
+        cachedOuterField = null;
+        cachedListField = null;
+        cachedStringField = null;
+    }
+
+    private static String[] extractWithCache(Object item) throws Exception {
         cachedOuterField.setAccessible(true);
         Object outer = cachedOuterField.get(item);
         cachedOuterField.setAccessible(false);
@@ -150,29 +167,14 @@ public class Rs2Reflection {
         cachedListField.setAccessible(true);
         Object listObj = cachedListField.get(outer);
         cachedListField.setAccessible(false);
-        if (!(listObj instanceof ArrayList)) return new String[]{};
+        if (!(listObj instanceof List)) return new String[]{};
 
-        ArrayList<?> list = (ArrayList<?>) listObj;
-        if (cachedStringField == null) return groundItemActionsOrDefault(toStringArray(list));
-        return groundItemActionsOrDefault(extractFromBeans(list, cachedStringField));
+        List<?> list = (List<?>) listObj;
+        if (cachedStringField == null) return toStringArray(list);
+        return extractFromBeans(list, cachedStringField);
     }
 
-    private static String[] groundItemActionsOrDefault(String[] actions) {
-        if (actions != null) {
-            for (String action : actions) {
-                if (action != null && !action.isBlank()) {
-                    return actions;
-                }
-            }
-        }
-        return defaultGroundItemActions();
-    }
-
-    private static String[] defaultGroundItemActions() {
-        return new String[]{null, null, "Take", null, null};
-    }
-
-    private static String[] toStringArray(ArrayList<?> list) {
+    private static String[] toStringArray(List<?> list) {
         String[] result = new String[list.size()];
         for (int i = 0; i < list.size(); i++) {
             Object el = list.get(i);
@@ -181,7 +183,7 @@ public class Rs2Reflection {
         return result;
     }
 
-    private static String[] extractFromBeans(ArrayList<?> list, Field stringField) throws Exception {
+    private static String[] extractFromBeans(List<?> list, Field stringField) throws Exception {
         String[] result = new String[list.size()];
         stringField.setAccessible(true);
         for (int i = 0; i < list.size(); i++) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/reflection/Rs2Reflection.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/reflection/Rs2Reflection.java
@@ -76,6 +76,7 @@ public class Rs2Reflection {
     private static volatile Field cachedOuterField;
     private static volatile Field cachedListField;
     private static volatile Field cachedStringField;
+    private static volatile Class<?> cachedGroundItemClass;
 
     public static String[] getGroundItemActions(ItemComposition item) {
         return getGroundItemActionsFromObject(item);
@@ -84,6 +85,11 @@ public class Rs2Reflection {
     @SneakyThrows
     static String[] getGroundItemActionsFromObject(Object item) {
         if (item == null) return new String[]{};
+        Class<?> itemClass = item.getClass();
+        if (cachedGroundItemClass != itemClass) {
+            resetGroundItemActionCache();
+            cachedGroundItemClass = itemClass;
+        }
 
         if (cachedOuterField != null && cachedListField != null) {
             try {
@@ -153,6 +159,7 @@ public class Rs2Reflection {
     }
 
     static void resetGroundItemActionCache() {
+        cachedGroundItemClass = null;
         cachedOuterField = null;
         cachedListField = null;
         cachedStringField = null;

--- a/runelite-client/src/test/java/groundactionfixture/GroundItemActionFixture.java
+++ b/runelite-client/src/test/java/groundactionfixture/GroundItemActionFixture.java
@@ -1,0 +1,74 @@
+package groundactionfixture;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+public final class GroundItemActionFixture {
+    private GroundItemActionFixture() {
+    }
+
+    public static Object create(String... actions) {
+        return new FakeItem(actions);
+    }
+
+    public static Object createWithListInterface(String... actions) {
+        return new FakeListItem(actions);
+    }
+
+    private static final class FakeItem {
+        private static final MisleadingOuter STATIC_OUTER = new MisleadingOuter();
+        private final GroundOps groundOps;
+
+        private FakeItem(String[] actions) {
+            groundOps = new GroundOps(actions);
+        }
+    }
+
+    private static final class MisleadingOuter {
+        private final ArrayList<ActionBean> actions = new ArrayList<>(
+                Arrays.asList(new ActionBean("Wrong static outer action")));
+    }
+
+    private static final class GroundOps {
+        private static final ArrayList<ActionBean> STATIC_ACTIONS = new ArrayList<>(
+                Arrays.asList(new ActionBean("Wrong static list action")));
+        private final ArrayList<ActionBean> actions;
+
+        private GroundOps(String[] actions) {
+            this.actions = new ArrayList<>();
+            for (String action : actions) {
+                this.actions.add(new ActionBean(action));
+            }
+        }
+    }
+
+    private static final class FakeListItem {
+        private static final GroundOpsList STATIC_OUTER = new GroundOpsList("Wrong static outer action");
+        private final GroundOpsList groundOps;
+
+        private FakeListItem(String[] actions) {
+            groundOps = new GroundOpsList(actions);
+        }
+    }
+
+    private static final class GroundOpsList {
+        private static final List<ActionBean> STATIC_ACTIONS = new LinkedList<>(
+                Arrays.asList(new ActionBean("Wrong static list action")));
+        private final List<ActionBean> actions = new LinkedList<>();
+
+        private GroundOpsList(String... actions) {
+            for (String action : actions) this.actions.add(new ActionBean(action));
+        }
+    }
+
+    private static final class ActionBean {
+        private static final String STATIC_ACTION = "Wrong static string action";
+        private final String action;
+
+        private ActionBean(String action) {
+            this.action = action;
+        }
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/grounditem/GroundItemMenuActionResolutionTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/grounditem/GroundItemMenuActionResolutionTest.java
@@ -1,0 +1,46 @@
+package net.runelite.client.plugins.microbot.util.grounditem;
+
+import java.lang.reflect.Method;
+import net.runelite.api.MenuAction;
+import net.runelite.client.plugins.microbot.api.tileitem.models.Rs2TileItemModel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+public class GroundItemMenuActionResolutionTest
+{
+    @Test
+    public void legacyGroundItemRejectsUnresolvedAction() throws Exception
+    {
+        assertUnresolvedActionIsNotCancel(Rs2GroundItem.class);
+    }
+
+    @Test
+    public void tileItemRejectsUnresolvedAction() throws Exception
+    {
+        assertUnresolvedActionIsNotCancel(Rs2TileItemModel.class);
+    }
+
+    @Test
+    public void bothPathsResolveTakeIndexToThirdOption() throws Exception
+    {
+        assertEquals(MenuAction.GROUND_ITEM_THIRD_OPTION, resolve(Rs2GroundItem.class, 2));
+        assertEquals(MenuAction.GROUND_ITEM_THIRD_OPTION, resolve(Rs2TileItemModel.class, 2));
+    }
+
+    private static void assertUnresolvedActionIsNotCancel(Class<?> type) throws Exception
+    {
+        MenuAction result = resolve(type, -1);
+        assertNull(result);
+        assertNotEquals(MenuAction.CANCEL, result);
+    }
+
+    private static MenuAction resolve(Class<?> type, int index) throws Exception
+    {
+        Method method = type.getDeclaredMethod("groundItemMenuAction", int.class);
+        method.setAccessible(true);
+        return (MenuAction) method.invoke(null, index);
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/reflection/Rs2ReflectionGroundItemActionsTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/reflection/Rs2ReflectionGroundItemActionsTest.java
@@ -1,0 +1,46 @@
+package net.runelite.client.plugins.microbot.util.reflection;
+
+import groundactionfixture.GroundItemActionFixture;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class Rs2ReflectionGroundItemActionsTest {
+    @Before
+    public void setUp() {
+        Rs2Reflection.resetGroundItemActionCache();
+    }
+
+    @After
+    public void tearDown() {
+        Rs2Reflection.resetGroundItemActionCache();
+    }
+
+    @Test
+    public void discoveryIgnoresMisleadingStaticFields() {
+        String[] actions = Rs2Reflection.getGroundItemActionsFromObject(
+                GroundItemActionFixture.create("Take", "Bury"));
+
+        assertArrayEquals(new String[]{"Take", "Bury"}, actions);
+    }
+
+    @Test
+    public void cachedInstanceFieldChainWorksAcrossItems() {
+        Rs2Reflection.getGroundItemActionsFromObject(GroundItemActionFixture.create("Take"));
+
+        String[] actions = Rs2Reflection.getGroundItemActionsFromObject(
+                GroundItemActionFixture.create("Take", "Destroy"));
+
+        assertArrayEquals(new String[]{"Take", "Destroy"}, actions);
+    }
+
+    @Test
+    public void discoverySupportsListInterfaceAndNonArrayListImplementation() {
+        String[] actions = Rs2Reflection.getGroundItemActionsFromObject(
+                GroundItemActionFixture.createWithListInterface("Take", "Destroy"));
+
+        assertArrayEquals(new String[]{"Take", "Destroy"}, actions);
+    }
+}


### PR DESCRIPTION
## Summary

Defensive hardening for Microbot ground item action reflection and action resolution.

This PR does not claim that normal ground item pickup is broadly broken upstream. The intent is narrower: avoid brittle reflection/action-resolution behavior when client internals include misleading static/synthetic fields or when the requested ground action cannot be resolved cleanly.

## Changes

- Ignore static and synthetic fields during ground item action reflection discovery.
- Accept `List` implementations rather than only concrete `ArrayList` fields.
- Reset cached ground item action reflection discovery when the inspected class changes.
- Avoid falling through to a default ground action when the requested action could not be resolved.
- Stop on the first matching ground action slot instead of allowing later duplicate matches to overwrite the resolved slot.
- Add regression coverage for static-field false positives, `List` implementations, cache behavior, and unresolved action handling.

## Validation

- `git diff --check upstream/development...HEAD`
- `./gradlew.bat :client:compileJava --console=plain`
