### PR TITLE
Fix world hopper TCP ping fallback

### DIFF
--- a/docs/entity-guides/README.md
+++ b/docs/entity-guides/README.md
@@ -11,6 +11,7 @@ Each guide lists known pitfalls when working with one specific game entity type.
 | Items (inventory, bank, ground, equipment, shops) | [items.md](items.md) | Any code calling `Rs2Inventory`, `Rs2Bank`, `Rs2Equipment`, `Rs2GroundItem`, `Rs2Shop`, or `Rs2DepositBox` interaction helpers, or any helper that takes a list of item names and applies a single action to all of them |
 | Movement (walker, minimap, pathing) | [movement.md](movement.md) | Any code calling or modifying `Rs2Walker`, `Rs2MiniMap`, shortest-path marker handling, or minimap/canvas walk-click logic |
 | Death (graves, Death's Office, recovery) | [death.md](death.md) | Any code calling or modifying `Rs2Death`, `DeathRecoveryEvent`, `DeathEvent`, or handling graves, retrieval fees, and post-death item recovery |
+| Worlds (selection, ping, hopping) | [worlds.md](worlds.md) | Any code measuring world latency, testing world reachability, or selecting worlds based on network availability |
 
 ## Format
 

--- a/docs/entity-guides/worlds.md
+++ b/docs/entity-guides/worlds.md
@@ -1,0 +1,21 @@
+# World Gotchas
+
+## 1. Probe supported endpoints; do not assign ports by world ID
+
+World-list entries provide hostnames, not a stable per-world port declaration. Use the shared world-hopper TCP ping routine, which tries the supported endpoints with bounded connect timeouts. Do not maintain a table of world IDs or assume that a successful or failed connection observed once is permanent.
+
+**Why this matters:** World endpoint availability can change within minutes. A world reachable only on TCP port 443 during one probe may later accept port 43594 as well, while another endpoint may temporarily accept neither. Hard-coding port 43594 caused valid worlds to be scored as unreachable by `Rs2WorldUtil`.
+
+**Pattern to follow:**
+
+```java
+// Wrong: duplicates one endpoint and can drift from World Hopper.
+socket.connect(new InetSocketAddress(world.getAddress(), 43594), 3000);
+
+// Right: shares the bounded endpoint fallback used by World Hopper.
+int ping = Ping.tcpPing(InetAddress.getByName(world.getAddress()));
+```
+
+**Where this applies:** `Ping`, `Rs2WorldUtil`, world selectors, login-world scoring, and any helper that tests world reachability.
+
+**Defensive check:** Test fallback with local sockets so the first port refuses the connection and the second succeeds. Live endpoint probes are useful evidence, but must not become a permanent world-to-port mapping.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/world/Rs2WorldUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/world/Rs2WorldUtil.java
@@ -12,6 +12,7 @@ import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.security.LoginManager;
 import net.runelite.client.plugins.microbot.util.shop.Rs2Shop;
+import net.runelite.client.plugins.worldhopper.ping.Ping;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -608,42 +609,23 @@ public class Rs2WorldUtil {
     
     
     /**
-     * Measures the ping to a specific world server by attempting a connection.
+     * Measures the ping to a specific world server using the same TCP endpoints as World Hopper.
      * This provides network latency measurement for intelligent world selection.
      * 
      * @param world The world to measure ping to
      * @return The ping in milliseconds, or -1 if measurement failed
      */
     public static long measureWorldPing(World world) {
+        if (world == null || world.getAddress() == null) {
+            return -1;
+        }
+
         try {
-            if (world == null || world.getAddress() == null) {
-                return -1;
-            }
-            
-            String address = world.getAddress();
-            // Extract hostname from full address if needed
-            if (address.contains(":")) {
-                address = address.substring(0, address.indexOf(":"));
-            }
-            
-            long startTime = System.currentTimeMillis();
-            
-            // Attempt a TCP connection to measure latency
-            try (java.net.Socket socket = new java.net.Socket()) {
-                socket.connect(new java.net.InetSocketAddress(address, 43594), 3000); // 3 second timeout
-                long endTime = System.currentTimeMillis();
-                long ping = endTime - startTime;
-                
-                log.debug("Measured ping to world {} ({}): {}ms", world.getId(), address, ping);
-                return ping;
-                
-            } catch (java.io.IOException e) {
-                log.debug("Failed to measure ping to world {} ({}): {}", world.getId(), address, e.getMessage());
-                return -1;
-            }
-            
-        } catch (Exception e) {
-            log.warn("Error measuring ping to world {}: {}", world.getId(), e.getMessage());
+            int ping = Ping.tcpPing(java.net.InetAddress.getByName(world.getAddress()));
+            log.debug("Measured ping to world {} ({}): {}ms", world.getId(), world.getAddress(), ping);
+            return ping;
+        } catch (java.io.IOException e) {
+            log.debug("Failed to measure ping to world {} ({}): {}", world.getId(), world.getAddress(), e.getMessage());
             return -1;
         }
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/ping/Ping.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/ping/Ping.java
@@ -50,7 +50,7 @@ public class Ping
 {
 	private static final byte[] RUNELITE_PING = "RuneLitePing".getBytes(Charsets.UTF_8);
 	private static final int TIMEOUT = 2000; // ms
-	private static final int PORT = 43594;
+	private static final int[] PORTS = {43594, 443};
 	private static final int MAX_IPV4_HEADER_SIZE = 60;
 
 	private static short seq;
@@ -280,16 +280,37 @@ public class Ping
 		return (short) (~a & 0xffff);
 	}
 
-	private static int tcpPing(InetAddress inetAddress) throws IOException
+	/**
+	 * Ping an address through the TCP endpoints used by the game worlds.
+	 *
+	 * @param inetAddress world address
+	 * @return connection latency in milliseconds
+	 * @throws IOException when none of the TCP endpoints can be reached
+	 */
+	public static int tcpPing(InetAddress inetAddress) throws IOException
 	{
-		try (Socket socket = new Socket())
+		return tcpPing(inetAddress, PORTS);
+	}
+
+	static int tcpPing(InetAddress inetAddress, int... ports) throws IOException
+	{
+		IOException lastException = null;
+		for (int port : ports)
 		{
-			socket.setSoTimeout(TIMEOUT);
-			long start = System.nanoTime();
-			socket.connect(new InetSocketAddress(inetAddress, PORT));
-			long end = System.nanoTime();
-			return (int) ((end - start) / 1000000L);
+			try (Socket socket = new Socket())
+			{
+				long start = System.nanoTime();
+				socket.connect(new InetSocketAddress(inetAddress, port), TIMEOUT);
+				long end = System.nanoTime();
+				return (int) ((end - start) / 1000000L);
+			}
+			catch (IOException ex)
+			{
+				lastException = ex;
+			}
 		}
+
+		throw lastException;
 	}
 
 	@Nullable

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/ping/Ping.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/ping/Ping.java
@@ -294,6 +294,11 @@ public class Ping
 
 	static int tcpPing(InetAddress inetAddress, int... ports) throws IOException
 	{
+		if (ports.length == 0)
+		{
+			throw new IOException("No TCP ports configured");
+		}
+
 		IOException lastException = null;
 		for (int port : ports)
 		{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/worldhopper/ping/PingTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/worldhopper/ping/PingTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, Microbot contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.worldhopper.ping;
+
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+public class PingTest
+{
+	@Test
+	public void retriesNextTcpPort() throws Exception
+	{
+		InetAddress loopback = InetAddress.getLoopbackAddress();
+		int unavailablePort;
+		try (ServerSocket socket = new ServerSocket(0, 1, loopback))
+		{
+			unavailablePort = socket.getLocalPort();
+		}
+
+		try (ServerSocket availableSocket = new ServerSocket(0, 1, loopback))
+		{
+			int ping = Ping.tcpPing(loopback, unavailablePort, availableSocket.getLocalPort());
+			assertThat(ping, greaterThanOrEqualTo(0));
+		}
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/worldhopper/ping/PingTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/worldhopper/ping/PingTest.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.worldhopper.ping;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import org.junit.Test;
@@ -32,6 +33,12 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class PingTest
 {
+	@Test(expected = IOException.class)
+	public void rejectsEmptyPortList() throws Exception
+	{
+		Ping.tcpPing(InetAddress.getLoopbackAddress(), new int[0]);
+	}
+
 	@Test
 	public void retriesNextTcpPort() throws Exception
 	{


### PR DESCRIPTION
World Hopper currently treats TCP port 43594 as the only endpoint and does not bound the socket connect operation. When that endpoint is unavailable, reachable worlds are reported as failed pings.

This change adds a bounded connect timeout and tries port 443 when 43594 fails. `Rs2WorldUtil` now uses the same shared ping logic so world selection and World Hopper report reachability consistently. A regression test covers falling back when the first endpoint refuses the connection.