### PR TITLE
Fix Break Handler V2 pause break completion

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2Script.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2Script.java
@@ -89,7 +89,7 @@ public class BreakHandlerV2Script extends Script {
     private static final int MAX_SAFETY_CHECK_ATTEMPTS = 60;
     private static final int SAFETY_CHECK_DELAY_MS = 5000; // 5 seconds between checks
 
-    public static String version = "2.0.6";
+    public static String version = "2.0.7";
 
     /**
      * Run the break handler script
@@ -110,7 +110,13 @@ public class BreakHandlerV2Script extends Script {
         originalWindowTitle = ClientUI.getFrame().getTitle();
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                if (!super.run() && !config.autoLogin() && BreakHandlerV2State.getCurrentState() != BreakHandlerV2State.LOGIN_REQUESTED) return;
+                BreakHandlerV2State stateBeforeRun = BreakHandlerV2State.getCurrentState();
+                boolean continueWhilePaused = shouldContinueWhenScriptGuardBlocks(
+                        Microbot.pauseAllScripts.get(),
+                        stateBeforeRun,
+                        pluginStopTriggered);
+                boolean continueForLogin = config.autoLogin() || stateBeforeRun == BreakHandlerV2State.LOGIN_REQUESTED;
+                if (!super.run() && !continueWhilePaused && !continueForLogin) return;
 
                 // Ensure previously stopped plugin is restarted once we're logged back in, even if the state machine
                 // hasn't reached BREAK_ENDING yet (e.g., manual login after extended sleep).
@@ -286,6 +292,23 @@ public class BreakHandlerV2Script extends Script {
      */
     static boolean shouldDeferRequestedBreak(Instant activeBreakEndTime) {
         return activeBreakEndTime == null && BreakHandlerScript.isLockState();
+    }
+
+    static boolean shouldContinueWhenScriptGuardBlocks(boolean scriptsPaused, BreakHandlerV2State state, boolean pluginStopTriggered) {
+        if (!scriptsPaused) {
+            return false;
+        }
+
+        return state == BreakHandlerV2State.BREAK_REQUESTED ||
+               state == BreakHandlerV2State.INITIATING_BREAK ||
+               state == BreakHandlerV2State.LOGOUT_REQUESTED ||
+               state == BreakHandlerV2State.LOGGED_OUT ||
+               state == BreakHandlerV2State.LOGIN_REQUESTED ||
+               state == BreakHandlerV2State.LOGGING_IN ||
+               state == BreakHandlerV2State.LOGIN_EXTENDED_SLEEP ||
+               state == BreakHandlerV2State.BREAK_ENDING ||
+               state == BreakHandlerV2State.PROFILE_SWITCHING ||
+               (state == BreakHandlerV2State.WAITING_FOR_BREAK && pluginStopTriggered);
     }
 
     /**

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2DeferralTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/breakhandler/breakhandlerv2/BreakHandlerV2DeferralTest.java
@@ -35,4 +35,36 @@ public class BreakHandlerV2DeferralTest {
 
         assertFalse(BreakHandlerV2Script.shouldDeferRequestedBreak(Instant.now()));
     }
+
+    @Test
+    public void continuesActiveBreakWhenGlobalPauseBlocksScripts() {
+        assertTrue(BreakHandlerV2Script.shouldContinueWhenScriptGuardBlocks(
+                true,
+                BreakHandlerV2State.BREAK_REQUESTED,
+                false));
+    }
+
+    @Test
+    public void doesNotContinueNormalWaitingStateWhenGlobalPauseBlocksScripts() {
+        assertFalse(BreakHandlerV2Script.shouldContinueWhenScriptGuardBlocks(
+                true,
+                BreakHandlerV2State.WAITING_FOR_BREAK,
+                false));
+    }
+
+    @Test
+    public void continuesWaitingStateAfterPreBreakPluginStopPausedScripts() {
+        assertTrue(BreakHandlerV2Script.shouldContinueWhenScriptGuardBlocks(
+                true,
+                BreakHandlerV2State.WAITING_FOR_BREAK,
+                true));
+    }
+
+    @Test
+    public void doesNotBypassScriptGuardWhenScriptsAreNotPaused() {
+        assertFalse(BreakHandlerV2Script.shouldContinueWhenScriptGuardBlocks(
+                false,
+                BreakHandlerV2State.BREAK_REQUESTED,
+                false));
+    }
 }


### PR DESCRIPTION
## Summary
- keep Break Handler V2 ticking when its own no-logout break pauses scripts globally
- allow pre-break plugin-stop pause state to continue to the requested break
- add unit coverage for script guard bypass decisions

## Why
No-logout breaks call `Microbot.pauseAllScripts.set(true)` while the Break Handler still needs to tick until `breakEndTime`. The next scheduler tick can hit `super.run() == false`, return early, and leave the break stuck in the requested/paused state instead of completing and rescheduling timers.

## Testing
- `./gradlew.bat :client:compileJava :client:compileTestJava --no-daemon --console=plain`
- `./gradlew.bat :client:test --tests "net.runelite.client.plugins.microbot.breakhandler.breakhandlerv2.BreakHandlerV2DeferralTest" --no-daemon --console=plain` (build successful; `:client:test` is skipped by the current Gradle configuration after compiling test classes)