### PR TITLE
fix: restore ground item Take fallback

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/reflection/Rs2Reflection.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/reflection/Rs2Reflection.java
@@ -169,12 +169,12 @@ public class Rs2Reflection {
         cachedOuterField.setAccessible(true);
         Object outer = cachedOuterField.get(item);
         cachedOuterField.setAccessible(false);
-        if (outer == null) return new String[]{};
+        if (outer == null) return defaultGroundItemActions();
 
         cachedListField.setAccessible(true);
         Object listObj = cachedListField.get(outer);
         cachedListField.setAccessible(false);
-        if (!(listObj instanceof List)) return new String[]{};
+        if (!(listObj instanceof List)) return defaultGroundItemActions();
 
         List<?> list = (List<?>) listObj;
         if (cachedStringField == null) return groundItemActionsOrDefault(toStringArray(list));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/reflection/Rs2Reflection.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/reflection/Rs2Reflection.java
@@ -135,7 +135,7 @@ public class Rs2Reflection {
                         cachedOuterField = outerField;
                         cachedListField = listField;
                         cachedStringField = null;
-                        return toStringArray(list);
+                        return groundItemActionsOrDefault(toStringArray(list));
                     }
 
                     Field stringField = null;
@@ -150,12 +150,12 @@ public class Rs2Reflection {
                     cachedOuterField = outerField;
                     cachedListField = listField;
                     cachedStringField = stringField;
-                    return extractFromBeans(list, stringField);
+                    return groundItemActionsOrDefault(extractFromBeans(list, stringField));
                 }
             }
         }
 
