### PR TITLE
fix(antiban): default mouse speed to low

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/AntibanPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/AntibanPlugin.java
@@ -77,6 +77,7 @@ import java.util.TimerTask;
 @PluginDescriptor(
         name = PluginDescriptor.See1Duck + "Antiban",
         description = "Antiban for microbot",
+        version = "1.0.1",
         tags = {"main", "microbot", "antiban parent"},
         alwaysOn = true,
         hidden = true
@@ -163,7 +164,7 @@ public class AntibanPlugin extends Plugin {
 
     @Override
     protected void startUp() throws AWTException {
-        Rs2Antiban.setActivityIntensity(ActivityIntensity.EXTREME);
+        Rs2Antiban.setActivityIntensity(Rs2Antiban.DEFAULT_ACTIVITY_INTENSITY);
         final MasterPanel panel = injector.getInstance(MasterPanel.class);
         final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "antiban.png");
         navButton = NavigationButton.builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/Rs2Antiban.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/Rs2Antiban.java
@@ -90,6 +90,7 @@ import static net.runelite.api.AnimationID.*;
 @Getter
 @Setter
 public class Rs2Antiban {
+    static final ActivityIntensity DEFAULT_ACTIVITY_INTENSITY = ActivityIntensity.LOW;
     public static final ImmutableSet<Integer> MINING_ANIMATION_IDS = ImmutableSet.of(
             MINING_BRONZE_PICKAXE, MINING_MOTHERLODE_BRONZE, MINING_CRASHEDSTAR_BRONZE,
             MINING_IRON_PICKAXE, MINING_MOTHERLODE_IRON, MINING_CRASHEDSTAR_IRON,
@@ -129,7 +130,7 @@ public class Rs2Antiban {
     @Getter
     private static Activity activity;
     @Getter
-    private static ActivityIntensity activityIntensity;
+    private static ActivityIntensity activityIntensity = DEFAULT_ACTIVITY_INTENSITY;
     @Getter
     @Setter
     private static Category category;
@@ -559,7 +560,7 @@ public class Rs2Antiban {
         Rs2AntibanSettings.reset();
         Rs2Antiban.playStyle = null;
         Rs2Antiban.activity = null;
-        Rs2Antiban.activityIntensity = ActivityIntensity.EXTREME;
+        Rs2Antiban.activityIntensity = DEFAULT_ACTIVITY_INTENSITY;
         Rs2Antiban.category = null;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/MousePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/antiban/ui/MousePanel.java
@@ -23,7 +23,7 @@ public class MousePanel extends JPanel
 
     // 1) Add new components for Activity Intensity
     private final JLabel mouseSpeedLabel = new JLabel();
-    private final JSlider mouseSpeedSlider = new JSlider(0, 4, 2); // default to index=2 (MODERATE)
+    private final JSlider mouseSpeedSlider = new JSlider(0, 4, 1); // default to index=1 (LOW)
 
     public MousePanel()
     {
@@ -154,7 +154,7 @@ public class MousePanel extends JPanel
             case MODERATE: return 2;
             case HIGH: return 3;
             case EXTREME: return 4;
-            default: return 2;
+            default: return 1;
         }
     }
 
@@ -168,7 +168,7 @@ public class MousePanel extends JPanel
             case 2: return ActivityIntensity.MODERATE;
             case 3: return ActivityIntensity.HIGH;
             case 4: return ActivityIntensity.EXTREME;
-            default: return ActivityIntensity.MODERATE;
+            default: return ActivityIntensity.LOW;
         }
     }
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/antiban/Rs2AntibanDefaultsTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/antiban/Rs2AntibanDefaultsTest.java
@@ -1,0 +1,26 @@
+package net.runelite.client.plugins.microbot.util.antiban;
+
+import net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class Rs2AntibanDefaultsTest
+{
+    @After
+    public void restoreDefaults()
+    {
+        Rs2Antiban.resetAntibanSettings(true);
+    }
+
+    @Test
+    public void resetRestoresLowMouseSpeed()
+    {
+        Rs2Antiban.setActivityIntensity(ActivityIntensity.HIGH);
+
+        Rs2Antiban.resetAntibanSettings(true);
+
+        assertEquals(ActivityIntensity.LOW, Rs2Antiban.getActivityIntensity());
+    }
+}


### PR DESCRIPTION
﻿Antiban initializes Mouse Speed to Extreme when the plugin starts and when settings are reset. Set both paths to a shared Low default, initialize the activity intensity to Low, and align the Mouse Speed slider defaults with it.

Bump the Antiban plugin version to 1.0.1. Explicit user and script speed selections remain available.

Validation: `:client:runUnitTests --tests net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanDefaultsTest` (includes client compilation); focused reset-default test passed. Source review completed. No live-client validation performed.
