### PR TITLE
fix: prevent Microbot plugin names clipping in sidebar

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/ui/MicrobotPluginListItem.java
@@ -46,6 +46,7 @@ class MicrobotPluginListItem extends JPanel implements SearchablePlugin
 {
 	private static final ImageIcon ON_STAR;
 	private static final ImageIcon OFF_STAR;
+	private static final int MIN_ITEM_HEIGHT = 20;
 
 	private final MicrobotPluginListPanel pluginListPanel;
 
@@ -90,9 +91,10 @@ class MicrobotPluginListItem extends JPanel implements SearchablePlugin
 		}
 
 		setLayout(new BorderLayout(3, 0));
-		setPreferredSize(new Dimension(MicrobotPluginListPanel.LIST_ITEM_WIDTH, 20));
 
 		JLabel nameLabel = createNameLabel(pluginConfig);
+		int itemHeight = Math.max(MIN_ITEM_HEIGHT, nameLabel.getPreferredSize().height);
+		setPreferredSize(new Dimension(MicrobotPluginListPanel.LIST_ITEM_WIDTH, itemHeight));
 
 		pinButton = new JToggleButton(OFF_STAR);
 		pinButton.setSelectedIcon(ON_STAR);
@@ -185,17 +187,25 @@ class MicrobotPluginListItem extends JPanel implements SearchablePlugin
 
 	@NotNull
 	private static JLabel createNameLabel(MicrobotPluginConfigurationDescriptor pluginConfig) {
-		JLabel nameLabel = new JLabel(pluginConfig.getName());
 		int buttons = 21 /*pin*/ + 25 /*config, if present*/ + 34 /*toggle approx*/ + 12 /*margins*/;
 		int textWidth = MicrobotPluginListPanel.LIST_ITEM_WIDTH - buttons;
-		nameLabel.setText("<html><div style='width:" + textWidth + "px'>" + pluginConfig.getName() + "</div></html>");
+		JLabel nameLabel = new JLabel("<html><div style='width:" + textWidth + "px'>" + htmlBody(pluginConfig.getName()) + "</div></html>");
 		nameLabel.setForeground(Color.WHITE);
+		nameLabel.setHorizontalAlignment(JLabel.LEFT);
+		nameLabel.setVerticalAlignment(JLabel.CENTER);
 
 		if (!pluginConfig.getDescription().isEmpty())
 		{
-			nameLabel.setToolTipText("<html>" + pluginConfig.getName() + ":<br>" + pluginConfig.getDescription() + "</html>");
+			nameLabel.setToolTipText("<html>" + htmlBody(pluginConfig.getName()) + ":<br>" + htmlBody(pluginConfig.getDescription()) + "</html>");
 		}
 		return nameLabel;
+	}
+
+	private static String htmlBody(String html)
+	{
+		return html
+			.replaceFirst("(?i)^\\s*<html>", "")
+			.replaceFirst("(?i)</html>\\s*$", "");
 	}
 
 	@Override


### PR DESCRIPTION
Fixes long Microbot plugin names clipping or overlapping in the  plugin sidebar.

The sidebar row was always fixed at 20px, so names that wrapped to a second line were clipped. 