### PR TITLE
Fix WebWalker continuity and automation interaction reliability

### DIFF
--- a/docs/entity-guides/movement.md
+++ b/docs/entity-guides/movement.md
@@ -325,8 +325,11 @@ An object transport can open quest dialogue instead of moving the player immedia
 **Pattern to follow:**
 
 ```java
-boolean landed = waitForPostHandleObjectLanding(...);
-if (Rs2Dialogue.isInDialogue()) {
+boolean dialogueWasOpen = Rs2Dialogue.isInDialogue();
+dispatchObjectTransport(...);
+boolean landed = waitForPostHandleObjectLanding(..., dialogueWasOpen);
+boolean dialogueOpened = !dialogueWasOpen && Rs2Dialogue.isInDialogue();
+if (!landed && dialogueOpened) {
     return true; // handled this transport pass
 }
 return landed;
@@ -336,6 +339,11 @@ if (Rs2Dialogue.isInDialogue() && isRouteProgressExit(exitReason)) {
     return WalkerState.MOVING; // caller can now process the dialogue
 }
 ```
+
+Only the closed-to-open transition counts as the object transport's handled result. The outer
+handoff remains level-triggered after route progress has been independently established, so the
+calling quest layer can also resume when genuine landing progress coincides with an existing
+dialogue; an open dialogue by itself does not create a route-progress exit.
 
 **Where this applies:** `Rs2Walker.handleObject`, post-object transport landing waits, and quest-driven doors or shortcuts that can display dialogue.
 

