### PR TITLE
fix(questhelper): allow local Misthalin item pickups

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestHelperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/QuestHelperPlugin.java
@@ -79,6 +79,7 @@ import java.util.stream.Collectors;
 
 @PluginDescriptor(
 	name = "Quest Helper",
+	version = "1.0.1",
 	description = "Helps you with questing",
 	tags = { "quest", "helper", "overlay" }
 )

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/helpers/quests/misthalinmystery/MisthalinMystery.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/questhelper/helpers/quests/misthalinmystery/MisthalinMystery.java
@@ -209,14 +209,15 @@ public class MisthalinMystery extends BasicQuestHelper
 		talkToAbigale = new NpcStep(this, NpcID.MISTMYST_ABIGALE_LUM_VIS, new WorldPoint(3237, 3155, 0), "Talk to Abigale in the south east corner of Lumbridge Swamp.");
 		talkToAbigale.addDialogStep("Yes.");
 		takeTheBoat = new ObjectStep(this, ObjectID.MISTMYST_BOAT_LUMBRIDGE, new WorldPoint(3240, 3140, 0), "Board the rowboat south of Abigale.");
-		takeTheBucket = new ObjectStep(this, ObjectID.MISTMYST_EMPTY_BUCKET, new WorldPoint(1619, 4816, 0), "Pick up the bucket near the fountain.", bucket);
+		// Pickup steps provide these items; requiring them here sends automation to the bank.
+		takeTheBucket = new ObjectStep(this, ObjectID.MISTMYST_EMPTY_BUCKET, new WorldPoint(1619, 4816, 0), "Pick up the bucket near the fountain.");
 		searchTheBarrel = new ObjectStep(this, ObjectID.MISTMYST_BARREL, new WorldPoint(1615, 4829, 0), "Search the barrel of rainwater north of the fountain to trigger a cutscene.", bucket);
 		useBucketOnBarrel = new ObjectStep(this, ObjectID.MISTMYST_BARREL, new WorldPoint(1615, 4829, 0), "Use the bucket on the barrel of rainwater.", bucket);
 		searchTheBarrelForKey = new ObjectStep(this, ObjectID.MISTMYST_BARREL, new WorldPoint(1615, 4829, 0), "Search the barrel of rainwater for the manor key.");
 		useBucketOnBarrel.addIcon(ItemID.BUCKET_EMPTY);
 		openManorDoor = new ObjectStep(this, ObjectID.MISTMYST_FRONT_DOORL, new WorldPoint(1636, 4824, 0), "Enter the manor.", true);
 		openManorDoor.addAlternateObjects(ObjectID.MISTMYST_FRONT_DOORR);
-		takeKnife = new ObjectStep(this, ObjectID.MISTMYST_TABLE_KNIFE, new WorldPoint(1639, 4831, 0), "Take the knife from the table.", knife);
+		takeKnife = new ObjectStep(this, ObjectID.MISTMYST_TABLE_KNIFE, new WorldPoint(1639, 4831, 0), "Take the knife from the table.");
 		tryToOpenPinkKnobDoor = new ObjectStep(this, ObjectID.MISTMYST_DOOR_REDTOPAZ, new WorldPoint(1635, 4838, 0), "Try to open the door with the pink handle.");
 		takeNote1 = new ObjectStep(this, ObjectID.MISTMYST_CLUE_LIBRARY, new WorldPoint(1635, 4839, 0), "Pick up the note that appeared.");
 		readNotes1 = new DetailedQuestStep(this, "Read the notes.", notes1.highlighted());

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/helpers/quests/misthalinmystery/MisthalinMysteryRequirementsTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/questhelper/helpers/quests/misthalinmystery/MisthalinMysteryRequirementsTest.java
@@ -1,0 +1,58 @@
+package net.runelite.client.plugins.microbot.questhelper.helpers.quests.misthalinmystery;
+
+import net.runelite.client.plugins.microbot.questhelper.QuestHelperConfig;
+import net.runelite.client.plugins.microbot.questhelper.requirements.item.ItemRequirement;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class MisthalinMysteryRequirementsTest
+{
+    private MisthalinMystery quest;
+
+    @Before
+    public void setup()
+    {
+        quest = new MisthalinMystery()
+        {
+            @Override
+            public QuestHelperConfig getConfig()
+            {
+                return new QuestHelperConfig() {};
+            }
+        };
+        quest.initializeRequirements();
+        quest.setupSteps();
+    }
+
+    @Test
+    public void bucketPickupDoesNotRequireSuppliesBeforeCollectingBucket()
+    {
+        assertTrue(quest.takeTheBucket.getRequirements().isEmpty());
+    }
+
+    @Test
+    public void knifePickupDoesNotRequireSuppliesBeforeCollectingKnife()
+    {
+        assertTrue(quest.takeKnife.getRequirements().isEmpty());
+    }
+
+    @Test
+    public void barrelStepsStillRequireBucket()
+    {
+        assertTrue(quest.searchTheBarrel.getRequirements().contains(quest.bucket));
+        assertTrue(quest.useBucketOnBarrel.getRequirements().contains(quest.bucket));
+    }
+
+    @Test
+    public void cuttingStepsStillRequireKnife()
+    {
+        assertTrue(quest.useKnifeOnPainting.getRequirements().stream()
+            .anyMatch(requirement -> requirement instanceof ItemRequirement
+                && ((ItemRequirement) requirement).getId() == quest.knife.getId()));
+        assertTrue(quest.useKnifeOnFireplace.getRequirements().stream()
+            .anyMatch(requirement -> requirement instanceof ItemRequirement
+                && ((ItemRequirement) requirement).getId() == quest.knife.getId()));
+    }
+}


### PR DESCRIPTION
Misthalin Mystery's bucket and table-knife pickup steps require the very items they provide. With automatic missing-item acquisition enabled, the quest runner attempts banking before executing the local pickup, causing repeated bank attempts when no bank route is available from the island.

Remove those two pickup prerequisites while retaining the bucket and knife requirements on the steps that use them. Bump Quest Helper to 1.0.1 and add four regression tests covering both pickups and the retained tool requirements.

Validation:
- Four Misthalin Mystery regression tests on the upstream main base.
- All 28 Quest Helper tests passed in the original integration checkout.
- git diff --check passed; code review found no issues.
- Live in-game pickup behavior has not been verified.