### PR TITLE
fix(walker): stop opening shop doors beside the path

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -3736,24 +3736,12 @@ public class Rs2Walker {
                 final String name = comp.getName();
 
                 if (object instanceof WallObject) {
-                    WallObject wallObj = (WallObject) object;
-                    int orientationA = wallObj.getOrientationA();
-                    int orientationB = wallObj.getOrientationB();
-                    boolean pathTouchesBothEnds = probe.distanceTo(fromWp) <= 1 && probe.distanceTo(toWp) <= 1
-                            && fromWp.distanceTo(toWp) >= 1 && fromWp.distanceTo(toWp) <= 2;
-                    boolean orientOk = false;
-                    if (orientationA != 0) {
-                        orientOk = searchNeighborPoint(orientationA, probe, fromWp)
-                                || searchNeighborPoint(orientationA, probe, toWp);
-                    }
-                    if (!orientOk && orientationB != 0) {
-                        orientOk = searchNeighborPoint(orientationB, probe, fromWp)
-                                || searchNeighborPoint(orientationB, probe, toWp);
-                    }
-                    if (!orientOk && pathTouchesBothEnds) {
-                        orientOk = true;
-                    }
-                    if (orientOk) {
+                    // Validate the door's ACTUAL blocked edge against the segment, not the probe
+                    // tile. The probe can sit a tile off the wall (adjacency fallback above), and the
+                    // old probe-orientation check plus the pathTouchesBothEnds shortcut opened doors
+                    // merely beside the path. isDoorOnSegment walks the segment against the wall's
+                    // real edge, matching the GameObject branch and findDoorNearSegment.
+                    if (isDoorOnSegment(object, fromWp, toWp)) {
                         log.info("Found WallObject door - name {} with action {} at {} - from {} to {}", name, action, probe, fromWp, toWp);
                         found = true;
                     } else {
@@ -4447,8 +4435,11 @@ public class Rs2Walker {
         if (wall.getWorldLocation().getPlane() != fromWp.getPlane() || fromWp.getPlane() != toWp.getPlane()) return false;
 
         WorldPoint doorTile = wall.getWorldLocation();
-        WorldPoint blockedNeighbor = getWallDoorNeighborPoint(wall.getOrientationA(), doorTile);
-        if (blockedNeighbor == null) return false;
+        // A door panel can advertise a blocked edge on either orientation; check both so a
+        // legitimately-on-path door is never missed.
+        WorldPoint blockedNeighborA = getWallDoorNeighborPoint(wall.getOrientationA(), doorTile);
+        WorldPoint blockedNeighborB = getWallDoorNeighborPoint(wall.getOrientationB(), doorTile);
+        if (blockedNeighborA == null && blockedNeighborB == null) return false;
 
         int x = fromWp.getX();
         int y = fromWp.getY();
@@ -4461,7 +4452,8 @@ public class Rs2Walker {
             x += Integer.signum(toWp.getX() - x);
             y += Integer.signum(toWp.getY() - y);
             WorldPoint next = new WorldPoint(x, y, fromWp.getPlane());
-            if (isDoorEdgeTransition(previous, next, doorTile, blockedNeighbor)) {
+            if ((blockedNeighborA != null && isDoorEdgeTransition(previous, next, doorTile, blockedNeighborA))
+                    || (blockedNeighborB != null && isDoorEdgeTransition(previous, next, doorTile, blockedNeighborB))) {
                 return true;
             }
             previous = next;


### PR DESCRIPTION
## What
The webwalker no longer opens closed doors that sit beside its path but don't
block it (e.g. shop doors on the Lumbridge net-fishing -> courtyard route).

## Why
Users reported the walker opening shop doors -- like Bob's Brilliant Axes --
that are near the path but not blocking it, intermittently. handleDoors'
WallObject branch found a door via a 1-tile probe-adjacency fallback, then
validated it against the probe tile (not the door's real location) and, failing
that, accepted it via a pathTouchesBothEnds catch-all that ignored orientation.
So a door one tile off the route -- whose blocked edge the path never crosses --
was opened anyway.

## How it works
- The WallObject branch now calls isDoorOnSegment(object, fromWp, toWp), which
  walks the segment against the wall's actual blocked edge -- the same validator
  the GameObject branch and findDoorNearSegment already use. The probe-orientation
  check and the pathTouchesBothEnds shortcut are gone.
- wallDoorTouchesSegment now derives the blocked neighbour from both orientationA
  and orientationB, so a legitimately on-path door advertising its edge on either
  orientation is still opened.

## Testing
Reproduced live on the reported route (Lumbridge net-fishing 3241,3154 ->
courtyard 3222,3218, shop doors confirmed closed) with a diagnostic build logging
isDoorOnSegment ground truth.
- Baseline (buggy): walker opened door (3234,3207) with onSegment=false, accepted
  purely by the catch-all -- a west-facing door while the path stepped north past it.
- After the fix, 8-run diagnostic batch: 0 off-segment opens; the fix actively
  rejected the bug geometry 14 times; 8/8 walks arrived.
- Collision-verified batch: door (3234,3207) stayed CLOSED before and after every
  walk; 0 wall-door opens logged; 4/4 arrived.
- Regression guard (sole-passage door, Bob's): walker still opens an on-path door
  and crosses through, 5/5.
- Rs2WalkerUnitTest passes, including wallDoorTouchesSegment_startingBesideDoorAnd
  MovingAway_returnsFalse and ..._crossingDoorEdge_returnsTrue.