### PR TITLE
Fix POH Web Config detection for unknown Nexus destinations

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/PohPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/shortestpath/PohPanel.java
@@ -147,13 +147,25 @@ public class PohPanel extends PluginPanel {
         }
         detectButton.setEnabled(false);
         detectButton.setText("Detecting...");
-        checkboxPanel.detectPohFacilities();
-        portalPanel.setAll(PohPortal.findPortalsInPoh());
-        nexusPanel.setAll(NexusPortal.getAvailableTeleports());
-        jewelleryBoxPanel.detectJewelleryBox();
-        tilePanel.detectTile();
-        detectButton.setEnabled(true);
-        detectButton.setText("Detect available POH teleports");
+        try {
+            detectSection("house features", () -> checkboxPanel.detectPohFacilities());
+            detectSection("portals", () -> portalPanel.setAll(PohPortal.findPortalsInPoh()));
+            detectSection("Nexus", () -> nexusPanel.setAll(NexusPortal.getAvailableTeleports()));
+            detectSection("jewellery box", () -> jewelleryBoxPanel.detectJewelleryBox());
+            detectSection("exit portal", () -> tilePanel.detectTile());
+        } finally {
+            detectButton.setEnabled(true);
+            detectButton.setText("Detect available POH teleports");
+        }
+    }
+
+    private static void detectSection(String name, Runnable detection) {
+        try {
+            detection.run();
+        } catch (RuntimeException ex) {
+            Microbot.log("POH detection failed for " + name + ": " + ex.getClass().getSimpleName());
+            Microbot.logStackTrace("POH detection: " + name, ex);
+        }
     }
 
     /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/data/NexusPortal.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/poh/data/NexusPortal.java
@@ -115,10 +115,20 @@ public enum NexusPortal implements PohTeleport {
                 }
                 continue;
             }
-            NexusPortal tp = NexusPortal.values()[value];
-            teleports.add(tp);
+            NexusPortal tp = fromVarbitValue(value);
+            if (tp != null) {
+                if (!teleports.contains(tp)) teleports.add(tp);
+            } else {
+                Microbot.log("POH Nexus: unsupported destination value " + value + "; skipping this slot.");
+            }
         }
         return teleports;
+    }
+
+    static NexusPortal fromVarbitValue(int value) {
+        if (value == 1) return VARROCK;
+        NexusPortal[] destinations = values();
+        return value > 1 && value < destinations.length ? destinations[value] : null;
     }
 
     public static final int[] VARBITS = new int[]{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/poh/data/NexusPortalTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/microbot/util/poh/data/NexusPortalTest.java
@@ -1,0 +1,21 @@
+package net.runelite.client.plugins.microbot.util.poh.data;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class NexusPortalTest {
+    @Test
+    public void unknownAndEmptySlotsDoNotIndexOutsideTheCatalog() {
+        assertNull(NexusPortal.fromVarbitValue(-1));
+        assertNull(NexusPortal.fromVarbitValue(0));
+        assertNull(NexusPortal.fromVarbitValue(32));
+        assertNull(NexusPortal.fromVarbitValue(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void knownSlotsKeepTheirMappings() {
+        assertEquals(NexusPortal.VARROCK, NexusPortal.fromVarbitValue(1));
+        assertEquals(NexusPortal.LUMBRIDGE, NexusPortal.fromVarbitValue(2));
+        assertEquals(NexusPortal.CIVITAS_ILLA_FORTIS, NexusPortal.fromVarbitValue(31));
+    }
+}


### PR DESCRIPTION
## Summary
Fix the POH Web Config detection action aborting with `ArrayIndexOutOfBoundsException: Index 32 out of bounds for length 32` in `NexusPortal.getAvailableTeleports`.

- Check destination values before indexing the supported Nexus catalog. Empty and unknown values are ignored safely; unknown positive values emit a diagnostic instead of being assigned an invented destination.
- Preserve existing known destination mappings and the Varrock/Grand Exchange special case.
- Isolate failures by detection section so a Nexus problem does not prevent jewellery box and exit portal detection.
- Restore the detection button in `finally` so failures do not leave it disabled.
- Add regression tests for value 32, empty/negative values, large values, and known mappings.

This deliberately does not claim support for destination value 32. Its mapping needs separate verification before adding it to routing.

## Scope
Independent of the Portal Nexus enable/disable setting in #1861. No walker movement changes, personal configuration, logs, or account data are included.

## Validation
Focused Nexus regression tests and the client-thread guardrail are run locally before publication. Equivalent compatible-client classes also compiled and passed the Nexus tests. Live detection should be retested in a POH after restarting with the fix.
