### PR TITLE
feat(breakhandler): honor plugin lock in Break Handler V2

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2Script.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2Script.java
@@ -6,6 +6,7 @@ import net.runelite.api.GameState;
 import net.runelite.client.config.ConfigProfile;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
 import net.runelite.client.plugins.microbot.util.discord.Rs2Discord;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
@@ -30,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 @Singleton
 @Slf4j
 public class BreakHandlerV2Script extends Script {
+    private static final long LOCK_DEFERRAL_LOG_INTERVAL_MS = 30_000L;
 
     // Instance tracking for debugging
     private static int instanceCounter = 0;
@@ -72,6 +74,7 @@ public class BreakHandlerV2Script extends Script {
     // Break duration in milliseconds
     private long currentBreakDuration = 0;
     private boolean logoutBreakActive = false;
+    private long lastLockDeferralLogAt = 0L;
     private boolean longBreakDue = false;
     private boolean megaBreakDue = false;
     private volatile boolean currentBreakIsLong = false;
@@ -236,6 +239,16 @@ public class BreakHandlerV2Script extends Script {
      * Initiates break based on configuration
      */
     private void handleBreakRequested() {
+        if (shouldDeferRequestedBreak()) {
+            long now = System.currentTimeMillis();
+            if (now - lastLockDeferralLogAt >= LOCK_DEFERRAL_LOG_INTERVAL_MS) {
+                log.info("[BreakHandlerV2] Break deferred while a plugin lock is active");
+                lastLockDeferralLogAt = now;
+            }
+            return;
+        }
+
+        lastLockDeferralLogAt = 0L;
         stopConfiguredPluginIfNeeded();
 
         // If breakEndTime is already set, we're in a no-logout break waiting for it to end
@@ -265,6 +278,10 @@ public class BreakHandlerV2Script extends Script {
             log.info("[BreakHandlerV2] Starting break (no logout - scripts paused)");
             beginPauseBreak();
         }
+    }
+
+    static boolean shouldDeferRequestedBreak() {
+        return BreakHandlerScript.isLockState();
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2Script.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2Script.java
@@ -239,7 +239,7 @@ public class BreakHandlerV2Script extends Script {
      * Initiates break based on configuration
      */
     private void handleBreakRequested() {
-        if (shouldDeferRequestedBreak()) {
+        if (shouldDeferRequestedBreak(breakEndTime)) {
             long now = System.currentTimeMillis();
             if (now - lastLockDeferralLogAt >= LOCK_DEFERRAL_LOG_INTERVAL_MS) {
                 log.info("[BreakHandlerV2] Break deferred while a plugin lock is active");
@@ -280,8 +280,12 @@ public class BreakHandlerV2Script extends Script {
         }
     }
 
-    static boolean shouldDeferRequestedBreak() {
-        return BreakHandlerScript.isLockState();
+    /**
+     * Defers only a new break request. A non-null end time represents an active
+     * no-logout break whose completion must continue to be processed.
+     */
+    static boolean shouldDeferRequestedBreak(Instant activeBreakEndTime) {
+        return activeBreakEndTime == null && BreakHandlerScript.isLockState();
     }
 
     /**

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2DeferralTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2DeferralTest.java
@@ -4,6 +4,8 @@ import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
 import org.junit.After;
 import org.junit.Test;
 
+import java.time.Instant;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -17,13 +19,20 @@ public class BreakHandlerV2DeferralTest {
     public void defersRequestedBreakWhilePluginLockIsHeld() {
         BreakHandlerScript.setLockState(true);
 
-        assertTrue(BreakHandlerV2Script.shouldDeferRequestedBreak());
+        assertTrue(BreakHandlerV2Script.shouldDeferRequestedBreak(null));
     }
 
     @Test
-    public void proceedsWhenPluginLockIsReleased() {
+    public void doesNotDeferNewBreakWhenPluginLockIsReleased() {
         BreakHandlerScript.setLockState(false);
 
-        assertFalse(BreakHandlerV2Script.shouldDeferRequestedBreak());
+        assertFalse(BreakHandlerV2Script.shouldDeferRequestedBreak(null));
+    }
+
+    @Test
+    public void doesNotDeferActiveNoLogoutBreakWhenPluginLockIsHeld() {
+        BreakHandlerScript.setLockState(true);
+
+        assertFalse(BreakHandlerV2Script.shouldDeferRequestedBreak(Instant.now()));
     }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2DeferralTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2DeferralTest.java
@@ -1,0 +1,29 @@
+package net.runelite.client.plugins.microbot.breakhandler.breakhandlerv2;
+
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BreakHandlerV2DeferralTest {
+    @After
+    public void clearPluginLock() {
+        BreakHandlerScript.setLockState(false);
+    }
+
+    @Test
+    public void defersRequestedBreakWhilePluginLockIsHeld() {
+        BreakHandlerScript.setLockState(true);
+
+        assertTrue(BreakHandlerV2Script.shouldDeferRequestedBreak());
+    }
+
+    @Test
+    public void proceedsWhenPluginLockIsReleased() {
+        BreakHandlerScript.setLockState(false);
+
+        assertFalse(BreakHandlerV2Script.shouldDeferRequestedBreak());
+    }
+}


### PR DESCRIPTION
## Summary
- defer a requested Break Handler V2 break while the existing global break lock is held
- keep the request pending and continue immediately after the lock is released
- rate-limit deferral logging to once every 30 seconds
- add focused coverage for locked and unlocked behavior

## Validation
- `.\gradlew.bat :client:runUnitTests --tests net.runelite.client.plugins.microbot.breakhandler.breakhandlerv2.BreakHandlerV2DeferralTest --no-daemon --console=plain`
- 2 tests passed
- live validation across multiple scheduled break cycles confirmed that logout remained deferred until the lock was released