-        return new String[]{};
+        return defaultGroundItemActions();
     }
 
     static void resetGroundItemActionCache() {
@@ -177,8 +177,20 @@ public class Rs2Reflection {
         if (!(listObj instanceof List)) return new String[]{};
 
         List<?> list = (List<?>) listObj;
-        if (cachedStringField == null) return toStringArray(list);
-        return extractFromBeans(list, cachedStringField);
+        if (cachedStringField == null) return groundItemActionsOrDefault(toStringArray(list));
+        return groundItemActionsOrDefault(extractFromBeans(list, cachedStringField));
+    }
+
+    private static String[] groundItemActionsOrDefault(String[] actions) {
+        if (actions == null || actions.length == 0) return defaultGroundItemActions();
+        for (String action : actions) {
+            if (action != null && !action.isBlank()) return actions;
+        }
+        return defaultGroundItemActions();
+    }
+
+    private static String[] defaultGroundItemActions() {
+        return new String[]{null, null, "Take", null, null};
     }
 
     private static String[] toStringArray(List<?> list) {

--- a/runelite-client/src/test/java/groundactionfixture/GroundItemActionFixture.java
+++ b/runelite-client/src/test/java/groundactionfixture/GroundItemActionFixture.java
@@ -21,6 +21,18 @@ public final class GroundItemActionFixture {
         return new FakeItemWithoutGroundActions();
     }
 
+    public static Object createWithNullGroundOps() {
+        return new FakeItem(null);
+    }
+
+    public static Object createWithFlexibleActions(String... actions) {
+        return new FakeFlexibleItem(new ArrayList<>(Arrays.asList(actions)));
+    }
+
+    public static Object createWithInvalidFlexibleActions() {
+        return new FakeFlexibleItem("not a list");
+    }
+
     private static final class FakeItemWithoutGroundActions {
         private final String name = "Amethyst";
     }
@@ -30,7 +42,23 @@ public final class GroundItemActionFixture {
         private final GroundOps groundOps;
 
         private FakeItem(String[] actions) {
-            groundOps = new GroundOps(actions);
+            groundOps = actions == null ? null : new GroundOps(actions);
+        }
+    }
+
+    private static final class FakeFlexibleItem {
+        private final FlexibleGroundOps groundOps;
+
+        private FakeFlexibleItem(Object actions) {
+            groundOps = new FlexibleGroundOps(actions);
+        }
+    }
+
+    private static final class FlexibleGroundOps {
+        private final Object actions;
+
+        private FlexibleGroundOps(Object actions) {
+            this.actions = actions;
         }
     }
 

--- a/runelite-client/src/test/java/groundactionfixture/GroundItemActionFixture.java
+++ b/runelite-client/src/test/java/groundactionfixture/GroundItemActionFixture.java
@@ -17,6 +17,14 @@ public final class GroundItemActionFixture {
         return new FakeListItem(actions);
     }
 
+    public static Object createWithoutGroundActions() {
+        return new FakeItemWithoutGroundActions();
+    }
+
+    private static final class FakeItemWithoutGroundActions {
+        private final String name = "Amethyst";
+    }
+
     private static final class FakeItem {
         private static final MisleadingOuter STATIC_OUTER = new MisleadingOuter();
         private final GroundOps groundOps;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/reflection/Rs2ReflectionGroundItemActionsTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/reflection/Rs2ReflectionGroundItemActionsTest.java
@@ -67,4 +67,25 @@ public class Rs2ReflectionGroundItemActionsTest {
 
         assertArrayEquals(new String[]{null, null, "Take", null, null}, actions);
     }
+
+    @Test
+    public void cachedPathFallsBackWhenOuterFieldBecomesNull() {
+        Rs2Reflection.getGroundItemActionsFromObject(GroundItemActionFixture.create("Take"));
+
+        String[] actions = Rs2Reflection.getGroundItemActionsFromObject(
+                GroundItemActionFixture.createWithNullGroundOps());
+
+        assertArrayEquals(new String[]{null, null, "Take", null, null}, actions);
+    }
+
+    @Test
+    public void cachedPathFallsBackWhenCachedActionFieldIsNotAList() {
+        Rs2Reflection.getGroundItemActionsFromObject(
+                GroundItemActionFixture.createWithFlexibleActions("Take"));
+
+        String[] actions = Rs2Reflection.getGroundItemActionsFromObject(
+                GroundItemActionFixture.createWithInvalidFlexibleActions());
+
+        assertArrayEquals(new String[]{null, null, "Take", null, null}, actions);
+    }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/reflection/Rs2ReflectionGroundItemActionsTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/reflection/Rs2ReflectionGroundItemActionsTest.java
@@ -43,4 +43,28 @@ public class Rs2ReflectionGroundItemActionsTest {
 
         assertArrayEquals(new String[]{"Take", "Destroy"}, actions);
     }
+
+    @Test
+    public void fallbackReturnsTakeWhenNoGroundActionStructureExists() {
+        String[] actions = Rs2Reflection.getGroundItemActionsFromObject(
+                GroundItemActionFixture.createWithoutGroundActions());
+
+        assertArrayEquals(new String[]{null, null, "Take", null, null}, actions);
+    }
+
+    @Test
+    public void fallbackReturnsTakeWhenGroundActionsAreEmpty() {
+        String[] actions = Rs2Reflection.getGroundItemActionsFromObject(
+                GroundItemActionFixture.create());
+
+        assertArrayEquals(new String[]{null, null, "Take", null, null}, actions);
+    }
+
+    @Test
+    public void fallbackReturnsTakeWhenGroundActionsAreNullOrBlank() {
+        String[] actions = Rs2Reflection.getGroundItemActionsFromObject(
+                GroundItemActionFixture.create(null, "", "   "));
+
+        assertArrayEquals(new String[]{null, null, "Take", null, null}, actions);
+    }
 }


### PR DESCRIPTION
Summary

Restores the legacy ground item action fallback for cases where reflection cannot resolve usable ground item actions from the item definition.

Details

- Preserves reflection-discovered ground item actions when present.
- Falls back to `{null, null, "Take", null, null}` only when no usable action data is found.
- Covers missing action structure, empty action lists, and null/blank-only action lists with focused tests.

Validation

- `./gradlew.bat :client:compileJava :client:compileTestJava --console=plain`
- Live forced-fallback smoke: dropped Amethyst was picked back up through the fallback path; inventory increased from 15 to 16.

Note

This PR is intentionally narrow. It does not replace normal reflected action resolution; it only restores the default Take fallback for failure cases.
