### PR TITLE
feat(webwalker): add manual walking controls and status notices

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathConfig.java
@@ -3,10 +3,24 @@ package net.runelite.client.plugins.microbot.shortestpath;
 import net.runelite.client.config.*;
 
 import java.awt.*;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 
 @ConfigGroup(ShortestPathPlugin.CONFIG_GROUP)
-@ConfigInformation("Press 'CTRL + X' to stop the webwalker automatically.")
+@ConfigInformation("Toggle walking pauses/resumes manual walking. Clear current path removes the destination (default: Ctrl + X).")
 public interface ShortestPathConfig extends Config {
+    @ConfigItem(keyName = "toggleWalkingHotkey", name = "Toggle walking",
+            description = "Enable or disable manual automatic walking, keeping the destination and route.", position = -2)
+    default Keybind toggleWalkingHotkey() {
+        return Keybind.NOT_SET;
+    }
+
+    @ConfigItem(keyName = "clearCurrentPathHotkey", name = "Clear current path",
+            description = "Cancel walking and remove the current route and destination.", position = -1)
+    default Keybind clearCurrentPathHotkey() {
+        return new Keybind(KeyEvent.VK_X, InputEvent.CTRL_DOWN_MASK);
+    }
+
     /* ------------------------------------------------------------------
      * Hotkeys — stored as config values but bound/displayed inline on
      * each side-panel category card (see ShortestPathPanel). Marked

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPanel.java
@@ -69,6 +69,7 @@ public class ShortestPathPanel extends PluginPanel
 	private final ShortestPathConfig config;
 	private final ConfigManager configManager;
 
+	private final JButton walkingToggleButton = new JButton("Automatic walking: ON");
 	private JTextField xField, yField, zField;
 	private JComboBox<BankLocation> bankComboBox;
 	private JComboBox<DepositBoxLocation> depositBoxComboBox;
@@ -102,6 +103,16 @@ public class ShortestPathPanel extends PluginPanel
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 		setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
+        walkingToggleButton.addActionListener(e -> plugin.toggleManualWalking());
+        walkingToggleButton.setAlignmentX(Component.CENTER_ALIGNMENT);
+        add(walkingToggleButton);
+        add(createHotkeyRow("toggleWalkingHotkey", config.toggleWalkingHotkey(), "Toggle automatic walking; keep the route."));
+        JButton clearPathButton = new JButton("Clear current path");
+        clearPathButton.addActionListener(e -> stopWalking());
+        clearPathButton.setAlignmentX(Component.CENTER_ALIGNMENT);
+        add(clearPathButton);
+        add(createHotkeyRow("clearCurrentPathHotkey", config.clearCurrentPathHotkey(), "Clear the destination and route."));
+        add(Box.createRigidArea(new Dimension(0, 10)));
 		add(createCustomLocationPanel());
 		add(Box.createRigidArea(new Dimension(0, 10)));
 		add(createBankPanel());
@@ -118,6 +129,11 @@ public class ShortestPathPanel extends PluginPanel
 		add(Box.createRigidArea(new Dimension(0, 10)));
 		add(createHunterCreaturePanel());
 	}
+
+    void updateWalkingState(boolean enabled)
+    {
+        walkingToggleButton.setText("Automatic walking: " + (enabled ? "ON" : "OFF"));
+    }
 
 	private Border createCenteredTitledBorder(String title, String iconPath)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
@@ -43,7 +43,6 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.PluginMessage;
 import net.runelite.client.game.SpriteManager;
-import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -76,7 +75,6 @@ import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.Text;
 
 import java.awt.*;
-import java.awt.event.KeyEvent;
 import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
 import java.util.List;
@@ -94,9 +92,16 @@ import java.util.regex.Pattern;
         description = "Draws the shortest path to a chosen destination on the map (right click a spot on the world map to use)",
         tags = {"pathfinder", "map", "waypoint", "navigation", "microbot"},
         enabledByDefault = false,
+        version = "1.0.2",
         alwaysOn = true
 )
-public class ShortestPathPlugin extends Plugin implements KeyListener {
+public class ShortestPathPlugin extends Plugin {
+    private static final java.util.concurrent.atomic.AtomicLong pathRequestRevision = new java.util.concurrent.atomic.AtomicLong();
+
+    static void invalidatePendingPathfinding() {
+        pathRequestRevision.incrementAndGet();
+    }
+
     public static final String CONFIG_GROUP = "shortestpath";
     private static final String PLUGIN_MESSAGE_PATH = "path";
     private static final String PLUGIN_MESSAGE_CLEAR = "clear";
@@ -146,6 +151,9 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
 
     @Inject
     private ETAOverlayPanel etaOverlayPanel;
+
+    @Inject
+    private WalkingNoticeOverlay walkingNoticeOverlay;
 
     @Inject
     private SpriteManager spriteManager;
@@ -254,9 +262,10 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
         clientToolbar.addNavigation(pohNavButton);
 
         Rs2Walker.setConfig(config);
-        shortestPathScript = new ShortestPathScript();
+        shortestPathScript = new ShortestPathScript(this::setTarget, this::showWalkingNotice);
         shortestPathScript.run(config);
 
+        overlayManager.add(walkingNoticeOverlay);
         overlayManager.add(pathOverlay);
         overlayManager.add(pathMinimapOverlay);
         overlayManager.add(pathMapOverlay);
@@ -268,7 +277,8 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
         if (config.drawDebugPanel()) {
             overlayManager.add(debugOverlayPanel);
         }
-        keyManager.registerKeyListener(this);
+        keyManager.registerKeyListener(toggleWalkingHotkeyListener);
+        keyManager.registerKeyListener(clearCurrentPathHotkeyListener);
         keyManager.registerKeyListener(customLocationHotkeyListener);
         keyManager.registerKeyListener(bankHotkeyListener);
         keyManager.registerKeyListener(nearestBankHotkeyListener);
@@ -295,7 +305,8 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
         keyManager.unregisterKeyListener(nearestBankHotkeyListener);
         keyManager.unregisterKeyListener(bankHotkeyListener);
         keyManager.unregisterKeyListener(customLocationHotkeyListener);
-        keyManager.unregisterKeyListener(this);
+        keyManager.unregisterKeyListener(toggleWalkingHotkeyListener);
+        keyManager.unregisterKeyListener(clearCurrentPathHotkeyListener);
 
         // Flush any live-collision the last capture learned and stop the I/O thread.
         if (liveCollisionPersistence != null) {
@@ -306,6 +317,8 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
             liveCollisionPersistence = null;
         }
 
+        overlayManager.remove(walkingNoticeOverlay);
+        walkingNoticeOverlay.clear();
         overlayManager.remove(pathOverlay);
         overlayManager.remove(pathMinimapOverlay);
         overlayManager.remove(pathMapOverlay);
@@ -329,6 +342,7 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
 
     //Method from microbot
     public static void exit() {
+        invalidatePendingPathfinding();
         if (pathfindingExecutor != null) {
             Rs2Walker.clearWalkingRoute("shortest-path-plugin:exit");
             pathfindingExecutor.shutdownNow();
@@ -337,11 +351,14 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
     }
 
     public void restartPathfinding(WorldPoint start, Set<WorldPoint> ends, boolean canReviveFiltered) {
+        final long requestRevision = pathRequestRevision.incrementAndGet();
         ExecutorService executor;
         synchronized (pathfinderMutex) {
             if (pathfinder != null) {
                 pathfinder.cancel();
-                pathfinderFuture.cancel(true);
+                if (pathfinderFuture != null) {
+                    pathfinderFuture.cancel(true);
+                }
             }
 
             if ((executor = pathfindingExecutor) == null) {
@@ -354,12 +371,18 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
         final ExecutorService finalExecutor = executor;
         final long scheduleTime = System.currentTimeMillis();
         getClientThread().invokeLater(() -> {
+            if (pathRequestRevision.get() != requestRevision || finalExecutor.isShutdown()) {
+                return;
+            }
             long invokeLaterDelay = System.currentTimeMillis() - scheduleTime;
             long refreshStart = System.currentTimeMillis();
             pathfinderConfig.refresh();
             long refreshTime = System.currentTimeMillis() - refreshStart;
             pathfinderConfig.filterLocations(ends, canReviveFiltered);
             synchronized (pathfinderMutex) {
+                if (pathRequestRevision.get() != requestRevision || finalExecutor.isShutdown()) {
+                    return;
+                }
                 if (ends.isEmpty()) {
                     setTarget(null);
                 } else {
@@ -881,7 +904,8 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
         handlePendingLoginRefresh();
         refreshLiveCollision();
 
-        if (Rs2Walker.getCurrentTarget() != null) {
+        if ((shortestPathScript != null && !shortestPathScript.isWalkingEnabled())
+                || Rs2Walker.getCurrentTarget() != null) {
             return;
         }
 
@@ -1118,6 +1142,7 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
 
     private void setTargets(Set<WorldPoint> targets, boolean append) {
         if (targets == null || targets.isEmpty()) {
+            invalidatePendingPathfinding();
             synchronized (pathfinderMutex) {
                 if (pathfinder != null) {
                     pathfinder.cancel();
@@ -1372,32 +1397,45 @@ public class ShortestPathPlugin extends Plugin implements KeyListener {
         }
     }
 
-    @Override
-    public void keyTyped(KeyEvent e) {
-
+    private void showWalkingNotice(ShortestPathScript.ManualWalkingNotice notice) {
+        final ShortestPathScript source = shortestPathScript;
+        getClientThread().invokeLater(() -> {
+            if (source != shortestPathScript || panel == null || !Microbot.isLoggedIn()) {
+                return;
+            }
+            String message = WalkingNoticeOverlay.messageFor(notice, config.toggleWalkingHotkey());
+            client.addChatMessage(net.runelite.api.ChatMessageType.GAMEMESSAGE, "", message, "");
+            walkingNoticeOverlay.show(message);
+        });
     }
 
-    @Override
-    public void keyPressed(KeyEvent e) {
-        if (client == null || !Microbot.isLoggedIn())
-        {
-            return;
+    public void toggleManualWalking() {
+        if (shortestPathScript != null) {
+            shortestPathScript.toggleWalking();
+            final boolean enabled = shortestPathScript.isWalkingEnabled();
+            javax.swing.SwingUtilities.invokeLater(() -> {
+                if (panel != null) {
+                    panel.updateWalkingState(enabled);
+                }
+            });
         }
-        /**
-         * We took decided to avoid "ESC" as this conflicts with the
-         * osrs keybindings and closing the world map
-         * Therefor CTRL + X seemed a bit more robust and userfriendly
-         */
-        if (e.getKeyCode() == KeyEvent.VK_X && e.isControlDown()) {
-			shortestPathScript.setTriggerWalker(null, "hotkey:ctrl+x");
-            e.consume();
+    }
+
+    private final HotkeyListener toggleWalkingHotkeyListener = new HotkeyListener(() -> config.toggleWalkingHotkey()) {
+        @Override
+        public void hotkeyPressed() {
+            toggleManualWalking();
         }
-    }
+    };
 