--- a/docs/entity-guides/movement.md
+++ b/docs/entity-guides/movement.md
@@ -284,6 +284,26 @@ if (isStuckTooLong()) {
 
 **Defensive check:** Start a long route and observe a stationary pause. A short idle pause should log `active route idle nudge`; if it reaches full stall recalc, the next log sequence should include `stall recovery click` and a position delta, not another idle-only `STALL_RECALC` loop at the same tile.
 
+## 14. A ranged door click owns the approach movement
+
+Object interaction can be dispatched several tiles from a door. Once the player starts moving toward the door's near-side edge, release the synchronous door await and retain that approach as in-flight route ownership. Do not burn the full traversal timeout waiting for an edge the player has not reached yet, and do not let recovery or another raw door probe replace the queued interaction while the approach is progressing.
+
+**Why this matters:** A four-tile approach can take longer than the door traversal wait. Treating ordinary approach movement as an unresolved traversal produces a timeout, followed by `door_recovery_suppressed` exits and a multi-second idle-nudge holdoff even though the original click is still working.
+
+**Pattern to follow:**
+
+```java
+if (movingTowardDoorNearSide(clickPosition, playerPosition, from, to)) {
+    releaseDoorAwait("approach-started");
+    retainDoorApproachUntilEdgeResolutionOrMovementStops();
+    return MOVING;
+}
+```
+
+**Where this applies:** ranged scene-object door interaction, `Rs2WalkerAwaits`, recent-door recovery gates, and any fallback scanner that can run before the queued interaction reaches the object.
+
+**Defensive check:** Interact with a door from three or four tiles away. The await should release as `approach-started` after the first position delta, recovery should yield while distance to the near-side edge decreases, and no second door interaction should fire before the approach stops or the edge resolves.
+
 After a handled transport, avoid expensive path-adjacent or raw transport scans on ordinary open-ground segments unless a nearby planned transport or recent door attempt exists. Those scans are recovery tools, and on long outdoor routes a no-op scan can add several seconds before the next minimap click.
 
 For long-route minimap walking, let the next checkpoint selection happen before the current minimap target is fully consumed. Waiting until the player is only a few tiles from the interim makes the walker visibly stop before issuing the next click; handing off at a moderate remaining distance keeps movement continuous without rapid re-clicking. If an interim clears as close and no nearby route door/transport is pending, issue the next route-aligned continuation click immediately instead of waiting for idle-nudge recovery.
@@ -295,3 +315,46 @@ Sticky interim targets should also clear when route-index progress goes stale. I
 When a route-following minimap click is outside the minimap clip, fallback clicks must stay on the raw path. A generic "reachable tile closer to target" fallback can select a tile far away from the route in open areas, especially near the final destination.
 
 For adjacent same-plane shortcuts, do not treat any movement away from the origin as success. Some shortcuts, such as stepping stones, can fail and place the player on a fallback tile; once the player is settled away from the expected destination, stop the landing wait and replan from the actual tile.
+
+## 15. Yield object-transport waits when dialogue opens
+
+An object transport can open quest dialogue instead of moving the player immediately. When that happens, end the synchronous transport landing wait and propagate that yield through the outer `processWalk` loop by returning `MOVING` to the calling script. The quest layer owns the dialogue response; the walker should not answer it or keep retrying the object.
+
+**Why this matters:** Quest walking and dialogue handling may run on the same script thread. If the walker keeps waiting for a destination or retries the door, the quest script cannot process the dialogue and movement appears stuck.
+
+**Pattern to follow:**
+
+```java
+boolean landed = waitForPostHandleObjectLanding(...);
+if (Rs2Dialogue.isInDialogue()) {
+    return true; // handled this transport pass
+}
+return landed;
+
+// In processWalk, after recording the handled transport/door:
+if (Rs2Dialogue.isInDialogue() && isRouteProgressExit(exitReason)) {
+    return WalkerState.MOVING; // caller can now process the dialogue
+}
+```
+
+**Where this applies:** `Rs2Walker.handleObject`, post-object transport landing waits, and quest-driven doors or shortcuts that can display dialogue.
+
+**Defensive check:** Open a quest door that displays dialogue. The walker should log `object_transport_dialogue_yield`, then `route_dialogue_yield_to_caller`, and then allow a `quest-helper:dialogue-space-step` without another door click.
+
+## 16. Match checkpoint handoff geometry to minimap selection
+
+Minimap route targets are selected inside a circular Euclidean radius, so the early-handoff check must use that same Euclidean radius. Do not use `WorldPoint.distanceTo2D` for this check: its square/Chebyshev distance can classify a diagonal checkpoint as close before the player has made meaningful progress toward it. Keep the separate close/arrival threshold unchanged.
+
+**Why this matters:** A checkpoint seven tiles away on both axes is within eight tiles by Chebyshev distance but almost ten tiles away geometrically. Releasing that checkpoint immediately defeats sticky-target pacing and causes repeated route processing and visible stop-start movement.
+
+**Pattern to follow:**
+
+```java
+long dx = (long) player.getX() - checkpoint.getX();
+long dy = (long) player.getY() - checkpoint.getY();
+boolean readyForHandoff = dx * dx + dy * dy <= (long) radius * radius;
+```
+
+**Where this applies:** `Rs2Walker` interim waits, active-route yield decisions, and any future minimap checkpoint handoff logic.
+
+**Defensive check:** For a running handoff radius of eight, `(7, 7)` must remain in flight while `(8, 0)` may hand off. Recovery and the five-tile checkpoint-clear contract must remain unchanged.

--- a/docs/entity-guides/movement.md
+++ b/docs/entity-guides/movement.md
@@ -70,7 +70,11 @@ Raw-path scene-object probing is a recovery aid for smoothed paths that hide nea
 if (Rs2Player.isMoving()) {
     return false;
 }
-waitForDoorInteractionProgress(fromWp, toWp);
+WorldPoint posBefore = Rs2Player.getWorldLocation();
+boolean interacted = Rs2GameObject.interact(door, action);
+if (interacted) {
+    waitForDoorInteractionProgress(posBefore, fromWp, toWp);
+}
 ```
 
 **Where this applies:** `Rs2Walker.handleNearbyRawPathSceneObjects`, door handlers that call `Rs2GameObject.interact`, and any recovery logic that recurses into `processWalk`.
@@ -351,7 +355,7 @@ dialogue; an open dialogue by itself does not create a route-progress exit.
 
 ## 16. Match checkpoint handoff geometry to minimap selection
 
-Minimap route targets are selected inside a circular Euclidean radius, so the early-handoff check must use that same Euclidean radius. Do not use `WorldPoint.distanceTo2D` for this check: its square/Chebyshev distance can classify a diagonal checkpoint as close before the player has made meaningful progress toward it. Keep the separate close/arrival threshold unchanged.
+Minimap route targets are selected inside a circular Euclidean radius, so the early-handoff check must use that same Euclidean radius. Do not use `WorldPoint.distanceTo2D` for this check: its Chebyshev (maximum-axis) distance can classify a diagonal checkpoint as close before the player has made meaningful progress toward it. Keep the separate close/arrival threshold unchanged.
 
 **Why this matters:** A checkpoint seven tiles away on both axes is within eight tiles by Chebyshev distance but almost ten tiles away geometrically. Releasing that checkpoint immediately defeats sticky-target pacing and causes repeated route processing and visible stop-start movement.
 

--- a/docs/entity-guides/movement.md
+++ b/docs/entity-guides/movement.md
@@ -358,3 +358,36 @@ boolean readyForHandoff = dx * dx + dy * dy <= (long) radius * radius;
 **Where this applies:** `Rs2Walker` interim waits, active-route yield decisions, and any future minimap checkpoint handoff logic.
 
 **Defensive check:** For a running handoff radius of eight, `(7, 7)` must remain in flight while `(8, 0)` may hand off. Recovery and the five-tile checkpoint-clear contract must remain unchanged.
+
+Apply the route handoff at the start of the next walk pass, before collision, door, and transport scans, and apply the same decision if the path loop revisits the checkpoint in the same pass that issued it. Waking the pass at the larger pre-click radius without releasing the route-owned checkpoint there still lets those scans consume the remaining movement time and produces a stop before the continuation click. Require observed distance progress before this early release so a newly issued seven-tile checkpoint is not immediately replaced by an eight-tile running handoff. Tag recovery-owned checkpoints separately and keep them on the five-tile clear threshold.
+
+## 18. Exit a walk when the local player disappears
+
+Login transitions, connection loss, profile changes, and client shutdown can make `Client.getLocalPlayer()` return null while a blocking walk is still inside a movement wait. Treat a missing player location as a normal walk exit. Do not dereference it for an arrival-distance check, and do not keep a stale walker target active.
+
+**Why this matters:** A Fishing return walk reached its anchor, then the local player disappeared during the final idle wait. `Rs2Player.getWorldLocation_Internal()` threw on the client thread and `Rs2Walker.processWalk()` immediately threw again while calculating the final distance.
+
+**Pattern to follow:**
+
+```java
+WorldPoint player = Rs2Player.getWorldLocation();
+if (player == null) {
+    setTarget(null, "rs2walker:player-unavailable");
+    return WalkerState.EXIT;
+}
+int distance = player.distanceTo(target);
+```
+
+**Where this applies:** `Rs2Player.getWorldLocation_Internal()`, blocking `Rs2Walker` waits, final arrival checks, and exception/diagnostic paths that run during login or shutdown transitions.
+
+**Defensive check:** Unit-test the local-player-null resolver, and guard every post-wait distance calculation before dereferencing the returned `WorldPoint`.
+
+## 19. Let the normal route selector own the first movement click
+
+Before the first movement click, skip speculative local-reachability recovery for unreachable smoothed waypoints. The startup path already avoids broad segment handlers, and the normal route selector can choose a collision-reachable raw-path point. Keep the final `handlePendingDoorBeforeRouteClick` guard so a real nearby door is still resolved before dispatch.
+
+**Why this matters:** A short route can contain a smoothed waypoint across a wall even though its raw route is valid. Treating that waypoint as a blocked frontier during startup runs several door and transport timeout windows, replans a walled recovery target, and can let the idle nudge issue the first click away from the goal. In the observed Varrock route, pathfinding completed in 344 ms but this recovery cascade delayed the first action until 6.8 seconds.
+
+**Where this applies:** the `Rs2Walker.processWalk` local-reachability branch before `firstMovementClickMarked`, startup obstacle policy, and the final route-click door check.
+
+**Defensive check:** On a fresh walk with an unreachable smoothed waypoint but a usable raw route, logs should progress from `preclick_segment_handler_skip` to `click_candidate_found` and `first_minimap_click`; they should not emit `frontier rewind`, `recovery_target_walled`, or `active_route_idle_nudge` before that first click.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestHelperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestHelperPlugin.java
@@ -234,6 +234,7 @@ public class QuestHelperPlugin extends Plugin
 	@Override
 	protected void shutDown()
 	{
+		questScript.shutdown();
 		runeliteObjectManager.shutDown();
 
 		eventBus.unregister(playerStateManager);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
@@ -1456,8 +1456,8 @@ public class QuestScript extends Script {
         // line of sight to decide whether to route to an interaction tile; only use coordinate distance as
         // the fallback when the object has not loaded yet.
         WorldPoint definedWorldPoint = step.getDefinedPoint().getWorldPoint();
-        boolean moreThanOneTileFromStep = definedWorldPoint != null
-                && Rs2Player.getWorldLocation().distanceTo2D(definedWorldPoint) > 1;
+        boolean moreThanOneTileFromStep = isAwayFromObjectStep(
+                Rs2Player.getWorldLocation(), definedWorldPoint);
         boolean objectInLineOfSight = tileObject != null
                 && Rs2GameObject.hasLineOfSight(Rs2Player.getWorldLocation(), tileObject);
         if (definedWorldPoint != null && shouldWalkToObjectApproach(object != null, moreThanOneTileFromStep,
@@ -1497,7 +1497,7 @@ public class QuestScript extends Script {
 
             if (ShortestPathPlugin.getPathfinder() != null) {
                 var path = ShortestPathPlugin.getPathfinder().getPath();
-                if (path.get(path.size() - 1).distanceTo(step.getDefinedPoint().getWorldPoint()) <= 1)
+                if (pathEndsNearObjectStep(path, definedWorldPoint))
                     return false;
             } else
                 return false;
@@ -1543,7 +1543,27 @@ public class QuestScript extends Script {
             return false;
         }
 
-        return true;
+        return canCompleteObjectStep(object != null);
+    }
+
+    static boolean isAwayFromObjectStep(WorldPoint playerLocation, WorldPoint stepLocation) {
+        if (playerLocation == null || stepLocation == null) {
+            return false;
+        }
+        return playerLocation.getPlane() != stepLocation.getPlane()
+                || playerLocation.distanceTo2D(stepLocation) > 1;
+    }
+
+    static boolean pathEndsNearObjectStep(List<WorldPoint> path, WorldPoint stepLocation) {
+        if (path == null || path.isEmpty() || stepLocation == null) {
+            return false;
+        }
+        WorldPoint endpoint = path.get(path.size() - 1);
+        return endpoint != null && endpoint.distanceTo(stepLocation) <= 1;
+    }
+
+    static boolean canCompleteObjectStep(boolean objectAvailable) {
+        return objectAvailable;
     }
 
     static boolean shouldWalkToObjectApproach(boolean objectAvailable, boolean moreThanOneTileFromStep,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
@@ -1504,6 +1504,8 @@ public class QuestScript extends Script {
 
             boolean interacted;
             boolean itemOnObjectInteraction = itemId != -1;
+            int initialItemQuantity = itemOnObjectInteraction ? Rs2Inventory.itemQuantity(itemId) : 0;
+            long interactedObjectHash = object.getHash();
             if (itemId == -1) {
                 interacted = Rs2GameObject.interact(tileObject, chooseCorrectObjectOption(step, object));
             } else {
@@ -1517,9 +1519,12 @@ public class QuestScript extends Script {
                 return false;
             }
 
-            boolean interactionStarted = sleepUntil(() -> Rs2Player.isMoving()
-                    || Rs2Player.isAnimating()
-                    || itemOnObjectInteraction && !isInventoryItemSelected(), 1_200);
+            boolean interactionStarted = sleepUntil(() -> isObjectInteractionConfirmed(
+                    Rs2Player.isMoving(),
+                    Rs2Player.isAnimating(),
+                    Rs2Dialogue.isInDialogue(),
+                    itemOnObjectInteraction && Rs2Inventory.itemQuantity(itemId) != initialItemQuantity,
+                    Rs2GameObject.getAll(candidate -> candidate.getHash() == interactedObjectHash).isEmpty()), 1_200);
             if (!interactionStarted) {
                 return false;
             }
@@ -1539,6 +1544,11 @@ public class QuestScript extends Script {
         return objectAvailable
                 ? !objectInLineOfSight
                 : moreThanOneTileFromStep;
+    }
+
+    static boolean isObjectInteractionConfirmed(boolean moving, boolean animating, boolean dialogueOpen,
+                                                boolean itemQuantityChanged, boolean objectChanged) {
+        return moving || animating || dialogueOpen || itemQuantityChanged || objectChanged;
     }
 
     static WorldPoint selectObjectApproachTile(WorldArea objectArea, WorldPoint playerLocation,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
@@ -1380,8 +1380,12 @@ public class QuestScript extends Script {
 
             var itemId = step.getIconItemID();
             if (itemId != -1) {
-                Rs2Inventory.use(itemId);
-                npc.click("");
+                if (!Rs2Inventory.use(itemId) || !waitForSelectedInventoryItem(itemId)) {
+                    return false;
+                }
+                if (!npc.click("")) {
+                    return false;
+                }
             } else {
                 npc.click(chooseCorrectNPCOption(step, npc));
             }
@@ -1512,7 +1516,7 @@ public class QuestScript extends Script {
             if (itemId == -1) {
                 interacted = Rs2GameObject.interact(tileObject, chooseCorrectObjectOption(step, object));
             } else {
-                if (!Rs2Inventory.use(itemId) || !waitForSelectedInventoryItem()) {
+                if (!Rs2Inventory.use(itemId) || !waitForSelectedInventoryItem(itemId)) {
                     return false;
                 }
                 interacted = Rs2GameObject.interact(tileObject, "Use");
@@ -1584,14 +1588,24 @@ public class QuestScript extends Script {
                 .orElse(null);
     }
 
-    private static boolean waitForSelectedInventoryItem() {
-        return sleepUntil(QuestScript::isInventoryItemSelected, 1_500);
+    private static boolean waitForSelectedInventoryItem(int expectedItemId) {
+        return sleepUntil(() -> isInventoryItemSelected(expectedItemId), 1_500);
     }
 
-    private static boolean isInventoryItemSelected() {
+    private static boolean isInventoryItemSelected(int expectedItemId) {
         return Microbot.getClientThread()
-                .runOnClientThreadOptional(() -> Microbot.getClient().isWidgetSelected())
+                .runOnClientThreadOptional(() -> {
+                    Widget selectedWidget = Microbot.getClient().getSelectedWidget();
+                    int selectedItemId = selectedWidget == null ? -1 : selectedWidget.getItemId();
+                    return isExpectedInventoryItemSelected(
+                            Microbot.getClient().isWidgetSelected(), selectedItemId, expectedItemId);
+                })
                 .orElse(false);
+    }
+
+    static boolean isExpectedInventoryItemSelected(boolean widgetSelected, int selectedItemId,
+                                                   int expectedItemId) {
+        return widgetSelected && selectedItemId == expectedItemId;
     }
 
     private boolean applyDigStep(DigStep step) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
@@ -26,6 +26,7 @@ import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
 import net.runelite.client.plugins.microbot.util.grandexchange.models.WikiPrice;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
@@ -53,6 +54,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
@@ -141,13 +144,53 @@ public class QuestScript extends Script {
                 }
 
                 if (questStep != null && !questStep.getWidgetsToHighlight().isEmpty()) {
-                    var widgetHighlight = questStep.getWidgetsToHighlight().stream()
+                    var visibleWidgetHighlights = questStep.getWidgetsToHighlight().stream()
                             .filter(x -> x instanceof WidgetHighlight)
                             .map(x -> (WidgetHighlight) x)
                             .filter(x -> Rs2Widget.isWidgetVisible(x.getInterfaceID()))
-                            .findFirst().orElse(null);
+                            .collect(Collectors.toList());
+
+                    List<Integer> shopItemIds = visibleWidgetHighlights.stream()
+                            .map(WidgetHighlight::getItemIdRequirement)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList());
+                    if (Rs2Shop.isOpen() && !shopItemIds.isEmpty()) {
+                        int itemId = firstMissingShopItemId(shopItemIds, Rs2Inventory::hasItem);
+                        if (itemId != -1 && Rs2Shop.buyItem(itemId, "1")) {
+                            sleepUntil(() -> Rs2Inventory.hasItem(itemId), 3_000);
+                        }
+                        return;
+                    }
+
+                    var widgetHighlight = visibleWidgetHighlights.stream().findFirst().orElse(null);
 
                     if (widgetHighlight != null) {
+                        Integer highlightedItemId = widgetHighlight.getItemIdRequirement();
+                        if (highlightedItemId != null) {
+                            if (Rs2Widget.isProductionWidgetOpen()) {
+                                ItemComposition itemComposition = Microbot.getRs2ItemManager()
+                                        .getItemComposition(highlightedItemId);
+                                if (itemComposition != null) {
+                                    Rs2Widget.enableQuantityOption("All");
+                                    if (Rs2Widget.handleProcessingInterface(itemComposition.getName())) {
+                                        Rs2Player.waitForAnimation();
+                                    }
+                                    return;
+                                }
+                            }
+
+                            Rectangle targetBounds = Microbot.getClientThread().runOnClientThreadOptional(() -> {
+                                Widget root = Microbot.getClient().getWidget(widgetHighlight.getInterfaceID());
+                                Widget target = findVisibleWidgetByItemId(root, highlightedItemId);
+                                return target == null ? null : new Rectangle(target.getBounds());
+                            }).orElse(null);
+                            if (targetBounds != null && !targetBounds.isEmpty()) {
+                                Microbot.getMouse().click(targetBounds);
+                                Rs2Player.waitForAnimation();
+                            }
+                            return;
+                        }
+
                         var widget = Rs2Widget.getWidget(widgetHighlight.getInterfaceID());
                         if (widget != null) {
                             if (widgetHighlight.getChildChildId() != -1) {
@@ -244,7 +287,7 @@ public class QuestScript extends Script {
 						return;
 					}
 
-					if (questStep instanceof DetailedQuestStep && shouldObtainMissingItems() && handleMissingItemRequirements((DetailedQuestStep) questStep)) {
+					if (questStep instanceof DetailedQuestStep && handleMissingItemRequirements((DetailedQuestStep) questStep)) {
 						return;
 					}
 
@@ -314,7 +357,7 @@ public class QuestScript extends Script {
 		List<ItemRequirement> missing = new ArrayList<>();
 		List<ItemRequirement> needsUnnoting = new ArrayList<>();
 
-		for (Requirement requirement : collectAllItemRequirements(questStep)) {
+		for (Requirement requirement : questStep.getRequirements()) {
 			if (!(requirement instanceof ItemRequirement)) {
 				continue;
 			}
@@ -346,6 +389,10 @@ public class QuestScript extends Script {
 
 		if (missing.isEmpty()) {
 			return false;
+		}
+
+		if (!shouldObtainMissingItems()) {
+			return obtainItemsPromptInFlight.get();
 		}
 
 		ItemRequirement nonTradable = missing.stream()
@@ -1358,24 +1405,24 @@ public class QuestScript extends Script {
 
 
     public boolean applyObjectStep(ObjectStep step) {
-        Rs2TileObjectModel object = step.getObjects().stream()
+        TileObject tileObject = step.getObjects().stream()
                 .filter(Objects::nonNull)
-                .map(Rs2TileObjectModel::new)
                 .findFirst().orElse(null);
+        Rs2TileObjectModel object = tileObject == null ? null : new Rs2TileObjectModel(tileObject);
         var itemId = step.getIconItemID();
 
-        List<Rs2TileObjectModel> stepObjects = step.getObjects().stream()
+        List<TileObject> stepObjects = step.getObjects().stream()
                 .filter(Objects::nonNull)
-                .map(Rs2TileObjectModel::new)
                 .collect(Collectors.toList());
 
         if (stepObjects.size() > 1) {
-            object = stepObjects.stream()
+            tileObject = stepObjects.stream()
                     .filter(x -> !objectsHandeled.contains(x.getHash()))
                     .findFirst()
                     .orElseGet(() -> stepObjects.stream()
                             .min(Comparator.comparing(x -> Rs2Player.getWorldLocation().distanceTo(x.getWorldLocation())))
                             .orElse(null));
+            object = tileObject == null ? null : new Rs2TileObjectModel(tileObject);
         }
 
         if (object != null && unreachableTarget) {
@@ -1401,13 +1448,29 @@ public class QuestScript extends Script {
             return false;
         }
 
-        // Walk first when more than one tile away AND the target is either unreachable or not in line of
-        // sight. canReach() can still return true with a closed door between us; routing through the
-        // walker lets it open the door before we try to interact.
-        if (step.getDefinedPoint().getWorldPoint() != null && Rs2Player.getWorldLocation().distanceTo2D(step.getDefinedPoint().getWorldPoint()) > 1
-                && (object == null || !Rs2Walker.canReach(object.getWorldLocation()) || !hasLineOfSightToObject(object))) {
+        // A nearby object can still be behind a wall. When the object is present, use its reachability and
+        // line of sight to decide whether to route to an interaction tile; only use coordinate distance as
+        // the fallback when the object has not loaded yet.
+        WorldPoint definedWorldPoint = step.getDefinedPoint().getWorldPoint();
+        boolean moreThanOneTileFromStep = definedWorldPoint != null
+                && Rs2Player.getWorldLocation().distanceTo2D(definedWorldPoint) > 1;
+        boolean objectInLineOfSight = tileObject != null
+                && Rs2GameObject.hasLineOfSight(Rs2Player.getWorldLocation(), tileObject);
+        if (definedWorldPoint != null && shouldWalkToObjectApproach(object != null, moreThanOneTileFromStep,
+                objectInLineOfSight)) {
             WorldPoint targetTile = null;
             WorldPoint stepLocation = object == null ? step.getDefinedPoint().getWorldPoint() : object.getWorldLocation();
+
+            if (tileObject instanceof GameObject) {
+                TileObject approachObject = tileObject;
+                WorldArea objectArea = Rs2GameObject.getWorldArea((GameObject) approachObject);
+                targetTile = selectObjectApproachTile(
+                        objectArea,
+                        Rs2Player.getWorldLocation(),
+                        Rs2Tile::isWalkable,
+                        point -> Rs2GameObject.hasLineOfSight(point, approachObject));
+            }
+
             int radius = 0;
             while (targetTile == null) {
                 if (mainScheduledFuture.isCancelled())
@@ -1422,7 +1485,11 @@ public class QuestScript extends Script {
                     targetTile = stepLocation;
             }
 
-            Rs2Walker.walkTo(targetTile, 3);
+            if (object == null) {
+                Rs2Walker.walkTo(targetTile, 1);
+            } else {
+                Rs2Walker.walkTo(targetTile, 0);
+            }
 
             if (ShortestPathPlugin.getPathfinder() != null) {
                 var path = ShortestPathPlugin.getPathfinder().getPath();
@@ -1432,17 +1499,30 @@ public class QuestScript extends Script {
                 return false;
         }
 
-        if (hasLineOfSightToObject(object) || object != null && (Rs2Camera.isTileOnScreen(object.getLocalLocation()) || object.getCanvasLocation() != null)) {
+        if (objectInLineOfSight || object != null && (Rs2Camera.isTileOnScreen(object.getLocalLocation()) || object.getCanvasLocation() != null)) {
             Rs2Walker.clearWalkingRoute("quest-helper:object-step-interact");
 
-            if (itemId == -1)
-                object.click(chooseCorrectObjectOption(step, object));
-            else {
-                Rs2Inventory.use(itemId);
-                object.click("");
+            boolean interacted;
+            boolean itemOnObjectInteraction = itemId != -1;
+            if (itemId == -1) {
+                interacted = Rs2GameObject.interact(tileObject, chooseCorrectObjectOption(step, object));
+            } else {
+                if (!Rs2Inventory.use(itemId) || !waitForSelectedInventoryItem()) {
+                    return false;
+                }
+                interacted = Rs2GameObject.interact(tileObject, "Use");
             }
 
-            sleepUntil(() -> Rs2Player.isMoving() || Rs2Player.isAnimating());
+            if (!interacted) {
+                return false;
+            }
+
+            boolean interactionStarted = sleepUntil(() -> Rs2Player.isMoving()
+                    || Rs2Player.isAnimating()
+                    || itemOnObjectInteraction && !isInventoryItemSelected(), 1_200);
+            if (!interactionStarted) {
+                return false;
+            }
             sleep(100);
             sleepUntil(() -> !Rs2Player.isMoving() && !Rs2Player.isAnimating());
             objectsHandeled.add(object.getHash());
@@ -1452,6 +1532,45 @@ public class QuestScript extends Script {
         }
 
         return true;
+    }
+
+    static boolean shouldWalkToObjectApproach(boolean objectAvailable, boolean moreThanOneTileFromStep,
+                                              boolean objectInLineOfSight) {
+        return objectAvailable
+                ? !objectInLineOfSight
+                : moreThanOneTileFromStep;
+    }
+
+    static WorldPoint selectObjectApproachTile(WorldArea objectArea, WorldPoint playerLocation,
+                                               Predicate<WorldPoint> isWalkable,
+                                               Predicate<WorldPoint> hasLineOfSight) {
+        if (objectArea == null || playerLocation == null) {
+            return null;
+        }
+
+        WorldArea surroundingArea = new WorldArea(
+                objectArea.getX() - 1,
+                objectArea.getY() - 1,
+                objectArea.getWidth() + 2,
+                objectArea.getHeight() + 2,
+                objectArea.getPlane());
+
+        return surroundingArea.toWorldPointList().stream()
+                .filter(point -> !objectArea.contains(point))
+                .filter(isWalkable)
+                .filter(hasLineOfSight)
+                .min(Comparator.comparingInt(point -> point.distanceTo2D(playerLocation)))
+                .orElse(null);
+    }
+
+    private static boolean waitForSelectedInventoryItem() {
+        return sleepUntil(QuestScript::isInventoryItemSelected, 1_500);
+    }
+
+    private static boolean isInventoryItemSelected() {
+        return Microbot.getClientThread()
+                .runOnClientThreadOptional(() -> Microbot.getClient().isWidgetSelected())
+                .orElse(false);
     }
 
     private boolean applyDigStep(DigStep step) {
@@ -1514,21 +1633,83 @@ public class QuestScript extends Script {
         if (npcComp == null)
             return "Talk-to";
 
-        var actions = npcComp.getActions();
+        boolean shopStep = step.getWidgetsToHighlight().stream()
+                .filter(WidgetHighlight.class::isInstance)
+                .map(WidgetHighlight.class::cast)
+                .anyMatch(highlight -> highlight.getItemIdRequirement() != null);
+        return chooseNpcAction(step.getText(), npcComp.getActions(), shopStep);
+    }
 
-        for (var action : actions) {
-            if (action != null && step.getText().stream().anyMatch(x -> x.toLowerCase().contains(action.toLowerCase())))
-                return action;
+    static String chooseNpcAction(List<String> stepText, String[] actions, boolean shopStep) {
+        if (actions == null) {
+            return "Talk-to";
         }
 
-        // Fallback: prefer Talk-to if the NPC has it, otherwise the first non-empty action.
+        if (shopStep) {
+            for (String action : actions) {
+                if ("Trade".equalsIgnoreCase(action)) {
+                    return action;
+                }
+            }
+        }
+
+        for (String action : actions) {
+            if (action != null && stepText.stream()
+                    .anyMatch(text -> text.toLowerCase().contains(action.toLowerCase()))) {
+                return action;
+            }
+        }
+
         String fallback = null;
-        for (var action : actions) {
-            if (action == null || action.isEmpty()) continue;
-            if ("Talk-to".equalsIgnoreCase(action)) return action;
-            if (fallback == null) fallback = action;
+        for (String action : actions) {
+            if (action == null || action.isEmpty()) {
+                continue;
+            }
+            if ("Talk-to".equalsIgnoreCase(action)) {
+                return action;
+            }
+            if (fallback == null) {
+                fallback = action;
+            }
         }
         return fallback != null ? fallback : "Talk-to";
+    }
+
+    static int firstMissingShopItemId(List<Integer> itemIds, IntPredicate hasItem) {
+        return itemIds.stream()
+                .filter(Objects::nonNull)
+                .mapToInt(Integer::intValue)
+                .filter(itemId -> !hasItem.test(itemId))
+                .findFirst()
+                .orElse(-1);
+    }
+
+    static Widget findVisibleWidgetByItemId(Widget widget, int itemId) {
+        if (widget == null || widget.isHidden()) {
+            return null;
+        }
+        if (widget.getItemId() == itemId) {
+            return widget;
+        }
+
+        Widget[][] childGroups = {
+                widget.getChildren(),
+                widget.getNestedChildren(),
+                widget.getDynamicChildren(),
+                widget.getStaticChildren()
+        };
+        for (Widget[] childGroup : childGroups) {
+            if (childGroup == null) {
+                continue;
+            }
+            for (Widget child : childGroup) {
+                Widget match = findVisibleWidgetByItemId(child, itemId);
+                if (match != null) {
+                    return match;
+                }
+            }
+        }
+        return null;
     }
 
 	private String chooseCorrectItemOption(QuestStep step, int itemId) {
@@ -1548,19 +1729,7 @@ public class QuestScript extends Script {
 		return "use";
 	}
 
-	private boolean hasLineOfSightToObject(Rs2TileObjectModel object) {
-		if (object == null || object.getWorldLocation() == null || Microbot.getClient().getLocalPlayer() == null) {
-			return false;
-		}
-
-		WorldArea objectArea = object.getWorldLocation().toWorldArea();
-		WorldArea playerArea = Rs2Player.getWorldLocation().toWorldArea();
-
-		return Microbot.getClient().getTopLevelWorldView() != null
-				&& playerArea.hasLineOfSightTo(Microbot.getClient().getTopLevelWorldView(), objectArea);
-	}
-
-	private boolean hasLineOfSightFrom(WorldPoint point, Rs2TileObjectModel object) {
+    private boolean hasLineOfSightFrom(WorldPoint point, Rs2TileObjectModel object) {
 		if (point == null || object == null || object.getWorldLocation() == null) {
 			return false;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestScript.java
@@ -1501,6 +1501,9 @@ public class QuestScript extends Script {
 
         if (objectInLineOfSight || object != null && (Rs2Camera.isTileOnScreen(object.getLocalLocation()) || object.getCanvasLocation() != null)) {
             Rs2Walker.clearWalkingRoute("quest-helper:object-step-interact");
+            if (!waitForObjectInteractionIdle()) {
+                return false;
+            }
 
             boolean interacted;
             boolean itemOnObjectInteraction = itemId != -1;
@@ -1549,6 +1552,14 @@ public class QuestScript extends Script {
     static boolean isObjectInteractionConfirmed(boolean moving, boolean animating, boolean dialogueOpen,
                                                 boolean itemQuantityChanged, boolean objectChanged) {
         return moving || animating || dialogueOpen || itemQuantityChanged || objectChanged;
+    }
+
+    private boolean waitForObjectInteractionIdle() {
+        return sleepUntil(() -> isObjectInteractionIdle(Rs2Player.isMoving(), Rs2Player.isAnimating()), 1_200);
+    }
+
+    static boolean isObjectInteractionIdle(boolean moving, boolean animating) {
+        return !moving && !animating;
     }
 
     static WorldPoint selectObjectApproachTile(WorldArea objectArea, WorldPoint playerLocation,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/helpers/quests/runemysteries/RuneMysteries.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/helpers/quests/runemysteries/RuneMysteries.java
@@ -164,13 +164,12 @@ public class RuneMysteries extends BasicQuestHelper
 
 		var steps = new HashMap<Integer, QuestStep>();
 
-		var goTalkToHoracio = new ConditionalStep(this, goUpToHoracio);
+		var goTalkToHoracio = new ConditionalStep(this, talkToHoracio);
 		goTalkToHoracio.addStep(inUpstairsLumbridge, talkToHoracio);
 
 		steps.put(0, goTalkToHoracio);
 
-		var goTalkToSedridor = new ConditionalStep(this, goDownToSedridor);
-		goTalkToSedridor.addStep(and(airTalisman, inUpstairsLumbridge), goF1ToF0LumbridgeCastle);
+		var goTalkToSedridor = new ConditionalStep(this, bringTalismanToSedridor);
 		goTalkToSedridor.addStep(inWizardBasement, bringTalismanToSedridor);
 
 		steps.put(1, goTalkToSedridor);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/logic/RomeoAndJuliet.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/logic/RomeoAndJuliet.java
@@ -15,7 +15,6 @@ import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
  * Romeo and Juliet quest custom logic
  */
 public class RomeoAndJuliet extends BaseQuest {
-    private static final WorldPoint JULIET_STAIR_ORIGIN = new WorldPoint(3159, 3436, 0);
     private static final WorldPoint JULIET_TOP_STAIR = new WorldPoint(3156, 3435, 1);
     private static final WorldPoint ROMEO_LOCATION = new WorldPoint(3211, 3422, 0);
 
@@ -33,34 +32,11 @@ public class RomeoAndJuliet extends BaseQuest {
                     return false;
                 }
             }
-            if (questStep.getText().contains("Bring the potion to Juliet in the house west of Varrock.")) {
-                return climbToJulietWithPotion();
-            }
             if (questStep.getText().contains("Talk to Romeo in Varrock Square to finish the quest.")) {
                 return leaveJulietRoomForRomeo();
             }
         }
         return true;
-    }
-
-    private boolean climbToJulietWithPotion() {
-        if (!Rs2Inventory.hasItem(ItemID.CADAVA)) {
-            return true;
-        }
-
-        WorldPoint playerLocation = Rs2Player.getWorldLocation();
-        if (playerLocation == null || playerLocation.getPlane() != 0) {
-            return true;
-        }
-
-        if (playerLocation.distanceTo2D(JULIET_STAIR_ORIGIN) > 0) {
-            Rs2Walker.walkFastCanvas(JULIET_STAIR_ORIGIN);
-            return false;
-        }
-
-        Rs2GameObject.interact(ObjectID.FAI_VARROCK_STAIRS_TALLER, "Climb-up");
-        Rs2Player.waitForWalking();
-        return false;
     }
 
     private boolean leaveJulietRoomForRomeo() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
@@ -1,7 +1,5 @@
 package net.runelite.client.plugins.microbot.shortestpath;
 
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
@@ -14,14 +12,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Objects;
 
 @Slf4j
 public class ShortestPathScript extends Script {
 
-    @Getter
     // used for calling the walker from a mainthread
     // running the walker on a seperate thread is a lot easier for debugging
-    private volatile WorldPoint triggerWalker;
+    private final WalkTargetState walkTargets = new WalkTargetState();
     private volatile ShortestPathConfig config;
     private volatile Future<?> walkTaskFuture;
     private final WalkTaskGate walkTaskGate = new WalkTaskGate();
@@ -51,10 +49,14 @@ public class ShortestPathScript extends Script {
     public void shutdown() {
         walkTaskGate.shutdown();
         resetExitRetryState();
-        triggerWalker = null;
+        walkTargets.publish(null);
         Rs2Walker.clearWalkingRoute("shortest-path-script:shutdown");
         cancelWalkTask();
         super.shutdown();
+    }
+
+    public WorldPoint getTriggerWalker() {
+        return walkTargets.get();
     }
 
 	public void setTriggerWalker(WorldPoint point) {
@@ -71,7 +73,7 @@ public class ShortestPathScript extends Script {
 			String r = stopReason != null && !stopReason.isBlank()
 					? stopReason
 					: "shortest-path-script:trigger-null";
-			triggerWalker = null;
+			walkTargets.publish(null);
 			Rs2Walker.clearWalkingRoute(r);
 			cancelWalkTask();
 		} else {
@@ -79,12 +81,12 @@ public class ShortestPathScript extends Script {
 			{
 				return;
 			}
-			boolean targetChanged = !point.equals(triggerWalker);
+			WalkTargetSnapshot published = walkTargets.publishIfChanged(point);
+			boolean targetChanged = published != null;
 			if (targetChanged)
 			{
 				resetExitRetryState();
 			}
-			triggerWalker = point;
 			if (targetChanged)
 			{
 				cancelWalkTask();
@@ -94,7 +96,8 @@ public class ShortestPathScript extends Script {
     }
 
     private void startWalkTask() {
-        if (!walkTaskGate.tryAcquire(getTriggerWalker())) {
+        WalkTargetSnapshot taskTarget = walkTargets.snapshot();
+        if (!walkTaskGate.tryAcquire(taskTarget.target)) {
             return;
         }
 
@@ -103,7 +106,10 @@ public class ShortestPathScript extends Script {
                 while (!walkTaskGate.isShutdown()
                         && !Thread.currentThread().isInterrupted()
                         && Microbot.isLoggedIn()) {
-                    WorldPoint target = getTriggerWalker();
+                    if (!walkTargets.owns(taskTarget)) {
+                        return;
+                    }
+                    WorldPoint target = taskTarget.target;
                     ShortestPathConfig currentConfig = config;
                     if (target == null || currentConfig == null) {
                         return;
@@ -119,19 +125,20 @@ public class ShortestPathScript extends Script {
                         state = Rs2Walker.walkWithState(target);
                     }
 
-                    WorldPoint currentTarget = getTriggerWalker();
-                    if (!target.equals(currentTarget)) {
+                    if (!walkTargets.owns(taskTarget)) {
                         return;
                     }
+                    WorldPoint currentTarget = getTriggerWalker();
                     if (state == WalkerState.EXIT && shouldRetryAfterExit(target)) {
                         sleepUntil(() -> Thread.currentThread().isInterrupted()
                                 || !target.equals(getTriggerWalker()), 150);
                         continue;
                     }
                     if (state == WalkerState.ARRIVED || state == WalkerState.UNREACHABLE || state == WalkerState.EXIT) {
-                        resetExitRetryState();
-                        triggerWalker = null;
-                        Rs2Walker.clearWalkingRoute("shortest-path-script:walk-task-terminal-state");
+                        walkTargets.clearIfOwned(taskTarget, () -> {
+                            resetExitRetryState();
+                            Rs2Walker.clearWalkingRoute("shortest-path-script:walk-task-terminal-state");
+                        });
                         return;
                     }
 
@@ -160,6 +167,64 @@ public class ShortestPathScript extends Script {
         Future<?> future = walkTaskFuture;
         if (future != null && !future.isDone()) {
             future.cancel(true);
+        }
+    }
+
+    static final class WalkTargetSnapshot {
+        private final WorldPoint target;
+        private final long generation;
+
+        private WalkTargetSnapshot(WorldPoint target, long generation) {
+            this.target = target;
+            this.generation = generation;
+        }
+    }
+
+    static final class WalkTargetState {
+        private WorldPoint target;
+        private long generation;
+
+        synchronized WorldPoint get() {
+            return target;
+        }
+
+        synchronized WalkTargetSnapshot snapshot() {
+            return new WalkTargetSnapshot(target, generation);
+        }
+
+        synchronized WalkTargetSnapshot publish(WorldPoint nextTarget) {
+            target = nextTarget;
+            generation++;
+            return new WalkTargetSnapshot(target, generation);
+        }
+
+        synchronized WalkTargetSnapshot publishIfChanged(WorldPoint nextTarget) {
+            if (Objects.equals(target, nextTarget)) {
+                return null;
+            }
+            return publish(nextTarget);
+        }
+
+        synchronized boolean owns(WalkTargetSnapshot snapshot) {
+            return snapshot != null
+                    && snapshot.generation == generation
+                    && Objects.equals(snapshot.target, target);
+        }
+
+        synchronized boolean clearIfOwned(WalkTargetSnapshot snapshot) {
+            return clearIfOwned(snapshot, null);
+        }
+
+        synchronized boolean clearIfOwned(WalkTargetSnapshot snapshot, Runnable cleanup) {
+            if (!owns(snapshot)) {
+                return false;
+            }
+            target = null;
+            generation++;
+            if (cleanup != null) {
+                cleanup.run();
+            }
+            return true;
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
@@ -47,11 +47,12 @@ public class ShortestPathScript extends Script {
 
     @Override
     public void shutdown() {
-        walkTaskGate.shutdown();
-        resetExitRetryState();
-        walkTargets.publish(null);
-        Rs2Walker.clearWalkingRoute("shortest-path-script:shutdown");
-        cancelWalkTask();
+        walkTargets.shutdown(() -> {
+            walkTaskGate.shutdown();
+            resetExitRetryState();
+            Rs2Walker.clearWalkingRoute("shortest-path-script:shutdown");
+            cancelWalkTask();
+        });
         super.shutdown();
     }
 
@@ -73,9 +74,11 @@ public class ShortestPathScript extends Script {
 			String r = stopReason != null && !stopReason.isBlank()
 					? stopReason
 					: "shortest-path-script:trigger-null";
-			walkTargets.publish(null);
-			Rs2Walker.clearWalkingRoute(r);
-			cancelWalkTask();
+			WalkTargetSnapshot stoppedTarget = walkTargets.publish(null);
+			walkTargets.clearIfOwned(stoppedTarget, () -> {
+				Rs2Walker.clearWalkingRoute(r);
+				cancelWalkTask();
+			});
 		} else {
 			if (walkTaskGate.isShutdown())
 			{
@@ -183,6 +186,7 @@ public class ShortestPathScript extends Script {
     static final class WalkTargetState {
         private WorldPoint target;
         private long generation;
+        private boolean shutdown;
 
         synchronized WorldPoint get() {
             return target;
@@ -199,10 +203,19 @@ public class ShortestPathScript extends Script {
         }
 
         synchronized WalkTargetSnapshot publishIfChanged(WorldPoint nextTarget) {
-            if (Objects.equals(target, nextTarget)) {
+            if (shutdown || Objects.equals(target, nextTarget)) {
                 return null;
             }
             return publish(nextTarget);
+        }
+
+        synchronized void shutdown(Runnable cleanup) {
+            shutdown = true;
+            target = null;
+            generation++;
+            if (cleanup != null) {
+                cleanup.run();
+            }
         }
 
         synchronized boolean owns(WalkTargetSnapshot snapshot) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
@@ -12,7 +12,6 @@ import net.runelite.client.plugins.microbot.util.walker.WalkerState;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
 public class ShortestPathScript extends Script {
@@ -23,7 +22,7 @@ public class ShortestPathScript extends Script {
     private volatile WorldPoint triggerWalker;
     private volatile ShortestPathConfig config;
     private volatile Future<?> walkTaskFuture;
-    private final AtomicBoolean walkTaskRunning = new AtomicBoolean(false);
+    private final WalkTaskGate walkTaskGate = new WalkTaskGate();
     private volatile WorldPoint lastExitRetryTarget;
     private volatile int consecutiveExitRetries = 0;
     private static final int MAX_CONSECUTIVE_EXIT_RETRIES = 3;
@@ -48,6 +47,14 @@ public class ShortestPathScript extends Script {
 
     @Override
     public void shutdown() {
+        walkTaskGate.shutdown();
+        resetExitRetryState();
+        triggerWalker = null;
+        Rs2Walker.clearWalkingRoute("shortest-path-script:shutdown");
+        Future<?> future = walkTaskFuture;
+        if (future != null && !future.isDone()) {
+            future.cancel(true);
+        }
         super.shutdown();
     }
 
@@ -67,12 +74,11 @@ public class ShortestPathScript extends Script {
 					: "shortest-path-script:trigger-null";
 			triggerWalker = null;
 			Rs2Walker.clearWalkingRoute(r);
-            Future<?> future = walkTaskFuture;
-            if (future != null && !future.isDone()) {
-                future.cancel(true);
-            }
-            walkTaskRunning.set(false);
 		} else {
+			if (walkTaskGate.isShutdown())
+			{
+				return;
+			}
 			if (!point.equals(triggerWalker))
 			{
 				resetExitRetryState();
@@ -80,62 +86,94 @@ public class ShortestPathScript extends Script {
 			triggerWalker = point;
             startWalkTask();
 		}
-	}
+    }
 
     private void startWalkTask() {
-        if (!walkTaskRunning.compareAndSet(false, true)) {
+        if (!walkTaskGate.tryAcquire(getTriggerWalker())) {
             return;
         }
 
-        walkTaskFuture = scheduledExecutorService.submit(() -> {
-            try {
-                while (!Thread.currentThread().isInterrupted() && Microbot.isLoggedIn()) {
-                    WorldPoint target = getTriggerWalker();
-                    ShortestPathConfig currentConfig = config;
-                    if (target == null || currentConfig == null) {
-                        return;
-                    }
+        try {
+            walkTaskFuture = scheduledExecutorService.submit(() -> {
+                try {
+                    while (!walkTaskGate.isShutdown()
+                            && !Thread.currentThread().isInterrupted()
+                            && Microbot.isLoggedIn()) {
+                        WorldPoint target = getTriggerWalker();
+                        ShortestPathConfig currentConfig = config;
+                        if (target == null || currentConfig == null) {
+                            return;
+                        }
 
-                    WalkerState state;
-                    if (currentConfig.walkWithBankedTransports()) {
-                        state = Rs2Walker.walkWithBankedTransportsAndState(
-                                target,
-                                currentConfig.reachedDistance(),
-                                false);
-                    } else {
-                        state = Rs2Walker.walkWithState(target);
-                    }
+                        WalkerState state;
+                        if (currentConfig.walkWithBankedTransports()) {
+                            state = Rs2Walker.walkWithBankedTransportsAndState(
+                                    target,
+                                    currentConfig.reachedDistance(),
+                                    false);
+                        } else {
+                            state = Rs2Walker.walkWithState(target);
+                        }
 
-                    WorldPoint currentTarget = getTriggerWalker();
-                    if (!target.equals(currentTarget)) {
-                        return;
-                    }
-                    if (state == WalkerState.EXIT && shouldRetryAfterExit(target)) {
+                        WorldPoint currentTarget = getTriggerWalker();
+                        if (!target.equals(currentTarget)) {
+                            return;
+                        }
+                        if (state == WalkerState.EXIT && shouldRetryAfterExit(target)) {
+                            sleepUntil(() -> Thread.currentThread().isInterrupted()
+                                    || !target.equals(getTriggerWalker()), 150);
+                            continue;
+                        }
+                        if (state == WalkerState.ARRIVED || state == WalkerState.UNREACHABLE || state == WalkerState.EXIT) {
+                            resetExitRetryState();
+                            triggerWalker = null;
+                            Rs2Walker.clearWalkingRoute("shortest-path-script:walk-task-terminal-state");
+                            return;
+                        }
+
+                        if (!shouldContinueWalkTask(target, currentTarget, state)) {
+                            return;
+                        }
                         sleepUntil(() -> Thread.currentThread().isInterrupted()
                                 || !target.equals(getTriggerWalker()), 150);
-                        continue;
                     }
-                    if (state == WalkerState.ARRIVED || state == WalkerState.UNREACHABLE || state == WalkerState.EXIT) {
-                        resetExitRetryState();
-                        triggerWalker = null;
-                        Rs2Walker.clearWalkingRoute("shortest-path-script:walk-task-terminal-state");
-                        return;
+                } catch (Exception ex) {
+                    if (!Thread.currentThread().isInterrupted()) {
+                        log.error("Exception in ShortestPathScript walk task: {} - ", ex.getMessage(), ex);
                     }
+                } finally {
+                    walkTaskGate.release();
+                }
+            });
+        } catch (RuntimeException ex) {
+            walkTaskGate.release();
+            throw ex;
+        }
+    }
 
-                    if (!shouldContinueWalkTask(target, currentTarget, state)) {
-                        return;
-                    }
-                    sleepUntil(() -> Thread.currentThread().isInterrupted()
-                            || !target.equals(getTriggerWalker()), 150);
-                }
-            } catch (Exception ex) {
-                if (!Thread.currentThread().isInterrupted()) {
-                    log.error("Exception in ShortestPathScript walk task: {} - ", ex.getMessage(), ex);
-                }
-            } finally {
-                walkTaskRunning.set(false);
+    static final class WalkTaskGate {
+        private boolean running;
+        private boolean shutdown;
+
+        synchronized boolean tryAcquire(WorldPoint target) {
+            if (shutdown || running || target == null) {
+                return false;
             }
-        });
+            running = true;
+            return true;
+        }
+
+        synchronized void release() {
+            running = false;
+        }
+
+        synchronized void shutdown() {
+            shutdown = true;
+        }
+
+        synchronized boolean isShutdown() {
+            return shutdown;
+        }
     }
 
     static boolean shouldContinueWalkTask(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
@@ -89,34 +89,62 @@ public class ShortestPathScript extends Script {
 
         walkTaskFuture = scheduledExecutorService.submit(() -> {
             try {
-                WorldPoint target = getTriggerWalker();
-                if (target == null || config == null || !Microbot.isLoggedIn()) {
-                    return;
-                }
-
-                WalkerState state;
-                if (config.walkWithBankedTransports()) {
-                    state = Rs2Walker.walkWithBankedTransportsAndState(target, 10, false);
-                } else {
-                    state = Rs2Walker.walkWithState(target);
-                }
-
-                if (target.equals(getTriggerWalker())) {
-                    if (state == WalkerState.EXIT && shouldRetryAfterExit(target)) {
+                while (!Thread.currentThread().isInterrupted() && Microbot.isLoggedIn()) {
+                    WorldPoint target = getTriggerWalker();
+                    ShortestPathConfig currentConfig = config;
+                    if (target == null || currentConfig == null) {
                         return;
+                    }
+
+                    WalkerState state;
+                    if (currentConfig.walkWithBankedTransports()) {
+                        state = Rs2Walker.walkWithBankedTransportsAndState(
+                                target,
+                                currentConfig.reachedDistance(),
+                                false);
+                    } else {
+                        state = Rs2Walker.walkWithState(target);
+                    }
+
+                    WorldPoint currentTarget = getTriggerWalker();
+                    if (!target.equals(currentTarget)) {
+                        return;
+                    }
+                    if (state == WalkerState.EXIT && shouldRetryAfterExit(target)) {
+                        sleepUntil(() -> Thread.currentThread().isInterrupted()
+                                || !target.equals(getTriggerWalker()), 150);
+                        continue;
                     }
                     if (state == WalkerState.ARRIVED || state == WalkerState.UNREACHABLE || state == WalkerState.EXIT) {
                         resetExitRetryState();
                         triggerWalker = null;
                         Rs2Walker.clearWalkingRoute("shortest-path-script:walk-task-terminal-state");
+                        return;
                     }
+
+                    if (!shouldContinueWalkTask(target, currentTarget, state)) {
+                        return;
+                    }
+                    sleepUntil(() -> Thread.currentThread().isInterrupted()
+                            || !target.equals(getTriggerWalker()), 150);
                 }
             } catch (Exception ex) {
-                log.error("Exception in ShortestPathScript walk task: {} - ", ex.getMessage(), ex);
+                if (!Thread.currentThread().isInterrupted()) {
+                    log.error("Exception in ShortestPathScript walk task: {} - ", ex.getMessage(), ex);
+                }
             } finally {
                 walkTaskRunning.set(false);
             }
         });
+    }
+
+    static boolean shouldContinueWalkTask(
+            WorldPoint target,
+            WorldPoint currentTarget,
+            WalkerState state) {
+        return target != null
+                && target.equals(currentTarget)
+                && state == WalkerState.MOVING;
     }
 
     private boolean shouldRetryAfterExit(WorldPoint target) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
@@ -12,6 +12,8 @@ import net.runelite.client.plugins.microbot.util.walker.WalkerState;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
 public class ShortestPathScript extends Script {
@@ -51,10 +53,7 @@ public class ShortestPathScript extends Script {
         resetExitRetryState();
         triggerWalker = null;
         Rs2Walker.clearWalkingRoute("shortest-path-script:shutdown");
-        Future<?> future = walkTaskFuture;
-        if (future != null && !future.isDone()) {
-            future.cancel(true);
-        }
+        cancelWalkTask();
         super.shutdown();
     }
 
@@ -74,16 +73,22 @@ public class ShortestPathScript extends Script {
 					: "shortest-path-script:trigger-null";
 			triggerWalker = null;
 			Rs2Walker.clearWalkingRoute(r);
+			cancelWalkTask();
 		} else {
 			if (walkTaskGate.isShutdown())
 			{
 				return;
 			}
-			if (!point.equals(triggerWalker))
+			boolean targetChanged = !point.equals(triggerWalker);
+			if (targetChanged)
 			{
 				resetExitRetryState();
 			}
 			triggerWalker = point;
+			if (targetChanged)
+			{
+				cancelWalkTask();
+			}
             startWalkTask();
 		}
     }
@@ -93,61 +98,102 @@ public class ShortestPathScript extends Script {
             return;
         }
 
-        try {
-            walkTaskFuture = scheduledExecutorService.submit(() -> {
-                try {
-                    while (!walkTaskGate.isShutdown()
-                            && !Thread.currentThread().isInterrupted()
-                            && Microbot.isLoggedIn()) {
-                        WorldPoint target = getTriggerWalker();
-                        ShortestPathConfig currentConfig = config;
-                        if (target == null || currentConfig == null) {
-                            return;
-                        }
+        GateReleasingFutureTask task = new GateReleasingFutureTask(walkTaskGate, () -> {
+            try {
+                while (!walkTaskGate.isShutdown()
+                        && !Thread.currentThread().isInterrupted()
+                        && Microbot.isLoggedIn()) {
+                    WorldPoint target = getTriggerWalker();
+                    ShortestPathConfig currentConfig = config;
+                    if (target == null || currentConfig == null) {
+                        return;
+                    }
 
-                        WalkerState state;
-                        if (currentConfig.walkWithBankedTransports()) {
-                            state = Rs2Walker.walkWithBankedTransportsAndState(
-                                    target,
-                                    currentConfig.reachedDistance(),
-                                    false);
-                        } else {
-                            state = Rs2Walker.walkWithState(target);
-                        }
+                    WalkerState state;
+                    if (currentConfig.walkWithBankedTransports()) {
+                        state = Rs2Walker.walkWithBankedTransportsAndState(
+                                target,
+                                currentConfig.reachedDistance(),
+                                false);
+                    } else {
+                        state = Rs2Walker.walkWithState(target);
+                    }
 
-                        WorldPoint currentTarget = getTriggerWalker();
-                        if (!target.equals(currentTarget)) {
-                            return;
-                        }
-                        if (state == WalkerState.EXIT && shouldRetryAfterExit(target)) {
-                            sleepUntil(() -> Thread.currentThread().isInterrupted()
-                                    || !target.equals(getTriggerWalker()), 150);
-                            continue;
-                        }
-                        if (state == WalkerState.ARRIVED || state == WalkerState.UNREACHABLE || state == WalkerState.EXIT) {
-                            resetExitRetryState();
-                            triggerWalker = null;
-                            Rs2Walker.clearWalkingRoute("shortest-path-script:walk-task-terminal-state");
-                            return;
-                        }
-
-                        if (!shouldContinueWalkTask(target, currentTarget, state)) {
-                            return;
-                        }
+                    WorldPoint currentTarget = getTriggerWalker();
+                    if (!target.equals(currentTarget)) {
+                        return;
+                    }
+                    if (state == WalkerState.EXIT && shouldRetryAfterExit(target)) {
                         sleepUntil(() -> Thread.currentThread().isInterrupted()
                                 || !target.equals(getTriggerWalker()), 150);
+                        continue;
                     }
-                } catch (Exception ex) {
-                    if (!Thread.currentThread().isInterrupted()) {
-                        log.error("Exception in ShortestPathScript walk task: {} - ", ex.getMessage(), ex);
+                    if (state == WalkerState.ARRIVED || state == WalkerState.UNREACHABLE || state == WalkerState.EXIT) {
+                        resetExitRetryState();
+                        triggerWalker = null;
+                        Rs2Walker.clearWalkingRoute("shortest-path-script:walk-task-terminal-state");
+                        return;
                     }
-                } finally {
-                    walkTaskGate.release();
+
+                    if (!shouldContinueWalkTask(target, currentTarget, state)) {
+                        return;
+                    }
+                    sleepUntil(() -> Thread.currentThread().isInterrupted()
+                            || !target.equals(getTriggerWalker()), 150);
                 }
-            });
+            } catch (Exception ex) {
+                if (!Thread.currentThread().isInterrupted()) {
+                    log.error("Exception in ShortestPathScript walk task: {} - ", ex.getMessage(), ex);
+                }
+            }
+        });
+        walkTaskFuture = task;
+        try {
+            scheduledExecutorService.execute(task);
         } catch (RuntimeException ex) {
-            walkTaskGate.release();
+            task.cancel(false);
             throw ex;
+        }
+    }
+
+    private void cancelWalkTask() {
+        Future<?> future = walkTaskFuture;
+        if (future != null && !future.isDone()) {
+            future.cancel(true);
+        }
+    }
+
+    static final class GateReleasingFutureTask extends FutureTask<Void> {
+        private final WalkTaskGate gate;
+        private final AtomicBoolean started = new AtomicBoolean(false);
+        private final AtomicBoolean gateReleased = new AtomicBoolean(false);
+
+        GateReleasingFutureTask(WalkTaskGate gate, Runnable runnable) {
+            super(runnable, null);
+            this.gate = gate;
+        }
+
+        @Override
+        public void run() {
+            started.set(true);
+            try {
+                super.run();
+            } finally {
+                releaseGate();
+            }
+        }
+
+        @Override
+        protected void done() {
+            if (!started.get()) {
+                releaseGate();
+            }
+        }
+
+        private void releaseGate() {
+            if (gateReleased.compareAndSet(false, true)) {
+                gate.release();
+            }
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItem.java
@@ -35,14 +35,31 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 @Deprecated(since = "2.1.0 - Use Rs2TileItemCache/Rs2TileItemQuery instead", forRemoval = true)
 public class Rs2GroundItem {
     private static final int DESPAWN_DELAY_THRESHOLD_TICKS = 150;
+    private static final Object PAUSE_SCOPE_LOCK = new Object();
+    private static int pauseScopeCount;
+    private static boolean restoreUnpausedState;
 
     public static boolean runWhilePaused(BooleanSupplier booleanSupplier) {
-        final boolean paused = Microbot.pauseAllScripts.getAndSet(true);
-        final boolean success = booleanSupplier.getAsBoolean();
-        if (!paused && !Microbot.pauseAllScripts.compareAndSet(true, false)) {
-            log.warn("Another script unpaused all scripts");
+        synchronized (PAUSE_SCOPE_LOCK) {
+            if (pauseScopeCount == 0) {
+                restoreUnpausedState = Microbot.pauseAllScripts.compareAndSet(false, true);
+            }
+            pauseScopeCount++;
         }
-        return success;
+
+        try {
+            return booleanSupplier.getAsBoolean();
+        } finally {
+            synchronized (PAUSE_SCOPE_LOCK) {
+                pauseScopeCount--;
+                if (pauseScopeCount == 0) {
+                    if (restoreUnpausedState && !Microbot.pauseAllScripts.compareAndSet(true, false)) {
+                        log.warn("Another script unpaused all scripts");
+                    }
+                    restoreUnpausedState = false;
+                }
+            }
+        }
     }
 
     private static boolean interact(RS2Item rs2Item, String action) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -964,12 +964,28 @@ public class Rs2Player {
 	 * @return The {@link WorldPoint} representing the player's current location, or {@code null} if unavailable.
 	 */
 	public static WorldPoint getWorldLocation_Internal(){
+		return worldLocationFromClient(Microbot.getClient());
+	}
+
+	static WorldPoint worldLocationFromClient(Client client) {
+		if (client == null || Microbot.getClientThread() == null) {
+			return null;
+		}
 		return Microbot.getClientThread().runOnClientThreadOptional(() -> {
-			if (Microbot.getClient().getTopLevelWorldView().getScene().isInstance()) {
-				LocalPoint l = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), Microbot.getClient().getLocalPlayer().getWorldLocation());
-				return WorldPoint.fromLocalInstance(Microbot.getClient(), l);
+			Player player = client.getLocalPlayer();
+			if (player == null) {
+				return null;
 			}
-			return Microbot.getClient().getLocalPlayer().getWorldLocation();
+			WorldPoint playerLocation = player.getWorldLocation();
+			WorldView worldView = client.getTopLevelWorldView();
+			if (playerLocation == null || worldView == null || worldView.getScene() == null) {
+				return playerLocation;
+			}
+			if (worldView.getScene().isInstance()) {
+				LocalPoint localPoint = LocalPoint.fromWorld(worldView, playerLocation);
+				return localPoint == null ? null : WorldPoint.fromLocalInstance(client, localPoint);
+			}
+			return playerLocation;
 		}).orElse(null);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -979,7 +979,7 @@ public class Rs2Player {
 			WorldPoint playerLocation = player.getWorldLocation();
 			WorldView worldView = client.getTopLevelWorldView();
 			if (playerLocation == null || worldView == null || worldView.getScene() == null) {
-				return playerLocation;
+				return null;
 			}
 			if (worldView.getScene().isInstance()) {
 				LocalPoint localPoint = LocalPoint.fromWorld(worldView, playerLocation);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -178,6 +178,7 @@ public class Rs2Walker {
     private static final int DOOR_APPROACH_INTERACT_MAX_TILES = 4;
     private static final long RECOVERY_MOVEMENT_IN_FLIGHT_MS = 3_500L;
     private static final long DOOR_TRAVERSAL_RECOVERY_BLOCK_MS = 2_200L;
+    private static final long DOOR_APPROACH_IN_FLIGHT_MS = 4_000L;
     private static final long POST_DOOR_NUDGE_RECENT_ATTEMPT_MS = 6_000L;
     private static final int PATHFINDER_DONE_POLL_WAIT_MS = 1200;
     private static final int PATHFINDER_DONE_RETRY_SLEEP_MIN_MS = 120;
@@ -808,6 +809,10 @@ public class Rs2Walker {
             default:
                 return false;
         }
+    }
+
+    static boolean shouldYieldRouteProgressToCaller(String exitReason, boolean dialogueOpen) {
+        return dialogueOpen && isRouteProgressExit(exitReason);
     }
 
     /** @return true only when a canvas click was actually issued, so the caller can size its minimap hold-off. */
@@ -2370,9 +2375,18 @@ public class Rs2Walker {
                             }
                             boolean gateDoorInteraction = isDoorInteractionSettling() || isDoorEdgePassSkipCoolingDown();
                             long recentDoorAgeMs = recentDoorAttemptAgeNearIndex(rawPath, rawEdgeStart);
-                            boolean pendingDoorTraversal = recentDoorAgeMs >= 0
+                            boolean playerMoving = Rs2Player.isMoving();
+                            boolean doorApproachInFlight = Rs2WalkerAwaits.isDoorApproachInFlight(
+                                    routeState.lastDoorAttemptPlayerPosition,
+                                    playerLoc,
+                                    routeState.lastDoorAttemptFrom,
+                                    routeState.lastDoorAttemptTo,
+                                    playerMoving,
+                                    recentDoorAgeMs,
+                                    DOOR_APPROACH_IN_FLIGHT_MS);
+                            boolean pendingDoorTraversal = doorApproachInFlight || (recentDoorAgeMs >= 0
                                     && recentDoorAgeMs <= DOOR_TRAVERSAL_RECOVERY_BLOCK_MS
-                                    && !Rs2Player.isMoving();
+                                    && !playerMoving);
                             if (gateDoorInteraction) {
                                 // Avoid any follow-up door probing right after an interaction;
                                 // resolver is still settling and re-probes can loop.
@@ -2723,8 +2737,9 @@ public class Rs2Walker {
                                     break;
                                 }
 								final WorldPoint posBeforeWait = playerLoc;
+								final int preclickTiles = interimPreclickTiles();
 								sleepUntil(() ->
-												interimFinal.distanceTo2D(Rs2Player.getWorldLocation()) <= interimPreclickTiles()
+												isWithinRouteHandoffRadius(Rs2Player.getWorldLocation(), interimFinal, preclickTiles)
 														|| !Rs2Player.isMoving(),
 										INTERIM_MOVING_POLL_MS);
                                 WorldPoint posAfterWait = Rs2Player.getWorldLocation();
@@ -2733,9 +2748,9 @@ public class Rs2Walker {
                                         || Rs2Player.isMoving()) {
 									routeState.lastMovedTimeMs = System.currentTimeMillis();
 									routeState.stuckCount = 0;
-								}
-                                boolean closeEnoughForNextClick = posAfterWait != null
-                                        && interimFinal.distanceTo2D(posAfterWait) <= INTERIM_CLOSE_TILES;
+                                }
+                                boolean closeEnoughForNextClick = isWithinRouteHandoffRadius(
+                                        posAfterWait, interimFinal, preclickTiles);
                                 if (!closeEnoughForNextClick && Rs2Player.isMoving()) {
                                     exitReason = "interim-in-flight";
                                     walkerDiag("interim-in-flight interim=%s interimDist=%d player=%s moving=true",
@@ -2998,6 +3013,14 @@ public class Rs2Walker {
                     // now behind the player.
                     i = targetIdx;
                 }
+            }
+
+            if (shouldYieldRouteProgressToCaller(exitReason, Rs2Dialogue.isInDialogue())) {
+                WebWalkLog.spInfo("route_dialogue_yield_to_caller | r={} at={} goal={}",
+                        exitReason,
+                        compactWorldPoint(Rs2Player.getWorldLocation()),
+                        compactWorldPoint(target));
+                return WalkerState.MOVING;
             }
 
             if (doorOrTransportResult && shouldCanvasNudgeAfterDoorLikeExit(exitReason)) {
@@ -6038,6 +6061,8 @@ public class Rs2Walker {
                                     compactWorldPoint(probe), compactWorldPoint(fromWp), compactWorldPoint(toWp), ex.getClass().getSimpleName());
                             return false;
                         }
+                        recordDoorApproachOwnership(routeState, interacted, posBefore,
+                                fromWp, toWp, System.currentTimeMillis());
                         if (!interacted) {
                             WebWalkLog.spInfo("door_interact_failed | mode=segment-door probe={} from={} to={}",
                                     compactWorldPoint(probe), compactWorldPoint(fromWp), compactWorldPoint(toWp));
@@ -6047,6 +6072,9 @@ public class Rs2Walker {
                         waitForDoorInteractionProgress(fromWp, toWp);
                         WorldPoint posAfter = Rs2Player.getWorldLocation();
                         boolean traversed = didTraverseInteractedDoor(posBefore, posAfter, probe, fromWp, toWp);
+                        if (!traversed && isDoorApproachInFlight(posBefore, posAfter, fromWp, toWp)) {
+                            return true;
+                        }
                         if (!traversed && isQuestLockedDoorDialogue()) {
                             String dialogue = Rs2Dialogue.getDialogueText();
                             log.warn("[Walker] Door at {} ({} action={}) appears quest/stat-locked — dialogue=\"{}\" — blacklisting tile, refreshing restrictions, recalculating",
@@ -6175,6 +6203,8 @@ public class Rs2Walker {
                     compactWorldPoint(probe), compactWorldPoint(fromWp), compactWorldPoint(toWp), ex.getClass().getSimpleName());
             return false;
         }
+        recordDoorApproachOwnership(routeState, interacted, posBefore,
+                fromWp, toWp, System.currentTimeMillis());
         if (!interacted) {
             WebWalkLog.spInfo("door_interact_failed | mode=segment-probe probe={} from={} to={}",
                     compactWorldPoint(probe), compactWorldPoint(fromWp), compactWorldPoint(toWp));
@@ -6184,6 +6214,9 @@ public class Rs2Walker {
         waitForDoorInteractionProgress(fromWp, toWp);
         WorldPoint posAfter = Rs2Player.getWorldLocation();
         boolean traversed = didTraverseInteractedDoor(posBefore, posAfter, probe, fromWp, toWp);
+        if (!traversed && isDoorApproachInFlight(posBefore, posAfter, fromWp, toWp)) {
+            return true;
+        }
         if (traversed) {
             markStationaryDoorOpened(probe);
             markNearbyDoorFamilyOpened(object, probe, action, SEGMENT_DOOR_FAMILY_MARK_RADIUS);
@@ -6668,14 +6701,32 @@ public class Rs2Walker {
                 routeState.interimLastProgressAtMs = nowMs;
             }
         }
-        return shouldDeferRouteWorkForActiveInterim(interim,
+        return shouldYieldForActiveRouteInterim(interim,
                 playerLoc,
                 routeState.interimSetAtMs,
                 routeState.interimLastProgressAtMs,
                 nowMs,
                 routeState.lastMovedTimeMs,
                 Rs2Player.isMoving(),
-                INTERIM_CLOSE_TILES);
+                interimPreclickTiles());
+    }
+
+    static boolean shouldYieldForActiveRouteInterim(WorldPoint interim,
+                                                     WorldPoint playerLoc,
+                                                     long setAtMs,
+                                                     long lastProgressAtMs,
+                                                     long nowMs,
+                                                     long lastMovedAtMs,
+                                                     boolean playerMoving,
+                                                     int handoffTiles) {
+        return shouldDeferRouteWorkForActiveInterim(interim,
+                playerLoc,
+                setAtMs,
+                lastProgressAtMs,
+                nowMs,
+                lastMovedAtMs,
+                playerMoving,
+                handoffTiles);
     }
 
     static boolean shouldYieldForActiveRecoveryInterim(WorldPoint interim,
@@ -6722,7 +6773,7 @@ public class Rs2Walker {
         if (playerLoc == null || playerLoc.getPlane() != interim.getPlane()) {
             return false;
         }
-        if (playerLoc.distanceTo2D(interim) <= Math.max(0, handoffTiles)) {
+        if (isWithinRouteHandoffRadius(playerLoc, interim, handoffTiles)) {
             return false;
         }
         if (playerMoving) {
@@ -6732,6 +6783,18 @@ public class Rs2Walker {
             return true;
         }
         return isRecentEvent(nowMs, lastMovedAtMs, RECOVERY_MOVEMENT_IN_FLIGHT_MS);
+    }
+
+    private static boolean isWithinRouteHandoffRadius(WorldPoint playerLoc,
+                                                       WorldPoint interim,
+                                                       int radius) {
+        if (playerLoc == null || interim == null || playerLoc.getPlane() != interim.getPlane()) {
+            return false;
+        }
+        long dx = (long) playerLoc.getX() - interim.getX();
+        long dy = (long) playerLoc.getY() - interim.getY();
+        long boundedRadius = Math.max(0, radius);
+        return dx * dx + dy * dy <= boundedRadius * boundedRadius;
     }
 
     private static void clearInterimTarget(String reason) {
@@ -6870,11 +6933,19 @@ public class Rs2Walker {
 
     private static void markDoorAttempt(WorldPoint doorTile, WorldPoint fromWp, WorldPoint toWp) {
         Rs2DoorHandler.markDoorAttempt(recentDoorAttemptByEdge, doorTile, fromWp, toWp);
-        if (fromWp != null && toWp != null) {
-            routeState.lastDoorAttemptFrom = fromWp;
-            routeState.lastDoorAttemptTo = toWp;
-            routeState.lastDoorAttemptAtMs = System.currentTimeMillis();
+    }
+
+    static void recordDoorApproachOwnership(WalkerRouteState state, boolean interactionDispatched,
+                                            WorldPoint playerPosition, WorldPoint fromWp, WorldPoint toWp,
+                                            long nowMs) {
+        if (!interactionDispatched || state == null || playerPosition == null
+                || fromWp == null || toWp == null || nowMs <= 0L) {
+            return;
         }
+        state.lastDoorAttemptPlayerPosition = playerPosition;
+        state.lastDoorAttemptFrom = fromWp;
+        state.lastDoorAttemptTo = toWp;
+        state.lastDoorAttemptAtMs = nowMs;
     }
 
     private static boolean shouldThrottleCurrentTileTransportAttempt(WorldPoint fromWp, WorldPoint toWp) {
@@ -7131,6 +7202,15 @@ public class Rs2Walker {
                 rawScanDoorInteractionWaitMs += System.currentTimeMillis() - startedAt;
             }
         }
+    }
+
+    private static boolean isDoorApproachInFlight(WorldPoint before, WorldPoint now,
+                                                   WorldPoint fromWp, WorldPoint toWp) {
+        long ageMs = routeState.lastDoorAttemptAtMs <= 0L
+                ? -1L
+                : System.currentTimeMillis() - routeState.lastDoorAttemptAtMs;
+        return Rs2WalkerAwaits.isDoorApproachInFlight(
+                before, now, fromWp, toWp, Rs2Player.isMoving(), ageMs, DOOR_APPROACH_IN_FLIGHT_MS);
     }
 
     private static boolean waitForDoorEdgeResolution(WorldPoint fromWp, WorldPoint toWp, int timeoutMs) {
@@ -7856,6 +7936,8 @@ public class Rs2Walker {
             }
 			return false;
 		}
+		recordDoorApproachOwnership(routeState, interacted, posBefore,
+				bestFrom, bestTo, System.currentTimeMillis());
 		if (!interacted) {
 			WebWalkLog.spInfo("door_interact_failed | mode=path-adj probe={} from={} to={}",
 					compactWorldPoint(bestLoc), compactWorldPoint(bestFrom), compactWorldPoint(bestTo));
@@ -7870,6 +7952,9 @@ public class Rs2Walker {
 		waitForDoorInteractionProgress(bestFrom, bestTo);
 		WorldPoint posAfter = Rs2Player.getWorldLocation();
 		boolean traversed = didTraverseInteractedDoor(posBefore, posAfter, bestLoc, bestFrom, bestTo);
+		if (!traversed && isDoorApproachInFlight(posBefore, posAfter, bestFrom, bestTo)) {
+			return true;
+		}
 		if (traversed) {
             for (WorldPoint loc : bestComponent.locations) {
                 if (loc != null) {
@@ -9146,6 +9231,18 @@ public class Rs2Walker {
                             return false;
                         }
                         boolean landedAfterObject = waitForPostHandleObjectLanding(transport, destWait, maxInclusive);
+                        boolean dialogueOpen = Rs2Dialogue.isInDialogue();
+                        if (shouldEndObjectTransportPass(landedAfterObject, dialogueOpen)) {
+                            if (dialogueOpen) {
+                                WebWalkLog.spInfo("object_transport_dialogue_yield | origin={} dest={} at={}",
+                                        compactWorldPoint(transport.getOrigin()),
+                                        compactWorldPoint(destWait),
+                                        compactWorldPoint(Rs2Player.getWorldLocation()));
+                                return true;
+                            }
+                            markAdjacentSamePlaneTransportHandled(transport, object);
+                            return finishHandledTransport(transport);
+                        }
                         if (!landedAfterObject) {
                             WorldPoint afterInteraction = Rs2Player.getWorldLocation();
                             // Adjacent same-plane transports demand landing on the EXACT destination
@@ -9168,10 +9265,6 @@ public class Rs2Walker {
                                     compactWorldPoint(destWait),
                                     compactWorldPoint(afterInteraction));
                         }
-                        if (landedAfterObject) {
-                            markAdjacentSamePlaneTransportHandled(transport, object);
-                            return finishHandledTransport(transport);
-                        }
                         return false;
                     }
                 }
@@ -9187,7 +9280,8 @@ public class Rs2Walker {
         AtomicBoolean settledAwayFromAdjacentDestination = new AtomicBoolean(false);
         AtomicBoolean settledNearAdjacentDestination = new AtomicBoolean(false);
         boolean completed = sleepUntil(() -> {
-            if (isPlayerWithinChebyshevInclusive(destWait, maxInclusive)) {
+            boolean atDestination = isPlayerWithinChebyshevInclusive(destWait, maxInclusive);
+            if (shouldEndObjectTransportPass(atDestination, Rs2Dialogue.isInDialogue())) {
                 return true;
             }
             if (!isAdjacentSamePlaneTransport(transport)
@@ -9213,6 +9307,9 @@ public class Rs2Walker {
             return false;
         }, POST_HANDLE_OBJECT_LANDING_WAIT_MS);
 
+        if (Rs2Dialogue.isInDialogue()) {
+            return false;
+        }
         if (settledNearAdjacentDestination.get()) {
             WebWalkLog.spInfo("post-handleObject adjacent landing accepted | dest={} at={}",
                     compactWorldPoint(destWait), compactWorldPoint(Rs2Player.getWorldLocation()));
@@ -9224,6 +9321,10 @@ public class Rs2Walker {
             return false;
         }
         return completed;
+    }
+
+    static boolean shouldEndObjectTransportPass(boolean landed, boolean dialogueOpen) {
+        return landed || dialogueOpen;
     }
 
     static boolean isSettledNearAdjacentSamePlaneLanding(Transport transport,
@@ -9393,11 +9494,17 @@ public class Rs2Walker {
                 Rs2Dialogue.clickOption("Yes please"); //shillo village cart
                 if (isAdjacentSamePlaneTransport(transport)) {
                     sleepUntil(() -> {
+                        if (Rs2Dialogue.isInDialogue()) {
+                            return true;
+                        }
                         WorldPoint now = Rs2Player.getWorldLocation();
                         return now != null && (now.equals(transport.getDestination())
                                 || !now.equals(before)
                                 || !Rs2Player.isMoving());
                     }, 2000);
+                    if (Rs2Dialogue.isInDialogue()) {
+                        return true;
+                    }
                     WorldPoint afterOpen = Rs2Player.getWorldLocation();
                     if (afterOpen != null && !afterOpen.equals(transport.getDestination())) {
                         boolean clicked = walkMiniMap(transport.getDestination());
@@ -12226,7 +12333,7 @@ public class Rs2Walker {
             WalkerState state = walkWithStateInternal(target, distance);
             if (state == WalkerState.ARRIVED) {
                 WebWalkLog.bankWalkDebug("arrived goal={}", target);
-            } else {
+            } else if (isTerminalBankedDirectWalkFailure(state)) {
                 WebWalkLog.bankWalkFailed(target, state);
                 setTarget(null, "rs2walker:walkWithBankedTransports:direct-walk-failed");
                 return state;
@@ -12260,6 +12367,10 @@ public class Rs2Walker {
         }
 
 
+    }
+
+    static boolean isTerminalBankedDirectWalkFailure(WalkerState state) {
+        return state == WalkerState.UNREACHABLE || state == WalkerState.EXIT;
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -6146,7 +6146,7 @@ public class Rs2Walker {
                             return false;
                         }
                         markDoorInteractionSettling(toWp);
-                        waitForDoorInteractionProgress(fromWp, toWp);
+                        waitForDoorInteractionProgress(posBefore, fromWp, toWp);
                         WorldPoint posAfter = Rs2Player.getWorldLocation();
                         boolean traversed = didTraverseInteractedDoor(posBefore, posAfter, probe, fromWp, toWp);
                         if (!traversed && isDoorApproachInFlight(posBefore, posAfter, fromWp, toWp)) {
@@ -6288,7 +6288,7 @@ public class Rs2Walker {
             return false;
         }
         markDoorInteractionSettling(toWp);
-        waitForDoorInteractionProgress(fromWp, toWp);
+        waitForDoorInteractionProgress(posBefore, fromWp, toWp);
         WorldPoint posAfter = Rs2Player.getWorldLocation();
         boolean traversed = didTraverseInteractedDoor(posBefore, posAfter, probe, fromWp, toWp);
         if (!traversed && isDoorApproachInFlight(posBefore, posAfter, fromWp, toWp)) {
@@ -7310,9 +7310,10 @@ public class Rs2Walker {
      * Door-ahead / fallback / LOS scans must treat it as non-door so {@link #handleTransports} owns it.
      */
 
-    private static void waitForDoorInteractionProgress(WorldPoint fromWp, WorldPoint toWp) {
+    private static void waitForDoorInteractionProgress(WorldPoint posBefore,
+                                                       WorldPoint fromWp, WorldPoint toWp) {
         long startedAt = System.currentTimeMillis();
-        AwaitTicket ticket = Rs2WalkerAwaits.beginTicket();
+        AwaitTicket ticket = Rs2WalkerAwaits.beginTicket(posBefore);
         try {
             Rs2WalkerAwaits.awaitDoorInteractionProgress(ticket, fromWp, toWp);
         } finally {
@@ -8067,7 +8068,7 @@ public class Rs2Walker {
 			return false;
 		}
         markDoorInteractionSettling(bestTo);
-		waitForDoorInteractionProgress(bestFrom, bestTo);
+		waitForDoorInteractionProgress(posBefore, bestFrom, bestTo);
 		WorldPoint posAfter = Rs2Player.getWorldLocation();
 		boolean traversed = didTraverseInteractedDoor(posBefore, posAfter, bestLoc, bestFrom, bestTo);
 		if (!traversed && isDoorApproachInFlight(posBefore, posAfter, bestFrom, bestTo)) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -2420,7 +2420,8 @@ public class Rs2Walker {
                                 }
                             }
                             boolean gateDoorInteraction = isDoorInteractionSettling() || isDoorEdgePassSkipCoolingDown();
-                            long recentDoorAgeMs = recentDoorAttemptAgeNearIndex(rawPath, rawEdgeStart);
+                            long recentDoorAgeMs = doorApproachAgeMs(
+                                    routeState, System.currentTimeMillis());
                             boolean playerMoving = Rs2Player.isMoving();
                             boolean doorApproachInFlight = Rs2WalkerAwaits.isDoorApproachInFlight(
                                     routeState.lastDoorAttemptPlayerPosition,
@@ -6432,28 +6433,6 @@ public class Rs2Walker {
         return false;
     }
 
-    private static long recentDoorAttemptAgeNearIndex(List<WorldPoint> path, int edgeIdx) {
-        if (path == null || path.size() < 2 || edgeIdx < 0) {
-            return -1L;
-        }
-        long now = System.currentTimeMillis();
-        long newestAttemptAt = -1L;
-        int start = Math.max(0, edgeIdx - 1);
-        int end = Math.min(path.size() - 2, edgeIdx + 1);
-        for (int i = start; i <= end; i++) {
-            WorldPoint from = path.get(i);
-            WorldPoint to = path.get(i + 1);
-            if (!isLikelyDoorEdgeTransition(from, to)) {
-                continue;
-            }
-            Long attemptedAt = recentDoorAttemptByEdge.get(doorAttemptKey(null, from, to));
-            if (attemptedAt != null) {
-                newestAttemptAt = Math.max(newestAttemptAt, attemptedAt);
-            }
-        }
-        return newestAttemptAt < 0 ? -1L : Math.max(0L, now - newestAttemptAt);
-    }
-
     private static boolean isLikelyDoorEdgeTransition(WorldPoint from, WorldPoint to) {
         if (from == null || to == null || from.getPlane() != to.getPlane()) {
             return false;
@@ -7078,6 +7057,13 @@ public class Rs2Walker {
         state.lastDoorAttemptFrom = fromWp;
         state.lastDoorAttemptTo = toWp;
         state.lastDoorAttemptAtMs = nowMs;
+    }
+
+    static long doorApproachAgeMs(WalkerRouteState state, long nowMs) {
+        if (state == null || state.lastDoorAttemptAtMs <= 0L) {
+            return -1L;
+        }
+        return Math.max(0L, nowMs - state.lastDoorAttemptAtMs);
     }
 
     private static boolean shouldThrottleCurrentTileTransportAttempt(WorldPoint fromWp, WorldPoint toWp) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1669,8 +1669,11 @@ public class Rs2Walker {
             }
             if (Rs2Player.getWorldLocation() == null) {
                 traceProcessWalkExit("player-unavailable", target, processWalkTail);
-                setTarget(null, "rs2walker:processWalk:player-unavailable");
-                return WalkerState.EXIT;
+                WalkerState unavailableState = playerSnapshotUnavailableState(Microbot.isLoggedIn());
+                if (unavailableState == WalkerState.EXIT) {
+                    setTarget(null, "rs2walker:processWalk:player-unavailable");
+                }
+                return unavailableState;
             }
             if (walkCancelledDiag(target, "processWalk:entry", processWalkTail)) {
                 return WalkerState.EXIT;
@@ -3164,8 +3167,11 @@ public class Rs2Walker {
             WorldPoint finalPlayerLocation = Rs2Player.getWorldLocation();
             if (finalPlayerLocation == null) {
                 traceProcessWalkExit("player-unavailable-after-movement", target, processWalkTail);
-                setTarget(null, "rs2walker:processWalk:player-unavailable-after-movement");
-                return WalkerState.EXIT;
+                WalkerState unavailableState = playerSnapshotUnavailableState(Microbot.isLoggedIn());
+                if (unavailableState == WalkerState.EXIT) {
+                    setTarget(null, "rs2walker:processWalk:player-unavailable-after-movement");
+                }
+                return unavailableState;
             }
             int finalDist = finalPlayerLocation.distanceTo(target);
             if (finalDist <= finishThreshold) {
@@ -3303,6 +3309,10 @@ public class Rs2Walker {
         WebWalkLog.tailExceeded(MAX_PROCESS_WALK_TAIL_ITERATIONS, target, currentTarget, routeState.interimTargetWp, routeState.stuckCount,
                 Rs2Player.getWorldLocation());
         return WalkerState.EXIT;
+    }
+
+    static WalkerState playerSnapshotUnavailableState(boolean loggedIn) {
+        return loggedIn ? WalkerState.MOVING : WalkerState.EXIT;
     }
 
     public static boolean walkNextTo(GameObject target) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -5430,6 +5430,7 @@ public class Rs2Walker {
                     boolean ranged = originDistance > RAW_TRANSPORT_DISPATCH_MAX_DISTANCE;
                     WorldPoint before = Rs2Player.getWorldLocation();
                     WorldPoint expectedDestination = expectedDest;
+                    boolean dialogueWasOpen = Rs2Dialogue.isInDialogue();
                     long t = System.currentTimeMillis();
                     if (ranged) {
                         WebWalkLog.spInfo("ranged_transport_dispatch | origin={} dist={} — clicking from range, server walks us",
@@ -5438,7 +5439,8 @@ public class Rs2Walker {
                     boolean handledTransport = handleTransports(rawPath, i);
                     transportMs += System.currentTimeMillis() - t;
                     if (handledTransport) {
-                        if (!didCurrentTileTransportProgress(before, expectedDestination, target)) {
+                        if (!didCurrentTileTransportProgress(
+                                before, expectedDestination, target, dialogueWasOpen)) {
                             WebWalkLog.spInfo("raw_path_transport_no_progress",
                                     "at=%s expected=%s target=%s",
                                     before, expectedDestination, target);
@@ -5792,11 +5794,13 @@ public class Rs2Walker {
             }
             markCurrentTileTransportAttempt(origin, transport.getDestination());
             WorldPoint before = Rs2Player.getWorldLocation();
+            boolean dialogueWasOpen = Rs2Dialogue.isInDialogue();
             // Pass the transport's own origin so handleTransports walks the short hop to it before
             // interacting (NPC dispatch already auto-walks via canWalkTo + interact); object/door
             // interactions that can't be reached from here simply return false and we fall through.
             if (handleTransports(Arrays.asList(origin, transport.getDestination()), 0)) {
-                if (didCurrentTileTransportProgress(before, transport.getDestination(), target)) {
+                if (didCurrentTileTransportProgress(
+                        before, transport.getDestination(), target, dialogueWasOpen)) {
                     log.info("[Walker] Nearby transport handler resolved obstacle: origin={} dest={} (player {})",
                             origin, transport.getDestination(), playerLoc);
                     return true;
@@ -5814,8 +5818,10 @@ public class Rs2Walker {
         return false;
     }
 
-    private static boolean didCurrentTileTransportProgress(WorldPoint before, WorldPoint expectedDestination, WorldPoint target) {
-        return Rs2WalkerTransportAwaits.didCurrentTileTransportProgress(before, expectedDestination, target);
+    private static boolean didCurrentTileTransportProgress(WorldPoint before, WorldPoint expectedDestination,
+                                                           WorldPoint target, boolean dialogueWasOpen) {
+        return Rs2WalkerTransportAwaits.didCurrentTileTransportProgress(
+                before, expectedDestination, target, dialogueWasOpen);
     }
 
     // Maps each tile on the planned route at/after the player's closest index to its route position.
@@ -9818,8 +9824,9 @@ public class Rs2Walker {
             WebWalkLog.spInfo("ranged_transport_dispatch | origin={} dist={} — clicking from range, server walks us",
                     compactWorldPoint(origin), originDistance);
             WorldPoint before = Rs2Player.getWorldLocation();
+            boolean dialogueWasOpen = Rs2Dialogue.isInDialogue();
             if (handleTransports(rawPath, ri)) {
-                if (didCurrentTileTransportProgress(before, dest, currentTarget)) {
+                if (didCurrentTileTransportProgress(before, dest, currentTarget, dialogueWasOpen)) {
                     return true;
                 }
                 markRangedTransportEdgeFailed(origin, dest);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -2454,7 +2454,7 @@ public class Rs2Walker {
                                 break;
                             }
                             if (handlePendingDoorNearRawPath(rawPath, obstaclePolicy.unreachableDoorTimeoutMs(),
-                                    doorEdgesAttemptedThisTail, playerLoc, 2, 14)) {
+                                    doorEdgesAttemptedThisTail, playerLoc, 2, 14, false)) {
                                 exitReason = "door-handled-local-reachability-raw-scan";
                                 break;
                             }
@@ -5183,11 +5183,11 @@ public class Rs2Walker {
                                                           WorldPoint playerLoc) {
         if (rawPath == null || rawPath.size() < 2 || playerLoc == null
                 || isDoorInteractionSettling() || isDoorEdgePassSkipCoolingDown()
-                || isRecoveryMovementInFlight() || Rs2Player.isMoving()) {
+                || isRecoveryMovementInFlight()) {
             return false;
         }
 
-        return handlePendingDoorNearRawPath(rawPath, timeoutMs, attempted, playerLoc, 2, 14);
+        return handlePendingDoorNearRawPath(rawPath, timeoutMs, attempted, playerLoc, 2, 14, true);
     }
 
     private static boolean handlePendingDoorNearRawPath(List<WorldPoint> rawPath,
@@ -5195,11 +5195,12 @@ public class Rs2Walker {
                                                         Map<String, WorldPoint> attempted,
                                                         WorldPoint playerLoc,
                                                         int backtrackEdges,
-                                                        int lookaheadEdges) {
+                                                        int lookaheadEdges,
+                                                        boolean allowMovingApproach) {
         if (rawPath == null || rawPath.size() < 2 || playerLoc == null) {
             return false;
         }
-        if (Rs2Player.isMoving()) {
+        if (shouldDeferPendingDoorRawScan(Rs2Player.isMoving(), allowMovingApproach)) {
             return false;
         }
 
@@ -5233,6 +5234,10 @@ public class Rs2Walker {
             }
         }
         return false;
+    }
+
+    static boolean shouldDeferPendingDoorRawScan(boolean moving, boolean allowMovingApproach) {
+        return moving && !allowMovingApproach;
     }
 
     private static boolean handleUnresolvedDoorNearRawPath(List<WorldPoint> rawPath,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -9353,6 +9353,7 @@ public class Rs2Walker {
                                     interactionAction, transportAction, object.getWorldLocation(), object.getId());
                         }
                         prepareTransportObjectForInteraction(object);
+                        boolean dialogueWasOpen = Rs2Dialogue.isInDialogue();
                         if (!handleObject(transport, object, interactionAction)) {
                             return false;
                         }
@@ -9362,10 +9363,11 @@ public class Rs2Walker {
                         if (destWait == null) {
                             return false;
                         }
-                        boolean landedAfterObject = waitForPostHandleObjectLanding(transport, destWait, maxInclusive);
+                        boolean landedAfterObject = waitForPostHandleObjectLanding(
+                                transport, destWait, maxInclusive, dialogueWasOpen);
                         boolean dialogueOpen = Rs2Dialogue.isInDialogue();
-                        if (shouldEndObjectTransportPass(landedAfterObject, dialogueOpen)) {
-                            if (dialogueOpen) {
+                        if (shouldEndObjectTransportPass(landedAfterObject, dialogueWasOpen, dialogueOpen)) {
+                            if (isNewObjectTransportDialogue(dialogueWasOpen, dialogueOpen)) {
                                 WebWalkLog.spInfo("object_transport_dialogue_yield | origin={} dest={} at={}",
                                         compactWorldPoint(transport.getOrigin()),
                                         compactWorldPoint(destWait),
@@ -9407,13 +9409,15 @@ public class Rs2Walker {
 
     private static boolean waitForPostHandleObjectLanding(Transport transport,
                                                           WorldPoint destWait,
-                                                          int maxInclusive) {
+                                                          int maxInclusive,
+                                                          boolean dialogueWasOpen) {
         long waitStartedAt = System.currentTimeMillis();
         AtomicBoolean settledAwayFromAdjacentDestination = new AtomicBoolean(false);
         AtomicBoolean settledNearAdjacentDestination = new AtomicBoolean(false);
         boolean completed = sleepUntil(() -> {
             boolean atDestination = isPlayerWithinChebyshevInclusive(destWait, maxInclusive);
-            if (shouldEndObjectTransportPass(atDestination, Rs2Dialogue.isInDialogue())) {
+            if (shouldEndObjectTransportPass(
+                    atDestination, dialogueWasOpen, Rs2Dialogue.isInDialogue())) {
                 return true;
             }
             if (!isAdjacentSamePlaneTransport(transport)
@@ -9439,7 +9443,7 @@ public class Rs2Walker {
             return false;
         }, POST_HANDLE_OBJECT_LANDING_WAIT_MS);
 
-        if (Rs2Dialogue.isInDialogue()) {
+        if (isNewObjectTransportDialogue(dialogueWasOpen, Rs2Dialogue.isInDialogue())) {
             return false;
         }
         if (settledNearAdjacentDestination.get()) {
@@ -9455,8 +9459,14 @@ public class Rs2Walker {
         return completed;
     }
 
-    static boolean shouldEndObjectTransportPass(boolean landed, boolean dialogueOpen) {
-        return landed || dialogueOpen;
+    static boolean shouldEndObjectTransportPass(boolean landed,
+                                                boolean dialogueWasOpen,
+                                                boolean dialogueOpen) {
+        return landed || isNewObjectTransportDialogue(dialogueWasOpen, dialogueOpen);
+    }
+
+    static boolean isNewObjectTransportDialogue(boolean dialogueWasOpen, boolean dialogueOpen) {
+        return !dialogueWasOpen && dialogueOpen;
     }
 
     static boolean isSettledNearAdjacentSamePlaneLanding(Transport transport,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -1651,7 +1651,6 @@ public class Rs2Walker {
         long pathfinderPendingSinceMs = 0L;
 
         Map<WorldPoint, Integer> reachableTilesCache = null;
-        WorldPoint reachableTilesCacheOrigin = null;
         for (int processWalkTail = 0; processWalkTail < MAX_PROCESS_WALK_TAIL_ITERATIONS; processWalkTail++) {
         walkerHeartbeat(target, processWalkTail);
         try {
@@ -2078,8 +2077,12 @@ public class Rs2Walker {
             }
 
             WorldPoint currentPlayerLoc = Rs2Player.getWorldLocation();
-            reachableTilesCache = Rs2Tile.getReachableTilesFromTile(currentPlayerLoc, HANDLER_RANGE * 3);
-            reachableTilesCacheOrigin = currentPlayerLoc;
+            if (currentWalkerPhase() == WalkerPhase.STARTUP
+                    && Objects.equals(currentPlayerLoc, walkLoop.playerLoc)) {
+                reachableTilesCache = walkLoop.closestReachableTiles;
+            } else {
+                reachableTilesCache = Rs2Tile.getReachableTilesFromTile(currentPlayerLoc, HANDLER_RANGE * 3);
+            }
             final int currentPlayerPlane = currentPlayerLoc != null ? currentPlayerLoc.getPlane() : -1;
 
             // Route order for interact-at-range: the loop walks segments outward from the player, so
@@ -2309,7 +2312,6 @@ public class Rs2Walker {
                         int unreachableDist = currentWorldPoint.distanceTo2D(playerLoc);
                         if (unreachableDist <= HANDLER_RANGE + 2) {
                             reachableTilesCache = Rs2Tile.getReachableTilesFromTile(playerLoc, HANDLER_RANGE + 5);
-                            reachableTilesCacheOrigin = playerLoc;
                             tileReachable = reachableTilesCache.containsKey(currentWorldPoint);
                             if (tileReachable) {
                                 log.debug("[Walker] tile {} reachable after cache refresh from {}", currentWorldPoint, playerLoc);
@@ -2579,8 +2581,9 @@ public class Rs2Walker {
                                 break;
                             }
                             final int recoveryMinimapReach = STALL_RECOVERY_MINIMAP_REACH_EUCLIDEAN;
+                            Map<WorldPoint, Integer> recoveryReachable = getClosestIndexReachableTiles(playerLoc);
                             int recoverIdx = findForwardReachableRecoveryIndex(path, i, playerLoc,
-                                    recoveryMinimapReach);
+                                    recoveryMinimapReach, recoveryReachable.keySet());
                             if (recoverIdx < 0) {
                                 recoverIdx = RouteRecovery.findFurthestClickableIndex(path, i, playerLoc,
                                         wp -> {
@@ -2622,7 +2625,8 @@ public class Rs2Walker {
                                     playerLoc,
                                     recoveryMinimapReach - 1,
                                     rawAnchorIndex,
-                                    Rs2Walker::isKnownWalkableOrUnloaded);
+                                    Rs2Walker::isKnownWalkableOrUnloaded,
+                                    recoveryReachable);
                             if (rawRecoveryTarget != null
                                     && !rawRecoveryTarget.equals(playerLoc)
                                     && (dangerCfg == null
@@ -2654,7 +2658,7 @@ public class Rs2Walker {
                                     isDoorInteractionSettling(),
                                     Rs2Player.isMoving()
                                             && isMovementWalkerOwned(System.currentTimeMillis(), lastAttemptedMinimapClickAtMs),
-                                    reachableTilesCache != null ? reachableTilesCache.keySet() : null,
+                                    recoveryReachable.keySet(),
                                     WALLED_RECOVERY_TARGET_EUCLIDEAN,
                                     System.currentTimeMillis(), routeState.lastWalledRecoveryReplanAtMs,
                                     WALLED_RECOVERY_REPLAN_COOLDOWN_MS);
@@ -2711,7 +2715,8 @@ public class Rs2Walker {
                                 routeState.interimTargetIdx = recoverIdx;
                                 routeState.interimSetAtMs = System.currentTimeMillis();
                                 routeState.interimLastProgressAtMs = routeState.interimSetAtMs;
-                                routeState.interimLastBestPathIdx = getClosestTileIndex(path, playerLoc);
+                                routeState.interimLastBestPathIdx = WalkerPathGeometry.getClosestTileIndex(
+                                        path, playerLoc, recoveryReachable);
                                 routeState.interimLastDistanceToTarget = distanceToInterimOrMax(clickedRecoveryTarget, playerLoc);
                                 routeState.interimLastRetargetAtMs = routeState.interimSetAtMs;
                                 routeState.interimTargetRecovery = true;
@@ -2831,6 +2836,16 @@ public class Rs2Walker {
 								: routeHandoffReady ? "handoff" : "stale-progress");
 					}
 
+                    // The interim door scan/wait above can change collision or move the player. Capture
+                    // once at the actual movement-decision boundary, then reuse this observation for
+                    // every target-index and route-selection retry below.
+                    playerLoc = Rs2Player.getWorldLocation();
+                    if (playerLoc == null) {
+                        exitReason = "player-location-null-before-route-click";
+                        break;
+                    }
+                    reachableTilesCache = getClosestIndexReachableTiles(playerLoc);
+
                     int targetIdx = RouteRecovery.findFurthestForwardClickableIndex(path, i, playerLoc,
                             wp -> {
                                 Set<Transport> ts = Rs2PathApi.getTransports().get(wp);
@@ -2870,7 +2885,8 @@ public class Rs2Walker {
 						} else {
 							// U-turn safe progress: track progress along the path index, not Euclidean
 							// distance-to-target (which can increase on U-shaped routes).
-							int bestIdxNow = getClosestTileIndex(path, playerLoc);
+							int bestIdxNow = WalkerPathGeometry.getClosestTileIndex(
+									path, playerLoc, reachableTilesCache);
 							if (bestIdxNow > routeState.interimLastBestPathIdx) {
 								routeState.interimLastBestPathIdx = bestIdxNow;
 								routeState.interimLastProgressAtMs = nowMs;
@@ -2901,7 +2917,8 @@ public class Rs2Walker {
                     // a Euclidean-close click there sends the player into the wall. Reachability
                     // gating excludes the wrong side outright. See movement.md #19.
                     WorldPoint rawRouteTarget = inInstance ? null
-                            : selectRouteClickTarget(rawPath, playerLoc, MINIMAP_REACH_EUCLIDEAN - 1, rawAnchorIndex);
+                            : selectRouteClickTarget(rawPath, playerLoc, MINIMAP_REACH_EUCLIDEAN - 1,
+                            rawAnchorIndex, reachableTilesCache);
                     WorldPoint clickTarget;
                     String fallbackTag = "-";
                     if (rawRouteTarget != null && !rawRouteTarget.equals(playerLoc)) {
@@ -2965,7 +2982,8 @@ public class Rs2Walker {
 						routeState.interimTargetIdx = targetIdx;
 						routeState.interimSetAtMs = nowMs;
 						routeState.interimLastProgressAtMs = nowMs;
-						routeState.interimLastBestPathIdx = getClosestTileIndex(path, posBefore);
+						routeState.interimLastBestPathIdx = WalkerPathGeometry.getClosestTileIndex(
+								path, posBefore, reachableTilesCache);
                         routeState.interimLastDistanceToTarget = distanceToInterimOrMax(clickedTarget, posBefore);
 						routeState.interimLastRetargetAtMs = nowMs;
                         routeState.interimTargetRecovery = false;
@@ -3781,18 +3799,19 @@ public class Rs2Walker {
      * additionally supplies the player-origin reachability BFS so forward click selection stops at the near
      * side of a closed door / wall ON the route instead of selecting statically-walkable tiles beyond it
      * (which made the server path the player AROUND buildings — the Clock Tower off-route bug). Kept
-     * separate from the ungated wrapper because the gate reads live game state (the BFS), which the
-     * pure-selection unit tests must not depend on.
+     * separate from the ungated wrapper because the gate consumes a live-game reachability snapshot,
+     * which the pure-selection unit tests must not depend on. The caller supplies that snapshot so all
+     * retries in one movement decision use the same collision observation instead of rebuilding it.
      */
-    private static WorldPoint findFurthestRawPathPointMatchingGated(List<WorldPoint> rawPath,
-                                                                    WorldPoint playerLoc,
-                                                                    int maxEuclidean,
-                                                                    int rawAnchorIndex,
-                                                                    Predicate<WorldPoint> isCandidate) {
-        Map<WorldPoint, Integer> reachable = getClosestIndexReachableTiles(playerLoc);
+    static WorldPoint findFurthestRawPathPointMatchingGated(List<WorldPoint> rawPath,
+                                                            WorldPoint playerLoc,
+                                                            int maxEuclidean,
+                                                            int rawAnchorIndex,
+                                                            Predicate<WorldPoint> isCandidate,
+                                                            Map<WorldPoint, Integer> reachable) {
         WorldPoint selected = WalkerPathGeometry.findFurthestRawPathPointMatching(rawPath, playerLoc, maxEuclidean,
                 rawAnchorIndex, isCandidate, ROUTE_PROGRESS_FORWARD_SEARCH_TILES,
-                () -> getClosestTileIndex(rawPath, playerLoc),
+                () -> WalkerPathGeometry.getClosestTileIndex(rawPath, playerLoc, reachable),
                 reachable, CLOSEST_INDEX_REACHABLE_STEP_BUDGET);
         // Output-side net: whatever path the scan took (stale anchor, player-anchored retry, a fold the
         // along-route gate could not vouch for), a selected tile that is Euclidean-NEAR the player yet
@@ -3828,7 +3847,8 @@ public class Rs2Walker {
      * plus {@link #findReachableRejoinRawPathPoint} rejoin handling.
      */
     private static WorldPoint selectRouteClickTarget(List<WorldPoint> rawPath, WorldPoint playerLoc,
-                                                     int maxEuclidean, int rawAnchorIndex) {
+                                                     int maxEuclidean, int rawAnchorIndex,
+                                                     Map<WorldPoint, Integer> reachable) {
         if (rawPath == null || rawPath.isEmpty() || playerLoc == null) {
             routeState.lastRouteClickTier = "norawpath";
             return null;
@@ -3840,11 +3860,13 @@ public class Rs2Walker {
         // tile offsets are the wrong axis and were removed for exactly that reason (#15); lateral
         // randomness belongs inside the tile (click-point jitter), not in tile selection.
         int jitteredReach = routeClickReach(maxEuclidean);
-        WorldPoint selected = selectRouteClickTargetAnchored(rawPath, playerLoc, jitteredReach, rawAnchorIndex);
+        WorldPoint selected = selectRouteClickTargetAnchored(rawPath, playerLoc, jitteredReach,
+                rawAnchorIndex, reachable);
         if (selected == null && jitteredReach < maxEuclidean) {
             // A shortened reach must never be the reason selection fails — that would drop the click
             // onto the caller's off-route wall-nudge clamp. Retry at full reach before giving up.
-            selected = selectRouteClickTargetAnchored(rawPath, playerLoc, maxEuclidean, rawAnchorIndex);
+            selected = selectRouteClickTargetAnchored(rawPath, playerLoc, maxEuclidean,
+                    rawAnchorIndex, reachable);
         }
         if (selected == null && rawAnchorIndex >= 0) {
             // The smoothed->raw anchor can point past the player's vicinity (stale mapping, sparse
@@ -3855,9 +3877,9 @@ public class Rs2Walker {
             // Keep the jitter on this path too. The player-anchored retry fires on most first clicks
             // of a route, so using full reach here bypassed the reach variation exactly where it is
             // most visible — measured click distances clustered at 9.0-10.0 instead of spreading.
-            selected = selectRouteClickTargetAnchored(rawPath, playerLoc, jitteredReach, -1);
+            selected = selectRouteClickTargetAnchored(rawPath, playerLoc, jitteredReach, -1, reachable);
             if (selected == null && jitteredReach < maxEuclidean) {
-                selected = selectRouteClickTargetAnchored(rawPath, playerLoc, maxEuclidean, -1);
+                selected = selectRouteClickTargetAnchored(rawPath, playerLoc, maxEuclidean, -1, reachable);
             }
             if (selected != null) {
                 routeState.lastRouteClickTier = routeState.lastRouteClickTier + "@player";
@@ -3884,7 +3906,8 @@ public class Rs2Walker {
     }
 
     private static WorldPoint selectRouteClickTargetAnchored(List<WorldPoint> rawPath, WorldPoint playerLoc,
-                                                             int maxEuclidean, int rawAnchorIndex) {
+                                                             int maxEuclidean, int rawAnchorIndex,
+                                                             Map<WorldPoint, Integer> reachable) {
         // Click the furthest forward point ON THE RAW ROUTE that is within minimap reach.
         //
         // A minimap click is resolved by the GAME's own pathing, so line of sight is irrelevant to
@@ -3899,7 +3922,7 @@ public class Rs2Walker {
         // from a lack of line of sight. Pending doors/gates are handled by
         // handlePendingDoorBeforeRouteClick, not by shortening the click.
         WorldPoint forward = findFurthestRawPathPointMatchingGated(rawPath, playerLoc, maxEuclidean,
-                rawAnchorIndex, Rs2Walker::isKnownWalkableOrUnloaded);
+                rawAnchorIndex, Rs2Walker::isKnownWalkableOrUnloaded, reachable);
         if (forward != null && !forward.equals(playerLoc)) {
             routeState.lastRouteClickTier = "route";
             return forward;
@@ -3966,10 +3989,12 @@ public class Rs2Walker {
             return null;
         }
 
+        Map<WorldPoint, Integer> reachable = getClosestIndexReachableTiles(playerLoc);
         return findFurthestRawPathPointMatchingGated(rawPath, playerLoc, maxEuclidean, rawAnchorIndex,
                 candidate -> !candidate.equals(playerLoc)
                         && isKnownWalkableOrUnloaded(candidate)
-                        && isMiniMapClickable(candidate, 5));
+                        && isMiniMapClickable(candidate, 5),
+                reachable);
     }
 
     // rawPathStepDistance (pure) moved to geometry/WalkerPathGeometry (P1) alongside its only caller,
@@ -4022,8 +4047,10 @@ public class Rs2Walker {
                                                       WorldPoint target,
                                                       int configuredDistance,
                                                       String logLabel) {
+        WorldPoint playerLoc = Rs2Player.getWorldLocation();
+        Map<WorldPoint, Integer> reachable = getClosestIndexReachableTiles(playerLoc);
         return tryIssueRouteMovementClick(rawPath, path, target, configuredDistance, logLabel,
-                STALL_RECOVERY_MINIMAP_REACH_EUCLIDEAN, true);
+                STALL_RECOVERY_MINIMAP_REACH_EUCLIDEAN, true, playerLoc, reachable);
     }
 
     private static boolean tryIssueRouteContinuationClick(List<WorldPoint> rawPath,
@@ -4034,8 +4061,9 @@ public class Rs2Walker {
         if (playerLoc == null || path == null || path.isEmpty()) {
             return false;
         }
+        Map<WorldPoint, Integer> reachable = getClosestIndexReachableTiles(playerLoc);
         if (rawPath != null && !rawPath.isEmpty()) {
-            int rawIdx = getClosestTileIndex(rawPath, playerLoc);
+            int rawIdx = WalkerPathGeometry.getClosestTileIndex(rawPath, playerLoc, reachable);
             if (rawIdx >= 0 && hasUnresolvedDoorLikeObjectNearRawPath(rawPath,
                     rawIdx,
                     playerLoc,
@@ -4045,14 +4073,14 @@ public class Rs2Walker {
                 return false;
             }
         }
-        int pathIdx = Math.max(0, getClosestTileIndex(path, playerLoc));
+        int pathIdx = Math.max(0, WalkerPathGeometry.getClosestTileIndex(path, playerLoc, reachable));
         if (hasUpcomingNearbyTransportStep(path, pathIdx, playerLoc,
                 POST_TRANSPORT_RAW_SCAN_TRANSPORT_LOOKAHEAD_EDGES,
                 POST_TRANSPORT_RAW_SCAN_TRANSPORT_MAX_DIST)) {
             return false;
         }
         return tryIssueRouteMovementClick(rawPath, path, target, configuredDistance, "interim close route click",
-                NORMAL_MINIMAP_REACH_EUCLIDEAN, false);
+                NORMAL_MINIMAP_REACH_EUCLIDEAN, false, playerLoc, reachable);
     }
 
     private static boolean tryIssueRouteMovementClick(List<WorldPoint> rawPath,
@@ -4061,15 +4089,17 @@ public class Rs2Walker {
                                                       int configuredDistance,
                                                       String logLabel,
                                                       int maxEuclidean,
-                                                      boolean markRecoveryCooldown) {
-        WorldPoint playerLoc = Rs2Player.getWorldLocation();
+                                                      boolean markRecoveryCooldown,
+                                                      WorldPoint playerLoc,
+                                                      Map<WorldPoint, Integer> reachable) {
         if (playerLoc == null || path == null || path.isEmpty()) {
             return false;
         }
         if (routeArrivalSatisfied(playerLoc, target, path, configuredDistance)) {
             return false;
         }
-        int targetIdx = stabilizeRouteProgressIndex(path, getClosestTileIndex(path, playerLoc), target, playerLoc);
+        int targetIdx = stabilizeRouteProgressIndex(path,
+                WalkerPathGeometry.getClosestTileIndex(path, playerLoc, reachable), target, playerLoc);
         int startIdx = Math.max(0, targetIdx);
         int[] routeSmoothedToRaw = mapSmoothedToRaw(path, rawPath);
         int rawAnchorIndex = rawIndexForSmoothedIndex(targetIdx, routeSmoothedToRaw, rawPath);
@@ -4078,7 +4108,8 @@ public class Rs2Walker {
         // interim continuation clicks previously had their own walkable-only selection, so which
         // policy applied depended on which path happened to fire (timing-dependent, e.g. a slow
         // pathfinder makes the idle nudge issue the first click instead of the main loop).
-        WorldPoint clickTarget = selectRouteClickTarget(rawPath, playerLoc, maxEuclidean, rawAnchorIndex);
+        WorldPoint clickTarget = selectRouteClickTarget(rawPath, playerLoc, maxEuclidean,
+                rawAnchorIndex, reachable);
         if (clickTarget == null) {
             int clickableIdx = RouteRecovery.findFurthestForwardClickableIndex(path, startIdx, playerLoc,
                     wp -> {
@@ -4130,7 +4161,7 @@ public class Rs2Walker {
         routeState.interimTargetIdx = targetIdx;
         routeState.interimSetAtMs = System.currentTimeMillis();
         routeState.interimLastProgressAtMs = routeState.interimSetAtMs;
-        routeState.interimLastBestPathIdx = getClosestTileIndex(path, playerLoc);
+        routeState.interimLastBestPathIdx = WalkerPathGeometry.getClosestTileIndex(path, playerLoc, reachable);
         routeState.interimLastDistanceToTarget = distanceToInterimOrMax(clickedTarget, playerLoc);
         routeState.interimLastRetargetAtMs = routeState.interimSetAtMs;
         routeState.interimTargetRecovery = markRecoveryCooldown;
@@ -5914,10 +5945,8 @@ public class Rs2Walker {
     private static int findForwardReachableRecoveryIndex(List<WorldPoint> path,
                                                          int startIdx,
                                                          WorldPoint playerLoc,
-                                                         int maxEuclidean) {
-        Set<WorldPoint> reachable = playerLoc == null
-                ? Collections.emptySet()
-                : Rs2Tile.getReachableTilesFromTile(playerLoc, Math.max(2, maxEuclidean)).keySet();
+                                                         int maxEuclidean,
+                                                         Set<WorldPoint> reachable) {
         return RouteRecovery.findForwardRecoveryIndex(
                 path,
                 startIdx,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -9367,7 +9367,8 @@ public class Rs2Walker {
                                 transport, destWait, maxInclusive, dialogueWasOpen);
                         boolean dialogueOpen = Rs2Dialogue.isInDialogue();
                         if (shouldEndObjectTransportPass(landedAfterObject, dialogueWasOpen, dialogueOpen)) {
-                            if (isNewObjectTransportDialogue(dialogueWasOpen, dialogueOpen)) {
+                            if (shouldYieldObjectTransportDialogue(
+                                    landedAfterObject, dialogueWasOpen, dialogueOpen)) {
                                 WebWalkLog.spInfo("object_transport_dialogue_yield | origin={} dest={} at={}",
                                         compactWorldPoint(transport.getOrigin()),
                                         compactWorldPoint(destWait),
@@ -9412,51 +9413,60 @@ public class Rs2Walker {
                                                           int maxInclusive,
                                                           boolean dialogueWasOpen) {
         long waitStartedAt = System.currentTimeMillis();
+        AtomicBoolean reachedDestination = new AtomicBoolean(false);
+        AtomicBoolean dialogueOpened = new AtomicBoolean(false);
         AtomicBoolean settledAwayFromAdjacentDestination = new AtomicBoolean(false);
         AtomicBoolean settledNearAdjacentDestination = new AtomicBoolean(false);
         boolean completed = sleepUntil(() -> {
             boolean atDestination = isPlayerWithinChebyshevInclusive(destWait, maxInclusive);
-            if (shouldEndObjectTransportPass(
-                    atDestination, dialogueWasOpen, Rs2Dialogue.isInDialogue())) {
-                return true;
+            boolean dialogueOpen = Rs2Dialogue.isInDialogue();
+            boolean newDialogue = isNewObjectTransportDialogue(dialogueWasOpen, dialogueOpen);
+            boolean settledNearDestination = false;
+            boolean settledAwayFromDestination = false;
+            if (isAdjacentSamePlaneTransport(transport)
+                    && System.currentTimeMillis() - waitStartedAt >= POST_HANDLE_OBJECT_FAILED_SETTLE_MS) {
+                WorldPoint playerLoc = Rs2Player.getWorldLocation();
+                if (playerLoc != null && destWait != null && playerLoc.getPlane() == destWait.getPlane()
+                        && !Rs2Player.isMoving() && !Rs2Player.isAnimating()) {
+                    settledNearDestination = isSettledNearAdjacentSamePlaneLanding(
+                            transport, playerLoc, destWait, maxInclusive);
+                    WorldPoint origin = transport == null ? null : transport.getOrigin();
+                    boolean settledAwayFromOrigin = origin != null && playerLoc.distanceTo2D(origin) > 1;
+                    settledAwayFromDestination = !settledNearDestination
+                            && playerLoc.distanceTo2D(destWait) > Math.max(1, maxInclusive)
+                            && settledAwayFromOrigin;
+                }
             }
-            if (!isAdjacentSamePlaneTransport(transport)
-                    || System.currentTimeMillis() - waitStartedAt < POST_HANDLE_OBJECT_FAILED_SETTLE_MS) {
-                return false;
+            if (atDestination) {
+                reachedDestination.set(true);
             }
-            WorldPoint playerLoc = Rs2Player.getWorldLocation();
-            if (playerLoc == null || destWait == null || playerLoc.getPlane() != destWait.getPlane()
-                    || Rs2Player.isMoving() || Rs2Player.isAnimating()) {
-                return false;
+            if (newDialogue) {
+                dialogueOpened.set(true);
             }
-            if (isSettledNearAdjacentSamePlaneLanding(transport, playerLoc, destWait, maxInclusive)) {
+            if (settledNearDestination) {
                 settledNearAdjacentDestination.set(true);
-                return true;
             }
-            WorldPoint origin = transport == null ? null : transport.getOrigin();
-            boolean settledAwayFromOrigin = origin != null && playerLoc.distanceTo2D(origin) > 1;
-            if (playerLoc.distanceTo2D(destWait) > Math.max(1, maxInclusive)
-                    && settledAwayFromOrigin) {
+            if (settledAwayFromDestination) {
                 settledAwayFromAdjacentDestination.set(true);
-                return true;
             }
-            return false;
+            return shouldEndObjectTransportLandingPoll(
+                    atDestination, newDialogue, settledNearDestination, settledAwayFromDestination);
         }, POST_HANDLE_OBJECT_LANDING_WAIT_MS);
 
-        if (isNewObjectTransportDialogue(dialogueWasOpen, Rs2Dialogue.isInDialogue())) {
-            return false;
-        }
         if (settledNearAdjacentDestination.get()) {
             WebWalkLog.spInfo("post-handleObject adjacent landing accepted | dest={} at={}",
                     compactWorldPoint(destWait), compactWorldPoint(Rs2Player.getWorldLocation()));
-            return true;
         }
         if (settledAwayFromAdjacentDestination.get()) {
             WebWalkLog.spInfo("post-handleObject adjacent landing failed | dest={} at={}",
                     compactWorldPoint(destWait), compactWorldPoint(Rs2Player.getWorldLocation()));
-            return false;
         }
-        return completed;
+        return resolveObjectTransportLandingWait(
+                reachedDestination.get(),
+                dialogueOpened.get(),
+                settledNearAdjacentDestination.get(),
+                settledAwayFromAdjacentDestination.get(),
+                completed);
     }
 
     static boolean shouldEndObjectTransportPass(boolean landed,
@@ -9467,6 +9477,39 @@ public class Rs2Walker {
 
     static boolean isNewObjectTransportDialogue(boolean dialogueWasOpen, boolean dialogueOpen) {
         return !dialogueWasOpen && dialogueOpen;
+    }
+
+    static boolean shouldYieldObjectTransportDialogue(boolean landed,
+                                                      boolean dialogueWasOpen,
+                                                      boolean dialogueOpen) {
+        return !landed && isNewObjectTransportDialogue(dialogueWasOpen, dialogueOpen);
+    }
+
+    static boolean shouldEndObjectTransportLandingPoll(boolean reachedDestination,
+                                                       boolean dialogueOpened,
+                                                       boolean settledNearDestination,
+                                                       boolean settledAwayFromDestination) {
+        return reachedDestination || dialogueOpened || settledNearDestination || settledAwayFromDestination;
+    }
+
+    static boolean resolveObjectTransportLandingWait(boolean reachedDestination,
+                                                     boolean dialogueOpened,
+                                                     boolean settledNearDestination,
+                                                     boolean settledAwayFromDestination,
+                                                     boolean completed) {
+        if (reachedDestination) {
+            return true;
+        }
+        if (settledNearDestination) {
+            return true;
+        }
+        if (dialogueOpened) {
+            return false;
+        }
+        if (settledAwayFromDestination) {
+            return false;
+        }
+        return completed;
     }
 
     static boolean isSettledNearAdjacentSamePlaneLanding(Transport transport,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/Rs2Walker.java
@@ -566,6 +566,21 @@ public class Rs2Walker {
         return true;
     }
 
+    static boolean shouldRunLocalReachabilityRecovery(boolean tileReachable,
+                                                       boolean inInstance,
+                                                       boolean startupBeforeFirstClick) {
+        return !tileReachable && !inInstance && !startupBeforeFirstClick;
+    }
+
+    static boolean shouldAttemptRouteClick(int waypointDistance,
+                                           int normalDistanceThreshold,
+                                           boolean approachPlannedTransportOrigin,
+                                           boolean startupBeforeFirstClick) {
+        return approachPlannedTransportOrigin
+                || waypointDistance > normalDistanceThreshold
+                || (startupBeforeFirstClick && waypointDistance > 0);
+    }
+
     static boolean shouldRunActiveRouteIdleNudge(boolean idleNudgeDue,
                                                 boolean immediateRouteTransportPending) {
         return idleNudgeDue && !immediateRouteTransportPending;
@@ -1427,6 +1442,7 @@ public class Rs2Walker {
         routeState.interimLastBestPathIdx = -1;
         routeState.interimLastDistanceToTarget = Integer.MAX_VALUE;
         routeState.interimLastRetargetAtMs = 0L;
+        routeState.interimTargetRecovery = false;
         routeState.lastPartialTransRecalcMs = 0L;
         routeState.idleNudgeLastObservedLocation = playerLocWalk;
         routeState.idleNudgeStationarySinceMs = System.currentTimeMillis();
@@ -1651,6 +1667,11 @@ public class Rs2Walker {
                 setTarget(null, "rs2walker:processWalk:not-logged-in");
                 return WalkerState.EXIT;
             }
+            if (Rs2Player.getWorldLocation() == null) {
+                traceProcessWalkExit("player-unavailable", target, processWalkTail);
+                setTarget(null, "rs2walker:processWalk:player-unavailable");
+                return WalkerState.EXIT;
+            }
             if (walkCancelledDiag(target, "processWalk:entry", processWalkTail)) {
                 return WalkerState.EXIT;
             }
@@ -1867,7 +1888,18 @@ public class Rs2Walker {
             primeExpectedTransportDestinations(path, indexOfStartPoint);
 
             routeState.lastPosition = playerLocForIndex;
-            boolean clearedInterimTarget = clearInterimTargetIfReachedOrExpired(routeState.lastPosition, path, System.currentTimeMillis());
+            boolean routeInterimHandoffReady = routeInterimReadyForContinuation(
+                    routeState.interimTargetWp,
+                    routeState.lastPosition,
+                    routeState.interimLastDistanceToTarget,
+                    routeState.interimTargetRecovery,
+                    interimPreclickTiles());
+            boolean clearedInterimTarget = clearInterimTargetIfReachedOrExpired(
+                    routeState.lastPosition, path, System.currentTimeMillis());
+            if (!clearedInterimTarget && routeInterimHandoffReady) {
+                clearInterimTarget("handoff");
+                clearedInterimTarget = true;
+            }
             WorldPoint plImmediate = routeState.lastPosition;
 
             WorldPoint pathLastForImmediate = path.isEmpty() ? null : path.get(path.size() - 1);
@@ -1951,7 +1983,17 @@ public class Rs2Walker {
                     && (target == null
                     || activeInterimPlayer == null
                     || activeInterimPlayer.distanceTo(target) > immediateFinishTh)
-                    && shouldYieldForActiveRouteInterim(activeInterimPlayer, path, activeInterimNowMs)) {
+                    && shouldHoldInterimBeforeRouteScans(
+                    routeState.interimTargetWp,
+                    activeInterimPlayer,
+                    routeState.interimSetAtMs,
+                    routeState.interimLastProgressAtMs,
+                    activeInterimNowMs,
+                    routeState.lastMovedTimeMs,
+                    routeState.interimLastDistanceToTarget,
+                    routeState.interimTargetRecovery,
+                    Rs2Player.isMoving(),
+                    interimPreclickTiles())) {
                 exitReason = "interim-in-flight";
                 WebWalkLog.earlyExit(exitReason,
                         activeInterimPlayer,
@@ -2257,6 +2299,7 @@ public class Rs2Walker {
                 }
 
                 boolean tileReachable = reachableTilesCache.containsKey(currentWorldPoint);
+                boolean startupBeforeFirstClick = currentWalkerPhase() == WalkerPhase.STARTUP;
                 if (!tileReachable && !inInstance) {
                     WorldPoint playerLoc = Rs2Player.getWorldLocation();
                     if (playerLoc != null) {
@@ -2271,7 +2314,7 @@ public class Rs2Walker {
                         }
                     }
                 }
-                if (!tileReachable && !inInstance) {
+                if (shouldRunLocalReachabilityRecovery(tileReachable, inInstance, startupBeforeFirstClick)) {
                     WorldPoint playerLoc = Rs2Player.getWorldLocation();
                     if (playerLoc != null) {
                         int unreachableDist = currentWorldPoint.distanceTo2D(playerLoc);
@@ -2667,6 +2710,7 @@ public class Rs2Walker {
                                 routeState.interimLastBestPathIdx = getClosestTileIndex(path, playerLoc);
                                 routeState.interimLastDistanceToTarget = distanceToInterimOrMax(clickedRecoveryTarget, playerLoc);
                                 routeState.interimLastRetargetAtMs = routeState.interimSetAtMs;
+                                routeState.interimTargetRecovery = true;
                                 WorldPoint pathLastRecovery = path.get(path.size() - 1);
                                 int finishThRecovery = tightFinishThreshold(target, pathLastRecovery, distance);
                                 waitForMovementStartAfterRecovery(target, playerLoc, clickedRecoveryTarget, target,
@@ -2684,6 +2728,10 @@ public class Rs2Walker {
                     }
                     continue;
                 }
+                // Before the first movement click, let the normal route selector choose a reachable raw-path
+                // target. Running speculative local recovery here repeats the startup scans skipped above and
+                // can spend several timeout windows on a smoothed waypoint across a wall. The final click path
+                // still calls handlePendingDoorBeforeRouteClick, so an actual nearby door remains protected.
                 // A door was just interacted with (settling window still active) but traversal isn't
                 // yet confirmed, so this forward tile may sit *behind* the opening door. Issuing the
                 // minimap click now cancels the in-progress open ("click door, then immediately click
@@ -2701,7 +2749,8 @@ public class Rs2Walker {
                         currentWorldPoint,
                         Rs2Player.getWorldLocation(),
                         RAW_TRANSPORT_DISPATCH_MAX_DISTANCE);
-                if (dist2d > nextWalkingDistance || approachPlannedTransportOrigin) {
+                if (shouldAttemptRouteClick(dist2d, nextWalkingDistance,
+                        approachPlannedTransportOrigin, startupBeforeFirstClick)) {
                     tmarkPostTransport("post_transport_click_eligibility", target,
                             "i=" + i + " dist2d=" + dist2d + " threshold=" + nextWalkingDistance
                                     + (approachPlannedTransportOrigin ? " reason=transport_approach" : ""));
@@ -2716,8 +2765,12 @@ public class Rs2Walker {
 					WorldPoint interim = routeState.interimTargetWp;
 					if (interim != null && interim.getPlane() == playerLoc.getPlane()) {
 						int interimDist = interim.distanceTo2D(playerLoc);
+						boolean routeHandoffReady = false;
 						if (interimDist > INTERIM_CLOSE_TILES) {
 							final WorldPoint interimFinal = interim;
+							final int bestDistanceBeforeWait = routeState.interimLastDistanceToTarget;
+							final int preclickTiles = interimPreclickTiles();
+							WorldPoint posAfterWait = playerLoc;
 							// If we're already moving toward the interim checkpoint, just wait until
 							// we get close. If we've stopped (no movement), re-click the same interim
 							// rather than spinning without issuing movement commands.
@@ -2725,61 +2778,53 @@ public class Rs2Walker {
                                 if (!inInstance && handlePendingDoorDuringInterim(rawPath,
                                         obstaclePolicy.segmentDoorTimeoutMs(), doorEdgesAttemptedThisTail,
                                         playerLoc)) {
-                                    routeState.interimTargetWp = null;
-                                    routeState.interimTargetIdx = -1;
-                                    routeState.interimSetAtMs = 0L;
-                                    routeState.interimLastProgressAtMs = 0L;
-                                    routeState.interimLastBestPathIdx = -1;
-                                    routeState.interimLastDistanceToTarget = Integer.MAX_VALUE;
-                                    routeState.interimLastRetargetAtMs = 0L;
+                                    clearInterimTarget("door-handled-during-interim");
                                     doorOrTransportResult = true;
                                     exitReason = "door-handled-during-interim";
                                     break;
-                                }
+								}
 								final WorldPoint posBeforeWait = playerLoc;
-								final int preclickTiles = interimPreclickTiles();
 								sleepUntil(() ->
 												isWithinRouteHandoffRadius(Rs2Player.getWorldLocation(), interimFinal, preclickTiles)
 														|| !Rs2Player.isMoving(),
 										INTERIM_MOVING_POLL_MS);
-                                WorldPoint posAfterWait = Rs2Player.getWorldLocation();
+                                posAfterWait = Rs2Player.getWorldLocation();
                                 recordInterimDistanceProgress(interimFinal, posAfterWait, System.currentTimeMillis());
 								if ((posAfterWait != null && posBeforeWait.distanceTo2D(posAfterWait) > 0)
                                         || Rs2Player.isMoving()) {
 									routeState.lastMovedTimeMs = System.currentTimeMillis();
 									routeState.stuckCount = 0;
                                 }
-                                boolean closeEnoughForNextClick = isWithinRouteHandoffRadius(
-                                        posAfterWait, interimFinal, preclickTiles);
-                                if (!closeEnoughForNextClick && Rs2Player.isMoving()) {
-                                    exitReason = "interim-in-flight";
-                                    walkerDiag("interim-in-flight interim=%s interimDist=%d player=%s moving=true",
-                                            interimFinal,
-                                            posAfterWait == null ? interimDist : interimFinal.distanceTo2D(posAfterWait),
-                                            posAfterWait == null ? playerLoc : posAfterWait);
-                                    break;
-                                }
-							} else {
-								// Not moving but still far from the interim checkpoint. Treat the interim
-								// as stale and pick a fresh checkpoint below (could still resolve to the
-								// same tile, but ensures we actually issue a new click).
-								routeState.interimTargetWp = null;
-								routeState.interimTargetIdx = -1;
-								routeState.interimSetAtMs = 0L;
-								routeState.interimLastProgressAtMs = 0L;
-								routeState.interimLastBestPathIdx = -1;
-                                routeState.interimLastDistanceToTarget = Integer.MAX_VALUE;
-								routeState.interimLastRetargetAtMs = 0L;
+							}
+							routeHandoffReady = routeInterimReadyForContinuation(
+									interimFinal,
+									posAfterWait,
+									bestDistanceBeforeWait,
+									routeState.interimTargetRecovery,
+									preclickTiles);
+							if (shouldHoldInterimBeforeRouteScans(
+									interimFinal,
+									posAfterWait,
+									routeState.interimSetAtMs,
+									routeState.interimLastProgressAtMs,
+									System.currentTimeMillis(),
+									routeState.lastMovedTimeMs,
+									bestDistanceBeforeWait,
+									routeState.interimTargetRecovery,
+									Rs2Player.isMoving(),
+									preclickTiles)) {
+								exitReason = "interim-in-flight";
+								walkerDiag("interim-in-flight interim=%s interimDist=%d player=%s moving=%s",
+										interimFinal,
+										posAfterWait == null ? interimDist : interimFinal.distanceTo2D(posAfterWait),
+										posAfterWait == null ? playerLoc : posAfterWait,
+										Rs2Player.isMoving());
+								break;
 							}
 						}
-						// Close enough: allow selecting a new checkpoint.
-						routeState.interimTargetWp = null;
-						routeState.interimTargetIdx = -1;
-						routeState.interimSetAtMs = 0L;
-						routeState.interimLastProgressAtMs = 0L;
-						routeState.interimLastBestPathIdx = -1;
-                        routeState.interimLastDistanceToTarget = Integer.MAX_VALUE;
-						routeState.interimLastRetargetAtMs = 0L;
+						clearInterimTarget(interimDist <= INTERIM_CLOSE_TILES
+								? "close"
+								: routeHandoffReady ? "handoff" : "stale-progress");
 					}
 
                     int targetIdx = RouteRecovery.findFurthestForwardClickableIndex(path, i, playerLoc,
@@ -2919,6 +2964,7 @@ public class Rs2Walker {
 						routeState.interimLastBestPathIdx = getClosestTileIndex(path, posBefore);
                         routeState.interimLastDistanceToTarget = distanceToInterimOrMax(clickedTarget, posBefore);
 						routeState.interimLastRetargetAtMs = nowMs;
+                        routeState.interimTargetRecovery = false;
 
                         final WorldPoint b = targetWp;
                         final WorldPoint before = posBefore;
@@ -3083,7 +3129,9 @@ public class Rs2Walker {
                         }
                     }
 
-                    if (Rs2Tile.isTileReachable(finalTile) && Rs2Player.getWorldLocation().distanceTo(finalTile) >= finishTh) {
+                    WorldPoint finalApproachPlayer = Rs2Player.getWorldLocation();
+                    if (finalApproachPlayer != null && Rs2Tile.isTileReachable(finalTile)
+                            && finalApproachPlayer.distanceTo(finalTile) >= finishTh) {
                         final WorldPoint canvasClickWp = finalTile;
                         WorldPoint finalPlayerLoc = Rs2Player.getWorldLocation();
                         boolean finalClick;
@@ -3113,7 +3161,13 @@ public class Rs2Walker {
             }
             WorldPoint pathLastForFinish = path.get(path.size() - 1);
             int finishThreshold = tightFinishThreshold(target, pathLastForFinish, distance);
-            int finalDist = Rs2Player.getWorldLocation().distanceTo(target);
+            WorldPoint finalPlayerLocation = Rs2Player.getWorldLocation();
+            if (finalPlayerLocation == null) {
+                traceProcessWalkExit("player-unavailable-after-movement", target, processWalkTail);
+                setTarget(null, "rs2walker:processWalk:player-unavailable-after-movement");
+                return WalkerState.EXIT;
+            }
+            int finalDist = finalPlayerLocation.distanceTo(target);
             if (finalDist <= finishThreshold) {
                 setTarget(null, "rs2walker:processWalk:arrived-within-distance");
                 return WalkerState.ARRIVED;
@@ -3221,7 +3275,7 @@ public class Rs2Walker {
                 walkerDiag("continue outer tail nextIdx=%d exitReason=%s finalDist=%d partialPath=%s",
                         processWalkTail + 1,
                         exitReason,
-                        Rs2Player.getWorldLocation().distanceTo(target),
+                        finalDist,
                         partialPath);
                 continue;
             }
@@ -4068,6 +4122,7 @@ public class Rs2Walker {
         routeState.interimLastBestPathIdx = getClosestTileIndex(path, playerLoc);
         routeState.interimLastDistanceToTarget = distanceToInterimOrMax(clickedTarget, playerLoc);
         routeState.interimLastRetargetAtMs = routeState.interimSetAtMs;
+        routeState.interimTargetRecovery = markRecoveryCooldown;
         if (markRecoveryCooldown) {
             routeState.lastUnreachableRecoveryClickAtMs = routeState.interimSetAtMs;
         }
@@ -6537,6 +6592,61 @@ public class Rs2Walker {
         return runEnabled ? INTERIM_RUN_PRECLICK_TILES : INTERIM_PRECLICK_TILES;
     }
 
+    static boolean routeInterimReadyForContinuation(WorldPoint interim,
+                                                     WorldPoint playerLoc,
+                                                     int bestDistanceSeen,
+                                                     boolean recoveryOwned,
+                                                     int handoffTiles) {
+        int currentDistance = distanceToInterimOrMax(interim, playerLoc);
+        return !recoveryOwned
+                && bestDistanceSeen != Integer.MAX_VALUE
+                && currentDistance < bestDistanceSeen
+                && isWithinRouteHandoffRadius(playerLoc, interim, handoffTiles);
+    }
+
+    static boolean shouldHoldInterimBeforeRouteScans(WorldPoint interim,
+                                                     WorldPoint playerLoc,
+                                                     long setAtMs,
+                                                     long lastProgressAtMs,
+                                                     long nowMs,
+                                                     long lastMovedAtMs,
+                                                     int bestDistanceSeen,
+                                                     boolean recoveryOwned,
+                                                     boolean playerMoving,
+                                                     int routeHandoffTiles) {
+        if (interim == null || shouldClearInterimTarget(interim, playerLoc, setAtMs,
+                lastProgressAtMs, nowMs, bestDistanceSeen)) {
+            return false;
+        }
+        if (recoveryOwned) {
+            return shouldDeferRouteWorkForActiveInterim(interim,
+                    playerLoc,
+                    setAtMs,
+                    lastProgressAtMs,
+                    nowMs,
+                    lastMovedAtMs,
+                    playerMoving,
+                    INTERIM_CLOSE_TILES);
+        }
+        if (routeInterimReadyForContinuation(
+                interim, playerLoc, bestDistanceSeen, false, routeHandoffTiles)) {
+            return false;
+        }
+        if (isWithinRouteHandoffRadius(playerLoc, interim, routeHandoffTiles)) {
+            return playerMoving
+                    || isRecentEvent(nowMs, lastProgressAtMs, INTERIM_PROGRESS_TIMEOUT_MS)
+                    || isRecentEvent(nowMs, lastMovedAtMs, RECOVERY_MOVEMENT_IN_FLIGHT_MS);
+        }
+        return shouldDeferRouteWorkForActiveInterim(interim,
+                playerLoc,
+                setAtMs,
+                lastProgressAtMs,
+                nowMs,
+                lastMovedAtMs,
+                playerMoving,
+                routeHandoffTiles);
+    }
+
     static boolean shouldClearInterimTarget(WorldPoint interim,
                                             WorldPoint playerLoc,
                                             long setAtMs,
@@ -6800,7 +6910,7 @@ public class Rs2Walker {
     private static void clearInterimTarget(String reason) {
         WorldPoint old = routeState.interimTargetWp;
         if (old != null) {
-            if ("close".equals(reason)) {
+            if ("close".equals(reason) || "handoff".equals(reason)) {
                 WebWalkLog.spDebug("interim_clear | reason={} interim={}", reason, compactWorldPoint(old));
             } else {
                 WebWalkLog.spInfo("interim_clear | reason={} interim={}", reason, compactWorldPoint(old));
@@ -6813,6 +6923,7 @@ public class Rs2Walker {
         routeState.interimLastBestPathIdx = -1;
         routeState.interimLastDistanceToTarget = Integer.MAX_VALUE;
         routeState.interimLastRetargetAtMs = 0L;
+        routeState.interimTargetRecovery = false;
     }
 
     private static boolean shouldThrottleGlobalDoorInteraction() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2DoorAheadResolver.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2DoorAheadResolver.java
@@ -7,10 +7,25 @@ import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Stateless helpers for resolving door interactions ahead of the player during path traversal.
+ * Generates probe points for diagonal path segments and checks whether path edges are blocked
+ * by collision or line-of-sight obstacles. Extracted from {@code Rs2Walker} — pure functions
+ * over {@link WorldPoint} and reachability checks, no walker state.
+ */
 public final class Rs2DoorAheadResolver {
     private Rs2DoorAheadResolver() {
     }
 
+    /**
+     * Generates a list of probe points for door detection along a path segment.
+     * For diagonal segments, includes intermediate corner points to handle doors on either axis.
+     *
+     * @param fromWp the starting point of the path segment
+     * @param toWp the ending point of the path segment
+     * @param doorWp the door's world location
+     * @return a list of probe points including the door location and diagonal corners if applicable
+     */
     public static List<WorldPoint> buildSegmentProbes(WorldPoint fromWp, WorldPoint toWp, WorldPoint doorWp) {
         if (fromWp == null || toWp == null || doorWp == null) {
             return List.of();
@@ -27,6 +42,13 @@ public final class Rs2DoorAheadResolver {
         return probes;
     }
 
+    /**
+     * Checks whether a path edge between two points is blocked by collision or line-of-sight obstacles.
+     *
+     * @param from the starting point of the edge
+     * @param to the ending point of the edge
+     * @return true if the edge is blocked (unreachable or no line of sight), false otherwise
+     */
     public static boolean isPathEdgeBlocked(WorldPoint from, WorldPoint to) {
         if (from == null || to == null) {
             return false;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2DoorAheadResolver.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2DoorAheadResolver.java
@@ -8,10 +8,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Stateless helpers for resolving door interactions ahead of the player during path traversal.
- * Generates probe points for diagonal path segments and checks whether path edges are blocked
- * by collision or line-of-sight obstacles. Extracted from {@code Rs2Walker} — pure functions
- * over {@link WorldPoint} and reachability checks, no walker state.
+ * Helpers for resolving door interactions ahead of the player during path traversal.
+ * Probe-point generation is stateless, while reachability checks consult live collision and
+ * line-of-sight state and marshal client access through the client thread. This class stores no
+ * walker route state.
  */
 public final class Rs2DoorAheadResolver {
     private Rs2DoorAheadResolver() {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2DoorGeometry.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2DoorGeometry.java
@@ -15,11 +15,29 @@ public final class Rs2DoorGeometry {
     private Rs2DoorGeometry() {
     }
 
+    /**
+     * Checks whether a door object sits on the given path segment. Delegates to the overloaded
+     * variant with explicit location to avoid redundant {@code getWorldLocation()} calls.
+     *
+     * @param object the door/gate tile object
+     * @param fromWp the starting point of the path segment
+     * @param toWp the ending point of the path segment
+     * @return true if the door is on the segment, false otherwise
+     */
     public static boolean isDoorOnSegment(TileObject object, WorldPoint fromWp, WorldPoint toWp) {
         return isDoorOnSegment(object, object == null ? null : object.getWorldLocation(), fromWp, toWp);
     }
 
-    /** As above, with the object's location supplied (see {@link #wallDoorTouchesSegment}). */
+    /**
+     * As above, with the object's location supplied. Optimized for batch door detection to avoid
+     * redundant {@code getWorldLocation()} calls (see {@link #wallDoorTouchesSegment}).
+     *
+     * @param object the door/gate tile object
+     * @param objectLocation the pre-fetched world location of the object
+     * @param fromWp the starting point of the path segment
+     * @param toWp the ending point of the path segment
+     * @return true if the door is on the segment, false otherwise
+     */
     public static boolean isDoorOnSegment(TileObject object, WorldPoint objectLocation,
                                           WorldPoint fromWp, WorldPoint toWp) {
         if (object == null || objectLocation == null) return false;
@@ -29,6 +47,19 @@ public final class Rs2DoorGeometry {
         return isPointNearSegment(objectLocation, fromWp, toWp, 1);
     }
 
+    /**
+     * Checks whether the player is within interaction range of a door on the given path segment.
+     * Considers the door's location, the probe point, and both segment endpoints to find the
+     * closest approach distance.
+     *
+     * @param object the door/gate tile object
+     * @param probe the probe point for door detection
+     * @param fromWp the starting point of the path segment
+     * @param toWp the ending point of the path segment
+     * @param playerLoc the player's current world location
+     * @param rangeTiles the maximum interaction range in tiles
+     * @return true if any relevant point is within range, false otherwise
+     */
     public static boolean isDoorInteractionWithinRange(TileObject object, WorldPoint probe,
                                                        WorldPoint fromWp, WorldPoint toWp,
                                                        WorldPoint playerLoc, int rangeTiles) {
@@ -52,6 +83,15 @@ public final class Rs2DoorGeometry {
         return best <= rangeTiles;
     }
 
+    /**
+     * Checks whether a wall door's blocked edge intersects the given path segment. Delegates to
+     * the overloaded variant with explicit location to avoid redundant {@code getWorldLocation()} calls.
+     *
+     * @param wall the wall door object
+     * @param fromWp the starting point of the path segment
+     * @param toWp the ending point of the path segment
+     * @return true if the wall door blocks the segment, false otherwise
+     */
     public static boolean wallDoorTouchesSegment(WallObject wall, WorldPoint fromWp, WorldPoint toWp) {
         return wallDoorTouchesSegment(wall, wall == null ? null : wall.getWorldLocation(), fromWp, toWp);
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2DoorHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2DoorHandler.java
@@ -5,10 +5,26 @@ import net.runelite.client.plugins.microbot.util.walker.door.model.DoorEdge;
 
 import java.util.Map;
 
+/**
+ * Stateless throttling and cooldown management for door interactions during path traversal.
+ * Tracks per-edge door attempts and stationary door open events to prevent redundant interactions
+ * and respect game timing constraints. Extracted from {@code Rs2Walker}; methods use the current
+ * wall-clock time and may mutate the supplied cooldown maps.
+ */
 public final class Rs2DoorHandler {
     private Rs2DoorHandler() {
     }
 
+    /**
+     * Generates a key for a door interaction attempt. When both endpoints are available, the key is
+     * a direction-independent normalized key for the path edge; otherwise, it includes the supplied
+     * door and endpoint values.
+     *
+     * @param doorTile the door's world location
+     * @param fromWp the starting point of the path segment
+     * @param toWp the ending point of the path segment
+     * @return a unique string key representing this door attempt
+     */
     public static String doorAttemptKey(WorldPoint doorTile, WorldPoint fromWp, WorldPoint toWp) {
         if (fromWp != null && toWp != null) {
             return new DoorEdge(fromWp, toWp).normalizedKey();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2DoorHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2DoorHandler.java
@@ -32,6 +32,17 @@ public final class Rs2DoorHandler {
         return compactWorldPoint(doorTile) + "|" + compactWorldPoint(fromWp) + "->" + compactWorldPoint(toWp);
     }
 
+    /**
+     * Checks whether a door interaction attempt should be throttled based on recent attempts.
+     * Cleans up expired entries from the cooldown map as a side effect.
+     *
+     * @param recentDoorAttemptByEdge map tracking recent door attempt timestamps by edge key
+     * @param cooldownMs the cooldown duration in milliseconds
+     * @param doorTile the door's world location
+     * @param fromWp the starting point of the path segment
+     * @param toWp the ending point of the path segment
+     * @return true if the door attempt should be throttled, false if it can proceed
+     */
     public static boolean shouldThrottleDoorAttempt(Map<String, Long> recentDoorAttemptByEdge,
                                                     long cooldownMs,
                                                     WorldPoint doorTile,
@@ -44,6 +55,14 @@ public final class Rs2DoorHandler {
         return last != null && now - last < cooldownMs;
     }
 
+    /**
+     * Records a door interaction attempt with the current timestamp in the cooldown map.
+     *
+     * @param recentDoorAttemptByEdge map tracking recent door attempt timestamps by edge key
+     * @param doorTile the door's world location
+     * @param fromWp the starting point of the path segment
+     * @param toWp the ending point of the path segment
+     */
     public static void markDoorAttempt(Map<String, Long> recentDoorAttemptByEdge,
                                        WorldPoint doorTile,
                                        WorldPoint fromWp,
@@ -51,12 +70,28 @@ public final class Rs2DoorHandler {
         recentDoorAttemptByEdge.put(doorAttemptKey(doorTile, fromWp, toWp), System.currentTimeMillis());
     }
 
+    /**
+     * Records that a stationary door at the given location was opened with the current timestamp.
+     *
+     * @param recentlyOpenedStationaryDoors map tracking recently opened stationary doors by location
+     * @param doorTile the door's world location, or null to skip recording
+     */
     public static void markStationaryDoorOpened(Map<WorldPoint, Long> recentlyOpenedStationaryDoors, WorldPoint doorTile) {
         if (doorTile != null) {
             recentlyOpenedStationaryDoors.put(doorTile, System.currentTimeMillis());
         }
     }
 
+    /**
+     * Checks whether a stationary door was recently opened near the given path segment.
+     * Cleans up expired entries from the tracking map as a side effect.
+     *
+     * @param recentlyOpenedStationaryDoors map tracking recently opened stationary doors by location
+     * @param suppressMs the time window in milliseconds to consider a door "recently opened"
+     * @param fromWp the starting point of the path segment
+     * @param toWp the ending point of the path segment
+     * @return true if a recently opened door is within 2 tiles of either segment endpoint
+     */
     public static boolean recentlyOpenedStationaryDoorOnSegment(Map<WorldPoint, Long> recentlyOpenedStationaryDoors,
                                                                 long suppressMs,
                                                                 WorldPoint fromWp,
@@ -73,10 +108,22 @@ public final class Rs2DoorHandler {
                         && (door.distanceTo2D(fromWp) <= segmentDoorSuppressDist || door.distanceTo2D(toWp) <= segmentDoorSuppressDist));
     }
 
+    /**
+     * Checks whether the global door interaction cooldown is still active.
+     *
+     * @param nextDoorInteractionAllowedAtMs the earliest timestamp when the next interaction is allowed
+     * @return true if the cooldown is still active and interactions should be throttled
+     */
     public static boolean shouldThrottleGlobalDoorInteraction(long nextDoorInteractionAllowedAtMs) {
         return System.currentTimeMillis() < nextDoorInteractionAllowedAtMs;
     }
 
+    /**
+     * Computes the timestamp when the next global door interaction should be allowed.
+     *
+     * @param cooldownMs the cooldown duration in milliseconds
+     * @return the timestamp (in milliseconds since epoch) when the next interaction is allowed
+     */
     public static long markGlobalDoorInteractionCooldown(long cooldownMs) {
         return System.currentTimeMillis() + cooldownMs;
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2WalkerAwaits.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2WalkerAwaits.java
@@ -27,6 +27,10 @@ public final class Rs2WalkerAwaits {
         return new AwaitTicket(System.currentTimeMillis(), Rs2Player.getWorldLocation());
     }
 
+    public static AwaitTicket beginTicket(WorldPoint beforePosition) {
+        return new AwaitTicket(System.currentTimeMillis(), beforePosition);
+    }
+
     /**
      * A door that answered with a conversation is never going to move us while we stand here waiting
      * for movement, so waiting out the full budget just burns the window in which the menu could be

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2WalkerAwaits.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2WalkerAwaits.java
@@ -14,6 +14,7 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 public final class Rs2WalkerAwaits {
     private static final int DOOR_INTERACTION_START_WAIT_MS = 700;
     private static final int DOOR_TRAVERSAL_PROGRESS_WAIT_MS = 2200;
+    private static final long DOOR_APPROACH_IN_FLIGHT_MS = 4_000L;
     /** Stationary and not animating for longer than this, with the edge unresolved, means the click didn't land. */
     private static final long DOOR_IDLE_ACCEPT_MIN_MS = 1_200L;
     /** Above this combined wait, say which condition released the door await. */
@@ -80,11 +81,16 @@ public final class Rs2WalkerAwaits {
                 releasedBy[0] = "arrived-far-side";
                 return true;
             }
+            long elapsedMs = System.currentTimeMillis() - ticket.startedAtMs();
+            if (isDoorApproachInFlight(ticket.beforePosition(), now, fromWp, toWp,
+                    Rs2Player.isMoving(), elapsedMs, DOOR_APPROACH_IN_FLIGHT_MS)) {
+                releasedBy[0] = "approach-started";
+                return true;
+            }
             if (hasMeaningfulDoorProgress(ticket.beforePosition(), now, fromWp, toWp)) {
                 releasedBy[0] = "progress";
                 return true;
             }
-            long elapsedMs = System.currentTimeMillis() - ticket.startedAtMs();
             boolean idleAccepted = shouldAcceptIdleDoorAwait(
                     Rs2Player.isMoving(),
                     Rs2Player.isAnimating(),
@@ -184,5 +190,29 @@ public final class Rs2WalkerAwaits {
         int beforeFrom = before.distanceTo2D(fromWp);
         int nowFrom = now.distanceTo2D(fromWp);
         return nowTo < beforeTo && nowFrom >= beforeFrom;
+    }
+
+    public static boolean isDoorApproachInFlight(WorldPoint before, WorldPoint now,
+                                                  WorldPoint fromWp, WorldPoint toWp,
+                                                  boolean moving, long ageMs, long maxAgeMs) {
+        if (!moving || ageMs < 0L || ageMs > maxAgeMs
+                || before == null || now == null || fromWp == null || toWp == null
+                || before.equals(now)) {
+            return false;
+        }
+        int plane = before.getPlane();
+        if (now.getPlane() != plane || fromWp.getPlane() != plane || toWp.getPlane() != plane) {
+            return false;
+        }
+        if (Rs2WalkerProgress.isWithinChebyshev(now, toWp, 1)) {
+            return false;
+        }
+
+        int nowFrom = now.distanceTo2D(fromWp);
+        int nowTo = now.distanceTo2D(toWp);
+        if (nowTo + 1 < nowFrom) {
+            return false;
+        }
+        return nowFrom < before.distanceTo2D(fromWp);
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/model/AwaitTicket.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/model/AwaitTicket.java
@@ -2,19 +2,40 @@ package net.runelite.client.plugins.microbot.util.walker.door.model;
 
 import net.runelite.api.coords.WorldPoint;
 
+/**
+ * Immutable ticket representing a pending door interaction await state.
+ * Captures the timestamp when the await began and the player's position before the interaction,
+ * used to detect timeout conditions and verify successful transitions.
+ */
 public final class AwaitTicket {
     private final long startedAtMs;
     private final WorldPoint beforePosition;
 
+    /**
+     * Creates a new await ticket.
+     *
+     * @param startedAtMs the timestamp (in milliseconds since epoch) when the await began
+     * @param beforePosition the player's world location before the door interaction
+     */
     public AwaitTicket(long startedAtMs, WorldPoint beforePosition) {
         this.startedAtMs = startedAtMs;
         this.beforePosition = beforePosition;
     }
 
+    /**
+     * Returns the timestamp when this await began.
+     *
+     * @return the start timestamp in milliseconds since epoch
+     */
     public long startedAtMs() {
         return startedAtMs;
     }
 
+    /**
+     * Returns the player's position before the door interaction.
+     *
+     * @return the world location before the interaction
+     */
     public WorldPoint beforePosition() {
         return beforePosition;
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/model/DoorCandidate.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/model/DoorCandidate.java
@@ -3,6 +3,11 @@ package net.runelite.client.plugins.microbot.util.walker.door.model;
 import net.runelite.api.TileObject;
 import net.runelite.api.coords.WorldPoint;
 
+/**
+ * Immutable candidate representing a door/gate object identified for potential interaction
+ * during path traversal. Contains the door object, probe point, path segment endpoints,
+ * intended action, and detection mode for debugging and decision-making.
+ */
 public final class DoorCandidate {
     private final TileObject object;
     private final WorldPoint probe;
@@ -11,6 +16,16 @@ public final class DoorCandidate {
     private final String action;
     private final String mode;
 
+    /**
+     * Creates a new door candidate.
+     *
+     * @param object the door/gate tile object
+     * @param probe the probe point used for door detection
+     * @param from the starting point of the path segment
+     * @param to the ending point of the path segment
+     * @param action the menu action to use for interacting with the door
+     * @param mode the detection mode (e.g., "ahead", "blocking") for debugging
+     */
     public DoorCandidate(TileObject object, WorldPoint probe, WorldPoint from, WorldPoint to, String action, String mode) {
         this.object = object;
         this.probe = probe;
@@ -20,26 +35,56 @@ public final class DoorCandidate {
         this.mode = mode;
     }
 
+    /**
+     * Returns the door/gate tile object.
+     *
+     * @return the tile object
+     */
     public TileObject object() {
         return object;
     }
 
+    /**
+     * Returns the probe point used for door detection.
+     *
+     * @return the probe world location
+     */
     public WorldPoint probe() {
         return probe;
     }
 
+    /**
+     * Returns the starting point of the path segment.
+     *
+     * @return the from world location
+     */
     public WorldPoint from() {
         return from;
     }
 
+    /**
+     * Returns the ending point of the path segment.
+     *
+     * @return the to world location
+     */
     public WorldPoint to() {
         return to;
     }
 
+    /**
+     * Returns the menu action to use for interacting with the door.
+     *
+     * @return the action string (e.g., "Open", "Walk-through")
+     */
     public String action() {
         return action;
     }
 
+    /**
+     * Returns the detection mode for debugging purposes.
+     *
+     * @return the mode string describing how this candidate was detected
+     */
     public String mode() {
         return mode;
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/model/DoorEdge.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/model/DoorEdge.java
@@ -2,15 +2,32 @@ package net.runelite.client.plugins.microbot.util.walker.door.model;
 
 import net.runelite.api.coords.WorldPoint;
 
+/**
+ * Immutable bidirectional edge between two world points, representing a door passage.
+ * Generates normalized keys for use in throttling maps, where the same physical door
+ * edge should produce the same key regardless of traversal direction.
+ */
 public final class DoorEdge {
     private final WorldPoint from;
     private final WorldPoint to;
 
+    /**
+     * Creates a new door edge between two world points.
+     *
+     * @param from the starting point of the edge
+     * @param to the ending point of the edge
+     */
     public DoorEdge(WorldPoint from, WorldPoint to) {
         this.from = from;
         this.to = to;
     }
 
+    /**
+     * Generates a normalized key for this edge. The key is direction-independent:
+     * an edge from A to B produces the same key as an edge from B to A.
+     *
+     * @return a normalized string key representing this bidirectional edge
+     */
     public String normalizedKey() {
         String a = compact(from);
         String b = compact(to);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/model/DoorResolution.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/door/model/DoorResolution.java
@@ -1,9 +1,23 @@
 package net.runelite.client.plugins.microbot.util.walker.door.model;
 
+/**
+ * Enumeration of door interaction resolution states during path traversal.
+ * Indicates whether a door interaction succeeded, is still awaiting completion,
+ * or failed for a specific reason.
+ */
 public enum DoorResolution {
+    /** The door interaction completed successfully and the path is now passable. */
     RESOLVED,
+
+    /** The door interaction is in progress and awaiting completion. */
     AWAITING,
+
+    /** The door interaction failed due to timeout. */
     FAILED_TIMEOUT,
+
+    /** The door interaction was cancelled before completion. */
     FAILED_CANCELLED,
+
+    /** The door interaction failed due to invalid state or preconditions. */
     FAILED_INVALID
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/state/WalkerRouteState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/state/WalkerRouteState.java
@@ -62,6 +62,8 @@ public final class WalkerRouteState {
     public volatile int interimLastDistanceToTarget = Integer.MAX_VALUE;
     /** Wall-clock ms the interim target was last re-chosen. */
     public volatile long interimLastRetargetAtMs = 0L;
+    /** Whether the current interim target was issued by recovery rather than normal route flow. */
+    public volatile boolean interimTargetRecovery = false;
 
     // ---- idle nudge: detects a stationary player mid-route and re-clicks to un-stick. ----
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/state/WalkerRouteState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/state/WalkerRouteState.java
@@ -109,6 +109,8 @@ public final class WalkerRouteState {
     /** Origin/destination/time of the last door interaction attempt (wrong-traversal detection reads these). */
     public volatile WorldPoint lastDoorAttemptFrom = null;
     public volatile WorldPoint lastDoorAttemptTo = null;
+    /** Player tile when the last door click was dispatched; used to recognize ranged approach progress. */
+    public volatile WorldPoint lastDoorAttemptPlayerPosition = null;
     public volatile long lastDoorAttemptAtMs = 0L;
     /** Global door-interaction throttle: no door interaction may fire before this wall-clock ms. */
     public volatile long nextDoorInteractionAllowedAtMs = 0L;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaits.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaits.java
@@ -16,14 +16,22 @@ public final class Rs2WalkerTransportAwaits {
         if (before == null) {
             return false;
         }
-        sleepUntil(() -> {
+        boolean progressedDuringWait = sleepUntil(() -> {
             WorldPoint now = Rs2Player.getWorldLocation();
             return hasTransportProgress(before, now, expectedDestination, target,
                     dialogueWasOpen, Rs2Dialogue.isInDialogue());
         }, 1800);
         WorldPoint after = Rs2Player.getWorldLocation();
-        return hasTransportProgress(before, after, expectedDestination, target,
+        return resolveTransportProgress(progressedDuringWait, before, after, expectedDestination, target,
                 dialogueWasOpen, Rs2Dialogue.isInDialogue());
+    }
+
+    static boolean resolveTransportProgress(boolean progressedDuringWait,
+                                            WorldPoint before, WorldPoint after,
+                                            WorldPoint expectedDestination, WorldPoint target,
+                                            boolean dialogueWasOpen, boolean dialogueOpen) {
+        return progressedDuringWait || hasTransportProgress(
+                before, after, expectedDestination, target, dialogueWasOpen, dialogueOpen);
     }
 
     static boolean hasTransportProgress(WorldPoint before, WorldPoint now, WorldPoint expectedDestination,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaits.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaits.java
@@ -1,6 +1,7 @@
 package net.runelite.client.plugins.microbot.util.walker.transport;
 
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.shared.Rs2WalkerProgress;
 
@@ -10,15 +11,24 @@ public final class Rs2WalkerTransportAwaits {
     private Rs2WalkerTransportAwaits() {
     }
 
-    public static boolean didCurrentTileTransportProgress(WorldPoint before, WorldPoint expectedDestination, WorldPoint target) {
+    public static boolean didCurrentTileTransportProgress(WorldPoint before, WorldPoint expectedDestination,
+                                                          WorldPoint target, boolean dialogueWasOpen) {
         if (before == null) {
             return false;
         }
         sleepUntil(() -> {
             WorldPoint now = Rs2Player.getWorldLocation();
-            return Rs2WalkerProgress.hasMovementOrProgress(before, now, expectedDestination, target);
+            return hasTransportProgress(before, now, expectedDestination, target,
+                    dialogueWasOpen, Rs2Dialogue.isInDialogue());
         }, 1800);
         WorldPoint after = Rs2Player.getWorldLocation();
-        return Rs2WalkerProgress.hasMovementOrProgress(before, after, expectedDestination, target);
+        return hasTransportProgress(before, after, expectedDestination, target,
+                dialogueWasOpen, Rs2Dialogue.isInDialogue());
+    }
+
+    static boolean hasTransportProgress(WorldPoint before, WorldPoint now, WorldPoint expectedDestination,
+                                        WorldPoint target, boolean dialogueWasOpen, boolean dialogueOpen) {
+        return !dialogueWasOpen && dialogueOpen
+                || Rs2WalkerProgress.hasMovementOrProgress(before, now, expectedDestination, target);
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaits.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaits.java
@@ -1,5 +1,7 @@
 package net.runelite.client.plugins.microbot.util.walker.transport;
 
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
@@ -14,7 +16,7 @@ public final class Rs2WalkerTransportAwaits {
     public static boolean didCurrentTileTransportProgress(WorldPoint before, WorldPoint expectedDestination,
                                                           WorldPoint target, boolean dialogueWasOpen) {
         if (before == null) {
-            return hasProgressWithoutPositionSnapshot(dialogueWasOpen, Rs2Dialogue.isInDialogue());
+            return waitForProgressWithoutPositionSnapshot(dialogueWasOpen, Rs2Dialogue::isInDialogue);
         }
         boolean progressedDuringWait = sleepUntil(() -> {
             WorldPoint now = Rs2Player.getWorldLocation();
@@ -28,6 +30,19 @@ public final class Rs2WalkerTransportAwaits {
 
     static boolean hasProgressWithoutPositionSnapshot(boolean dialogueWasOpen, boolean dialogueOpen) {
         return !dialogueWasOpen && dialogueOpen;
+    }
+
+    static boolean waitForProgressWithoutPositionSnapshot(boolean dialogueWasOpen,
+                                                          BooleanSupplier dialogueOpen) {
+        return waitForProgressWithoutPositionSnapshot(
+                dialogueWasOpen, dialogueOpen, condition -> sleepUntil(condition, 1800));
+    }
+
+    static boolean waitForProgressWithoutPositionSnapshot(boolean dialogueWasOpen,
+                                                          BooleanSupplier dialogueOpen,
+                                                          Function<BooleanSupplier, Boolean> waitFor) {
+        return dialogueOpen != null && waitFor != null && Boolean.TRUE.equals(waitFor.apply(
+                () -> hasProgressWithoutPositionSnapshot(dialogueWasOpen, dialogueOpen.getAsBoolean())));
     }
 
     static boolean resolveTransportProgress(boolean progressedDuringWait,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaits.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaits.java
@@ -14,7 +14,7 @@ public final class Rs2WalkerTransportAwaits {
     public static boolean didCurrentTileTransportProgress(WorldPoint before, WorldPoint expectedDestination,
                                                           WorldPoint target, boolean dialogueWasOpen) {
         if (before == null) {
-            return false;
+            return hasProgressWithoutPositionSnapshot(dialogueWasOpen, Rs2Dialogue.isInDialogue());
         }
         boolean progressedDuringWait = sleepUntil(() -> {
             WorldPoint now = Rs2Player.getWorldLocation();
@@ -24,6 +24,10 @@ public final class Rs2WalkerTransportAwaits {
         WorldPoint after = Rs2Player.getWorldLocation();
         return resolveTransportProgress(progressedDuringWait, before, after, expectedDestination, target,
                 dialogueWasOpen, Rs2Dialogue.isInDialogue());
+    }
+
+    static boolean hasProgressWithoutPositionSnapshot(boolean dialogueWasOpen, boolean dialogueOpen) {
+        return !dialogueWasOpen && dialogueOpen;
     }
 
     static boolean resolveTransportProgress(boolean progressedDuringWait,

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestMissingItemPromptFlowTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestMissingItemPromptFlowTest.java
@@ -1,0 +1,96 @@
+package net.runelite.client.plugins.microbot.questhelper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import net.runelite.client.plugins.microbot.questhelper.steps.DetailedQuestStep;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import static org.junit.Assert.assertEquals;
+
+public class QuestMissingItemPromptFlowTest
+{
+    @Test
+    public void missingItemsAreDetectedBeforeAskingWhetherToObtainThem() throws IOException
+    {
+        PromptCalls calls = readPromptCalls();
+
+        assertEquals("Missing-item handling must own the obtain-items decision",
+                1, calls.callsFromMissingItemHandler);
+        assertEquals("The quest loop must not ask before it knows an item is missing",
+                0, calls.callsFromOtherMethods);
+        assertEquals("Missing-item handling must inspect only the active step requirements",
+                1, calls.currentStepRequirementReads);
+        assertEquals("Missing-item handling must not preempt the active step with future quest requirements",
+                0, calls.allQuestRequirementReads);
+    }
+
+    private static PromptCalls readPromptCalls() throws IOException
+    {
+        String resource = "/" + Type.getInternalName(QuestScript.class) + ".class";
+        PromptCalls calls = new PromptCalls();
+        try (InputStream input = QuestScript.class.getResourceAsStream(resource))
+        {
+            if (input == null)
+            {
+                throw new IOException("Unable to load " + resource);
+            }
+
+            new ClassReader(input).accept(new ClassVisitor(Opcodes.ASM9)
+            {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                                 String signature, String[] exceptions)
+                {
+                    return new MethodVisitor(Opcodes.ASM9)
+                    {
+                        @Override
+                        public void visitMethodInsn(int opcode, String owner, String methodName,
+                                                    String methodDescriptor, boolean isInterface)
+                        {
+                            if (!owner.equals(Type.getInternalName(QuestScript.class))
+                                    || !methodName.equals("shouldObtainMissingItems"))
+                            {
+                                if (name.equals("handleMissingItemRequirements")
+                                        && owner.equals(Type.getInternalName(DetailedQuestStep.class))
+                                        && methodName.equals("getRequirements"))
+                                {
+                                    calls.currentStepRequirementReads++;
+                                }
+                                if (name.equals("handleMissingItemRequirements")
+                                        && owner.equals(Type.getInternalName(QuestScript.class))
+                                        && methodName.equals("collectAllItemRequirements"))
+                                {
+                                    calls.allQuestRequirementReads++;
+                                }
+                                return;
+                            }
+
+                            if (name.equals("handleMissingItemRequirements"))
+                            {
+                                calls.callsFromMissingItemHandler++;
+                            }
+                            else
+                            {
+                                calls.callsFromOtherMethods++;
+                            }
+                        }
+                    };
+                }
+            }, ClassReader.SKIP_FRAMES);
+        }
+        return calls;
+    }
+
+    private static final class PromptCalls
+    {
+        private int callsFromMissingItemHandler;
+        private int callsFromOtherMethods;
+        private int currentStepRequirementReads;
+        private int allQuestRequirementReads;
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectApproachSelectionTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectApproachSelectionTest.java
@@ -1,0 +1,44 @@
+package net.runelite.client.plugins.microbot.questhelper;
+
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+import net.runelite.api.coords.WorldArea;
+import net.runelite.api.coords.WorldPoint;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class QuestObjectApproachSelectionTest
+{
+    @Test
+    public void multiTileObjectApproachSkipsTilesInsideTheObjectFootprint() throws Exception
+    {
+        Method selector;
+        try
+        {
+            selector = QuestScript.class.getDeclaredMethod(
+                    "selectObjectApproachTile",
+                    WorldArea.class,
+                    WorldPoint.class,
+                    Predicate.class,
+                    Predicate.class);
+        }
+        catch (NoSuchMethodException ex)
+        {
+            fail("Object approach selection must account for the full object footprint");
+            return;
+        }
+
+        WorldArea twoTileCrate = new WorldArea(3008, 3207, 2, 1, 0);
+        WorldPoint player = new WorldPoint(3008, 3207, 0);
+        WorldPoint insideInteractionTile = new WorldPoint(3010, 3207, 0);
+        Predicate<WorldPoint> walkable = point -> true;
+        Predicate<WorldPoint> visibleFromObjectSide = insideInteractionTile::equals;
+
+        WorldPoint selected = (WorldPoint) selector.invoke(
+                null, twoTileCrate, player, walkable, visibleFromObjectSide);
+
+        assertEquals(insideInteractionTile, selected);
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectApproachSelectionTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectApproachSelectionTest.java
@@ -1,12 +1,16 @@
 package net.runelite.client.plugins.microbot.questhelper;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Predicate;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class QuestObjectApproachSelectionTest
@@ -40,5 +44,33 @@ public class QuestObjectApproachSelectionTest
                 null, twoTileCrate, player, walkable, visibleFromObjectSide);
 
         assertEquals(insideInteractionTile, selected);
+    }
+
+    @Test
+    public void unloadedObjectOnAnotherPlaneStillRequiresAnApproach()
+    {
+        WorldPoint player = new WorldPoint(3200, 3200, 0);
+        WorldPoint step = new WorldPoint(3200, 3200, 1);
+
+        assertTrue(QuestScript.isAwayFromObjectStep(player, step));
+        assertFalse(QuestScript.isAwayFromObjectStep(player, new WorldPoint(3201, 3200, 0)));
+    }
+
+    @Test
+    public void unloadedObjectStepCannotReportCompletion()
+    {
+        assertFalse(QuestScript.canCompleteObjectStep(false));
+        assertTrue(QuestScript.canCompleteObjectStep(true));
+    }
+
+    @Test
+    public void emptyPathHasNoEndpointNearTheObjectStep()
+    {
+        WorldPoint step = new WorldPoint(3200, 3200, 0);
+
+        assertFalse(QuestScript.pathEndsNearObjectStep(null, step));
+        assertFalse(QuestScript.pathEndsNearObjectStep(Collections.emptyList(), step));
+        assertTrue(QuestScript.pathEndsNearObjectStep(
+                List.of(new WorldPoint(3190, 3190, 0), new WorldPoint(3201, 3200, 0)), step));
     }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectInteractionDispatchTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectInteractionDispatchTest.java
@@ -275,6 +275,7 @@ public class QuestObjectInteractionDispatchTest
                             }
 
                             lastIntConstant = null;
+                            lastStringConstant = null;
                         }
                     };
                 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectInteractionDispatchTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectInteractionDispatchTest.java
@@ -6,7 +6,9 @@ import java.util.ArrayList;
 import java.util.List;
 import net.runelite.api.TileObject;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
+import net.runelite.client.plugins.microbot.questhelper.steps.NpcStep;
 import net.runelite.client.plugins.microbot.questhelper.steps.ObjectStep;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
@@ -47,6 +49,29 @@ public class QuestObjectInteractionDispatchTest
                 calls.itemObjectInteractionOrder > calls.selectionWaitOrder);
         assertTrue("Selected items must be applied to objects with the Use action",
                 calls.itemObjectInteractionUsesUseAction);
+    }
+
+    @Test
+    public void itemObjectStepsRequireTheExpectedInventoryItemSelection()
+    {
+        int expectedItemId = 1925;
+
+        assertFalse(QuestScript.isExpectedInventoryItemSelected(false, expectedItemId, expectedItemId));
+        assertFalse(QuestScript.isExpectedInventoryItemSelected(true, -1, expectedItemId));
+        assertFalse(QuestScript.isExpectedInventoryItemSelected(true, 1931, expectedItemId));
+        assertTrue(QuestScript.isExpectedInventoryItemSelected(true, expectedItemId, expectedItemId));
+    }
+
+    @Test
+    public void itemNpcStepsWaitForSelectionBeforeNpcDispatch() throws IOException
+    {
+        DispatchCalls calls = readApplyNpcStepCalls();
+
+        assertTrue("NPC-step item selection must be dispatched", calls.inventoryUseOrder > 0);
+        assertTrue("QuestScript must confirm the expected item before targeting an NPC",
+                calls.selectionWaitOrder > calls.inventoryUseOrder);
+        assertTrue("The NPC target must be dispatched only after item selection is confirmed",
+                calls.itemNpcInteractionOrder > calls.selectionWaitOrder);
     }
 
     @Test
@@ -284,6 +309,68 @@ public class QuestObjectInteractionDispatchTest
         return calls;
     }
 
+    private static DispatchCalls readApplyNpcStepCalls() throws IOException
+    {
+        String resource = "/" + Type.getInternalName(QuestScript.class) + ".class";
+        DispatchCalls calls = new DispatchCalls();
+        try (InputStream input = QuestScript.class.getResourceAsStream(resource))
+        {
+            if (input == null)
+            {
+                throw new IOException("Unable to load " + resource);
+            }
+
+            String expectedDescriptor = Type.getMethodDescriptor(Type.BOOLEAN_TYPE, Type.getType(NpcStep.class));
+            new ClassReader(input).accept(new ClassVisitor(Opcodes.ASM9)
+            {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                                 String signature, String[] exceptions)
+                {
+                    boolean expectedMethod = name.equals("applyNpcStep")
+                            && descriptor.equals(expectedDescriptor);
+                    return new MethodVisitor(Opcodes.ASM9)
+                    {
+                        private int callOrder;
+
+                        @Override
+                        public void visitMethodInsn(int opcode, String owner, String methodName,
+                                                    String methodDescriptor, boolean isInterface)
+                        {
+                            if (!expectedMethod)
+                            {
+                                return;
+                            }
+
+                            callOrder++;
+                            if (owner.equals(Type.getInternalName(Rs2Inventory.class))
+                                    && methodName.equals("use")
+                                    && methodDescriptor.equals(Type.getMethodDescriptor(
+                                    Type.BOOLEAN_TYPE, Type.INT_TYPE)))
+                            {
+                                calls.inventoryUseOrder = callOrder;
+                            }
+                            if (owner.equals(Type.getInternalName(QuestScript.class))
+                                    && methodName.equals("waitForSelectedInventoryItem"))
+                            {
+                                calls.selectionWaitOrder = callOrder;
+                            }
+                            if (owner.equals(Type.getInternalName(Rs2NpcModel.class))
+                                    && methodName.equals("click")
+                                    && methodDescriptor.equals(Type.getMethodDescriptor(
+                                    Type.BOOLEAN_TYPE, Type.getType(String.class)))
+                                    && calls.selectionWaitOrder > 0)
+                            {
+                                calls.itemNpcInteractionOrder = callOrder;
+                            }
+                        }
+                    };
+                }
+            }, ClassReader.SKIP_FRAMES);
+        }
+        return calls;
+    }
+
     private static final class DispatchCalls
     {
         private int matchedMethods;
@@ -292,6 +379,7 @@ public class QuestObjectInteractionDispatchTest
         private int inventoryUseOrder;
         private int selectionWaitOrder;
         private int itemObjectInteractionOrder;
+        private int itemNpcInteractionOrder;
         private int preDispatchIdleWaitOrder;
         private int rawGameObjectInteractionOrder;
         private int globalReachabilityChecks;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectInteractionDispatchTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectInteractionDispatchTest.java
@@ -1,0 +1,261 @@
+package net.runelite.client.plugins.microbot.questhelper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import net.runelite.api.TileObject;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
+import net.runelite.client.plugins.microbot.questhelper.steps.ObjectStep;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class QuestObjectInteractionDispatchTest
+{
+    @Test
+    public void objectStepsUseTheRawGameObjectInteractionUtility() throws IOException
+    {
+        DispatchCalls calls = readApplyObjectStepCalls();
+
+        assertEquals("QuestScript must contain applyObjectStep", 1, calls.matchedMethods);
+        assertTrue("Object steps must use the same raw-object interaction utility as walker transports",
+                calls.rawGameObjectInteractions > 0);
+        assertEquals("Object steps must not use the duplicated tile-object wrapper click path",
+                0, calls.wrapperClicks);
+    }
+
+    @Test
+    public void itemObjectStepsWaitForSelectionBeforeObjectDispatch() throws IOException
+    {
+        DispatchCalls calls = readApplyObjectStepCalls();
+
+        assertTrue("Object-step item selection must be dispatched", calls.inventoryUseOrder > 0);
+        assertTrue("QuestScript must wait for the selected inventory item",
+                calls.selectionWaitOrder > calls.inventoryUseOrder);
+        assertTrue("The object target must be dispatched only after item selection is confirmed",
+                calls.itemObjectInteractionOrder > calls.selectionWaitOrder);
+        assertTrue("Selected items must be applied to objects with the Use action",
+                calls.itemObjectInteractionUsesUseAction);
+    }
+
+    @Test
+    public void loadedObjectApproachMustReachItsSelectedInteractionTileExactly() throws IOException
+    {
+        DispatchCalls calls = readApplyObjectStepCalls();
+
+        assertTrue("A wall must not satisfy the arrival distance for a selected interaction tile",
+                calls.walkReachedDistances.contains(0));
+    }
+
+    @Test
+    public void adjacentObjectBehindBarrierStillRequiresAnApproachWalk()
+    {
+        boolean objectAvailable = true;
+        boolean moreThanOneTileFromStep = false;
+        boolean objectInLineOfSight = false;
+
+        assertTrue("Coordinate distance must not bypass the reachable interaction side",
+                QuestScript.shouldWalkToObjectApproach(objectAvailable, moreThanOneTileFromStep,
+                        objectInLineOfSight));
+    }
+
+    @Test
+    public void objectApproachMustNotRunTheGlobalReachabilityPathfinder() throws IOException
+    {
+        DispatchCalls calls = readApplyObjectStepCalls();
+
+        assertEquals("Object approach must not block the quest thread in Rs2Walker.canReach",
+                0, calls.globalReachabilityChecks);
+    }
+
+    @Test
+    public void objectVisibilityUsesTheFullTileObjectFootprint() throws IOException
+    {
+        DispatchCalls calls = readApplyObjectStepCalls();
+
+        assertTrue("Multi-tile object visibility must not be reduced to the origin tile",
+                calls.fullObjectLineOfSightChecks > 0);
+    }
+
+    @Test
+    public void objectInteractionStartWaitIsBoundedToTwoGameTicks() throws IOException
+    {
+        DispatchCalls calls = readApplyObjectStepCalls();
+
+        assertEquals("Object steps must not inherit the unrelated five-second default wait",
+                Integer.valueOf(1_200), calls.objectInteractionStartTimeout);
+    }
+
+    private static DispatchCalls readApplyObjectStepCalls() throws IOException
+    {
+        String resource = "/" + Type.getInternalName(QuestScript.class) + ".class";
+        DispatchCalls calls = new DispatchCalls();
+        try (InputStream input = QuestScript.class.getResourceAsStream(resource))
+        {
+            if (input == null)
+            {
+                throw new IOException("Unable to load " + resource);
+            }
+
+            String expectedDescriptor = Type.getMethodDescriptor(Type.BOOLEAN_TYPE, Type.getType(ObjectStep.class));
+            String rawInteractionDescriptor = Type.getMethodDescriptor(
+                    Type.BOOLEAN_TYPE, Type.getType(TileObject.class), Type.getType(String.class));
+
+            new ClassReader(input).accept(new ClassVisitor(Opcodes.ASM9)
+            {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                                 String signature, String[] exceptions)
+                {
+                    boolean expectedMethod = name.equals("applyObjectStep")
+                            && descriptor.equals(expectedDescriptor);
+                    if (expectedMethod)
+                    {
+                        calls.matchedMethods++;
+                    }
+
+                    return new MethodVisitor(Opcodes.ASM9)
+                    {
+                        private int callOrder;
+                        private String lastStringConstant;
+                        private Integer lastIntConstant;
+
+                        @Override
+                        public void visitLdcInsn(Object value)
+                        {
+                            if (expectedMethod && value instanceof String)
+                            {
+                                lastStringConstant = (String) value;
+                            }
+                            if (expectedMethod && value instanceof Integer)
+                            {
+                                lastIntConstant = (Integer) value;
+                            }
+                        }
+
+                        @Override
+                        public void visitInsn(int opcode)
+                        {
+                            if (expectedMethod && opcode >= Opcodes.ICONST_M1 && opcode <= Opcodes.ICONST_5)
+                            {
+                                lastIntConstant = opcode - Opcodes.ICONST_0;
+                            }
+                        }
+
+                        @Override
+                        public void visitIntInsn(int opcode, int operand)
+                        {
+                            if (expectedMethod && (opcode == Opcodes.BIPUSH || opcode == Opcodes.SIPUSH))
+                            {
+                                lastIntConstant = operand;
+                            }
+                        }
+
+                        @Override
+                        public void visitMethodInsn(int opcode, String owner, String methodName,
+                                                    String methodDescriptor, boolean isInterface)
+                        {
+                            if (!expectedMethod)
+                            {
+                                return;
+                            }
+
+                            callOrder++;
+
+                            if (owner.equals(Type.getInternalName(Rs2Inventory.class))
+                                    && methodName.equals("use")
+                                    && methodDescriptor.equals(Type.getMethodDescriptor(
+                                    Type.BOOLEAN_TYPE, Type.INT_TYPE)))
+                            {
+                                calls.inventoryUseOrder = callOrder;
+                            }
+                            if (owner.equals(Type.getInternalName(QuestScript.class))
+                                    && methodName.equals("waitForSelectedInventoryItem"))
+                            {
+                                calls.selectionWaitOrder = callOrder;
+                            }
+
+                            if (owner.equals(Type.getInternalName(Rs2GameObject.class))
+                                    && methodName.equals("interact")
+                                    && methodDescriptor.equals(rawInteractionDescriptor))
+                            {
+                                calls.rawGameObjectInteractions++;
+                                if (calls.selectionWaitOrder > 0
+                                        && calls.itemObjectInteractionOrder == 0)
+                                {
+                                    calls.itemObjectInteractionOrder = callOrder;
+                                    calls.itemObjectInteractionUsesUseAction = "Use".equals(lastStringConstant);
+                                }
+                            }
+                            if (owner.equals(Type.getInternalName(Rs2TileObjectModel.class))
+                                    && methodName.equals("click"))
+                            {
+                                calls.wrapperClicks++;
+                            }
+                            if (owner.equals(Type.getInternalName(net.runelite.client.plugins.microbot.util.walker.Rs2Walker.class))
+                                    && methodName.equals("walkTo")
+                                    && methodDescriptor.equals(Type.getMethodDescriptor(
+                                    Type.BOOLEAN_TYPE, Type.getType(WorldPoint.class), Type.INT_TYPE)))
+                            {
+                                calls.walkReachedDistances.add(lastIntConstant);
+                            }
+                            if (owner.equals(Type.getInternalName(net.runelite.client.plugins.microbot.util.walker.Rs2Walker.class))
+                                    && methodName.equals("canReach"))
+                            {
+                                    calls.globalReachabilityChecks++;
+                            }
+                            if (owner.equals(Type.getInternalName(Rs2GameObject.class))
+                                    && methodName.equals("hasLineOfSight")
+                                    && methodDescriptor.equals(Type.getMethodDescriptor(
+                                    Type.BOOLEAN_TYPE,
+                                    Type.getType(WorldPoint.class),
+                                    Type.getType(TileObject.class))))
+                            {
+                                calls.fullObjectLineOfSightChecks++;
+                            }
+                            if (owner.equals(Type.getInternalName(QuestScript.class))
+                                    && methodName.equals("sleepUntil")
+                                    && methodDescriptor.equals(Type.getMethodDescriptor(
+                                    Type.BOOLEAN_TYPE,
+                                    Type.getType(java.util.function.BooleanSupplier.class),
+                                    Type.INT_TYPE))
+                                    && calls.rawGameObjectInteractions > 0
+                                    && calls.objectInteractionStartTimeout == null)
+                            {
+                                calls.objectInteractionStartTimeout = lastIntConstant;
+                            }
+
+                            lastIntConstant = null;
+                        }
+                    };
+                }
+            }, ClassReader.SKIP_FRAMES);
+        }
+        return calls;
+    }
+
+    private static final class DispatchCalls
+    {
+        private int matchedMethods;
+        private int rawGameObjectInteractions;
+        private int wrapperClicks;
+        private int inventoryUseOrder;
+        private int selectionWaitOrder;
+        private int itemObjectInteractionOrder;
+        private int globalReachabilityChecks;
+        private int fullObjectLineOfSightChecks;
+        private boolean itemObjectInteractionUsesUseAction;
+        private final List<Integer> walkReachedDistances = new ArrayList<>();
+        private Integer objectInteractionStartTimeout;
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectInteractionDispatchTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectInteractionDispatchTest.java
@@ -114,6 +114,18 @@ public class QuestObjectInteractionDispatchTest
                 false, false, false, false, true));
     }
 
+    @Test
+    public void objectDispatchWaitsForPreexistingMovementToSettle() throws IOException
+    {
+        DispatchCalls calls = readApplyObjectStepCalls();
+
+        assertTrue(calls.preDispatchIdleWaitOrder > 0);
+        assertTrue(calls.preDispatchIdleWaitOrder < calls.rawGameObjectInteractionOrder);
+        assertFalse(QuestScript.isObjectInteractionIdle(true, false));
+        assertFalse(QuestScript.isObjectInteractionIdle(false, true));
+        assertTrue(QuestScript.isObjectInteractionIdle(false, false));
+    }
+
     private static DispatchCalls readApplyObjectStepCalls() throws IOException
     {
         String resource = "/" + Type.getInternalName(QuestScript.class) + ".class";
@@ -202,12 +214,21 @@ public class QuestObjectInteractionDispatchTest
                             {
                                 calls.selectionWaitOrder = callOrder;
                             }
+                            if (owner.equals(Type.getInternalName(QuestScript.class))
+                                    && methodName.equals("waitForObjectInteractionIdle"))
+                            {
+                                calls.preDispatchIdleWaitOrder = callOrder;
+                            }
 
                             if (owner.equals(Type.getInternalName(Rs2GameObject.class))
                                     && methodName.equals("interact")
                                     && methodDescriptor.equals(rawInteractionDescriptor))
                             {
                                 calls.rawGameObjectInteractions++;
+                                if (calls.rawGameObjectInteractionOrder == 0)
+                                {
+                                    calls.rawGameObjectInteractionOrder = callOrder;
+                                }
                                 if (calls.selectionWaitOrder > 0
                                         && calls.itemObjectInteractionOrder == 0)
                                 {
@@ -270,6 +291,8 @@ public class QuestObjectInteractionDispatchTest
         private int inventoryUseOrder;
         private int selectionWaitOrder;
         private int itemObjectInteractionOrder;
+        private int preDispatchIdleWaitOrder;
+        private int rawGameObjectInteractionOrder;
         private int globalReachabilityChecks;
         private int fullObjectLineOfSightChecks;
         private boolean itemObjectInteractionUsesUseAction;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectInteractionDispatchTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestObjectInteractionDispatchTest.java
@@ -18,6 +18,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class QuestObjectInteractionDispatchTest
@@ -94,6 +95,23 @@ public class QuestObjectInteractionDispatchTest
 
         assertEquals("Object steps must not inherit the unrelated five-second default wait",
                 Integer.valueOf(1_200), calls.objectInteractionStartTimeout);
+    }
+
+    @Test
+    public void itemDeselectionAloneDoesNotConfirmObjectInteraction()
+    {
+        assertFalse(QuestScript.isObjectInteractionConfirmed(
+                false, false, false, false, false));
+        assertTrue(QuestScript.isObjectInteractionConfirmed(
+                true, false, false, false, false));
+        assertTrue(QuestScript.isObjectInteractionConfirmed(
+                false, true, false, false, false));
+        assertTrue(QuestScript.isObjectInteractionConfirmed(
+                false, false, true, false, false));
+        assertTrue(QuestScript.isObjectInteractionConfirmed(
+                false, false, false, true, false));
+        assertTrue(QuestScript.isObjectInteractionConfirmed(
+                false, false, false, false, true));
     }
 
     private static DispatchCalls readApplyObjectStepCalls() throws IOException

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestProductionWidgetTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestProductionWidgetTest.java
@@ -1,0 +1,133 @@
+package net.runelite.client.plugins.microbot.questhelper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import net.runelite.api.ItemID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class QuestProductionWidgetTest
+{
+    @Test
+    public void productionHighlightSelectsTheRequestedItemChildInsteadOfTheInterfaceParent() throws Exception
+    {
+        Widget root = visibleWidget(-1);
+        Widget wrongChoice = visibleWidget(ItemID.WOOL);
+        Widget choiceContainer = visibleWidget(-1);
+        Widget ballOfWoolChoice = visibleWidget(ItemID.BALL_OF_WOOL);
+
+        when(root.getChildren()).thenReturn(new Widget[]{wrongChoice, choiceContainer});
+        when(choiceContainer.getDynamicChildren()).thenReturn(new Widget[]{ballOfWoolChoice});
+
+        Method selector;
+        try
+        {
+            selector = QuestScript.class.getDeclaredMethod("findVisibleWidgetByItemId", Widget.class, int.class);
+        }
+        catch (NoSuchMethodException ex)
+        {
+            fail("QuestScript must resolve the exact item child in a production interface");
+            return;
+        }
+        selector.setAccessible(true);
+
+        assertSame(ballOfWoolChoice, selector.invoke(null, root, ItemID.BALL_OF_WOOL));
+    }
+
+    @Test
+    public void productionItemHighlightsUseTheMicrobotMakeAllProcessingFlow() throws IOException
+    {
+        ProcessingCalls calls = readProcessingCalls();
+
+        assertTrue("Production must select a quantity before choosing the output", calls.quantityOrder > 0);
+        assertEquals("All", calls.quantity);
+        assertTrue("Production must use the processing-interface API after selecting All",
+                calls.processingOrder > calls.quantityOrder);
+    }
+
+    private static Widget visibleWidget(int itemId)
+    {
+        Widget widget = mock(Widget.class);
+        when(widget.isHidden()).thenReturn(false);
+        when(widget.getItemId()).thenReturn(itemId);
+        return widget;
+    }
+
+    private static ProcessingCalls readProcessingCalls() throws IOException
+    {
+        String resource = "/" + Type.getInternalName(QuestScript.class) + ".class";
+        ProcessingCalls calls = new ProcessingCalls();
+        try (InputStream input = QuestScript.class.getResourceAsStream(resource))
+        {
+            if (input == null)
+            {
+                throw new IOException("Unable to load " + resource);
+            }
+
+            new ClassReader(input).accept(new ClassVisitor(Opcodes.ASM9)
+            {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                                 String signature, String[] exceptions)
+                {
+                    return new MethodVisitor(Opcodes.ASM9)
+                    {
+                        private int callOrder;
+                        private String lastStringConstant;
+
+                        @Override
+                        public void visitLdcInsn(Object value)
+                        {
+                            if (value instanceof String)
+                            {
+                                lastStringConstant = (String) value;
+                            }
+                        }
+
+                        @Override
+                        public void visitMethodInsn(int opcode, String owner, String methodName,
+                                                    String methodDescriptor, boolean isInterface)
+                        {
+                            callOrder++;
+                            if (!owner.equals(Type.getInternalName(Rs2Widget.class)))
+                            {
+                                return;
+                            }
+                            if (methodName.equals("enableQuantityOption"))
+                            {
+                                calls.quantityOrder = callOrder;
+                                calls.quantity = lastStringConstant;
+                            }
+                            if (methodName.equals("handleProcessingInterface"))
+                            {
+                                calls.processingOrder = callOrder;
+                            }
+                        }
+                    };
+                }
+            }, ClassReader.SKIP_FRAMES);
+        }
+        return calls;
+    }
+
+    private static final class ProcessingCalls
+    {
+        private int quantityOrder;
+        private int processingOrder;
+        private String quantity;
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestScriptLifecycleTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestScriptLifecycleTest.java
@@ -1,0 +1,56 @@
+package net.runelite.client.plugins.microbot.questhelper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import static org.junit.Assert.assertEquals;
+
+public class QuestScriptLifecycleTest
+{
+    @Test
+    public void pluginShutdownStopsQuestAutomationLoop() throws IOException
+    {
+        String resource = "/" + Type.getInternalName(QuestHelperPlugin.class) + ".class";
+        int[] shutdownCalls = {0};
+        try (InputStream input = QuestHelperPlugin.class.getResourceAsStream(resource))
+        {
+            if (input == null)
+            {
+                throw new IOException("Unable to load " + resource);
+            }
+
+            new ClassReader(input).accept(new ClassVisitor(Opcodes.ASM9)
+            {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                                 String signature, String[] exceptions)
+                {
+                    boolean pluginShutdown = name.equals("shutDown") && descriptor.equals("()V");
+                    return new MethodVisitor(Opcodes.ASM9)
+                    {
+                        @Override
+                        public void visitMethodInsn(int opcode, String owner, String methodName,
+                                                    String methodDescriptor, boolean isInterface)
+                        {
+                            if (pluginShutdown
+                                    && owner.equals(Type.getInternalName(QuestScript.class))
+                                    && methodName.equals("shutdown")
+                                    && methodDescriptor.equals("()V"))
+                            {
+                                shutdownCalls[0]++;
+                            }
+                        }
+                    };
+                }
+            }, ClassReader.SKIP_FRAMES);
+        }
+
+        assertEquals("Disabling Quest Helper must cancel its automation schedule", 1, shutdownCalls[0]);
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestShopAutomationTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/QuestShopAutomationTest.java
@@ -1,0 +1,41 @@
+package net.runelite.client.plugins.microbot.questhelper;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.function.IntPredicate;
+
+import static org.junit.Assert.assertEquals;
+
+public class QuestShopAutomationTest {
+
+    @Test
+    public void shopNpcStepPrefersTradeOverTalkTo() {
+        String action = QuestScript.chooseNpcAction(
+                Collections.singletonList("Purchase a bucket from the general store."),
+                new String[]{"Talk-to", "Trade"},
+                true);
+
+        assertEquals("Trade", action);
+    }
+
+    @Test
+    public void ordinaryNpcStepStillPrefersMatchingTalkAction() {
+        String action = QuestScript.chooseNpcAction(
+                Collections.singletonList("Talk to the cook."),
+                new String[]{"Talk-to", "Trade"},
+                false);
+
+        assertEquals("Talk-to", action);
+    }
+
+    @Test
+    public void shopStepSelectsFirstItemNotAlreadyInInventory() {
+        IntPredicate hasItem = itemId -> itemId == 100;
+
+        int itemId = QuestScript.firstMissingShopItemId(Arrays.asList(100, 200), hasItem);
+
+        assertEquals(200, itemId);
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/helpers/quests/runemysteries/RuneMysteriesRoutingTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/helpers/quests/runemysteries/RuneMysteriesRoutingTest.java
@@ -1,0 +1,41 @@
+package net.runelite.client.plugins.microbot.questhelper.helpers.quests.runemysteries;
+
+import java.util.Collection;
+import java.util.Map;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.questhelper.steps.ConditionalStep;
+import net.runelite.client.plugins.microbot.questhelper.steps.DetailedQuestStep;
+import net.runelite.client.plugins.microbot.questhelper.steps.NpcStep;
+import net.runelite.client.plugins.microbot.questhelper.steps.QuestStep;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RuneMysteriesRoutingTest
+{
+	@Test
+	public void crossPlaneStagesRouteToNpcDestinationsInsteadOfIntermediateStairs()
+	{
+		RuneMysteries helper = new RuneMysteries();
+		Map<Integer, QuestStep> steps = helper.loadSteps();
+
+		assertNpcDestinations(steps.get(0), new WorldPoint(3209, 3222, 1));
+		assertNpcDestinations(steps.get(1), new WorldPoint(3104, 9571, 0));
+	}
+
+	private static void assertNpcDestinations(QuestStep step, WorldPoint expectedDestination)
+	{
+		assertTrue("Cross-plane stage must remain conditional", step instanceof ConditionalStep);
+		Collection<QuestStep> routeChoices = ((ConditionalStep) step).getSteps();
+		assertTrue("Cross-plane stage must have at least one route choice", !routeChoices.isEmpty());
+
+		for (QuestStep routeChoice : routeChoices)
+		{
+			assertTrue("Route choices must target the final NPC, not an intermediate object",
+				routeChoice instanceof NpcStep);
+			assertEquals(expectedDestination,
+				((DetailedQuestStep) routeChoice).getDefinedPoint().getWorldPoint());
+		}
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/logic/RomeoAndJulietRoutingTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/logic/RomeoAndJulietRoutingTest.java
@@ -1,0 +1,44 @@
+package net.runelite.client.plugins.microbot.questhelper.logic;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import static org.junit.Assert.assertFalse;
+
+public class RomeoAndJulietRoutingTest {
+    @Test
+    public void potionStepUsesTheStandardObjectStepInsteadOfCustomCanvasWalking() throws IOException {
+        boolean[] invokesCustomPotionClimb = {false};
+
+        try (InputStream classBytes = RomeoAndJuliet.class
+                .getResourceAsStream("/" + RomeoAndJuliet.class.getName().replace('.', '/') + ".class")) {
+            new ClassReader(classBytes).accept(new ClassVisitor(Opcodes.ASM9) {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                                 String signature, String[] exceptions) {
+                    if (!"executeCustomLogic".equals(name)) {
+                        return null;
+                    }
+                    return new MethodVisitor(Opcodes.ASM9) {
+                        @Override
+                        public void visitMethodInsn(int opcode, String owner, String invokedName,
+                                                    String invokedDescriptor, boolean isInterface) {
+                            if (owner.equals(RomeoAndJuliet.class.getName().replace('.', '/'))
+                                    && "climbToJulietWithPotion".equals(invokedName)) {
+                                invokesCustomPotionClimb[0] = true;
+                            }
+                        }
+                    };
+                }
+            }, 0);
+        }
+
+        assertFalse("The potion step must fall through to QuestScript's door-aware ObjectStep",
+                invokesCustomPotionClimb[0]);
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathWalkTaskPolicyTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathWalkTaskPolicyTest.java
@@ -26,4 +26,30 @@ public class ShortestPathWalkTaskPolicyTest {
                 new WorldPoint(3201, 3200, 0),
                 WalkerState.MOVING));
     }
+
+    @Test
+    public void stoppedWorkerMustFinishBeforeAReplacementCanStart() {
+        ShortestPathScript.WalkTaskGate gate = new ShortestPathScript.WalkTaskGate();
+        WorldPoint target = new WorldPoint(3200, 3200, 0);
+
+        assertTrue(gate.tryAcquire(target));
+        assertFalse("clearing/cancelling a target must not release a worker that is still unwinding",
+                gate.tryAcquire(target));
+
+        gate.release();
+        assertTrue(gate.tryAcquire(target));
+    }
+
+    @Test
+    public void shutdownPermanentlyRejectsWalkWorkers() {
+        ShortestPathScript.WalkTaskGate gate = new ShortestPathScript.WalkTaskGate();
+        WorldPoint target = new WorldPoint(3200, 3200, 0);
+
+        assertTrue(gate.tryAcquire(target));
+        gate.shutdown();
+        gate.release();
+
+        assertTrue(gate.isShutdown());
+        assertFalse(gate.tryAcquire(target));
+    }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathWalkTaskPolicyTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathWalkTaskPolicyTest.java
@@ -1,0 +1,29 @@
+package net.runelite.client.plugins.microbot.shortestpath;
+
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.util.walker.WalkerState;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ShortestPathWalkTaskPolicyTest {
+
+    @Test
+    public void movingSameTargetKeepsCurrentWalkTaskAlive() {
+        WorldPoint target = new WorldPoint(3200, 3200, 0);
+
+        assertTrue(ShortestPathScript.shouldContinueWalkTask(target, target, WalkerState.MOVING));
+    }
+
+    @Test
+    public void terminalOrReplacedTargetStopsCurrentWalkTask() {
+        WorldPoint target = new WorldPoint(3200, 3200, 0);
+
+        assertFalse(ShortestPathScript.shouldContinueWalkTask(target, target, WalkerState.ARRIVED));
+        assertFalse(ShortestPathScript.shouldContinueWalkTask(
+                target,
+                new WorldPoint(3201, 3200, 0),
+                WalkerState.MOVING));
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathWalkTaskPolicyTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathWalkTaskPolicyTest.java
@@ -157,4 +157,55 @@ public class ShortestPathWalkTaskPolicyTest {
         assertFalse(replacementWorker.isAlive());
         assertEquals(replacementTarget, targets.get());
     }
+
+    @Test
+    public void replacementCannotPublishUntilStopCleanupFinishes() throws Exception {
+        ShortestPathScript.WalkTargetState targets = new ShortestPathScript.WalkTargetState();
+        WorldPoint replacementTarget = new WorldPoint(3210, 3210, 0);
+        targets.publish(new WorldPoint(3200, 3200, 0));
+        ShortestPathScript.WalkTargetSnapshot stopped = targets.publish(null);
+        CountDownLatch cleanupStarted = new CountDownLatch(1);
+        CountDownLatch allowCleanupToFinish = new CountDownLatch(1);
+        CountDownLatch replacementAttempted = new CountDownLatch(1);
+        CountDownLatch replacementPublished = new CountDownLatch(1);
+
+        Thread stopWorker = new Thread(() -> targets.clearIfOwned(stopped, () -> {
+            cleanupStarted.countDown();
+            try {
+                allowCleanupToFinish.await(1, TimeUnit.SECONDS);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+        }));
+        stopWorker.start();
+        assertTrue(cleanupStarted.await(1, TimeUnit.SECONDS));
+
+        Thread replacementWorker = new Thread(() -> {
+            replacementAttempted.countDown();
+            targets.publishIfChanged(replacementTarget);
+            replacementPublished.countDown();
+        });
+        replacementWorker.start();
+        assertTrue(replacementAttempted.await(1, TimeUnit.SECONDS));
+        assertFalse("replacement publication must wait until stop cleanup finishes",
+                replacementPublished.await(100, TimeUnit.MILLISECONDS));
+
+        allowCleanupToFinish.countDown();
+        stopWorker.join(1_000L);
+        replacementWorker.join(1_000L);
+        assertFalse(stopWorker.isAlive());
+        assertFalse(replacementWorker.isAlive());
+        assertEquals(replacementTarget, targets.get());
+    }
+
+    @Test
+    public void shutdownTargetStateRejectsLaterPublication() {
+        ShortestPathScript.WalkTargetState targets = new ShortestPathScript.WalkTargetState();
+        targets.publish(new WorldPoint(3200, 3200, 0));
+
+        targets.shutdown(null);
+
+        assertNull(targets.publishIfChanged(new WorldPoint(3210, 3210, 0)));
+        assertNull(targets.get());
+    }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathWalkTaskPolicyTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathWalkTaskPolicyTest.java
@@ -4,6 +4,9 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.util.walker.WalkerState;
 import org.junit.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -51,5 +54,50 @@ public class ShortestPathWalkTaskPolicyTest {
 
         assertTrue(gate.isShutdown());
         assertFalse(gate.tryAcquire(target));
+    }
+
+    @Test
+    public void cancellingBeforeWorkerStartsReleasesGate() {
+        ShortestPathScript.WalkTaskGate gate = new ShortestPathScript.WalkTaskGate();
+        WorldPoint target = new WorldPoint(3200, 3200, 0);
+        assertTrue(gate.tryAcquire(target));
+        ShortestPathScript.GateReleasingFutureTask task =
+                new ShortestPathScript.GateReleasingFutureTask(gate, () -> { });
+
+        assertTrue(task.cancel(false));
+
+        assertTrue(gate.tryAcquire(target));
+    }
+
+    @Test
+    public void cancellingRunningWorkerKeepsGateUntilWorkerActuallyExits() throws Exception {
+        ShortestPathScript.WalkTaskGate gate = new ShortestPathScript.WalkTaskGate();
+        WorldPoint target = new WorldPoint(3200, 3200, 0);
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch allowExit = new CountDownLatch(1);
+        assertTrue(gate.tryAcquire(target));
+        ShortestPathScript.GateReleasingFutureTask task =
+                new ShortestPathScript.GateReleasingFutureTask(gate, () -> {
+                    entered.countDown();
+                    boolean released = false;
+                    while (!released) {
+                        try {
+                            released = allowExit.await(1, TimeUnit.SECONDS);
+                        } catch (InterruptedException ignored) {
+                            // Deliberately remain in-flight to prove cancellation does not release early.
+                        }
+                    }
+                });
+        Thread worker = new Thread(task);
+        worker.start();
+        assertTrue(entered.await(1, TimeUnit.SECONDS));
+
+        assertTrue(task.cancel(true));
+        assertFalse(gate.tryAcquire(target));
+
+        allowExit.countDown();
+        worker.join(1_000L);
+        assertFalse(worker.isAlive());
+        assertTrue(gate.tryAcquire(target));
     }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathWalkTaskPolicyTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathWalkTaskPolicyTest.java
@@ -8,6 +8,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ShortestPathWalkTaskPolicyTest {
@@ -99,5 +101,60 @@ public class ShortestPathWalkTaskPolicyTest {
         worker.join(1_000L);
         assertFalse(worker.isAlive());
         assertTrue(gate.tryAcquire(target));
+    }
+
+    @Test
+    public void replacedTargetCannotBeClearedByThePreviousWorker() {
+        ShortestPathScript.WalkTargetState targets = new ShortestPathScript.WalkTargetState();
+        WorldPoint firstTarget = new WorldPoint(3200, 3200, 0);
+        WorldPoint replacementTarget = new WorldPoint(3210, 3210, 0);
+
+        ShortestPathScript.WalkTargetSnapshot first = targets.publish(firstTarget);
+        ShortestPathScript.WalkTargetSnapshot replacement = targets.publish(replacementTarget);
+
+        assertFalse(targets.clearIfOwned(first));
+        assertEquals(replacementTarget, targets.get());
+        assertTrue(targets.clearIfOwned(replacement));
+        assertNull(targets.get());
+    }
+
+    @Test
+    public void replacementCannotPublishUntilOwnedRouteCleanupFinishes() throws Exception {
+        ShortestPathScript.WalkTargetState targets = new ShortestPathScript.WalkTargetState();
+        WorldPoint firstTarget = new WorldPoint(3200, 3200, 0);
+        WorldPoint replacementTarget = new WorldPoint(3210, 3210, 0);
+        ShortestPathScript.WalkTargetSnapshot first = targets.publish(firstTarget);
+        CountDownLatch cleanupStarted = new CountDownLatch(1);
+        CountDownLatch allowCleanupToFinish = new CountDownLatch(1);
+        CountDownLatch replacementAttempted = new CountDownLatch(1);
+        CountDownLatch replacementPublished = new CountDownLatch(1);
+
+        Thread terminalWorker = new Thread(() -> targets.clearIfOwned(first, () -> {
+            cleanupStarted.countDown();
+            try {
+                allowCleanupToFinish.await(1, TimeUnit.SECONDS);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+        }));
+        terminalWorker.start();
+        assertTrue(cleanupStarted.await(1, TimeUnit.SECONDS));
+
+        Thread replacementWorker = new Thread(() -> {
+            replacementAttempted.countDown();
+            targets.publish(replacementTarget);
+            replacementPublished.countDown();
+        });
+        replacementWorker.start();
+        assertTrue(replacementAttempted.await(1, TimeUnit.SECONDS));
+        assertFalse("replacement publication must wait until old route cleanup finishes",
+                replacementPublished.await(100, TimeUnit.MILLISECONDS));
+
+        allowCleanupToFinish.countDown();
+        terminalWorker.join(1_000L);
+        replacementWorker.join(1_000L);
+        assertFalse(terminalWorker.isAlive());
+        assertFalse(replacementWorker.isAlive());
+        assertEquals(replacementTarget, targets.get());
     }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItemPauseTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/grounditem/Rs2GroundItemPauseTest.java
@@ -1,0 +1,120 @@
+package net.runelite.client.plugins.microbot.util.grounditem;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class Rs2GroundItemPauseTest {
+
+    @Test
+    public void exceptionRestoresUnpausedState() {
+        boolean original = Microbot.pauseAllScripts.get();
+        try {
+            Microbot.pauseAllScripts.set(false);
+
+            try {
+                Rs2GroundItem.runWhilePaused(() -> {
+                    throw new IllegalStateException("loot failed");
+                });
+                fail("Expected loot failure");
+            } catch (IllegalStateException expected) {
+                // Expected: the assertion below verifies cleanup on the exceptional path.
+            }
+
+            assertFalse(Microbot.pauseAllScripts.get());
+        } finally {
+            Microbot.pauseAllScripts.set(original);
+        }
+    }
+
+    @Test
+    public void preExistingPauseRemainsPaused() {
+        boolean original = Microbot.pauseAllScripts.get();
+        try {
+            Microbot.pauseAllScripts.set(true);
+
+            assertTrue(Rs2GroundItem.runWhilePaused(() -> true));
+
+            assertTrue(Microbot.pauseAllScripts.get());
+        } finally {
+            Microbot.pauseAllScripts.set(original);
+        }
+    }
+
+    @Test
+    public void nestedPauseRestoresUnpausedStateAfterOuterScope() {
+        boolean original = Microbot.pauseAllScripts.get();
+        try {
+            Microbot.pauseAllScripts.set(false);
+
+            assertTrue(Rs2GroundItem.runWhilePaused(() -> {
+                assertTrue(Microbot.pauseAllScripts.get());
+                return Rs2GroundItem.runWhilePaused(Microbot.pauseAllScripts::get);
+            }));
+
+            assertFalse(Microbot.pauseAllScripts.get());
+        } finally {
+            Microbot.pauseAllScripts.set(original);
+        }
+    }
+
+    @Test
+    public void overlappingCallsRemainPausedUntilLastScopeExits() throws Exception {
+        boolean original = Microbot.pauseAllScripts.get();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch firstEntered = new CountDownLatch(1);
+        CountDownLatch secondEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch releaseSecond = new CountDownLatch(1);
+        try {
+            Microbot.pauseAllScripts.set(false);
+
+            Future<Boolean> first = executor.submit(() -> Rs2GroundItem.runWhilePaused(() -> {
+                firstEntered.countDown();
+                await(releaseFirst);
+                return true;
+            }));
+            assertTrue(firstEntered.await(5, TimeUnit.SECONDS));
+
+            Future<Boolean> second = executor.submit(() -> Rs2GroundItem.runWhilePaused(() -> {
+                secondEntered.countDown();
+                await(releaseSecond);
+                return true;
+            }));
+            assertTrue(secondEntered.await(5, TimeUnit.SECONDS));
+
+            releaseFirst.countDown();
+            assertTrue(first.get(5, TimeUnit.SECONDS));
+            assertTrue(Microbot.pauseAllScripts.get());
+
+            releaseSecond.countDown();
+            assertTrue(second.get(5, TimeUnit.SECONDS));
+            assertFalse(Microbot.pauseAllScripts.get());
+        } finally {
+            releaseFirst.countDown();
+            releaseSecond.countDown();
+            executor.shutdownNow();
+            Microbot.pauseAllScripts.set(original);
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                throw new AssertionError("Timed out waiting for test latch");
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for test latch", ex);
+        }
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/player/Rs2PlayerNullSafetyTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/player/Rs2PlayerNullSafetyTest.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.plugins.microbot.Microbot;
 import org.junit.After;
@@ -57,6 +59,25 @@ public class Rs2PlayerNullSafetyTest
         assertNull(resolver.invoke(null, client));
         verify(clientThread).runOnClientThreadOptional(any());
         verify(client).getLocalPlayer();
+    }
+
+    @Test
+    public void worldLocationReturnsNullWhenTopLevelWorldViewDisappears() throws Exception
+    {
+        Method resolver = Arrays.stream(Rs2Player.class.getDeclaredMethods())
+                .filter(method -> method.getName().equals("worldLocationFromClient"))
+                .findFirst()
+                .orElse(null);
+        assertNotNull("Rs2Player needs a directly testable null-safe location resolver", resolver);
+
+        Client client = mock(Client.class);
+        Player player = mock(Player.class);
+        when(client.getLocalPlayer()).thenReturn(player);
+        when(player.getWorldLocation()).thenReturn(new WorldPoint(3200, 3200, 0));
+        when(client.getTopLevelWorldView()).thenReturn(null);
+        resolver.setAccessible(true);
+
+        assertNull(resolver.invoke(null, client));
     }
 
     private static Object swapClientThread(Object value) throws Exception

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/player/Rs2PlayerNullSafetyTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/player/Rs2PlayerNullSafetyTest.java
@@ -1,0 +1,70 @@
+package net.runelite.client.plugins.microbot.util.player;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.plugins.microbot.Microbot;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Rs2PlayerNullSafetyTest
+{
+    private ClientThread clientThread;
+    private Object previousClientThread;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        clientThread = mock(ClientThread.class);
+        when(clientThread.runOnClientThreadOptional(any())).thenAnswer(invocation ->
+        {
+            Callable<?> callable = invocation.getArgument(0);
+            return Optional.ofNullable(callable.call());
+        });
+        previousClientThread = swapClientThread(clientThread);
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        swapClientThread(previousClientThread);
+    }
+
+    @Test
+    public void worldLocationReturnsNullWhenLocalPlayerDisappears() throws Exception
+    {
+        Method resolver = Arrays.stream(Rs2Player.class.getDeclaredMethods())
+                .filter(method -> method.getName().equals("worldLocationFromClient"))
+                .findFirst()
+                .orElse(null);
+        assertNotNull("Rs2Player needs a directly testable null-safe location resolver", resolver);
+
+        Client client = mock(Client.class);
+        resolver.setAccessible(true);
+
+        assertNull(resolver.invoke(null, client));
+        verify(clientThread).runOnClientThreadOptional(any());
+        verify(client).getLocalPlayer();
+    }
+
+    private static Object swapClientThread(Object value) throws Exception
+    {
+        Field field = Microbot.class.getDeclaredField("clientThread");
+        field.setAccessible(true);
+        Object previous = field.get(null);
+        field.set(null, value);
+        return previous;
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/BankedWalkStatePolicyTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/BankedWalkStatePolicyTest.java
@@ -1,0 +1,20 @@
+package net.runelite.client.plugins.microbot.util.walker;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BankedWalkStatePolicyTest {
+
+    @Test
+    public void movingIsNotATerminalDirectWalkFailure() {
+        assertFalse(Rs2Walker.isTerminalBankedDirectWalkFailure(WalkerState.MOVING));
+    }
+
+    @Test
+    public void unreachableAndExitAreTerminalDirectWalkFailures() {
+        assertTrue(Rs2Walker.isTerminalBankedDirectWalkFailure(WalkerState.UNREACHABLE));
+        assertTrue(Rs2Walker.isTerminalBankedDirectWalkFailure(WalkerState.EXIT));
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/DoorApproachOwnershipTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/DoorApproachOwnershipTest.java
@@ -1,0 +1,40 @@
+package net.runelite.client.plugins.microbot.util.walker;
+
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.util.walker.state.WalkerRouteState;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class DoorApproachOwnershipTest {
+    @Test
+    public void failedInteractionDoesNotClaimApproachOwnership() {
+        WalkerRouteState state = new WalkerRouteState();
+        WorldPoint player = new WorldPoint(3170, 3300, 0);
+        WorldPoint from = new WorldPoint(3167, 3302, 0);
+        WorldPoint to = new WorldPoint(3166, 3303, 0);
+
+        Rs2Walker.recordDoorApproachOwnership(state, false, player, from, to, 1000L);
+
+        assertNull(state.lastDoorAttemptPlayerPosition);
+        assertNull(state.lastDoorAttemptFrom);
+        assertNull(state.lastDoorAttemptTo);
+        assertEquals(0L, state.lastDoorAttemptAtMs);
+    }
+
+    @Test
+    public void successfulInteractionClaimsApproachOwnership() {
+        WalkerRouteState state = new WalkerRouteState();
+        WorldPoint player = new WorldPoint(3170, 3300, 0);
+        WorldPoint from = new WorldPoint(3167, 3302, 0);
+        WorldPoint to = new WorldPoint(3166, 3303, 0);
+
+        Rs2Walker.recordDoorApproachOwnership(state, true, player, from, to, 1000L);
+
+        assertEquals(player, state.lastDoorAttemptPlayerPosition);
+        assertEquals(from, state.lastDoorAttemptFrom);
+        assertEquals(to, state.lastDoorAttemptTo);
+        assertEquals(1000L, state.lastDoorAttemptAtMs);
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/DoorApproachOwnershipTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/DoorApproachOwnershipTest.java
@@ -37,4 +37,14 @@ public class DoorApproachOwnershipTest {
         assertEquals(to, state.lastDoorAttemptTo);
         assertEquals(1000L, state.lastDoorAttemptAtMs);
     }
+
+    @Test
+    public void doorApproachAgeComesFromTheOwnedAttemptTimestamp() {
+        WalkerRouteState state = new WalkerRouteState();
+
+        assertEquals(-1L, Rs2Walker.doorApproachAgeMs(state, 1_700L));
+        state.lastDoorAttemptAtMs = 1_000L;
+        assertEquals(700L, Rs2Walker.doorApproachAgeMs(state, 1_700L));
+        assertEquals(0L, Rs2Walker.doorApproachAgeMs(state, 900L));
+    }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/DoorAwaitDispatchWiringTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/DoorAwaitDispatchWiringTest.java
@@ -1,0 +1,120 @@
+package net.runelite.client.plugins.microbot.util.walker;
+
+import java.io.InputStream;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class DoorAwaitDispatchWiringTest
+{
+    private static final String RS2_WALKER =
+            "net/runelite/client/plugins/microbot/util/walker/Rs2Walker";
+    private static final String RS2_GAME_OBJECT =
+            "net/runelite/client/plugins/microbot/util/gameobject/Rs2GameObject";
+    private static final String RS2_PLAYER =
+            "net/runelite/client/plugins/microbot/util/player/Rs2Player";
+    private static final String WORLD_POINT = "Lnet/runelite/api/coords/WorldPoint;";
+    private static final String AWAIT_DESCRIPTOR =
+            "(" + WORLD_POINT + WORLD_POINT + WORLD_POINT + ")V";
+
+    @Test
+    public void everyDoorAwaitReceivesThePositionCapturedBeforeInteraction() throws Exception
+    {
+        ClassNode classNode = new ClassNode();
+        try (InputStream input = Rs2Walker.class.getResourceAsStream("/" + RS2_WALKER + ".class"))
+        {
+            assertNotNull(input);
+            new ClassReader(input).accept(classNode, ClassReader.SKIP_FRAMES);
+        }
+
+        int awaitCalls = 0;
+        for (MethodNode method : classNode.methods)
+        {
+            for (AbstractInsnNode instruction = method.instructions.getFirst();
+                 instruction != null; instruction = instruction.getNext())
+            {
+                if (!(instruction instanceof MethodInsnNode))
+                {
+                    continue;
+                }
+                MethodInsnNode call = (MethodInsnNode) instruction;
+                if (!RS2_WALKER.equals(call.owner)
+                        || !"waitForDoorInteractionProgress".equals(call.name)
+                        || !AWAIT_DESCRIPTOR.equals(call.desc))
+                {
+                    continue;
+                }
+
+                awaitCalls++;
+                AbstractInsnNode toLoad = previousInstruction(call);
+                AbstractInsnNode fromLoad = previousInstruction(toLoad);
+                AbstractInsnNode beforeLoad = previousInstruction(fromLoad);
+                assertTrue(beforeLoad instanceof VarInsnNode
+                        && beforeLoad.getOpcode() == Opcodes.ALOAD);
+                assertTrue(fromLoad instanceof VarInsnNode
+                        && fromLoad.getOpcode() == Opcodes.ALOAD);
+                assertTrue(toLoad instanceof VarInsnNode
+                        && toLoad.getOpcode() == Opcodes.ALOAD);
+                int beforeLocal = ((VarInsnNode) beforeLoad).var;
+
+                MethodInsnNode interaction = previousCall(beforeLoad, RS2_GAME_OBJECT, "interact");
+                assertNotNull("door await must follow an Rs2GameObject interaction", interaction);
+                MethodInsnNode positionRead = previousCall(interaction, RS2_PLAYER, "getWorldLocation");
+                assertNotNull("door interaction must have a pre-dispatch position read", positionRead);
+                AbstractInsnNode positionStore = nextInstruction(positionRead);
+                assertTrue(positionStore instanceof VarInsnNode
+                        && positionStore.getOpcode() == Opcodes.ASTORE);
+                assertEquals("door await must reuse the pre-dispatch position local",
+                        beforeLocal, ((VarInsnNode) positionStore).var);
+            }
+        }
+
+        assertEquals("all three shared door-await dispatch paths must be covered", 3, awaitCalls);
+    }
+
+    private static MethodInsnNode previousCall(AbstractInsnNode start, String owner, String name)
+    {
+        for (AbstractInsnNode instruction = previousInstruction(start);
+             instruction != null; instruction = previousInstruction(instruction))
+        {
+            if (instruction instanceof MethodInsnNode)
+            {
+                MethodInsnNode call = (MethodInsnNode) instruction;
+                if (owner.equals(call.owner) && name.equals(call.name))
+                {
+                    return call;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static AbstractInsnNode previousInstruction(AbstractInsnNode instruction)
+    {
+        AbstractInsnNode previous = instruction == null ? null : instruction.getPrevious();
+        while (previous != null && previous.getOpcode() < 0)
+        {
+            previous = previous.getPrevious();
+        }
+        return previous;
+    }
+
+    private static AbstractInsnNode nextInstruction(AbstractInsnNode instruction)
+    {
+        AbstractInsnNode next = instruction == null ? null : instruction.getNext();
+        while (next != null && next.getOpcode() < 0)
+        {
+            next = next.getNext();
+        }
+        return next;
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/RouteReachabilitySnapshotWiringTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/RouteReachabilitySnapshotWiringTest.java
@@ -1,0 +1,147 @@
+package net.runelite.client.plugins.microbot.util.walker;
+
+import java.io.InputStream;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class RouteReachabilitySnapshotWiringTest
+{
+    private static final String RS2_WALKER =
+            "net/runelite/client/plugins/microbot/util/walker/Rs2Walker";
+    private static final String RS2_PLAYER =
+            "net/runelite/client/plugins/microbot/util/player/Rs2Player";
+    private static final String GLOBAL =
+            "net/runelite/client/plugins/microbot/util/Global";
+    private static final String SELECTOR_DESCRIPTOR =
+            "(Ljava/util/List;Lnet/runelite/api/coords/WorldPoint;IILjava/util/Map;)"
+                    + "Lnet/runelite/api/coords/WorldPoint;";
+
+    @Test
+    public void routeSelectionUsesTheSnapshotCapturedAfterInterimHandling() throws Exception
+    {
+        ClassNode classNode = new ClassNode();
+        try (InputStream input = Rs2Walker.class.getResourceAsStream("/" + RS2_WALKER + ".class"))
+        {
+            assertNotNull(input);
+            new ClassReader(input).accept(classNode, ClassReader.SKIP_FRAMES);
+        }
+
+        int selectorCalls = 0;
+        for (MethodNode processWalk : classNode.methods)
+        {
+            if (!"processWalk".equals(processWalk.name))
+            {
+                continue;
+            }
+            for (AbstractInsnNode instruction = processWalk.instructions.getFirst();
+                 instruction != null; instruction = instruction.getNext())
+            {
+                if (!(instruction instanceof MethodInsnNode))
+                {
+                    continue;
+                }
+                MethodInsnNode selector = (MethodInsnNode) instruction;
+                if (!RS2_WALKER.equals(selector.owner)
+                        || !"selectRouteClickTarget".equals(selector.name)
+                        || !SELECTOR_DESCRIPTOR.equals(selector.desc))
+                {
+                    continue;
+                }
+
+                selectorCalls++;
+                MethodInsnNode capture = previousCall(selector, RS2_WALKER,
+                        "getClosestIndexReachableTiles");
+                assertNotNull("route selection must have a reachability capture", capture);
+                MethodInsnNode interimDoorScan = previousCall(capture, RS2_WALKER,
+                        "handlePendingDoorDuringInterim");
+                assertNotNull("reachability must be captured after interim door handling", interimDoorScan);
+                assertTrue("the interim movement wait must precede the reachability capture",
+                        containsCallBetween(interimDoorScan, capture, GLOBAL, "sleepUntil"));
+                assertFalse("no wait may age the reachability snapshot before route selection",
+                        containsCallBetween(capture, selector, GLOBAL, "sleepUntil"));
+
+                MethodInsnNode playerRead = previousCall(capture, RS2_PLAYER, "getWorldLocation");
+                assertNotNull("reachability capture must follow a fresh player snapshot", playerRead);
+                assertFalse("the player and collision snapshots must be captured together",
+                        containsCallBetween(playerRead, capture, GLOBAL, "sleepUntil"));
+
+                AbstractInsnNode mapStore = nextInstruction(capture);
+                AbstractInsnNode mapLoad = previousInstruction(selector);
+                assertTrue(mapStore instanceof VarInsnNode && mapStore.getOpcode() == Opcodes.ASTORE);
+                assertTrue(mapLoad instanceof VarInsnNode && mapLoad.getOpcode() == Opcodes.ALOAD);
+                assertEquals("selector must receive the map captured at the decision boundary",
+                        ((VarInsnNode) mapStore).var, ((VarInsnNode) mapLoad).var);
+            }
+        }
+
+        assertEquals("processWalk must have one normal route-selection site", 1, selectorCalls);
+    }
+
+    private static boolean containsCallBetween(AbstractInsnNode start,
+                                               AbstractInsnNode end,
+                                               String owner,
+                                               String name)
+    {
+        for (AbstractInsnNode instruction = start.getNext();
+             instruction != null && instruction != end; instruction = instruction.getNext())
+        {
+            if (instruction instanceof MethodInsnNode)
+            {
+                MethodInsnNode call = (MethodInsnNode) instruction;
+                if (owner.equals(call.owner) && name.equals(call.name))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static MethodInsnNode previousCall(AbstractInsnNode start, String owner, String name)
+    {
+        for (AbstractInsnNode instruction = previousInstruction(start);
+             instruction != null; instruction = previousInstruction(instruction))
+        {
+            if (instruction instanceof MethodInsnNode)
+            {
+                MethodInsnNode call = (MethodInsnNode) instruction;
+                if (owner.equals(call.owner) && name.equals(call.name))
+                {
+                    return call;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static AbstractInsnNode previousInstruction(AbstractInsnNode instruction)
+    {
+        AbstractInsnNode previous = instruction == null ? null : instruction.getPrevious();
+        while (previous != null && previous.getOpcode() < 0)
+        {
+            previous = previous.getPrevious();
+        }
+        return previous;
+    }
+
+    private static AbstractInsnNode nextInstruction(AbstractInsnNode instruction)
+    {
+        AbstractInsnNode next = instruction == null ? null : instruction.getNext();
+        while (next != null && next.getOpcode() < 0)
+        {
+            next = next.getNext();
+        }
+        return next;
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
@@ -1094,9 +1094,15 @@ public class Rs2WalkerUnitTest {
 
     @Test
     public void objectTransportPassEndsWhenDialogueOpensBeforeLanding() {
-        assertTrue(Rs2Walker.shouldEndObjectTransportPass(false, true));
-        assertTrue(Rs2Walker.shouldEndObjectTransportPass(true, false));
-        assertFalse(Rs2Walker.shouldEndObjectTransportPass(false, false));
+        assertTrue(Rs2Walker.shouldEndObjectTransportPass(false, false, true));
+        assertTrue(Rs2Walker.shouldEndObjectTransportPass(true, false, false));
+        assertTrue("a real landing remains progress while an unrelated dialogue stays open",
+                Rs2Walker.shouldEndObjectTransportPass(true, true, true));
+        assertFalse(Rs2Walker.shouldEndObjectTransportPass(false, false, false));
+        assertFalse("an unrelated dialogue that was already open is not transport progress",
+                Rs2Walker.shouldEndObjectTransportPass(false, true, true));
+        assertTrue(Rs2Walker.isNewObjectTransportDialogue(false, true));
+        assertFalse(Rs2Walker.isNewObjectTransportDialogue(true, true));
     }
 
     @Test

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
@@ -1645,6 +1645,22 @@ public class Rs2WalkerUnitTest {
     }
 
     @Test
+    public void routeClickSelectionUsesTheCapturedReachabilitySnapshot() {
+        WorldPoint player = new WorldPoint(3200, 3200, 0);
+        List<WorldPoint> rawPath = Arrays.asList(
+                player,
+                new WorldPoint(3201, 3200, 0),
+                new WorldPoint(3202, 3200, 0),
+                new WorldPoint(3203, 3200, 0));
+        Map<WorldPoint, Integer> reachable = new HashMap<>();
+        reachable.put(player, 0);
+        reachable.put(rawPath.get(1), 1);
+
+        assertEquals(rawPath.get(1), Rs2Walker.findFurthestRawPathPointMatchingGated(
+                rawPath, player, 7, 0, point -> true, reachable));
+    }
+
+    @Test
     public void shouldHoldInterimBeforeRouteScans_enforcesProgressAndRecoveryBoundaries() {
         WorldPoint interim = new WorldPoint(2890, 3396, 0);
         long now = 5_000L;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
@@ -1096,6 +1096,8 @@ public class Rs2WalkerUnitTest {
     public void objectTransportPassEndsWhenDialogueOpensBeforeLanding() {
         assertTrue(Rs2Walker.shouldEndObjectTransportPass(false, false, true));
         assertTrue(Rs2Walker.shouldEndObjectTransportPass(true, false, false));
+        assertTrue("a real landing wins even when a new dialogue also opens",
+                Rs2Walker.shouldEndObjectTransportPass(true, false, true));
         assertTrue("a real landing remains progress while an unrelated dialogue stays open",
                 Rs2Walker.shouldEndObjectTransportPass(true, true, true));
         assertFalse(Rs2Walker.shouldEndObjectTransportPass(false, false, false));
@@ -1103,6 +1105,15 @@ public class Rs2WalkerUnitTest {
                 Rs2Walker.shouldEndObjectTransportPass(false, true, true));
         assertTrue(Rs2Walker.isNewObjectTransportDialogue(false, true));
         assertFalse(Rs2Walker.isNewObjectTransportDialogue(true, true));
+        assertTrue(Rs2Walker.shouldYieldObjectTransportDialogue(false, false, true));
+        assertFalse(Rs2Walker.shouldYieldObjectTransportDialogue(true, false, true));
+        assertFalse(Rs2Walker.shouldYieldObjectTransportDialogue(false, true, true));
+        assertTrue(Rs2Walker.resolveObjectTransportLandingWait(true, true, false, false, true));
+        assertTrue("an accepted adjacent landing wins even when dialogue opens",
+                Rs2Walker.resolveObjectTransportLandingWait(false, true, true, false, true));
+        assertFalse(Rs2Walker.resolveObjectTransportLandingWait(false, true, false, false, true));
+        assertTrue(Rs2Walker.shouldEndObjectTransportLandingPoll(false, true, true, false));
+        assertFalse(Rs2Walker.shouldEndObjectTransportLandingPoll(false, false, false, false));
     }
 
     @Test

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
@@ -53,6 +53,13 @@ public class Rs2WalkerUnitTest {
         assertEquals(WalkerState.EXIT, Rs2Walker.playerSnapshotUnavailableState(false));
     }
 
+    @Test
+    public void interimDoorScanMayRunDuringApproachButRecoveryScanStillWaits() {
+        assertFalse(Rs2Walker.shouldDeferPendingDoorRawScan(true, true));
+        assertTrue(Rs2Walker.shouldDeferPendingDoorRawScan(true, false));
+        assertFalse(Rs2Walker.shouldDeferPendingDoorRawScan(false, false));
+    }
+
     @Before
     public void resetTelemetry() {
         Rs2Walker.clearWalkerDedupeForTesting();

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
@@ -1601,6 +1601,42 @@ public class Rs2WalkerUnitTest {
     }
 
     @Test
+    public void routeInterimReadyForContinuation_handsOffEarlyWithoutWeakeningRecovery() {
+        WorldPoint interim = new WorldPoint(2890, 3396, 0);
+        WorldPoint initialPlayer = new WorldPoint(2883, 3396, 0);
+        WorldPoint progressedPlayer = new WorldPoint(2884, 3396, 0);
+
+        assertFalse(Rs2Walker.routeInterimReadyForContinuation(
+                interim, initialPlayer, 7, false, 8));
+        assertTrue(Rs2Walker.routeInterimReadyForContinuation(
+                interim, progressedPlayer, 7, false, 8));
+        assertFalse(Rs2Walker.routeInterimReadyForContinuation(
+                interim, progressedPlayer, 7, true, 8));
+    }
+
+    @Test
+    public void shouldHoldInterimBeforeRouteScans_enforcesProgressAndRecoveryBoundaries() {
+        WorldPoint interim = new WorldPoint(2890, 3396, 0);
+        long now = 5_000L;
+
+        assertTrue(Rs2Walker.shouldHoldInterimBeforeRouteScans(
+                interim, new WorldPoint(2883, 3396, 0),
+                4_900L, 4_900L, now, 4_900L, 7, false, true, 8));
+        assertFalse(Rs2Walker.shouldHoldInterimBeforeRouteScans(
+                interim, new WorldPoint(2884, 3396, 0),
+                4_900L, 4_900L, now, 4_900L, 7, false, true, 8));
+        assertTrue(Rs2Walker.shouldHoldInterimBeforeRouteScans(
+                interim, new WorldPoint(2884, 3396, 0),
+                4_900L, 4_900L, now, 4_900L, 7, true, true, 8));
+        assertFalse(Rs2Walker.shouldHoldInterimBeforeRouteScans(
+                interim, new WorldPoint(2885, 3396, 0),
+                4_900L, 4_900L, now, 4_900L, 7, true, true, 8));
+        assertTrue(Rs2Walker.shouldHoldInterimBeforeRouteScans(
+                interim, new WorldPoint(2883, 3389, 0),
+                4_900L, 4_900L, now, 4_900L, 7, false, true, 8));
+    }
+
+    @Test
     public void routeMovementClickPhase_labelsContinuationSeparatelyFromRecovery() {
         assertEquals("stall_recovery_click", Rs2Walker.routeMovementClickPhase("stall recovery click"));
         assertEquals("active_route_idle_nudge", Rs2Walker.routeMovementClickPhase("active route idle nudge"));
@@ -1698,6 +1734,30 @@ public class Rs2WalkerUnitTest {
                 false,
                 false,
                 false));
+    }
+
+    @Test
+    public void shouldRunLocalReachabilityRecovery_startupBeforeFirstClick_usesNormalRouteClick() {
+        assertFalse("startup must reach the normal route-click path before speculative recovery scans",
+                Rs2Walker.shouldRunLocalReachabilityRecovery(false, false, true));
+        assertTrue("steady walking must retain blocked-frontier recovery",
+                Rs2Walker.shouldRunLocalReachabilityRecovery(false, false, false));
+        assertFalse("reachable route tiles do not need recovery",
+                Rs2Walker.shouldRunLocalReachabilityRecovery(true, false, false));
+        assertFalse("instances do not use overworld local recovery",
+                Rs2Walker.shouldRunLocalReachabilityRecovery(false, true, false));
+    }
+
+    @Test
+    public void shouldAttemptRouteClick_startupWaypointBypassesRandomDistanceThreshold() {
+        assertTrue("startup must enter the common click dispatcher for the first nonzero waypoint",
+                Rs2Walker.shouldAttemptRouteClick(6, 12, false, true));
+        assertFalse("steady walking keeps the normal checkpoint distance threshold",
+                Rs2Walker.shouldAttemptRouteClick(6, 12, false, false));
+        assertFalse("the player's current tile is not a movement target",
+                Rs2Walker.shouldAttemptRouteClick(0, 12, false, true));
+        assertTrue("planned transport approaches remain eligible in every phase",
+                Rs2Walker.shouldAttemptRouteClick(0, 12, true, false));
     }
 
     @Test

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
@@ -1079,6 +1079,21 @@ public class Rs2WalkerUnitTest {
         assertEquals(300, Rs2Walker.shortWalkDirectPathCeiling(100));
     }
 
+    @Test
+    public void objectTransportPassEndsWhenDialogueOpensBeforeLanding() {
+        assertTrue(Rs2Walker.shouldEndObjectTransportPass(false, true));
+        assertTrue(Rs2Walker.shouldEndObjectTransportPass(true, false));
+        assertFalse(Rs2Walker.shouldEndObjectTransportPass(false, false));
+    }
+
+    @Test
+    public void handledRouteTransportDialogueReturnsControlToCaller() {
+        assertTrue(Rs2Walker.shouldYieldRouteProgressToCaller("transport-handled", true));
+        assertTrue(Rs2Walker.shouldYieldRouteProgressToCaller("raw-path-scene-object-handled", true));
+        assertFalse(Rs2Walker.shouldYieldRouteProgressToCaller("transport-handled", false));
+        assertFalse(Rs2Walker.shouldYieldRouteProgressToCaller("click-failed-off-minimap", true));
+    }
+
     /**
      * A guarded door replies with a conversation instead of opening; re-clicking it cancels that menu,
      * so whatever answers dialogue never gets a menu that survives long enough to act on and the walk
@@ -1525,6 +1540,58 @@ public class Rs2WalkerUnitTest {
                 0L,
                 false,
                 5));
+    }
+
+    @Test
+    public void shouldYieldForActiveRouteInterim_runningWithinPreclickRange_returnsFalse() {
+        assertFalse(Rs2Walker.shouldYieldForActiveRouteInterim(
+                new WorldPoint(2890, 3396, 0),
+                new WorldPoint(2883, 3396, 0),
+                1_000L,
+                4_900L,
+                5_000L,
+                4_500L,
+                true,
+                8));
+    }
+
+    @Test
+    public void shouldYieldForActiveRouteInterim_walkingBeforePreclickRange_returnsTrue() {
+        assertTrue(Rs2Walker.shouldYieldForActiveRouteInterim(
+                new WorldPoint(2890, 3396, 0),
+                new WorldPoint(2883, 3396, 0),
+                1_000L,
+                4_900L,
+                5_000L,
+                4_500L,
+                true,
+                6));
+    }
+
+    @Test
+    public void shouldYieldForActiveRouteInterim_runningDiagonalOutsideCircularPreclickRange_returnsTrue() {
+        assertTrue(Rs2Walker.shouldYieldForActiveRouteInterim(
+                new WorldPoint(2890, 3396, 0),
+                new WorldPoint(2883, 3389, 0),
+                1_000L,
+                4_900L,
+                5_000L,
+                4_500L,
+                true,
+                8));
+    }
+
+    @Test
+    public void shouldYieldForActiveRouteInterim_walkingDiagonalOutsideCircularPreclickRange_returnsTrue() {
+        assertTrue(Rs2Walker.shouldYieldForActiveRouteInterim(
+                new WorldPoint(2890, 3396, 0),
+                new WorldPoint(2884, 3390, 0),
+                1_000L,
+                4_900L,
+                5_000L,
+                4_500L,
+                true,
+                6));
     }
 
     @Test

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/Rs2WalkerUnitTest.java
@@ -47,6 +47,12 @@ import static org.mockito.Mockito.when;
  */
 public class Rs2WalkerUnitTest {
 
+    @Test
+    public void transientMissingPlayerSnapshotKeepsRouteAlive() {
+        assertEquals(WalkerState.MOVING, Rs2Walker.playerSnapshotUnavailableState(true));
+        assertEquals(WalkerState.EXIT, Rs2Walker.playerSnapshotUnavailableState(false));
+    }
+
     @Before
     public void resetTelemetry() {
         Rs2Walker.clearWalkerDedupeForTesting();

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2WalkerAwaitsTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2WalkerAwaitsTest.java
@@ -1,8 +1,10 @@
 package net.runelite.client.plugins.microbot.util.walker.door;
 
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.util.walker.door.model.AwaitTicket;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -73,6 +75,21 @@ public class Rs2WalkerAwaitsTest {
                 true, 4001L, 4000L));
         assertFalse(Rs2WalkerAwaits.isDoorApproachInFlight(
                 before, farSide, nearSide, farSide,
+                true, 700L, 4000L));
+    }
+
+    @Test
+    public void beginTicketPreservesPreDispatchPositionWhenMovementStartsImmediately() {
+        WorldPoint beforeDispatch = new WorldPoint(3170, 3300, 0);
+        WorldPoint afterDispatch = new WorldPoint(3169, 3301, 0);
+        WorldPoint nearSide = new WorldPoint(3167, 3302, 0);
+        WorldPoint farSide = new WorldPoint(3166, 3303, 0);
+
+        AwaitTicket ticket = Rs2WalkerAwaits.beginTicket(beforeDispatch);
+
+        assertEquals(beforeDispatch, ticket.beforePosition());
+        assertTrue(Rs2WalkerAwaits.isDoorApproachInFlight(
+                ticket.beforePosition(), afterDispatch, nearSide, farSide,
                 true, 700L, 4000L));
     }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2WalkerAwaitsTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/door/Rs2WalkerAwaitsTest.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.util.walker.door;
 
+import net.runelite.api.coords.WorldPoint;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -32,5 +33,46 @@ public class Rs2WalkerAwaitsTest {
     public void shouldAcceptIdleDoorAwait_rejectsBeforeMinimumElapsed() {
         assertFalse(Rs2WalkerAwaits.shouldAcceptIdleDoorAwait(false, false, 1200L, true));
         assertFalse(Rs2WalkerAwaits.shouldAcceptIdleDoorAwait(false, false, 800L, true));
+    }
+
+    @Test
+    public void doorApproachInFlight_acceptsMovementTowardNearSide() {
+        assertTrue(Rs2WalkerAwaits.isDoorApproachInFlight(
+                new WorldPoint(3170, 3300, 0),
+                new WorldPoint(3169, 3301, 0),
+                new WorldPoint(3167, 3302, 0),
+                new WorldPoint(3166, 3303, 0),
+                true,
+                700L,
+                4000L));
+    }
+
+    @Test
+    public void doorApproachInFlight_rejectsMovementAwayFromDoor() {
+        assertFalse(Rs2WalkerAwaits.isDoorApproachInFlight(
+                new WorldPoint(3169, 3301, 0),
+                new WorldPoint(3170, 3300, 0),
+                new WorldPoint(3167, 3302, 0),
+                new WorldPoint(3166, 3303, 0),
+                true,
+                700L,
+                4000L));
+    }
+
+    @Test
+    public void doorApproachInFlight_rejectsExpiredStationaryOrCrossedMovement() {
+        WorldPoint before = new WorldPoint(3169, 3301, 0);
+        WorldPoint nearSide = new WorldPoint(3167, 3302, 0);
+        WorldPoint farSide = new WorldPoint(3166, 3303, 0);
+
+        assertFalse(Rs2WalkerAwaits.isDoorApproachInFlight(
+                before, new WorldPoint(3168, 3302, 0), nearSide, farSide,
+                false, 700L, 4000L));
+        assertFalse(Rs2WalkerAwaits.isDoorApproachInFlight(
+                before, new WorldPoint(3168, 3302, 0), nearSide, farSide,
+                true, 4001L, 4000L));
+        assertFalse(Rs2WalkerAwaits.isDoorApproachInFlight(
+                before, farSide, nearSide, farSide,
+                true, 700L, 4000L));
     }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaitsTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaitsTest.java
@@ -39,4 +39,11 @@ public class Rs2WalkerTransportAwaitsTest
         assertTrue(Rs2WalkerTransportAwaits.hasTransportProgress(
                 BEFORE, DESTINATION, DESTINATION, TARGET, false, false));
     }
+
+    @Test
+    public void progressObservedDuringWaitIsNotLostWhenDialogueCloses()
+    {
+        assertTrue(Rs2WalkerTransportAwaits.resolveTransportProgress(
+                true, BEFORE, BEFORE, DESTINATION, TARGET, false, false));
+    }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaitsTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaitsTest.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.util.walker.transport;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import net.runelite.api.coords.WorldPoint;
 import org.junit.Test;
 
@@ -57,5 +58,17 @@ public class Rs2WalkerTransportAwaitsTest
     public void preexistingDialogueDoesNotCountWhenPositionSnapshotIsMissing()
     {
         assertFalse(Rs2WalkerTransportAwaits.hasProgressWithoutPositionSnapshot(true, true));
+    }
+
+    @Test
+    public void delayedDialogueOpeningCountsWhenPositionSnapshotIsMissing()
+    {
+        AtomicInteger samples = new AtomicInteger();
+
+        assertTrue(Rs2WalkerTransportAwaits.waitForProgressWithoutPositionSnapshot(
+                false,
+                () -> samples.incrementAndGet() >= 2,
+                condition -> !condition.getAsBoolean() && condition.getAsBoolean()));
+        assertTrue("the dialogue must be polled rather than sampled once", samples.get() >= 2);
     }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaitsTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaitsTest.java
@@ -46,4 +46,16 @@ public class Rs2WalkerTransportAwaitsTest
         assertTrue(Rs2WalkerTransportAwaits.resolveTransportProgress(
                 true, BEFORE, BEFORE, DESTINATION, TARGET, false, false));
     }
+
+    @Test
+    public void newlyOpenedDialogueCountsWhenPositionSnapshotIsMissing()
+    {
+        assertTrue(Rs2WalkerTransportAwaits.hasProgressWithoutPositionSnapshot(false, true));
+    }
+
+    @Test
+    public void preexistingDialogueDoesNotCountWhenPositionSnapshotIsMissing()
+    {
+        assertFalse(Rs2WalkerTransportAwaits.hasProgressWithoutPositionSnapshot(true, true));
+    }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaitsTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/walker/transport/Rs2WalkerTransportAwaitsTest.java
@@ -1,0 +1,42 @@
+package net.runelite.client.plugins.microbot.util.walker.transport;
+
+import net.runelite.api.coords.WorldPoint;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Rs2WalkerTransportAwaitsTest
+{
+    private static final WorldPoint BEFORE = new WorldPoint(3200, 3200, 0);
+    private static final WorldPoint DESTINATION = new WorldPoint(3203, 3200, 0);
+    private static final WorldPoint TARGET = new WorldPoint(3210, 3200, 0);
+
+    @Test
+    public void openDialogueCountsAsTransportProgressWithoutMovement()
+    {
+        assertTrue(Rs2WalkerTransportAwaits.hasTransportProgress(
+                BEFORE, BEFORE, DESTINATION, TARGET, false, true));
+    }
+
+    @Test
+    public void preexistingDialogueDoesNotCountAsTransportProgress()
+    {
+        assertFalse(Rs2WalkerTransportAwaits.hasTransportProgress(
+                BEFORE, BEFORE, DESTINATION, TARGET, true, true));
+    }
+
+    @Test
+    public void noDialogueOrMovementDoesNotCountAsTransportProgress()
+    {
+        assertFalse(Rs2WalkerTransportAwaits.hasTransportProgress(
+                BEFORE, BEFORE, DESTINATION, TARGET, false, false));
+    }
+
+    @Test
+    public void movementStillCountsAsTransportProgress()
+    {
+        assertTrue(Rs2WalkerTransportAwaits.hasTransportProgress(
+                BEFORE, DESTINATION, DESTINATION, TARGET, false, false));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes WebWalker continuity and responsiveness problems caused by repeated collision/reachability scans inside a single movement decision, while preserving door, transport, recovery, and route-ownership behavior.

This PR also includes the already reviewed public fixes on itsBOTzilla:main for ShortestPath worker lifecycle, QuestHelper interaction safety, and nested GroundItem pause ownership. No private iBOT scripts or plugin code are included.

## Changes

- Captures one fresh reachability snapshot at the actual movement-decision boundary and reuses it across route-candidate retries
- Re-captures player position and collision reachability after interim door handling or movement waits, preventing stale maps from producing through-wall or off-route clicks
- Applies the same decision-snapshot contract to normal movement, continuation, and recovery
- Preserves transport landing/dialogue evidence, pre-dispatch door baselines, and route target ownership across transient lifecycle gaps
- Serializes ShortestPath stop, shutdown, and target-replacement cleanup without overlapping workers
- Hardens QuestHelper object/NPC item selection, lifecycle shutdown, routing, and observable interaction confirmation
- Preserves nested and overlapping GroundItem pause scopes
- Adds focused unit, concurrency, truth-table, and bytecode-wiring regressions
- Updates the movement guide to match the implemented timing and distance contracts

## Why

Live timing logs showed path creation completing in roughly 40–244 ms while the first minimap click was delayed by roughly 2.5–4.4 seconds. The delay was not the pathfinder; Rs2Walker was repeatedly rebuilding collision reachability during one click decision and retrying selection against separately sampled world state.

Using one fresh player/reachability observation per movement decision removes that repeated work and keeps every candidate in the decision tied to the same collision snapshot. Capturing after interim door handling is essential because doors and player position can change while the handler waits.

## Testing

- :client:runUnitTests for the complete Microbot walker package — 270 tests passed
- Focused QuestHelper, ShortestPath, GroundItem, and player null-safety suites — 40 tests passed
- :client:checkstyleMain passed
- :client:checkstyleTest passed
- :client:assemble passed
- check passed
- git diff --check passed
- Two independent Java/code reviews completed with no remaining blocking findings
- Release JAR rebuilt with embedded commit 30cc09e and dirty=false

## Checklist

- [x] Code compiles
- [x] Focused regression tests pass
- [x] No unused imports
- [x] Follows existing Microbot code style
- [x] No debug-only logs added
- [x] No private iBOT scripts or credentials included
- [x] No new WebWalker subsystem or parallel architecture introduced
- [x] Existing public APIs remain compatible
- [ ] Final in-game smoothness qualification on the exact staged JAR

## Notes

The behavioral change is intentionally in-place: it reuses existing Microbot walker data and helpers rather than importing or creating a RuneWalker subsystem.

The release artifact is source/build verified. In-game behavior will only be treated as proven after the launcher loads the exact hash and a fresh startup log reports commit 30cc09e.