-    @Override
-    public void keyReleased(KeyEvent e) {
-
-    }
+    private final HotkeyListener clearCurrentPathHotkeyListener = new HotkeyListener(() -> config.clearCurrentPathHotkey()) {
+        @Override
+        public void hotkeyPressed() {
+            if (shortestPathScript != null) {
+                shortestPathScript.setTriggerWalker(null, "hotkey:clear-current-path");
+            }
+        }
+    };
 
     private final HotkeyListener customLocationHotkeyListener = new HotkeyListener(() -> config.customLocationToggleHotkey()) {
         @Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathPlugin.java
@@ -152,8 +152,7 @@ public class ShortestPathPlugin extends Plugin {
     @Inject
     private ETAOverlayPanel etaOverlayPanel;
 
-    @Inject
-    private WalkingNoticeOverlay walkingNoticeOverlay;
+    private final WalkingNoticeOverlay walkingNoticeOverlay;
 
     @Inject
     private SpriteManager spriteManager;
@@ -226,6 +225,11 @@ public class ShortestPathPlugin extends Plugin {
     @Provides
     public ShortestPathConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(ShortestPathConfig.class);
+    }
+
+    @Inject
+    public ShortestPathPlugin(WalkingNoticeOverlay walkingNoticeOverlay) {
+        this.walkingNoticeOverlay = walkingNoticeOverlay;
     }
 
     @Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathScript.java
@@ -1,7 +1,6 @@
 package net.runelite.client.plugins.microbot.shortestpath;
 
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
@@ -11,8 +10,7 @@ import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.walker.WalkerState;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 @Slf4j
 public class ShortestPathScript extends Script {
@@ -22,25 +20,41 @@ public class ShortestPathScript extends Script {
     // running the walker on a seperate thread is a lot easier for debugging
     private volatile WorldPoint triggerWalker;
     private volatile ShortestPathConfig config;
-    private volatile Future<?> walkTaskFuture;
-    private final AtomicBoolean walkTaskRunning = new AtomicBoolean(false);
+    private final Consumer<WorldPoint> preview;
+    private final Consumer<ManualWalkingNotice> notice;
+
+    enum ManualWalkingNotice {
+        PATH_SET, ENABLED, PAUSED, CLEARED
+    }
+    private boolean walkingEnabled = true;
+    private boolean stopped;
+    private boolean walkTaskRunning;
+    private Thread walkThread;
+    private boolean previewPending;
+    private long revision;
     private volatile WorldPoint lastExitRetryTarget;
-    private volatile int consecutiveExitRetries = 0;
+    private volatile int consecutiveExitRetries;
     private static final int MAX_CONSECUTIVE_EXIT_RETRIES = 3;
     private static final long USER_STOP_REASON_WINDOW_MS = 3_000L;
+
+    public ShortestPathScript(Consumer<WorldPoint> preview) {
+        this(preview, ignored -> {});
+    }
+
+    ShortestPathScript(Consumer<WorldPoint> preview, Consumer<ManualWalkingNotice> notice) {
+        this.preview = preview;
+        this.notice = notice;
+    }
 
     public boolean run(ShortestPathConfig config) {
         this.config = config;
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                if (!Microbot.isLoggedIn()) return;
-
-                if (getTriggerWalker() != null) {
+                if (loggedIn()) {
                     startWalkTask();
                 }
-
             } catch (Exception ex) {
-                log.error("Exception in ShortestPathScript: {} - ", ex.getMessage(), ex);
+                log.error("Exception in ShortestPathScript", ex);
             }
         }, 0, 100, TimeUnit.MILLISECONDS);
         return true;
@@ -48,87 +62,163 @@ public class ShortestPathScript extends Script {
 
     @Override
     public void shutdown() {
+        synchronized (this) {
+            stopped = true;
+            revision++;
+            triggerWalker = null;
+            interruptWalk();
+        }
         super.shutdown();
     }
 
-	public void setTriggerWalker(WorldPoint point) {
-		setTriggerWalker(point, null);
-	}
+    public synchronized boolean isWalkingEnabled() {
+        return walkingEnabled;
+    }
 
-	/**
-	 * @param stopReason when {@code point} is null, passed to {@link Rs2Walker#clearWalkingRoute(String)} (e.g. {@code hotkey:ctrl+x})
-	 */
-	public void setTriggerWalker(WorldPoint point, String stopReason) {
-		if (point == null)
-		{
-			resetExitRetryState();
-			String r = stopReason != null && !stopReason.isBlank()
-					? stopReason
-					: "shortest-path-script:trigger-null";
-			triggerWalker = null;
-			Rs2Walker.clearWalkingRoute(r);
-            Future<?> future = walkTaskFuture;
-            if (future != null && !future.isDone()) {
-                future.cancel(true);
-            }
-            walkTaskRunning.set(false);
-		} else {
-			if (!point.equals(triggerWalker))
-			{
-				resetExitRetryState();
-			}
-			triggerWalker = point;
-            startWalkTask();
-		}
-	}
-
-    private void startWalkTask() {
-        if (!walkTaskRunning.compareAndSet(false, true)) {
+    public synchronized void toggleWalking() {
+        if (stopped) {
             return;
         }
+        walkingEnabled = !walkingEnabled;
+        notice.accept(walkingEnabled ? ManualWalkingNotice.ENABLED : ManualWalkingNotice.PAUSED);
+        revision++;
+        resetExitRetryState();
+        interruptWalk();
+        // The old worker must finish before a preview or a replacement walk can own the route.
+        if (!walkTaskRunning && triggerWalker != null) {
+            refreshPreview();
+        }
+    }
 
-        walkTaskFuture = scheduledExecutorService.submit(() -> {
+    public void setTriggerWalker(WorldPoint point) {
+        setTriggerWalker(point, null);
+    }
+
+    public synchronized void setTriggerWalker(WorldPoint point, String stopReason) {
+        if (stopped) {
+            return;
+        }
+        revision++;
+        previewPending = false;
+        triggerWalker = point;
+        resetExitRetryState();
+        interruptWalk();
+        if (point == null) {
+            clearRoute(stopReason == null ? "shortest-path-script:trigger-null" : stopReason);
+        }
+        if (!walkTaskRunning && point != null) {
+            refreshPreview();
+        }
+        if (point == null) {
+            notice.accept(ManualWalkingNotice.CLEARED);
+        } else if (!walkingEnabled) {
+            notice.accept(ManualWalkingNotice.PATH_SET);
+        }
+    }
+
+    private void interruptWalk() {
+        if (walkThread != null) {
+            walkThread.interrupt();
+        }
+    }
+
+    private void refreshPreview() {
+        previewPending = true;
+        final long expectedRevision = revision;
+        final WorldPoint target = triggerWalker;
+        onClientThread(() -> {
+            synchronized (ShortestPathScript.this) {
+                if (!stopped && revision == expectedRevision && !walkTaskRunning) {
+                    try {
+                        if (loggedIn()) {
+                            preview.accept(target);
+                        }
+                    } finally {
+                        previewPending = false;
+                    }
+                }
+            }
+        });
+    }
+
+    synchronized void startWalkTask() {
+        if (stopped || !walkingEnabled || triggerWalker == null || walkTaskRunning || previewPending) {
+            return;
+        }
+        final long taskRevision = revision;
+        final WorldPoint target = triggerWalker;
+        walkTaskRunning = true;
+        scheduledExecutorService.submit(() -> {
             try {
-                WorldPoint target = getTriggerWalker();
-                if (target == null || config == null || !Microbot.isLoggedIn()) {
+                synchronized (ShortestPathScript.this) {
+                    if (stopped || taskRevision != revision) {
+                        return;
+                    }
+                    walkThread = Thread.currentThread();
+                }
+                if (!loggedIn()) {
                     return;
                 }
-
-                WalkerState state;
-                if (config.walkWithBankedTransports()) {
-                    state = Rs2Walker.walkWithBankedTransportsAndState(target, 10, false);
-                } else {
-                    state = Rs2Walker.walkWithState(target);
-                }
-
-                if (target.equals(getTriggerWalker())) {
-                    if (state == WalkerState.EXIT && shouldRetryAfterExit(target)) {
+                WalkerState state = executeWalk(target);
+                // Client-thread reads must not hold this monitor: hotkeys also acquire it.
+                boolean retryAllowed = state == WalkerState.EXIT
+                        && !Thread.currentThread().isInterrupted() && !isLocalPlayerDead() && !isRecentUserStopClear();
+                synchronized (ShortestPathScript.this) {
+                    if (taskRevision != revision || stopped) {
+                        return;
+                    }
+                    if (state == WalkerState.EXIT && retryAllowed && shouldRetryAfterExit(target)) {
                         return;
                     }
                     if (state == WalkerState.ARRIVED || state == WalkerState.UNREACHABLE || state == WalkerState.EXIT) {
                         resetExitRetryState();
                         triggerWalker = null;
-                        Rs2Walker.clearWalkingRoute("shortest-path-script:walk-task-terminal-state");
+                        revision++;
+                        clearRoute("shortest-path-script:walk-task-terminal-state");
                     }
                 }
             } catch (Exception ex) {
-                log.error("Exception in ShortestPathScript walk task: {} - ", ex.getMessage(), ex);
+                if (!Thread.currentThread().isInterrupted()) {
+                    log.error("Exception in ShortestPathScript walk task", ex);
+                }
             } finally {
-                walkTaskRunning.set(false);
+                synchronized (ShortestPathScript.this) {
+                    walkThread = null;
+                    walkTaskRunning = false;
+                    // Clear the cancellation flag before scheduling client-thread work on this pool thread.
+                    Thread.interrupted();
+                    if (!stopped && taskRevision != revision) {
+                        clearRoute("shortest-path-script:manual-route-changed");
+                        if (triggerWalker != null) {
+                            refreshPreview();
+                        }
+                    }
+                }
             }
         });
     }
 
+    boolean loggedIn() {
+        return Microbot.isLoggedIn();
+    }
+
+    WalkerState executeWalk(WorldPoint target) {
+        return config.walkWithBankedTransports()
+                ? Rs2Walker.walkWithBankedTransportsAndState(target, 10, false)
+                : Rs2Walker.walkWithState(target);
+    }
+
+    void clearRoute(String reason) {
+        ShortestPathPlugin.invalidatePendingPathfinding();
+        Rs2Walker.clearWalkingRoute(reason);
+    }
+
+    void onClientThread(Runnable action) {
+        Microbot.getClientThread().invokeLater(action);
+    }
+
     private boolean shouldRetryAfterExit(WorldPoint target) {
         if (target == null || !target.equals(getTriggerWalker())) {
-            resetExitRetryState();
-            return false;
-        }
-        if (isLocalPlayerDead()) {
-            resetExitRetryState();
-            return false;
-        }
-        if (isRecentUserStopClear()) {
             resetExitRetryState();
             return false;
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/WalkingNoticeOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/WalkingNoticeOverlay.java
@@ -1,0 +1,63 @@
+package net.runelite.client.plugins.microbot.shortestpath;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import net.runelite.client.config.Keybind;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+
+/** Transient feedback for explicit manual walker actions; route recalculations stay silent. */
+public class WalkingNoticeOverlay extends OverlayPanel {
+    private static final long DISPLAY_NANOS = TimeUnit.SECONDS.toNanos(5);
+    private String message;
+    private long shownAt;
+
+    @Inject
+    WalkingNoticeOverlay() {
+        setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
+        panelComponent.setBackgroundColor(new Color(0, 0, 0, 0));
+        panelComponent.setPreferredSize(new Dimension(480, 0));
+    }
+
+    void show(String message) {
+        this.message = message;
+        shownAt = System.nanoTime();
+    }
+
+    void clear() {
+        message = null;
+    }
+
+    static String messageFor(ShortestPathScript.ManualWalkingNotice notice, Keybind toggleKey) {
+        switch (notice) {
+            case PATH_SET:
+                return toggleKey == null || Keybind.NOT_SET.equals(toggleKey)
+                        ? "Web Walker: Path set - use the panel's Automatic walking button to start walking."
+                        : "Web Walker: Path set - press [" + toggleKey + "] to start walking.";
+            case ENABLED:
+                return "Web Walker: Walking enabled.";
+            case PAUSED:
+                return "Web Walker: Walking paused.";
+            case CLEARED:
+                return "Web Walker: Current path cleared.";
+            default:
+                throw new IllegalArgumentException("Unknown manual walking notice: " + notice);
+        }
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        if (message == null || System.nanoTime() - shownAt >= DISPLAY_NANOS) {
+            return null;
+        }
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left(message)
+                .leftColor(Color.YELLOW)
+                .build());
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathManualWalkingTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathManualWalkingTest.java
@@ -1,0 +1,220 @@
+package net.runelite.client.plugins.microbot.shortestpath;
+
+import java.awt.Canvas;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.config.Keybind;
+import net.runelite.client.plugins.microbot.util.walker.WalkerState;
+import net.runelite.client.util.HotkeyListener;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ShortestPathManualWalkingTest {
+    private static final WorldPoint FIRST = new WorldPoint(3200, 3200, 0);
+    private static final WorldPoint SECOND = new WorldPoint(3210, 3210, 0);
+
+    @Test
+    public void disabledSelectionOnlyPreviewsAndClearKeepsPreference() throws Exception {
+        List<WorldPoint> previews = new ArrayList<>();
+        try (Harness script = new Harness(previews)) {
+            script.toggleWalking();
+            script.setTriggerWalker(FIRST);
+            script.flushPreview();
+            script.startWalkTask();
+            assertEquals(List.of(FIRST), previews);
+            assertEquals(FIRST, script.getTriggerWalker());
+            assertTrue(script.started.isEmpty());
+            script.setTriggerWalker(null);
+            assertNull(script.getTriggerWalker());
+            assertFalse(script.isWalkingEnabled());
+            assertEquals(1, script.clears.get());
+        }
+    }
+
+    @Test
+    public void cancelledWorkerCannotClearReplacementOrStartOverlappingWalk() throws Exception {
+        List<WorldPoint> previews = new ArrayList<>();
+        try (Harness script = new Harness(previews)) {
+            script.setTriggerWalker(FIRST);
+            script.flushPreview();
+            script.startWalkTask();
+            assertEquals(FIRST, script.started.poll(5, TimeUnit.SECONDS));
+            script.toggleWalking();
+            assertTrue(script.interrupted.await(5, TimeUnit.SECONDS));
+            script.setTriggerWalker(SECOND);
+            script.toggleWalking();
+            script.startWalkTask();
+            assertTrue(script.started.isEmpty());
+            script.release.release();
+            script.flushPreview();
+            assertEquals(SECOND, script.getTriggerWalker());
+            assertEquals(List.of(FIRST, SECOND), previews);
+            script.startWalkTask();
+            assertEquals(SECOND, script.started.poll(5, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    public void pausedWalkRestoresPreviewWithoutRestarting() throws Exception {
+        List<WorldPoint> previews = new ArrayList<>();
+        try (Harness script = new Harness(previews)) {
+            script.setTriggerWalker(FIRST);
+            script.flushPreview();
+            script.startWalkTask();
+            assertEquals(FIRST, script.started.poll(5, TimeUnit.SECONDS));
+            script.toggleWalking();
+            script.release.release();
+            script.flushPreview();
+            script.startWalkTask();
+            assertEquals(FIRST, script.getTriggerWalker());
+            assertEquals(List.of(FIRST, FIRST), previews);
+            assertTrue(script.started.isEmpty());
+        }
+    }
+
+    @Test
+    public void clearInvalidatesQueuedPreview() throws Exception {
+        List<WorldPoint> previews = new ArrayList<>();
+        try (Harness script = new Harness(previews)) {
+            script.toggleWalking();
+            script.setTriggerWalker(FIRST);
+            script.setTriggerWalker(null);
+            script.flushPreview();
+            assertTrue(previews.isEmpty());
+            assertNull(script.getTriggerWalker());
+        }
+    }
+
+    @Test
+    public void hotkeyDefaultsAndHeldKeyOnlyToggleOnce() {
+        ShortestPathConfig config = new ShortestPathConfig() {};
+        assertEquals(Keybind.NOT_SET, config.toggleWalkingHotkey());
+        AtomicInteger presses = new AtomicInteger();
+        HotkeyListener listener = new HotkeyListener(config::clearCurrentPathHotkey) {
+            @Override
+            public void hotkeyPressed() {
+                presses.incrementAndGet();
+            }
+        };
+        Canvas source = new Canvas();
+        for (int i = 0; i < 3; i++) {
+            listener.keyPressed(keyEvent(source, KeyEvent.KEY_PRESSED));
+        }
+        assertEquals(1, presses.get());
+        listener.keyReleased(keyEvent(source, KeyEvent.KEY_RELEASED));
+        listener.keyPressed(keyEvent(source, KeyEvent.KEY_PRESSED));
+        assertEquals(2, presses.get());
+    }
+
+    @Test
+    public void noticesFollowUserActionsWithoutPreviewDuplicates() throws Exception {
+        List<WorldPoint> previews = new ArrayList<>();
+        List<ShortestPathScript.ManualWalkingNotice> notices = new ArrayList<>();
+        try (Harness script = new Harness(previews, notices)) {
+            script.toggleWalking();
+            script.setTriggerWalker(FIRST);
+            script.flushPreview();
+            script.startWalkTask();
+            script.toggleWalking();
+            script.flushPreview();
+            script.setTriggerWalker(null);
+            assertEquals(List.of(ShortestPathScript.ManualWalkingNotice.PAUSED,
+                    ShortestPathScript.ManualWalkingNotice.PATH_SET,
+                    ShortestPathScript.ManualWalkingNotice.ENABLED,
+                    ShortestPathScript.ManualWalkingNotice.CLEARED), notices);
+        }
+    }
+
+    @Test
+    public void pathNoticeUsesConfiguredKeyOrPanelFallback() {
+        String keyed = WalkingNoticeOverlay.messageFor(ShortestPathScript.ManualWalkingNotice.PATH_SET,
+                new Keybind(KeyEvent.VK_F6, 0));
+        assertTrue(keyed.contains("[F6]"));
+        String unbound = WalkingNoticeOverlay.messageFor(ShortestPathScript.ManualWalkingNotice.PATH_SET,
+                Keybind.NOT_SET);
+        assertTrue(unbound.contains("Automatic walking button"));
+        assertFalse(unbound.contains("Not set"));
+    }
+
+    private static KeyEvent keyEvent(Canvas source, int id) {
+        // Synthetic AWT events do not populate the native extended key code.
+        return new KeyEvent(source, id, 0, InputEvent.CTRL_DOWN_MASK, KeyEvent.VK_X, 'x') {
+            @Override
+            public int getExtendedKeyCode() {
+                return KeyEvent.VK_X;
+            }
+        };
+    }
+
+    private static final class Harness extends ShortestPathScript implements AutoCloseable {
+        final BlockingQueue<Runnable> clientTasks = new LinkedBlockingQueue<>();
+        final BlockingQueue<WorldPoint> started = new LinkedBlockingQueue<>();
+        final Semaphore release = new Semaphore(0);
+        final CountDownLatch interrupted = new CountDownLatch(1);
+        final AtomicInteger clears = new AtomicInteger();
+
+        Harness(List<WorldPoint> previews) {
+            this(previews, new ArrayList<>());
+        }
+
+        Harness(List<WorldPoint> previews, List<ManualWalkingNotice> notices) {
+            super(previews::add, notices::add);
+        }
+
+        @Override
+        boolean loggedIn() {
+            return true;
+        }
+
+        @Override
+        WalkerState executeWalk(WorldPoint target) {
+            started.add(target);
+            boolean waiting = true;
+            while (waiting) {
+                try {
+                    waiting = !release.tryAcquire(5, TimeUnit.SECONDS);
+                    if (waiting) {
+                        throw new AssertionError("Walk was not released");
+                    }
+                } catch (InterruptedException ex) {
+                    interrupted.countDown();
+                }
+            }
+            return WalkerState.ARRIVED;
+        }
+
+        @Override
+        void clearRoute(String reason) {
+            clears.incrementAndGet();
+        }
+
+        @Override
+        void onClientThread(Runnable action) {
+            clientTasks.add(action);
+        }
+
+        void flushPreview() throws Exception {
+            Runnable action = clientTasks.poll(5, TimeUnit.SECONDS);
+            assertNotNull("Expected a preview callback", action);
+            action.run();
+        }
+
+        @Override
+        public void close() throws Exception {
+            setTriggerWalker(null);
+            release.release(10);
+            scheduledExecutorService.shutdown();
+            assertTrue(scheduledExecutorService.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathTier1RegressionTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/shortestpath/ShortestPathTier1RegressionTest.java
@@ -223,7 +223,7 @@ public class ShortestPathTier1RegressionTest {
 
     @Test
     public void bug5_loggedInSetsPendingRefresh() {
-        ShortestPathPlugin plugin = new ShortestPathPlugin();
+        ShortestPathPlugin plugin = new ShortestPathPlugin(mock(WalkingNoticeOverlay.class));
         assertFalse("new plugin starts without pending refresh", plugin.pendingLoginRefresh);
 
         plugin.onGameStateChanged(gameStateEvent(GameState.LOGGED_IN));
@@ -233,7 +233,7 @@ public class ShortestPathTier1RegressionTest {
 
     @Test
     public void bug5_nonLoggedInStatesDoNotSetFlag() {
-        ShortestPathPlugin plugin = new ShortestPathPlugin();
+        ShortestPathPlugin plugin = new ShortestPathPlugin(mock(WalkingNoticeOverlay.class));
 
         for (GameState s : new GameState[]{
                 GameState.LOGIN_SCREEN,
@@ -249,7 +249,7 @@ public class ShortestPathTier1RegressionTest {
 
     @Test
     public void bug5_pendingRefreshConsumedExactlyOncePerLogin() {
-        ShortestPathPlugin plugin = new ShortestPathPlugin();
+        ShortestPathPlugin plugin = new ShortestPathPlugin(mock(WalkingNoticeOverlay.class));
         PathfinderConfig cfg = mock(PathfinderConfig.class);
         ShortestPathPlugin.pathfinderConfig = cfg;
 
@@ -264,7 +264,7 @@ public class ShortestPathTier1RegressionTest {
 
     @Test
     public void bug5_nullConfigLeavesFlagSoRefreshHappensWhenConfigArrives() {
-        ShortestPathPlugin plugin = new ShortestPathPlugin();
+        ShortestPathPlugin plugin = new ShortestPathPlugin(mock(WalkingNoticeOverlay.class));
         ShortestPathPlugin.pathfinderConfig = null;
         plugin.pendingLoginRefresh = true;
 
@@ -276,7 +276,7 @@ public class ShortestPathTier1RegressionTest {
 
     @Test
     public void bug5_refreshExceptionLeavesFlagSetForNextTickRetry() {
-        ShortestPathPlugin plugin = new ShortestPathPlugin();
+        ShortestPathPlugin plugin = new ShortestPathPlugin(mock(WalkingNoticeOverlay.class));
         PathfinderConfig cfg = mock(PathfinderConfig.class);
         org.mockito.Mockito.doThrow(new RuntimeException("boom")).when(cfg).refresh();
         ShortestPathPlugin.pathfinderConfig = cfg;
@@ -291,7 +291,7 @@ public class ShortestPathTier1RegressionTest {
 
     @Test
     public void bug5_multipleLoginTransitionsEachRefreshOnce() {
-        ShortestPathPlugin plugin = new ShortestPathPlugin();
+        ShortestPathPlugin plugin = new ShortestPathPlugin(mock(WalkingNoticeOverlay.class));
         PathfinderConfig cfg = mock(PathfinderConfig.class);
         ShortestPathPlugin.pathfinderConfig = cfg;
 
@@ -309,7 +309,7 @@ public class ShortestPathTier1RegressionTest {
 
     @Test
     public void bug5_handleRefreshWhenFlagClearDoesNothing() {
-        ShortestPathPlugin plugin = new ShortestPathPlugin();
+        ShortestPathPlugin plugin = new ShortestPathPlugin(mock(WalkingNoticeOverlay.class));
         PathfinderConfig cfg = mock(PathfinderConfig.class);
         ShortestPathPlugin.pathfinderConfig = cfg;
         plugin.pendingLoginRefresh = false;


### PR DESCRIPTION
## Summary

- add a configurable walking toggle to pause and resume manual WebWalker movement while preserving the destination
- allow route previews while automatic walking is disabled
- add a configurable hotkey to clear the current path, defaulting to Ctrl+X
- show walking controls in the panel, with action feedback in chat and a temporary overlay
- prevent cancelled walk tasks and stale pathfinding requests from replacing newer routes

## Testing

- `./gradlew :client:runUnitTests --tests net.runelite.client.plugins.microbot.shortestpath.ShortestPathManualWalkingTest --tests net.runelite.client.plugins.microbot.shortestpath.ShortestPathTier1RegressionTest`
- compilation succeeded and all 25 tests passed on the development base
- manually verified all features in-game, including walking toggle, route preview, pause/resume, path clearing, configurable hotkeys, chat messages, and overlay notifications